### PR TITLE
feat: Add agent task planning UI and todowrite tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@floating-ui/dom": "^1.7.6",
     "@mlc-ai/web-llm": "^0.2.82",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/src/components/ai-elements/chain-of-thought.tsx
+++ b/src/components/ai-elements/chain-of-thought.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+import { cva } from "class-variance-authority";
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  CircleIcon,
+  Loader2Icon,
+  XIcon,
+} from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const ChainOfThought = CollapsiblePrimitive.Root;
+
+const ChainOfThoughtHeader = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <CollapsiblePrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "group flex items-center gap-1.5 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground",
+      className
+    )}
+    {...props}
+  >
+    <ChevronRightIcon className="h-3 w-3 shrink-0 transition-transform duration-200 group-data-[state=open]:rotate-90" />
+    <span className="font-medium">{children}</span>
+  </CollapsiblePrimitive.Trigger>
+));
+ChainOfThoughtHeader.displayName = "ChainOfThoughtHeader";
+
+const ChainOfThoughtContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <CollapsiblePrimitive.Content
+    ref={ref}
+    className={cn(
+      "overflow-hidden transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down ml-[5px] border-l pl-4 pb-2 mt-1",
+      className
+    )}
+    {...props}
+  >
+    <div className="flex flex-col gap-3 pt-1">{children}</div>
+  </CollapsiblePrimitive.Content>
+));
+ChainOfThoughtContent.displayName = "ChainOfThoughtContent";
+
+const stepVariants = cva("flex items-start gap-2.5 text-xs", {
+  variants: {
+    status: {
+      pending: "text-muted-foreground/70",
+      active: "text-foreground font-medium",
+      complete: "text-muted-foreground",
+      cancelled: "text-muted-foreground/50 line-through",
+    },
+  },
+  defaultVariants: {
+    status: "pending",
+  },
+});
+
+interface ChainOfThoughtStepProps extends React.HTMLAttributes<HTMLDivElement> {
+  status?: "pending" | "active" | "complete" | "cancelled";
+  label: string;
+}
+
+const ChainOfThoughtStep = React.forwardRef<
+  HTMLDivElement,
+  ChainOfThoughtStepProps
+>(({ className, status = "pending", label, children, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn(stepVariants({ status }), className)}
+      {...props}
+    >
+      <div className="mt-0.5 flex h-3 w-3 shrink-0 items-center justify-center bg-background">
+        {status === "pending" && <CircleIcon className="h-2 w-2" />}
+        {status === "active" && (
+          <Loader2Icon className="h-3 w-3 text-blue-500 animate-spin" />
+        )}
+        {status === "complete" && <CheckIcon className="h-3 w-3" />}
+        {status === "cancelled" && <XIcon className="h-3 w-3" />}
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="leading-tight">{label}</span>
+        {children && <div className="text-muted-foreground/80">{children}</div>}
+      </div>
+    </div>
+  );
+});
+ChainOfThoughtStep.displayName = "ChainOfThoughtStep";
+
+export {
+  ChainOfThought,
+  ChainOfThoughtContent,
+  ChainOfThoughtHeader,
+  ChainOfThoughtStep,
+};

--- a/src/components/ai-elements/task.tsx
+++ b/src/components/ai-elements/task.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+import { cva } from "class-variance-authority";
+import {
+  CheckCircle2Icon,
+  ChevronRightIcon,
+  CircleIcon,
+  Loader2Icon,
+  XCircleIcon,
+} from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Task = CollapsiblePrimitive.Root;
+
+const TaskTrigger = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger> & {
+    title: string;
+  }
+>(({ className, title, ...props }, ref) => (
+  <CollapsiblePrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "group flex w-full items-center gap-2 rounded-t-lg bg-muted px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/80 data-[state=closed]:rounded-b-lg",
+      className
+    )}
+    {...props}
+  >
+    <ChevronRightIcon className="h-4 w-4 shrink-0 transition-transform duration-200 group-data-[state=open]:rotate-90" />
+    <span className="flex-1 text-left">{title}</span>
+  </CollapsiblePrimitive.Trigger>
+));
+TaskTrigger.displayName = "TaskTrigger";
+
+const TaskContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <CollapsiblePrimitive.Content
+    ref={ref}
+    className={cn(
+      "overflow-hidden rounded-b-lg border border-t-0 bg-background transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down",
+      className
+    )}
+    {...props}
+  >
+    <div className="p-4 flex flex-col gap-3">{children}</div>
+  </CollapsiblePrimitive.Content>
+));
+TaskContent.displayName = "TaskContent";
+
+const taskItemVariants = cva(
+  "flex items-start gap-2.5 text-sm transition-colors",
+  {
+    variants: {
+      status: {
+        pending: "text-muted-foreground",
+        in_progress: "text-foreground",
+        completed: "text-foreground",
+        cancelled: "text-muted-foreground line-through",
+      },
+    },
+    defaultVariants: {
+      status: "pending",
+    },
+  }
+);
+
+interface TaskItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  status?: "pending" | "in_progress" | "completed" | "cancelled";
+}
+
+const TaskItem = React.forwardRef<HTMLDivElement, TaskItemProps>(
+  ({ className, status = "pending", children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(taskItemVariants({ status }), className)}
+        {...props}
+      >
+        <div className="mt-0.5 shrink-0 flex items-center justify-center">
+          {status === "pending" && <CircleIcon className="h-4 w-4 text-muted-foreground" />}
+          {status === "in_progress" && <Loader2Icon className="h-4 w-4 text-blue-500 animate-spin" />}
+          {status === "completed" && <CheckCircle2Icon className="h-4 w-4 text-green-500" />}
+          {status === "cancelled" && <XCircleIcon className="h-4 w-4 text-muted-foreground" />}
+        </div>
+        <div className="flex-1 leading-normal">{children}</div>
+      </div>
+    );
+  }
+);
+TaskItem.displayName = "TaskItem";
+
+export { Task, TaskContent, TaskItem, TaskTrigger };

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -22,7 +22,7 @@ import {
 } from "lucide-react";
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { useCallback, useEffect, useMemo, useState } from "react";
-
+import { TodoPanel } from "./TodoPanel";
 
 interface ChatViewProps {
   conversationId: string | null;
@@ -195,15 +195,28 @@ const providerModels = useMemo(() => {
             </button>
             <button
               type="button"
-              onClick={openSettings}
+              onClick={onSettingsClick}
               className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
               title="Settings"
             >
               <Settings2 className="size-3.5" />
             </button>
+            {onClose && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                title="Close"
+              >
+                <X className="size-3.5" />
+              </button>
+            )}
           </div>
         </div>
       )}
+
+      {/* Todo Panel */}
+      <TodoPanel conversationId={conversationId} />
 
       {/* Messages */}
       <Conversation className="flex-1">

--- a/src/components/chat/TodoPanel.tsx
+++ b/src/components/chat/TodoPanel.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { chatDb } from "@/lib/chat-db";
+import type { TodoItem } from "@/lib/types";
+import {
+  ChainOfThought,
+  ChainOfThoughtContent,
+  ChainOfThoughtHeader,
+  ChainOfThoughtStep,
+} from "../ai-elements/chain-of-thought";
+import { Shimmer } from "../ai-elements/shimmer";
+
+interface TodoPanelProps {
+  conversationId: string | null;
+}
+
+export function TodoPanel({ conversationId }: TodoPanelProps) {
+  const [todos, setTodos] = useState<TodoItem[]>([]);
+
+  useEffect(() => {
+    if (!conversationId) {
+      setTodos([]);
+      return;
+    }
+
+    let isMounted = true;
+    
+    // Initial fetch
+    chatDb.getConversation(conversationId).then(conv => {
+      if (isMounted && conv) {
+        setTodos(conv.todos || []);
+      }
+    });
+
+    // Poll for updates since IndexedDB doesn't have native reactivity
+    // in this app's architecture for non-message fields yet
+    const interval = setInterval(async () => {
+      const conv = await chatDb.getConversation(conversationId);
+      if (isMounted && conv) {
+        setTodos(conv.todos || []);
+      }
+    }, 1000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, [conversationId]);
+
+  if (todos.length === 0) return null;
+
+  const completed = todos.filter(t => t.status === "completed").length;
+  const inProgress = todos.find(t => t.status === "in_progress");
+  const headerText = inProgress 
+    ? `Plan (${completed}/${todos.length}) — ${inProgress.content}`
+    : `Plan (${completed}/${todos.length})`;
+
+  // Map our domain statuses to ChainOfThought statuses
+  const mapStatus = (status: string) => {
+    switch (status) {
+      case "in_progress": return "active";
+      case "completed": return "complete";
+      case "cancelled": return "cancelled";
+      default: return "pending";
+    }
+  };
+
+  return (
+    <div className="border-b border-border bg-muted/20 px-4 py-2">
+      <ChainOfThought defaultOpen={false}>
+        <ChainOfThoughtHeader>
+          {inProgress ? (
+            <Shimmer duration={3} spread={1.5} className="font-medium text-blue-500/90 dark:text-blue-400/90">
+              {headerText}
+            </Shimmer>
+          ) : (
+            headerText
+          )}
+        </ChainOfThoughtHeader>
+        <ChainOfThoughtContent>
+          {todos.map((todo, idx) => (
+            <ChainOfThoughtStep
+              key={todo.id || idx}
+              label={todo.content}
+              status={mapStatus(todo.status)}
+            />
+          ))}
+        </ChainOfThoughtContent>
+      </ChainOfThought>
+    </div>
+  );
+}

--- a/src/components/chat/ToolCallBlock.tsx
+++ b/src/components/chat/ToolCallBlock.tsx
@@ -10,6 +10,8 @@ import { SnapshotResult } from "./tool-results/snapshot";
 import { ScreenshotResult } from "./tool-results/screenshot";
 import { CodeResult } from "./tool-results/execute-code";
 
+import { getToolPreview } from "./tool-previews";
+
 type ResultRenderer = (props: { args: Record<string, unknown>; result: unknown }) => ReactNode;
 
 const BUILTIN_RESULT_RENDERERS: Record<string, ResultRenderer> = {
@@ -43,6 +45,8 @@ const TOOL_LABELS: Record<string, { pending: string; done: string }> = {
   updateMemory: { pending: "Updating memory...", done: "Updated memory" },
   deleteMemory: { pending: "Deleting memory...", done: "Deleted memory" },
   recallMemory: { pending: "Recalling memory...", done: "Recalled memory" },
+  todoWrite: { pending: "Updating plan...", done: "Updated plan" },
+  extract: { pending: "Extracting data...", done: "Extracted data" },
 };
 
 const TAB_TOOLS = new Set([
@@ -193,15 +197,27 @@ export function ToolCallBlock({ toolName, toolCallId, args, result, state }: Too
 
       {expanded && !pending && (
         <div className="ml-3 mt-1 border-l border-muted pl-3 pb-1 overflow-hidden">
-          {resolvedResult !== undefined ? (
-            <pre className="whitespace-pre-wrap font-mono text-xs text-muted-foreground max-h-48 overflow-y-auto styled-scrollbar">
-              {typeof resolvedResult === "string" ? resolvedResult : JSON.stringify(resolvedResult, null, 2)}
-            </pre>
-          ) : Object.keys(args).length > 0 ? (
-            <pre className="whitespace-pre-wrap font-mono text-xs text-muted-foreground">
-              {JSON.stringify(args, null, 2)}
-            </pre>
-          ) : null}
+          {(() => {
+            const previewRenderer = getToolPreview(mcpToolName ?? toolName);
+            if (previewRenderer) {
+              return previewRenderer(args);
+            }
+            if (resolvedResult !== undefined) {
+              return (
+                <pre className="whitespace-pre-wrap font-mono text-xs text-muted-foreground max-h-48 overflow-y-auto styled-scrollbar">
+                  {typeof resolvedResult === "string" ? resolvedResult : JSON.stringify(resolvedResult, null, 2)}
+                </pre>
+              );
+            }
+            if (Object.keys(args).length > 0) {
+              return (
+                <pre className="whitespace-pre-wrap font-mono text-xs text-muted-foreground">
+                  {JSON.stringify(args, null, 2)}
+                </pre>
+              );
+            }
+            return null;
+          })()}
         </div>
       )}
     </div>

--- a/src/components/chat/tool-previews/index.ts
+++ b/src/components/chat/tool-previews/index.ts
@@ -1,5 +1,6 @@
 import "./execute-on-page";
 import "./update-memory";
+import "./todowrite";
 
 export { getToolPreview, registerToolPreview } from "./registry";
 export type { ToolPreviewRenderer } from "./registry";

--- a/src/components/chat/tool-previews/todowrite.tsx
+++ b/src/components/chat/tool-previews/todowrite.tsx
@@ -1,0 +1,41 @@
+import {
+  Task,
+  TaskContent,
+  TaskItem,
+  TaskTrigger,
+} from "../../ai-elements/task";
+import { registerToolPreview } from "./registry";
+import type { TodoItem } from "@/lib/types";
+
+registerToolPreview("todoWrite", (args) => {
+  const todos = (args.todos as TodoItem[]) || [];
+  if (todos.length === 0) {
+    return (
+      <div className="px-4 py-3 bg-muted/50 rounded-lg text-sm text-muted-foreground italic">
+        Plan cleared.
+      </div>
+    );
+  }
+
+  const completedCount = todos.filter((t) => t.status === "completed").length;
+  const inProgress = todos.some((t) => t.status === "in_progress");
+
+  return (
+    <div className="my-2">
+      <Task defaultOpen={inProgress}>
+        <TaskTrigger title={`Plan · ${completedCount}/${todos.length} complete`} />
+        <TaskContent>
+          {todos.map((todo, idx) => (
+            <TaskItem
+              key={todo.id || idx}
+              status={todo.status}
+              className={todo.priority === "high" ? "font-medium" : ""}
+            >
+              {todo.content}
+            </TaskItem>
+          ))}
+        </TaskContent>
+      </Task>
+    </div>
+  );
+});

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,31 @@
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/lib/agent/agent-transport.ts
+++ b/src/lib/agent/agent-transport.ts
@@ -1,5 +1,11 @@
 import type { ModelDefinition } from "@/registry/providers/types";
-import type { ChatTransport, LanguageModel, ToolLoopAgentSettings, ToolSet, UIMessage } from "ai";
+import type {
+  ChatTransport,
+  LanguageModel,
+  ToolLoopAgentSettings,
+  ToolSet,
+  UIMessage,
+} from "ai";
 import { DirectChatTransport, ToolLoopAgent, tool } from "ai";
 import { z } from "zod";
 import { chatDb } from "../chat-db";
@@ -24,6 +30,7 @@ import {
   scrollPageTool,
   selectTabTool,
   snapshotTool,
+  todoWriteTool,
   typeInElementTool,
   updateMemoryTool,
 } from "./tools";
@@ -32,6 +39,17 @@ import type { BrowserTool } from "./types";
 const SYSTEM_PROMPT = `You are OpenBrowse, an AI browser agent. You help users understand and interact with web pages.
 
 You have tools to interact with the user's browser tabs. Tools automatically target the user's active browsing tab — you do NOT need to select or switch tabs unless the user asks to work with a different one.
+
+## Planning with todoWrite
+For tasks that require multiple steps or distinct objectives, call \`todoWrite\` BEFORE acting to lay out your steps.
+As you work:
+- Keep EXACTLY ONE item "in_progress" before starting work on it
+- Mark it "completed" immediately when done — never batch completions at the end
+- Add new items if you discover follow-up work or roadblocks
+- Cancel items that become irrelevant rather than silently skipping them
+- Before providing your final text response to the user, you MUST ensure all tasks in your plan are marked "completed" or "cancelled" via a final \`todoWrite\` call.
+
+Your current plan will be appended to your instructions at every turn. Keep it in sync with reality. You may skip this for trivial, single-action requests.
 
 ## Page Interaction Workflow
 
@@ -631,6 +649,7 @@ export async function createAgentTransport(
     executeCode: toSDKTool(executeCodeTool, "executeCode"),
     executeOnPage: toSDKTool(executeOnPageTool, "executeOnPage"),
     extract: toSDKTool(extractTool, "extract"),
+    todoWrite: toSDKTool(todoWriteTool, "todoWrite"),
   };
 
   const mcpTools = getMcpRegistry().toSDKTools();
@@ -641,6 +660,26 @@ export async function createAgentTransport(
 
   if (spaceId && spaceName) {
     instructions += `\n\nYou are chatting from the space "${spaceName}" (id: ${spaceId}). When saving space-scoped memories, use this spaceId.`;
+  }
+
+  // Inject current todo plan into system prompt
+  const conv = agentConversationId
+    ? await chatDb.getConversation(agentConversationId)
+    : null;
+  if (conv?.todos && conv.todos.length > 0) {
+    instructions += `\n\n### Current Plan (todoWrite)\n`;
+    const inProgress = conv.todos.find((t) => t.status === "in_progress");
+    const completed = conv.todos.filter((t) => t.status === "completed").length;
+    instructions += `Total tasks: ${conv.todos.length} (${completed} completed)\n`;
+    if (inProgress) {
+      instructions += `Currently working on: ${inProgress.content}\n`;
+    } else {
+      instructions += `No task currently marked in_progress.\n`;
+    }
+    instructions += `\nFull list:\n`;
+    instructions += conv.todos
+      .map((t, i) => `${i + 1}. [${t.status.toUpperCase()}] ${t.content}`)
+      .join("\n");
   }
 
   const memories = await memoryDb.list(spaceId);

--- a/src/lib/agent/cdp-session.ts
+++ b/src/lib/agent/cdp-session.ts
@@ -25,7 +25,7 @@ const DETACH_ERROR_PATTERNS = [
   /No tab with given id/i,
 ];
 
-function isDetachError(err: unknown): boolean {
+export function isDetachError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return DETACH_ERROR_PATTERNS.some((re) => re.test(msg));
 }

--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -29,6 +29,9 @@ const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown below. Kee
 ## Goal
 - [what the user is trying to accomplish]
 
+## Plan
+- [current todo list state and progress, if any plan was created]
+
 ## Pages & Context
 - [url]: [what was learned/done there]
 

--- a/src/lib/agent/tools/click-element.ts
+++ b/src/lib/agent/tools/click-element.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getActiveUserTab, sendToContentScript, waitForTabLoad } from "../active-tab";
-import { sendCommand } from "../cdp-session";
+import { sendCommand, isDetachError } from "../cdp-session";
 import { getRef, getPreviousSnapshot, invalidateRefs } from "../ref-store";
 import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
@@ -33,10 +33,17 @@ export const clickElementTool: BrowserTool<Input, Output> = {
 
     const previousSnapshot = getPreviousSnapshot(tabId);
 
-    if (target.startsWith("@e")) {
-      await clickByRef(tabId, target);
-    } else {
-      await clickBySelector(tabId, target);
+    try {
+      if (target.startsWith("@e")) {
+        await clickByRef(tabId, target);
+      } else {
+        await clickBySelector(tabId, target);
+      }
+    } catch (err) {
+      if (!isDetachError(err)) throw err;
+      // If the page detached during the click sequence, it means the click 
+      // successfully triggered a navigation. We swallow the error and proceed 
+      // to wait for the new page to load.
     }
 
     invalidateRefs(tabId);

--- a/src/lib/agent/tools/index.ts
+++ b/src/lib/agent/tools/index.ts
@@ -14,3 +14,5 @@ export { recallMemoryTool } from "./recall-memory";
 export { executeCodeTool } from "./execute-code";
 export { executeOnPageTool } from "./execute-on-page";
 export { extractTool } from "./extract";
+export { todoWriteTool } from "./todowrite";
+

--- a/src/lib/agent/tools/todowrite.ts
+++ b/src/lib/agent/tools/todowrite.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { chatDb } from "@/lib/chat-db";
+import { getAgentContext } from "../agent-transport";
+import type { BrowserTool } from "../types";
+import type { TodoItem } from "@/lib/types";
+
+const todoSchema = z.object({
+  content: z.string().describe("Imperative task description (e.g., 'Search for top 3 mechanical keyboards')"),
+  status: z.enum(["pending", "in_progress", "completed", "cancelled"]),
+  priority: z.enum(["high", "medium", "low"]).optional(),
+});
+
+const parameters = z.object({
+  todos: z.array(todoSchema).describe("The complete, updated list of tasks. This entirely replaces the current plan. Provide the FULL list every time."),
+});
+
+type Input = z.infer<typeof parameters>;
+type Output = { saved: true } | { saved: false; reason: string };
+
+export const todoWriteTool: BrowserTool<Input, Output> = {
+  name: "todoWrite",
+  description:
+    "Proactively manage a structured task list to track progress during complex, multi-step tasks. Overwrites the current plan with the provided list. The list is preserved across conversation turns. RULES: At most one task can be 'in_progress' at a time. Mark tasks 'completed' immediately when done, do not batch completions.",
+  parameters,
+  execute: async (input) => {
+    const { conversationId } = getAgentContext();
+    if (!conversationId) {
+      return { saved: false, reason: "No active conversation context to save todos against." };
+    }
+
+    const { todos: newTodosInput } = parameters.parse(input);
+
+    const inProgressCount = newTodosInput.filter(t => t.status === "in_progress").length;
+    if (inProgressCount > 1) {
+      return { saved: false, reason: "Constraint violated: At most one task can be 'in_progress' at a time. Please update the statuses and try again." };
+    }
+
+    const conv = await chatDb.getConversation(conversationId);
+    if (!conv) {
+      return { saved: false, reason: "Active conversation not found in database." };
+    }
+
+    const now = Date.now();
+    const existingTodos = conv.todos || [];
+    
+    // Map existing todos by content to preserve their IDs and createdAt times
+    // (since we overwrite the whole list and don't want to re-create IDs every turn)
+    const existingTodosMap = new Map<string, TodoItem>(
+      existingTodos.map(t => [t.content, t])
+    );
+
+    const finalTodos: TodoItem[] = newTodosInput.map(item => {
+      const existing = existingTodosMap.get(item.content);
+      if (existing) {
+        return {
+          ...item,
+          id: existing.id,
+          createdAt: existing.createdAt,
+          updatedAt: item.status !== existing.status ? now : existing.updatedAt,
+        };
+      }
+      return {
+        ...item,
+        id: crypto.randomUUID(),
+        createdAt: now,
+        updatedAt: now,
+      };
+    });
+
+    await chatDb.updateConversation(conversationId, {
+      todos: finalTodos,
+      updatedAt: now,
+    });
+
+    return { saved: true };
+  },
+};

--- a/src/lib/agent/tools/type-in-element.ts
+++ b/src/lib/agent/tools/type-in-element.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getActiveUserTab, sendToContentScript, waitForTabLoad } from "../active-tab";
-import { sendCommand } from "../cdp-session";
+import { sendCommand, isDetachError } from "../cdp-session";
 import { getRef, getPreviousSnapshot, invalidateRefs } from "../ref-store";
 import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
@@ -51,10 +51,33 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     const textToType = legacyNewlineSubmit ? text.slice(0, -1) : text;
     const shouldPressEnter = submit ?? legacyNewlineSubmit;
 
-    if (target.startsWith("@e")) {
-      await typeByRef(tabId, target, textToType, clearFirst ?? true);
-    } else {
-      await typeBySelector(tabId, target, textToType, clearFirst ?? true);
+    try {
+      if (target.startsWith("@e")) {
+        await typeByRef(tabId, target, textToType, clearFirst ?? true);
+      } else {
+        await typeBySelector(tabId, target, textToType, clearFirst ?? true);
+      }
+
+      if (shouldPressEnter) {
+        await sendCommand(tabId, "Input.dispatchKeyEvent", {
+          type: "keyDown",
+          key: "Enter",
+          code: "Enter",
+          windowsVirtualKeyCode: 13,
+          nativeVirtualKeyCode: 13,
+        });
+        await sendCommand(tabId, "Input.dispatchKeyEvent", {
+          type: "keyUp",
+          key: "Enter",
+          code: "Enter",
+          windowsVirtualKeyCode: 13,
+          nativeVirtualKeyCode: 13,
+        });
+      }
+    } catch (err) {
+      if (!isDetachError(err)) throw err;
+      // If typing or pressing Enter triggered a navigation that detached the debugger,
+      // it means the submission successfully triggered a navigation.
     }
 
     if (shouldPressEnter) {

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -1,5 +1,5 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
-import type { SerializedUIPart } from "./types";
+import type { SerializedUIPart, TodoItem } from "./types";
 
 interface ChatDB extends DBSchema {
   conversations: {
@@ -10,6 +10,7 @@ interface ChatDB extends DBSchema {
       spaceId: string | null;
       ownedGroupId: number | null;
       ownedTabIds: number[];
+      todos?: TodoItem[];
       createdAt: number;
       updatedAt: number;
     };
@@ -49,7 +50,7 @@ let dbPromise: Promise<IDBPDatabase<ChatDB>> | null = null;
 
 function getDb(): Promise<IDBPDatabase<ChatDB>> {
   if (!dbPromise) {
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 4, {
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 5, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -101,6 +102,20 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
           };
           migrateConversations();
         }
+
+        if (oldVersion < 5) {
+          const convStore = transaction.objectStore("conversations");
+          const migrateConversationsTodos = async () => {
+            let cursor = await convStore.openCursor();
+            while (cursor) {
+              const record = cursor.value as Record<string, unknown>;
+              if (record.todos === undefined) record.todos = [];
+              cursor.update(record as ChatDB["conversations"]["value"]);
+              cursor = await cursor.continue();
+            }
+          };
+          migrateConversationsTodos();
+        }
       },
     });
   }
@@ -129,13 +144,14 @@ export const chatDb = {
   },
 
   async createConversation(
-    conv: Omit<ChatDB["conversations"]["value"], "ownedGroupId" | "ownedTabIds"> &
-      Partial<Pick<ChatDB["conversations"]["value"], "ownedGroupId" | "ownedTabIds">>,
+    conv: Omit<ChatDB["conversations"]["value"], "ownedGroupId" | "ownedTabIds" | "todos"> &
+      Partial<Pick<ChatDB["conversations"]["value"], "ownedGroupId" | "ownedTabIds" | "todos">>,
   ): Promise<void> {
     const db = await getDb();
     await db.put("conversations", {
       ownedGroupId: null,
       ownedTabIds: [],
+      todos: [],
       ...conv,
     });
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,6 +84,16 @@ export interface Conversation {
   spaceId: string | null;
   ownedGroupId: number | null;
   ownedTabIds: number[];
+  todos?: TodoItem[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TodoItem {
+  id: string;
+  content: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  priority?: "high" | "medium" | "low";
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Summary
Adds a comprehensive task management system to OpenBrowse to help the agent reliably complete multi-step tasks without losing context, getting distracted, or failing when page navigations occur.

- **Persistent State**: Bumps IndexedDB to v5 to add persistent `todos` tracking to conversations, ensuring plans survive extension restarts.
- **The Tool**: Adds `todoWrite` tool that enforces single `in_progress` tasks and overwrites the plan, modeled after Claude Code / OpenCode.
- **Context Injection**: Injects the active plan into `SYSTEM_PROMPT` on every turn to prevent compaction amnesia, and updates the memory compaction template to preserve long-running plans.
- **Rich UI**: Integrates Vercel `ai-elements` (`Task` and `ChainOfThought`) for beautiful, collapsible inline tool blocks and a pinned global `TodoPanel` that floats at the top of the chat view.
- **Bug Fix**: Fixes the infamous "Detached while handling command" bug gracefully by swallowing expected detachments during valid page navigations (e.g. clicking a link), which previously caused the agent to panic and drop its plan.