### PR TITLE
feat(overlay): unified ranked search with personalized shortcuts

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -565,18 +565,40 @@ export default defineBackground({
               tidyState = tidyData[tidyKey] ?? null;
             }
 
-            const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-            const historyItems = await chrome.history.search({ text: "", maxResults: 200, startTime: thirtyDaysAgo });
-            const openUrls = new Set(windowTabs.map((t) => t.url));
-            const recentlyClosed = historyItems
-              .filter((h) => h.url && !openUrls.has(h.url))
-              .map((h) => ({
-                url: h.url!,
-                title: h.title ?? "",
-                favicon: "",
-                lastVisitTime: h.lastVisitTime ?? 0,
-                visitCount: h.visitCount ?? 0,
-              }));
+            const recentlyClosed: { url: string; title: string; favicon: string; lastVisitTime: number; visitCount: number; sessionId?: string }[] = [];
+            try {
+              const sessions = await chrome.sessions.getRecentlyClosed({ maxResults: 25 });
+              const seenUrls = new Set<string>();
+              const openUrls = new Set(windowTabs.map((t) => t.url));
+              for (const s of sessions) {
+                if (s.tab && s.tab.url && !openUrls.has(s.tab.url) && !seenUrls.has(s.tab.url)) {
+                  seenUrls.add(s.tab.url);
+                  recentlyClosed.push({
+                    url: s.tab.url,
+                    title: s.tab.title ?? "",
+                    favicon: s.tab.favIconUrl ?? "",
+                    lastVisitTime: s.lastModified ? s.lastModified * 1000 : Date.now(),
+                    visitCount: 1,
+                    sessionId: s.tab.sessionId,
+                  });
+                } else if (s.window && s.window.tabs) {
+                  for (const t of s.window.tabs) {
+                    if (!t.url || openUrls.has(t.url) || seenUrls.has(t.url)) continue;
+                    seenUrls.add(t.url);
+                    recentlyClosed.push({
+                      url: t.url,
+                      title: t.title ?? "",
+                      favicon: t.favIconUrl ?? "",
+                      lastVisitTime: s.lastModified ? s.lastModified * 1000 : Date.now(),
+                      visitCount: 1,
+                      sessionId: t.sessionId,
+                    });
+                  }
+                }
+              }
+            } catch {
+              // chrome.sessions may be unavailable in some contexts; fall back gracefully.
+            }
 
             const bookmarkTree = await chrome.bookmarks.getTree();
             const bookmarks: { url: string; title: string; favicon: string }[] = [];
@@ -604,8 +626,10 @@ export default defineBackground({
       if (message.type === "SEARCH_HISTORY") {
         (async () => {
           try {
-            const { query, maxResults = 50 } = message as { type: string; query: string; maxResults?: number };
-            const historyItems = await chrome.history.search({ text: query, maxResults });
+            const { query, maxResults = 200 } = message as { type: string; query: string; maxResults?: number };
+            // chrome.history.search defaults startTime to 24h ago; pass 0 to search the full history
+            // (Chrome internally caps the candidate pool, and maxResults bounds the response).
+            const historyItems = await chrome.history.search({ text: query, maxResults, startTime: 0 });
             const results = historyItems
               .filter((h) => h.url)
               .map((h) => ({
@@ -1100,9 +1124,24 @@ export default defineBackground({
           try {
             const url = message.url as string;
             const source = message.source as string | undefined;
+            const sessionId = (message as { sessionId?: string }).sessionId;
             const windowId = sender.tab?.windowId;
             let focusedTabId: number | undefined;
-            if (windowId) {
+
+            // If a sessionId is provided (true Recently Closed), restore via sessions API
+            // — this preserves scroll, history, etc.
+            if (sessionId) {
+              try {
+                const restored = await chrome.sessions.restore(sessionId);
+                if (restored?.tab?.id) {
+                  focusedTabId = restored.tab.id;
+                }
+              } catch {
+                // fall through to URL-based open
+              }
+            }
+
+            if (!focusedTabId && windowId) {
               const tabs = await chrome.tabs.query({ windowId });
               const existing = tabs.find((t) => t.url === url);
               if (existing?.id) {

--- a/src/entrypoints/overlay/OverlayApp.tsx
+++ b/src/entrypoints/overlay/OverlayApp.tsx
@@ -12,6 +12,9 @@ import { ConfigureSpaceView } from "./components/ConfigureSpaceView";
 import { SpaceColorPicker } from "./components/SpaceColorPicker";
 import { AutoTidyBanner } from "./components/AutoTidyBanner";
 import { adjustColorsForMode, buildGradientBorder } from "@/lib/color-utils";
+import { MatchList } from "./components/match/MatchList";
+import { buildMatches, MAX_RESULTS, type Match } from "./search/matches";
+import { loadShortcuts, recordShortcutSelection } from "./search/shortcuts";
 
 export interface OverlayTab {
   id: number;
@@ -28,38 +31,7 @@ export interface OverlayTab {
   kind: "tab" | "favorite" | "closed" | "bookmark";
   lastVisitTime?: number;
   visitCount?: number;
-}
-
-function fuzzyScore(query: string, target: string): number {
-  const q = query.toLowerCase();
-  const t = target.toLowerCase();
-  if (t.includes(q)) return 1000 + (q.length / t.length) * 100;
-
-  let qi = 0;
-  let score = 0;
-  let consecutive = 0;
-  let lastMatchIdx = -2;
-
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) {
-      qi++;
-      consecutive = ti === lastMatchIdx + 1 ? consecutive + 1 : 1;
-      score += consecutive * 2;
-      if (ti === 0 || t[ti - 1] === "/" || t[ti - 1] === "." || t[ti - 1] === " " || t[ti - 1] === "-") {
-        score += 5;
-      }
-      lastMatchIdx = ti;
-    }
-  }
-
-  return qi === q.length ? score : 0;
-}
-
-function frecencyScore(tab: { lastVisitTime?: number; visitCount?: number }): number {
-  const visits = tab.visitCount ?? 1;
-  const ageMs = Date.now() - (tab.lastVisitTime ?? 0);
-  const ageDays = Math.max(ageMs / (1000 * 60 * 60 * 24), 0.1);
-  return visits / ageDays;
+  sessionId?: string;
 }
 
 function closeOverlay() {
@@ -68,6 +40,47 @@ function closeOverlay() {
 
 function showToast(message: string, undoData?: any) {
   window.parent.postMessage({ type: "OPENBROWSE_TOAST", message, undoData }, "*");
+}
+
+/**
+ * Convert a Match back into an OverlayTab-shaped object so the existing
+ * execAction / footer code can keep operating on a single shape.
+ */
+function matchToOverlayTab(m: Match, windowId: number | null): OverlayTab {
+  let kind: OverlayTab["kind"];
+  switch (m.source) {
+    case "tab":
+    case "tab-other-space":
+      kind = "tab";
+      break;
+    case "favorite-open":
+    case "favorite-closed":
+      kind = "favorite";
+      break;
+    case "bookmark":
+      kind = "bookmark";
+      break;
+    case "history":
+    case "closed":
+      kind = "closed";
+      break;
+  }
+  return {
+    id: m.tabId ?? -1,
+    url: m.url,
+    title: m.title,
+    favicon: m.favicon,
+    pinned: m.pinned ?? false,
+    active: m.active ?? false,
+    windowId: m.windowId ?? windowId ?? -1,
+    spaceName: m.spaceName,
+    spaceIcon: m.spaceIcon,
+    sectionName: m.sectionName,
+    kind,
+    lastVisitTime: m.lastVisitTime,
+    visitCount: m.visitCount,
+    sessionId: (m as Match & { sessionId?: string }).sessionId,
+  };
 }
 
 export function OverlayApp() {
@@ -139,7 +152,7 @@ export function OverlayApp() {
         if (res.spaces) setSpaces(res.spaces);
         if (res.activeSpaceId && !spaceIdOverridden.current) setActiveSpaceId(res.activeSpaceId);
         setRecentlyClosed(
-          (res.recentlyClosed ?? []).map((rc: { url: string; title: string; favicon: string; lastVisitTime: number; visitCount: number }) => ({
+          (res.recentlyClosed ?? []).map((rc: { url: string; title: string; favicon: string; lastVisitTime: number; visitCount: number; sessionId?: string }) => ({
             id: -1,
             url: rc.url,
             title: rc.title,
@@ -150,6 +163,7 @@ export function OverlayApp() {
             kind: "closed" as const,
             lastVisitTime: rc.lastVisitTime,
             visitCount: rc.visitCount,
+            sessionId: rc.sessionId,
           })),
         );
         setFavoriteAssociationsList(res.favoriteAssociations ?? []);
@@ -291,10 +305,10 @@ export function OverlayApp() {
     return map;
   }, [tidyState]);
 
+  const hasQuery = useMemo(() => query.trim().length > 0, [query]);
+
   const enrichedTabs = useMemo(() => {
-    const baseTabs = query.trim()
-      ? [...tabs, ...allTabs]
-      : tabs;
+    const baseTabs = hasQuery ? [...tabs, ...allTabs] : tabs;
     return baseTabs.map((t) => {
       const sectionId = tidyState?.tabAssignments[t.id];
       const manualTitle = tidyState?.manualTitles?.[t.id];
@@ -311,22 +325,7 @@ export function OverlayApp() {
         sectionName: sectionId ? sectionById.get(sectionId) : undefined,
       };
     });
-  }, [tabs, allTabs, query, tidyState, sectionById]);
-
-  const filteredTabs = useMemo(() => {
-    if (isActionMode) return enrichedTabs;
-    if (!query.trim()) return enrichedTabs;
-    const q = query.trim();
-    const scored = enrichedTabs
-      .map((t) => {
-        const titleScore = Math.max(...(t.searchTitles?.map((s) => fuzzyScore(q, s)) ?? [0]));
-        const urlScore = fuzzyScore(q, t.url);
-        return { tab: t, score: Math.max(titleScore, urlScore) };
-      })
-      .filter((s) => s.score > 0);
-    scored.sort((a, b) => b.score - a.score);
-    return scored.map((s) => s.tab);
-  }, [enrichedTabs, query, isActionMode]);
+  }, [tabs, allTabs, hasQuery, tidyState, sectionById]);
 
   const closedFavorites = useMemo((): OverlayTab[] => {
     if (!activeSpace) return [];
@@ -345,46 +344,75 @@ export function OverlayApp() {
       }));
   }, [activeSpace, favoriteAssociationsList, windowId]);
 
-  const filteredRecentlyClosed = useMemo(() => {
-    const liveUrls = new Set(enrichedTabs.map((t) => t.url));
+  // Load Shortcuts personalization data once (used inside buildMatches via cache).
+  const [shortcutsLoaded, setShortcutsLoaded] = useState(false);
+  useEffect(() => {
+    loadShortcuts().then(() => setShortcutsLoaded(true));
+  }, []);
 
-    if (!query.trim()) {
-      const deduped = recentlyClosed.filter((t) => !liveUrls.has(t.url) && !favoriteUrls.has(t.url));
-      return deduped.sort((a, b) => frecencyScore(b) - frecencyScore(a));
+  const isFlatMode = hasQuery || historyMode;
+
+  /**
+   * Unified ranked match list — used whenever the user is searching or in
+   * history mode. Empty state (no query, not in history mode) falls back to
+   * the legacy sectioned `OverlayTabList`.
+   */
+  const matches = useMemo<Match[]>(() => {
+    if (isActionMode || !isFlatMode) return [];
+    // Reference shortcutsLoaded to recompute when personalization arrives.
+    void shortcutsLoaded;
+
+    // Split current-window tabs vs. cross-space tabs for the new pipeline.
+    const currentTabs = enrichedTabs.filter((t) => !t.spaceName);
+    const otherSpaceTabs = enrichedTabs.filter((t) => !!t.spaceName);
+
+    const all = buildMatches({
+      query: query.trim(),
+      tabs: currentTabs,
+      otherSpaceTabs,
+      closedFavorites,
+      bookmarks,
+      recentlyClosed,
+      history: historySearchResults,
+      tidyState,
+      sectionById,
+      favoriteUrls,
+      associatedTabIds,
+      associations: favoriteAssociationsList,
+    });
+    return all.slice(0, MAX_RESULTS);
+  }, [
+    isActionMode,
+    isFlatMode,
+    query,
+    enrichedTabs,
+    closedFavorites,
+    bookmarks,
+    recentlyClosed,
+    historySearchResults,
+    tidyState,
+    sectionById,
+    favoriteUrls,
+    associatedTabIds,
+    favoriteAssociationsList,
+    shortcutsLoaded,
+  ]);
+
+  /**
+   * Legacy sectioned list — used only for the empty (no-query, no-history-mode)
+   * default view. Includes pinned, favorites, tidy sections, ungrouped, and
+   * recently-closed bottom block.
+   */
+  const orderedTabs = useMemo(() => {
+    if (isActionMode) return enrichedTabs;
+    if (isFlatMode) {
+      // When in flat mode, return matches converted to OverlayTab for footer/keyboard ops.
+      return matches.map((m) => matchToOverlayTab(m, windowId));
     }
 
-    const results = historySearchResults.filter(
-      (t) => !liveUrls.has(t.url) && !favoriteUrls.has(t.url),
-    );
-    return results.sort((a, b) => frecencyScore(b) - frecencyScore(a));
-  }, [recentlyClosed, historySearchResults, query, enrichedTabs, favoriteUrls]);
-
-  const filteredBookmarks = useMemo(() => {
-    if (!query.trim()) return [];
-    const liveUrls = new Set(enrichedTabs.map((t) => t.url));
-    const closedUrls = new Set(filteredRecentlyClosed.map((t) => t.url));
-    const q = query.trim();
-    return bookmarks
-      .filter((b) => !liveUrls.has(b.url) && !favoriteUrls.has(b.url) && !closedUrls.has(b.url))
-      .map((b) => ({ b, score: Math.max(fuzzyScore(q, b.title), fuzzyScore(q, b.url)) }))
-      .filter((s) => s.score > 0)
-      .sort((a, b) => b.score - a.score)
-      .slice(0, 5)
-      .map((s) => s.b);
-  }, [bookmarks, query, enrichedTabs, filteredRecentlyClosed, favoriteUrls]);
-
-  const orderedTabs = useMemo(() => {
-    if (isActionMode) return filteredTabs;
-    if (historyMode) return filteredRecentlyClosed;
-    const q = query.toLowerCase();
-
-    const favItems = closedFavorites.filter(
-      (f) => !q || fuzzyScore(query.trim(), f.title) > 0 || fuzzyScore(query.trim(), f.url) > 0,
-    );
-
-    const pinned = filteredTabs.filter((t) => t.pinned);
-    const openFavs = filteredTabs.filter((t) => !t.pinned && associatedTabIds.has(t.id));
-    const active = filteredTabs.filter((t) => !t.pinned && !associatedTabIds.has(t.id));
+    const pinned = enrichedTabs.filter((t) => t.pinned);
+    const openFavs = enrichedTabs.filter((t) => !t.pinned && associatedTabIds.has(t.id));
+    const active = enrichedTabs.filter((t) => !t.pinned && !associatedTabIds.has(t.id));
 
     const sectionMap = new Map<string, OverlayTab[]>();
     const ungrouped: OverlayTab[] = [];
@@ -398,39 +426,87 @@ export function OverlayApp() {
       }
     }
 
-    const result: OverlayTab[] = [...pinned, ...favItems, ...openFavs];
+    const result: OverlayTab[] = [...pinned, ...closedFavorites, ...openFavs];
     for (const sectionTabs of sectionMap.values()) {
       result.push(...sectionTabs);
     }
-    const closedToShow = query.trim() ? filteredRecentlyClosed : filteredRecentlyClosed.slice(0, 8);
-    result.push(...ungrouped, ...filteredBookmarks, ...closedToShow);
+    const closedToShow = recentlyClosed
+      .filter((t) => !enrichedTabs.some((e) => e.url === t.url) && !favoriteUrls.has(t.url))
+      .slice(0, 8);
+    result.push(...ungrouped, ...closedToShow);
     return result;
-  }, [filteredTabs, closedFavorites, associatedTabIds, isActionMode, query, historyMode, filteredRecentlyClosed, filteredBookmarks]);
+  }, [
+    isActionMode,
+    isFlatMode,
+    matches,
+    windowId,
+    enrichedTabs,
+    associatedTabIds,
+    closedFavorites,
+    recentlyClosed,
+    favoriteUrls,
+  ]);
 
   const initialFocusSet = useRef(false);
   useEffect(() => {
-    if (!initialFocusSet.current && orderedTabs.length > 0 && !query) {
+    if (!initialFocusSet.current && orderedTabs.length > 0 && !query && !historyMode) {
       const activeIndex = orderedTabs.findIndex((t) => t.active);
       if (activeIndex >= 0) {
         setFocusIndex(activeIndex);
         initialFocusSet.current = true;
       }
     }
-  }, [orderedTabs, query]);
+  }, [orderedTabs, query, historyMode]);
 
   useEffect(() => {
     if (initialFocusSet.current) setFocusIndex(0);
   }, [query]);
 
+  // Reset focus when entering/exiting flat-mode.
+  useEffect(() => {
+    setFocusIndex(0);
+  }, [isFlatMode]);
+
+  /**
+   * Inline autocomplete: if the top match is a personalized Shortcut and its
+   * title or compact URL has the current query as a case-insensitive prefix,
+   * surface a ghost suffix in the input. Conservative — only on Shortcuts to
+   * avoid suggestions feeling intrusive.
+   */
+  const inlineCompletion = useMemo(() => {
+    const q = query.trim();
+    if (!q || isActionMode || !matches.length) return "";
+    const top = matches[0];
+    if (!top.isShortcut) return "";
+    const candidates: string[] = [];
+    if (top.title) candidates.push(top.title);
+    try {
+      const u = new URL(top.url);
+      const compact = u.hostname.replace(/^www\./, "") + (u.pathname === "/" ? "" : u.pathname);
+      candidates.push(compact);
+    } catch {
+      candidates.push(top.url);
+    }
+    const qLower = q.toLowerCase();
+    for (const c of candidates) {
+      if (c.toLowerCase().startsWith(qLower) && c.length > q.length) {
+        // Preserve original case from the candidate so the displayed text reads naturally.
+        return c.slice(q.length);
+      }
+    }
+    return "";
+  }, [matches, query, isActionMode]);
+
   useEffect(() => {
     const q = query.trim();
-    if (!q) {
+    // In history mode we want to fetch even with empty query (show recent history).
+    if (!q && !historyMode) {
       setHistorySearchResults([]);
       return;
     }
     let cancelled = false;
     const timer = setTimeout(() => {
-      chrome.runtime.sendMessage({ type: "SEARCH_HISTORY", query: q, maxResults: 50 }).then((res) => {
+      chrome.runtime.sendMessage({ type: "SEARCH_HISTORY", query: q, maxResults: 200 }).then((res) => {
         if (cancelled) return;
         if (res?.ok) {
           setHistorySearchResults(
@@ -449,9 +525,9 @@ export function OverlayApp() {
           );
         }
       });
-    }, 150);
+    }, 80);
     return () => { cancelled = true; clearTimeout(timer); };
-  }, [query, windowId]);
+  }, [query, windowId, historyMode]);
 
   const handleFocusIndex = useCallback((i: number) => {
     if (actionsOpen) return;
@@ -529,15 +605,19 @@ export function OverlayApp() {
       }
 
       if ((target.kind === "closed" || target.kind === "bookmark") && action === "open") {
+        // Record personalization signal: user picked this URL for this query.
+        if (query.trim()) recordShortcutSelection(query, target.url, target.title);
         await chrome.runtime.sendMessage({
           type: "OVERLAY_OPEN_URL",
           url: target.url,
+          sessionId: target.sessionId,
         });
         closeOverlay();
         return;
       }
 
       if (target.kind === "favorite" && action === "open") {
+        if (query.trim()) recordShortcutSelection(query, target.url, target.title);
         await chrome.runtime.sendMessage({
           type: "OVERLAY_OPEN_URL",
           url: target.url,
@@ -562,6 +642,12 @@ export function OverlayApp() {
 
       if (action === "favorite" || action === "pin") {
         generateTitleIfNeeded(target);
+      }
+
+      // Personalization: record any "open"/"switch" selection from a search
+      // query so future searches surface this URL faster.
+      if (action === "open" && query.trim()) {
+        recordShortcutSelection(query, target.url, target.title);
       }
 
       const res = await chrome.runtime.sendMessage({
@@ -590,7 +676,7 @@ export function OverlayApp() {
         fetchTabs();
       }
     },
-    [focusedTab, fetchTabs, generateTitleIfNeeded, spaces, favoriteUrls],
+    [focusedTab, fetchTabs, generateTitleIfNeeded, spaces, favoriteUrls, query],
   );
 
   const execGlobalAction = useCallback(
@@ -634,6 +720,9 @@ export function OverlayApp() {
         closeOverlay();
       }
     },
+    // NOTE: relies on `handleOpenConfigureSpace` being a stable callback (its
+    // own deps are []). Adding it to deps would cause a TDZ error since it's
+    // declared further down in this component.
     [],
   );
 
@@ -1009,6 +1098,7 @@ export function OverlayApp() {
           onSwitchSpace={handleSwitchSpace}
           historyMode={historyMode}
           onOpenChat={() => execGlobalAction("chat")}
+          inlineCompletion={inlineCompletion}
           onExitHistory={() => {
             setHistoryMode(false);
             setQuery("");
@@ -1069,6 +1159,27 @@ export function OverlayApp() {
             onSwitchSpace={handleSwitchSpace}
             onReorderSpaces={handleReorderSpaces}
           />
+        ) : isFlatMode ? (
+          <MatchList
+            matches={matches}
+            focusIndex={focusIndex}
+            onFocusIndex={handleFocusIndex}
+            onAccept={(m) => execAction("open", matchToOverlayTab(m, windowId))}
+            onClose={(m) => execAction("close", matchToOverlayTab(m, windowId))}
+            onTogglePin={(m) =>
+              execAction(m.pinned ? "unpin" : "pin", matchToOverlayTab(m, windowId))
+            }
+            onToggleFavorite={(m) => {
+              const isFav =
+                m.source === "favorite-open" ||
+                m.source === "favorite-closed" ||
+                favoriteUrls.has(m.url);
+              execAction(isFav ? "unfavorite" : "favorite", matchToOverlayTab(m, windowId));
+            }}
+            emptyMessage={
+              historyMode && !query.trim() ? "No history yet." : "No matching results."
+            }
+          />
         ) : (
           <OverlayTabList
             tabs={orderedTabs}
@@ -1086,8 +1197,8 @@ export function OverlayApp() {
             favoriteUrls={favoriteUrls}
             associatedTabIds={associatedTabIds}
             favoriteAssociations={favoriteAssociationsMap}
-            isSearching={query.trim().length > 0}
-            historyMode={historyMode}
+            isSearching={false}
+            historyMode={false}
             generatingTitles={generatingTitles}
           />
         )}

--- a/src/entrypoints/overlay/components/OverlayHeader.tsx
+++ b/src/entrypoints/overlay/components/OverlayHeader.tsx
@@ -4,6 +4,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ArrowLeft, Clock, Search, Sparkles } from "lucide-react";
 import { SpacePicker } from "./SpacePicker";
 
+function isCaretAtEnd(el: HTMLInputElement): boolean {
+  return el.selectionStart === el.value.length && el.selectionEnd === el.value.length;
+}
+
 interface OverlayHeaderProps {
   activeSpace: Space | null;
   spaces: Space[];
@@ -20,6 +24,8 @@ interface OverlayHeaderProps {
   onExitHistory?: () => void;
   onConfigureSpace?: () => void;
   onOpenChat?: () => void;
+  /** Optional ghost-suffix for inline autocomplete. Rendered after `query`. */
+  inlineCompletion?: string;
 }
 
 export function OverlayHeader({
@@ -38,6 +44,7 @@ export function OverlayHeader({
   onExitHistory,
   onConfigureSpace,
   onOpenChat,
+  inlineCompletion,
 }: OverlayHeaderProps) {
   if (creatingSpace) {
     return (
@@ -107,20 +114,41 @@ export function OverlayHeader({
         ) : (
           <Search className="size-3.5 shrink-0 text-muted-foreground" />
         )}
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={(e) => onQueryChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape" && query) {
-              e.preventDefault();
-              e.stopPropagation();
-              onQueryChange("");
-            }
-          }}
-          placeholder={placeholder}
-          className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-        />
+        <div className="relative flex-1 flex items-center">
+          {inlineCompletion && (
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 flex items-center text-sm whitespace-pre"
+            >
+              <span className="invisible">{query}</span>
+              <span className="text-muted-foreground/50">{inlineCompletion}</span>
+            </div>
+          )}
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && query) {
+                e.preventDefault();
+                e.stopPropagation();
+                onQueryChange("");
+                return;
+              }
+              if (
+                inlineCompletion &&
+                (e.key === "Tab" || (e.key === "ArrowRight" && isCaretAtEnd(e.currentTarget)))
+              ) {
+                e.preventDefault();
+                e.stopPropagation();
+                onQueryChange(query + inlineCompletion);
+                return;
+              }
+            }}
+            placeholder={placeholder}
+            className="relative flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
         {query ? (
           <button
             onClick={() => {

--- a/src/entrypoints/overlay/components/match/HighlightedText.tsx
+++ b/src/entrypoints/overlay/components/match/HighlightedText.tsx
@@ -1,0 +1,44 @@
+import type { Range } from "../../search/score";
+
+interface HighlightedTextProps {
+  text: string;
+  ranges: Range[];
+  className?: string;
+}
+
+/**
+ * Render a string with the given character ranges bolded.
+ * Ranges are assumed to be sorted and non-overlapping.
+ */
+export function HighlightedText({ text, ranges, className }: HighlightedTextProps) {
+  if (!ranges.length) {
+    return <span className={className}>{text}</span>;
+  }
+  const parts: Array<{ text: string; highlighted: boolean }> = [];
+  let cursor = 0;
+  for (const [start, end] of ranges) {
+    if (start > cursor) {
+      parts.push({ text: text.slice(cursor, start), highlighted: false });
+    }
+    if (end > start) {
+      parts.push({ text: text.slice(start, end), highlighted: true });
+    }
+    cursor = Math.max(cursor, end);
+  }
+  if (cursor < text.length) {
+    parts.push({ text: text.slice(cursor), highlighted: false });
+  }
+  return (
+    <span className={className}>
+      {parts.map((p, i) =>
+        p.highlighted ? (
+          <span key={i} className="font-semibold text-foreground">
+            {p.text}
+          </span>
+        ) : (
+          <span key={i}>{p.text}</span>
+        ),
+      )}
+    </span>
+  );
+}

--- a/src/entrypoints/overlay/components/match/MatchBadge.tsx
+++ b/src/entrypoints/overlay/components/match/MatchBadge.tsx
@@ -1,0 +1,59 @@
+import { Bookmark, Clock, Heart, History, Pin } from "lucide-react";
+import type { Match, MatchSource } from "../../search/matches";
+
+interface MatchBadgeProps {
+  match: Match;
+}
+
+interface BadgeSpec {
+  label: string;
+  icon: typeof Bookmark | null;
+  emoji?: string;
+}
+
+function specForSource(source: MatchSource, match: Match): BadgeSpec | null {
+  switch (source) {
+    case "tab":
+      if (match.active) return { label: "Current tab", icon: null };
+      if (match.pinned) return { label: "Pinned", icon: Pin };
+      return { label: "Switch to tab", icon: null };
+    case "tab-other-space":
+      return {
+        label: match.spaceName ? `Switch to ${match.spaceName}` : "Other space",
+        icon: null,
+        emoji: match.spaceIcon,
+      };
+    case "favorite-open":
+      return { label: "Favorited", icon: Heart };
+    case "favorite-closed":
+      return { label: "Favorite", icon: Heart };
+    case "bookmark":
+      return { label: "Bookmark", icon: Bookmark };
+    case "closed":
+      return { label: "Recently closed", icon: Clock };
+    case "history":
+      return { label: "History", icon: History };
+  }
+}
+
+export function MatchBadge({ match }: MatchBadgeProps) {
+  const primary = specForSource(match.source, match);
+  if (!primary) return null;
+
+  const PrimaryIcon = primary.icon;
+
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground bg-muted">
+        {primary.emoji && <span>{primary.emoji}</span>}
+        {PrimaryIcon && <PrimaryIcon className="size-2.5" />}
+        <span>{primary.label}</span>
+      </span>
+      {match.sectionName && match.source === "tab" && (
+        <span className="rounded px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground bg-muted">
+          {match.sectionName}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/entrypoints/overlay/components/match/MatchList.tsx
+++ b/src/entrypoints/overlay/components/match/MatchList.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+import type { Match } from "../../search/matches";
+import { MatchRow } from "./MatchRow";
+
+interface MatchListProps {
+  matches: Match[];
+  focusIndex: number;
+  onFocusIndex: (i: number) => void;
+  onAccept: (match: Match) => void;
+  onClose?: (match: Match) => void;
+  onToggleFavorite?: (match: Match) => void;
+  onTogglePin?: (match: Match) => void;
+  emptyMessage?: string;
+  /** Optional hint shown at the bottom (e.g. "Searching history…"). */
+  bottomHint?: string;
+}
+
+export function MatchList({
+  matches,
+  focusIndex,
+  onFocusIndex,
+  onAccept,
+  onClose,
+  onToggleFavorite,
+  onTogglePin,
+  emptyMessage,
+  bottomHint,
+}: MatchListProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const initialScrollDone = useRef(false);
+
+  useEffect(() => {
+    const el = listRef.current?.querySelector(`[data-tab-index="${focusIndex}"]`) as
+      | HTMLElement
+      | undefined;
+    if (!el) return;
+    if (!initialScrollDone.current) {
+      el.scrollIntoView({ block: "center" });
+      initialScrollDone.current = true;
+    } else {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [focusIndex]);
+
+  if (matches.length === 0) {
+    return (
+      <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+        {emptyMessage ?? "No results."}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={listRef} className="max-h-72 overflow-y-auto overflow-x-hidden py-1">
+      {matches.map((m, i) => (
+        <MatchRow
+          key={m.id}
+          match={m}
+          idx={i}
+          isFocused={i === focusIndex}
+          onFocusIndex={onFocusIndex}
+          onAccept={onAccept}
+          onClose={onClose}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePin={onTogglePin}
+        />
+      ))}
+      {bottomHint && (
+        <div className="px-3 py-1.5 text-xs text-muted-foreground/60 italic">{bottomHint}</div>
+      )}
+    </div>
+  );
+}

--- a/src/entrypoints/overlay/components/match/MatchRow.tsx
+++ b/src/entrypoints/overlay/components/match/MatchRow.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from "react";
+import { Heart, Pin, RotateCcw, X } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { Match } from "../../search/matches";
+import { HighlightedText } from "./HighlightedText";
+import { MatchBadge } from "./MatchBadge";
+
+function faviconUrl(pageUrl: string, favicon: string): string {
+  if (favicon) return favicon;
+  try {
+    const hostname = new URL(pageUrl).hostname;
+    return `https://www.google.com/s2/favicons?domain=${hostname}&sz=32`;
+  } catch {
+    return "";
+  }
+}
+
+function compactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.replace(/^www\./, "");
+    const path = u.pathname === "/" ? "" : u.pathname;
+    return host + path + u.search;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Adjust title ranges from full URL onto compact URL string. If we can't
+ * realign cleanly, return [] so we just show the compact URL plain.
+ */
+function adjustUrlRanges(fullUrl: string, compact: string, ranges: Match["urlRanges"]): Match["urlRanges"] {
+  if (!ranges.length) return [];
+  // Try to align: find compact inside fullUrl (e.g. fullUrl might have "https://www." prefix)
+  const lowerFull = fullUrl.toLowerCase();
+  const lowerCompact = compact.toLowerCase();
+  // Approach: find the offset where compact starts in fullUrl by lining up the host.
+  // Simpler: for each range, slice fullUrl, then find that slice in compact.
+  const out: Match["urlRanges"] = [];
+  for (const [start, end] of ranges) {
+    const slice = lowerFull.slice(start, end);
+    if (!slice) continue;
+    const idx = lowerCompact.indexOf(slice);
+    if (idx >= 0) out.push([idx, idx + slice.length]);
+  }
+  return out;
+}
+
+interface MatchRowProps {
+  match: Match;
+  idx: number;
+  isFocused: boolean;
+  onFocusIndex: (i: number) => void;
+  onAccept: (match: Match) => void;
+  onClose?: (match: Match) => void;
+  onToggleFavorite?: (match: Match) => void;
+  onTogglePin?: (match: Match) => void;
+}
+
+export function MatchRow({
+  match,
+  idx,
+  isFocused,
+  onFocusIndex,
+  onAccept,
+  onClose,
+  onToggleFavorite,
+  onTogglePin,
+}: MatchRowProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isFocused) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [isFocused]);
+
+  const isTabLike =
+    match.source === "tab" ||
+    match.source === "tab-other-space" ||
+    match.source === "favorite-open";
+  const compact = compactUrl(match.url);
+  const adjustedUrlRanges = adjustUrlRanges(match.url, compact, match.urlRanges);
+  const faviconSrc = faviconUrl(match.url, match.favicon);
+  const [faviconFailed, setFaviconFailed] = useState(false);
+
+  // Reset failure flag when the favicon URL changes (e.g. row reused for a different match).
+  useEffect(() => {
+    setFaviconFailed(false);
+  }, [faviconSrc]);
+
+  return (
+    <div
+      ref={ref}
+      data-tab-index={idx}
+      className={`group flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors cursor-pointer ${
+        isFocused ? "bg-accent text-accent-foreground" : "text-foreground hover:bg-muted"
+      }`}
+      onClick={() => onFocusIndex(idx)}
+      onDoubleClick={() => onAccept(match)}
+    >
+      {faviconFailed ? (
+        <span className="size-4 shrink-0" />
+      ) : (
+        <img
+          src={faviconSrc}
+          alt=""
+          className="size-4 shrink-0 rounded-sm"
+          onError={() => setFaviconFailed(true)}
+        />
+      )}
+      <div className="flex-1 min-w-0 flex items-baseline gap-2">
+        <HighlightedText
+          text={match.title || compact}
+          ranges={match.titleRanges}
+          className="truncate"
+        />
+        <HighlightedText
+          text={compact}
+          ranges={adjustedUrlRanges}
+          className="hidden md:block truncate text-xs text-muted-foreground/70"
+        />
+      </div>
+      <MatchBadge match={match} />
+      <div className="hidden group-hover:flex items-center gap-0.5 shrink-0">
+        {isTabLike ? (
+          <>
+            {onTogglePin && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    role="button"
+                    className="flex size-5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-muted"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTogglePin(match);
+                    }}
+                  >
+                    <Pin className="size-3" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">{match.pinned ? "Unpin" : "Pin"}</TooltipContent>
+              </Tooltip>
+            )}
+            {onToggleFavorite && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    role="button"
+                    className="flex size-5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-muted"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onToggleFavorite(match);
+                    }}
+                  >
+                    <Heart
+                      className={`size-3 ${match.source === "favorite-open" || match.source === "favorite-closed" ? "fill-current" : ""}`}
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {match.source === "favorite-open" || match.source === "favorite-closed"
+                    ? "Unfavorite"
+                    : "Favorite"}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {onClose && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    role="button"
+                    className="flex size-5 items-center justify-center rounded-sm text-muted-foreground hover:text-destructive hover:bg-muted"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onClose(match);
+                    }}
+                  >
+                    <X className="size-3" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">Close tab</TooltipContent>
+              </Tooltip>
+            )}
+          </>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                role="button"
+                className="flex size-5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground hover:bg-muted"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAccept(match);
+                }}
+              >
+                <RotateCcw className="size-3" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {match.action === "restore" ? "Restore tab" : "Open"}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/entrypoints/overlay/search/canonical.ts
+++ b/src/entrypoints/overlay/search/canonical.ts
@@ -1,0 +1,30 @@
+/**
+ * URL canonicalization for dedup across sources (tabs, history, bookmarks, etc.).
+ *
+ * Mirrors Chrome's `GURLToStrippedGURL` minimally:
+ * - lowercase hostname
+ * - drop leading `www.` and `m.`
+ * - drop trailing slash on path
+ * - drop URL fragment
+ * - drop default ports (http:80, https:443)
+ *
+ * Two distinct URLs that differ only in these dimensions collapse to the same key.
+ */
+export function canonicalUrl(raw: string): string {
+  if (!raw) return "";
+  try {
+    const u = new URL(raw);
+    const host = u.hostname.toLowerCase().replace(/^(www|m)\./, "");
+    const path = u.pathname === "/" ? "" : u.pathname.replace(/\/$/, "");
+    const port =
+      (u.protocol === "http:" && u.port === "80") ||
+      (u.protocol === "https:" && u.port === "443")
+        ? ""
+        : u.port
+          ? `:${u.port}`
+          : "";
+    return `${host}${port}${path}${u.search}`;
+  } catch {
+    return raw.toLowerCase();
+  }
+}

--- a/src/entrypoints/overlay/search/matches.ts
+++ b/src/entrypoints/overlay/search/matches.ts
@@ -1,0 +1,439 @@
+import type { FavoriteTabAssociation, TidyState } from "@/lib/types";
+import type { OverlayTab } from "../OverlayApp";
+import { canonicalUrl } from "./canonical";
+import { frecencyScore, scoreQuery, type Range } from "./score";
+import { shortcutBoost } from "./shortcuts";
+
+export type MatchSource =
+  | "tab"
+  | "tab-other-space"
+  | "favorite-open"
+  | "favorite-closed"
+  | "bookmark"
+  | "history"
+  | "closed";
+
+export type MatchAction = "switch" | "open" | "restore";
+
+export interface Match {
+  /** Stable unique id for React keys / focus tracking. */
+  id: string;
+  /** Canonical (deduped) URL key. */
+  canonicalUrl: string;
+  /** Display URL. */
+  url: string;
+  /** Display title (already resolved with manual / tidied / native title for tabs). */
+  title: string;
+  favicon: string;
+  score: number;
+  source: MatchSource;
+  /** Additional sources merged into this match (e.g. an open tab that's also a favorite). */
+  extraSources: MatchSource[];
+  /** Highlight ranges in the title. */
+  titleRanges: Range[];
+  /** Highlight ranges in the URL. */
+  urlRanges: Range[];
+  /** Whether the match was boosted by the personalized Shortcuts store. */
+  isShortcut: boolean;
+
+  // Source metadata (optional — present only when applicable)
+  tabId?: number;
+  windowId?: number;
+  pinned?: boolean;
+  active?: boolean;
+  spaceId?: string;
+  spaceName?: string;
+  spaceIcon?: string;
+  sectionName?: string;
+  lastVisitTime?: number;
+  visitCount?: number;
+  /** Default action to invoke on Enter. */
+  action: MatchAction;
+}
+
+interface BuildContext {
+  query: string;
+  /** Current-window/space tabs. */
+  tabs: OverlayTab[];
+  /** Tabs in other windows/spaces. */
+  otherSpaceTabs: OverlayTab[];
+  /** Closed-favorite items (favorites that aren't open right now). */
+  closedFavorites: OverlayTab[];
+  /** Bookmarks (raw, unfiltered). */
+  bookmarks: OverlayTab[];
+  /** Real recently-closed items from chrome.sessions. */
+  recentlyClosed: OverlayTab[];
+  /** History search results (live, query-driven). Empty when no query. */
+  history: OverlayTab[];
+  tidyState: TidyState | null;
+  sectionById: Map<string, string>;
+  favoriteUrls: Set<string>;
+  associatedTabIds: Set<number>;
+  associations: FavoriteTabAssociation[];
+}
+
+/**
+ * Score `query` against a candidate's title(s) and URL.
+ *
+ * - `titles` — all strings to compare for *scoring* (e.g. native + tidied + manual);
+ *   the highest-scoring is used for ranking. May be empty.
+ * - `displayTitle` — the string actually rendered in the UI; we only compute
+ *   highlight ranges against this exact text so bolded characters always align
+ *   with what the user sees, even if the user's typed query matched a different
+ *   alternate title.
+ * - `url` — the URL string for both scoring and URL highlights.
+ */
+function scoreCandidate(
+  query: string,
+  titles: string[],
+  displayTitle: string,
+  url: string,
+): { score: number; titleRanges: Range[]; urlRanges: Range[] } {
+  let bestScore = 0;
+
+  // Score against every alternate title to find the best ranking signal.
+  for (const t of titles) {
+    if (!t) continue;
+    const r = scoreQuery(query, t, false);
+    if (r.score > bestScore) bestScore = r.score;
+  }
+
+  // Score against URL.
+  const urlR = url ? scoreQuery(query, url, true) : { score: 0, ranges: [] as Range[] };
+  if (urlR.score > bestScore) bestScore = urlR.score;
+
+  // Compute highlight ranges *only* against text that's actually rendered.
+  const displayR = displayTitle ? scoreQuery(query, displayTitle, false) : { score: 0, ranges: [] as Range[] };
+
+  return {
+    score: bestScore,
+    titleRanges: displayR.ranges,
+    urlRanges: urlR.ranges,
+  };
+}
+
+interface RawCandidate {
+  source: MatchSource;
+  url: string;
+  title: string;
+  favicon: string;
+  // Composite scoring inputs
+  matchScore: number;
+  titleRanges: Range[];
+  urlRanges: Range[];
+  // Bonuses applied later
+  sourceWeight: number;
+  // Source metadata
+  tabId?: number;
+  windowId?: number;
+  pinned?: boolean;
+  active?: boolean;
+  spaceId?: string;
+  spaceName?: string;
+  spaceIcon?: string;
+  sectionName?: string;
+  lastVisitTime?: number;
+  visitCount?: number;
+}
+
+const SOURCE_WEIGHTS: Record<MatchSource, number> = {
+  tab: 1.4,
+  "favorite-open": 1.45,
+  "favorite-closed": 1.3,
+  "tab-other-space": 1.2,
+  bookmark: 1.1,
+  closed: 1.05,
+  history: 1.0,
+};
+
+function actionFor(source: MatchSource): MatchAction {
+  switch (source) {
+    case "tab":
+    case "tab-other-space":
+    case "favorite-open":
+      return "switch";
+    case "closed":
+      return "restore";
+    default:
+      return "open";
+  }
+}
+
+/**
+ * Order of merge precedence when the same canonical URL appears from multiple
+ * sources. Lower index wins; others become `extraSources`.
+ */
+const SOURCE_PRIORITY: MatchSource[] = [
+  "tab",
+  "favorite-open",
+  "tab-other-space",
+  "favorite-closed",
+  "bookmark",
+  "closed",
+  "history",
+];
+
+function priorityOf(source: MatchSource): number {
+  const i = SOURCE_PRIORITY.indexOf(source);
+  return i < 0 ? 99 : i;
+}
+
+/**
+ * Build the unified ranked list of Match items from all sources.
+ */
+export function buildMatches(ctx: BuildContext): Match[] {
+  const q = ctx.query.trim();
+  const isQuery = q.length > 0;
+  const candidates: RawCandidate[] = [];
+
+  // ---- Tabs (current space) ----
+  for (const t of ctx.tabs) {
+    const isFav = ctx.favoriteUrls.has(t.url) || ctx.associatedTabIds.has(t.id);
+    const source: MatchSource = isFav ? "favorite-open" : "tab";
+    const titles = uniqueTitles(t, ctx.tidyState);
+    const display = displayTitle(t, ctx.tidyState);
+    const sc = isQuery
+      ? scoreCandidate(q, titles, display, t.url)
+      : { score: 1, titleRanges: [], urlRanges: [] };
+    if (isQuery && sc.score === 0) continue;
+    candidates.push({
+      source,
+      url: t.url,
+      title: display,
+      favicon: t.favicon,
+      matchScore: sc.score,
+      titleRanges: sc.titleRanges,
+      urlRanges: sc.urlRanges,
+      sourceWeight: SOURCE_WEIGHTS[source],
+      tabId: t.id,
+      windowId: t.windowId,
+      pinned: t.pinned,
+      active: t.active,
+      sectionName: ctx.tidyState?.tabAssignments[t.id]
+        ? ctx.sectionById.get(ctx.tidyState.tabAssignments[t.id])
+        : undefined,
+    });
+  }
+
+  // ---- Tabs (other spaces) — only when querying ----
+  if (isQuery) {
+    for (const t of ctx.otherSpaceTabs) {
+      const sc = scoreCandidate(q, [t.title], t.title, t.url);
+      if (sc.score === 0) continue;
+      candidates.push({
+        source: "tab-other-space",
+        url: t.url,
+        title: t.title,
+        favicon: t.favicon,
+        matchScore: sc.score,
+        titleRanges: sc.titleRanges,
+        urlRanges: sc.urlRanges,
+        sourceWeight: SOURCE_WEIGHTS["tab-other-space"],
+        tabId: t.id,
+        windowId: t.windowId,
+        pinned: t.pinned,
+        active: t.active,
+        spaceName: t.spaceName,
+        spaceIcon: t.spaceIcon,
+      });
+    }
+  }
+
+  // ---- Closed favorites (favorites whose URL has no live tab) ----
+  for (const f of ctx.closedFavorites) {
+    const sc = isQuery
+      ? scoreCandidate(q, [f.title], f.title, f.url)
+      : { score: 1, titleRanges: [], urlRanges: [] };
+    if (isQuery && sc.score === 0) continue;
+    candidates.push({
+      source: "favorite-closed",
+      url: f.url,
+      title: f.title,
+      favicon: f.favicon,
+      matchScore: sc.score,
+      titleRanges: sc.titleRanges,
+      urlRanges: sc.urlRanges,
+      sourceWeight: SOURCE_WEIGHTS["favorite-closed"],
+    });
+  }
+
+  // ---- Bookmarks (only when querying) ----
+  if (isQuery) {
+    for (const b of ctx.bookmarks) {
+      const sc = scoreCandidate(q, [b.title], b.title, b.url);
+      if (sc.score === 0) continue;
+      candidates.push({
+        source: "bookmark",
+        url: b.url,
+        title: b.title,
+        favicon: b.favicon,
+        matchScore: sc.score,
+        titleRanges: sc.titleRanges,
+        urlRanges: sc.urlRanges,
+        sourceWeight: SOURCE_WEIGHTS["bookmark"],
+      });
+    }
+  }
+
+  // ---- Recently closed (chrome.sessions) ----
+  for (const c of ctx.recentlyClosed) {
+    const sc = isQuery
+      ? scoreCandidate(q, [c.title], c.title, c.url)
+      : { score: 1, titleRanges: [], urlRanges: [] };
+    if (isQuery && sc.score === 0) continue;
+    candidates.push({
+      source: "closed",
+      url: c.url,
+      title: c.title,
+      favicon: c.favicon,
+      matchScore: sc.score,
+      titleRanges: sc.titleRanges,
+      urlRanges: sc.urlRanges,
+      sourceWeight: SOURCE_WEIGHTS["closed"],
+      lastVisitTime: c.lastVisitTime,
+      visitCount: c.visitCount,
+    });
+  }
+
+  // ---- History (only when querying) ----
+  if (isQuery) {
+    for (const h of ctx.history) {
+      const sc = scoreCandidate(q, [h.title], h.title, h.url);
+      if (sc.score === 0) continue;
+      candidates.push({
+        source: "history",
+        url: h.url,
+        title: h.title,
+        favicon: h.favicon,
+        matchScore: sc.score,
+        titleRanges: sc.titleRanges,
+        urlRanges: sc.urlRanges,
+        sourceWeight: SOURCE_WEIGHTS["history"],
+        lastVisitTime: h.lastVisitTime,
+        visitCount: h.visitCount,
+      });
+    }
+  }
+
+  // ---- Compute final scores and dedup by canonical URL ----
+  const byKey = new Map<string, Match>();
+  for (const c of candidates) {
+    const key = canonicalUrl(c.url);
+    if (!key) continue;
+
+    // Composite score
+    const frecency = frecencyScore({
+      lastVisitTime: c.lastVisitTime,
+      visitCount: c.visitCount,
+    });
+    const frecencyMultiplier = 1 + Math.min(0.6, frecency * 0.15);
+    const boost = isQuery ? shortcutBoost(q, c.url) : 0;
+    const isShortcut = boost > 0;
+
+    let score: number;
+    if (isQuery) {
+      score = c.matchScore * c.sourceWeight * frecencyMultiplier + boost;
+    } else {
+      // Empty-query ranking: rely on source weight + frecency. Closed and
+      // open favorites and tabs all get baseline scores.
+      score = c.sourceWeight * 100 * frecencyMultiplier;
+    }
+
+    const candidateMatch: Match = {
+      id: key,
+      canonicalUrl: key,
+      url: c.url,
+      title: c.title || c.url,
+      favicon: c.favicon,
+      score,
+      source: c.source,
+      extraSources: [],
+      titleRanges: c.titleRanges,
+      urlRanges: c.urlRanges,
+      isShortcut,
+      tabId: c.tabId,
+      windowId: c.windowId,
+      pinned: c.pinned,
+      active: c.active,
+      spaceId: c.spaceId,
+      spaceName: c.spaceName,
+      spaceIcon: c.spaceIcon,
+      sectionName: c.sectionName,
+      lastVisitTime: c.lastVisitTime,
+      visitCount: c.visitCount,
+      action: actionFor(c.source),
+    };
+
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, candidateMatch);
+    } else {
+      // Merge: keep the higher-priority source as primary; merge metadata; sum scores cap.
+      const winner =
+        priorityOf(candidateMatch.source) < priorityOf(existing.source) ? candidateMatch : existing;
+      const loser = winner === existing ? candidateMatch : existing;
+
+      const merged: Match = {
+        ...winner,
+        score: Math.max(winner.score, loser.score) + Math.min(winner.score, loser.score) * 0.1,
+        extraSources: dedupeSources([
+          ...winner.extraSources,
+          ...loser.extraSources,
+          loser.source,
+        ]).filter((s) => s !== winner.source),
+        // Preserve highlight ranges from whichever had more matches
+        titleRanges:
+          winner.titleRanges.length >= loser.titleRanges.length
+            ? winner.titleRanges
+            : loser.titleRanges,
+        urlRanges:
+          winner.urlRanges.length >= loser.urlRanges.length ? winner.urlRanges : loser.urlRanges,
+        isShortcut: winner.isShortcut || loser.isShortcut,
+        // Keep tab info if present from either side
+        tabId: winner.tabId ?? loser.tabId,
+        windowId: winner.windowId ?? loser.windowId,
+        pinned: winner.pinned ?? loser.pinned,
+        active: winner.active ?? loser.active,
+        spaceName: winner.spaceName ?? loser.spaceName,
+        spaceIcon: winner.spaceIcon ?? loser.spaceIcon,
+        sectionName: winner.sectionName ?? loser.sectionName,
+        lastVisitTime: winner.lastVisitTime ?? loser.lastVisitTime,
+        visitCount: winner.visitCount ?? loser.visitCount,
+      };
+      byKey.set(key, merged);
+    }
+  }
+
+  const result = [...byKey.values()];
+  result.sort((a, b) => b.score - a.score);
+  return result;
+}
+
+/** Maximum number of matches to render. */
+export const MAX_RESULTS = 50;
+
+function dedupeSources(arr: MatchSource[]): MatchSource[] {
+  const seen = new Set<MatchSource>();
+  const out: MatchSource[] = [];
+  for (const s of arr) {
+    if (!seen.has(s)) {
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+function uniqueTitles(t: OverlayTab, tidy: TidyState | null): string[] {
+  const out = new Set<string>();
+  if (t.title) out.add(t.title);
+  const tidied = tidy?.tidiedTitles?.[t.id];
+  const manual = tidy?.manualTitles?.[t.id];
+  if (tidied) out.add(tidied);
+  if (manual) out.add(manual);
+  return [...out];
+}
+
+function displayTitle(t: OverlayTab, tidy: TidyState | null): string {
+  return tidy?.manualTitles?.[t.id] ?? tidy?.tidiedTitles?.[t.id] ?? t.title;
+}

--- a/src/entrypoints/overlay/search/score.ts
+++ b/src/entrypoints/overlay/search/score.ts
@@ -1,0 +1,112 @@
+import { hostBoundsInUrl, tokens } from "./tokenize";
+
+export type Range = [number, number];
+
+export interface ScoreResult {
+  /** Numeric relevance, higher is better. 0 means no match. */
+  score: number;
+  /** Character ranges in the target where query tokens matched. */
+  ranges: Range[];
+}
+
+const WORD_BOUNDARY = /[\s\-_./?#=&:;,!@()[\]{}<>"'`~]/;
+
+function isWordStart(target: string, idx: number): boolean {
+  if (idx === 0) return true;
+  return WORD_BOUNDARY.test(target[idx - 1]);
+}
+
+/**
+ * Score a query against a target string. Implementation:
+ *
+ * - Split query into tokens; each token must be found contiguously in the target.
+ * - If any query token cannot be found, returns score 0.
+ * - Per-token scoring rewards length, word-start matches, and (for URL targets) host-bounded matches.
+ * - All-tokens-matched bonus added on success.
+ *
+ * Targets shorter than the query (in chars) get a length bonus so a short title
+ * with a perfect match outranks a long URL with the same match.
+ */
+export function scoreQuery(query: string, target: string, isUrl = false): ScoreResult {
+  if (!query || !target) return { score: 0, ranges: [] };
+  const qTokens = tokens(query);
+  if (qTokens.length === 0) return { score: 0, ranges: [] };
+
+  const tLower = target.toLowerCase();
+  const hostBounds = isUrl ? hostBoundsInUrl(target) : null;
+
+  let score = 0;
+  const ranges: Range[] = [];
+  let cursor = 0; // soft-prefer matches in order, but allow any-position fallback
+  let allInOrder = true;
+
+  for (const qTok of qTokens) {
+    let idx = tLower.indexOf(qTok, cursor);
+    if (idx < 0) {
+      idx = tLower.indexOf(qTok);
+      allInOrder = false;
+    }
+    if (idx < 0) {
+      return { score: 0, ranges: [] };
+    }
+
+    const tokLen = qTok.length;
+    let tokScore = tokLen * 10;
+
+    if (isWordStart(tLower, idx)) tokScore += 8;
+    if (idx === 0) tokScore += 6;
+    if (hostBounds && idx >= hostBounds[0] && idx < hostBounds[1]) tokScore += 12;
+
+    // Whole-token match (matched portion ends on a word boundary too)
+    const endIdx = idx + tokLen;
+    if (endIdx === tLower.length || WORD_BOUNDARY.test(tLower[endIdx])) {
+      tokScore += 4;
+    }
+
+    score += tokScore;
+    ranges.push([idx, endIdx]);
+    cursor = endIdx;
+  }
+
+  // Bonuses
+  score += 20; // all tokens matched
+  if (allInOrder) score += 10;
+
+  // Length bonus: favor short targets (e.g. short title beats long URL with same match).
+  // Cap so absurdly short strings don't dominate.
+  const lenPenalty = Math.min(tLower.length / 100, 1);
+  score = Math.round(score * (1.2 - lenPenalty * 0.4));
+
+  return { score, ranges: mergeRanges(ranges) };
+}
+
+function mergeRanges(input: Range[]): Range[] {
+  if (input.length <= 1) return input;
+  const sorted = [...input].sort((a, b) => a[0] - b[0]);
+  const out: Range[] = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = out[out.length - 1];
+    const curr = sorted[i];
+    if (curr[0] <= last[1]) {
+      last[1] = Math.max(last[1], curr[1]);
+    } else {
+      out.push(curr);
+    }
+  }
+  return out;
+}
+
+/**
+ * Frequency-recency score for a history-like item.
+ *
+ * Uses log-damped visit count over log-damped age in days, with a +2 offset
+ * on the divisor so very-recent items (ageDays floored at 0.1) don't blow up
+ * to infinity. Returns roughly [0, 5+]: highly visited recent pages score
+ * ~3-5, sporadic old pages score < 1.
+ */
+export function frecencyScore(item: { lastVisitTime?: number; visitCount?: number }): number {
+  const visits = Math.max(item.visitCount ?? 0, 1);
+  const ageMs = Date.now() - (item.lastVisitTime ?? 0);
+  const ageDays = Math.max(ageMs / (1000 * 60 * 60 * 24), 0.1);
+  return Math.log10(1 + visits) / Math.log10(2 + ageDays);
+}

--- a/src/entrypoints/overlay/search/shortcuts.ts
+++ b/src/entrypoints/overlay/search/shortcuts.ts
@@ -1,0 +1,161 @@
+/**
+ * Shortcuts: learn (query → URL) selections so frequently-picked URLs for a
+ * given query rise to the top on subsequent searches.
+ *
+ * Storage: chrome.storage.local under key `_overlayShortcuts`.
+ *
+ * Shape:
+ *   {
+ *     [canonicalUrl]: {
+ *       hits: number,            // total selections of this URL
+ *       lastUsedAt: number,      // ms
+ *       title?: string,          // last-known title (display fallback)
+ *       url: string,             // last-known full URL
+ *       queries: { [normalizedQuery: string]: { hits: number, lastUsedAt: number } }
+ *     }
+ *   }
+ *
+ * Bounded LRU: max ~500 entries, pruned by lastUsedAt asc when over capacity.
+ */
+import { canonicalUrl } from "./canonical";
+
+const STORAGE_KEY = "_overlayShortcuts";
+const MAX_ENTRIES = 500;
+const MAX_QUERIES_PER_ENTRY = 16;
+
+export interface ShortcutQuery {
+  hits: number;
+  lastUsedAt: number;
+}
+
+export interface ShortcutEntry {
+  hits: number;
+  lastUsedAt: number;
+  title?: string;
+  url: string;
+  queries: { [normalizedQuery: string]: ShortcutQuery };
+}
+
+export type ShortcutStore = { [canonicalUrl: string]: ShortcutEntry };
+
+/** Cached in-memory copy. Loaded on first `loadShortcuts()` call. */
+let cache: ShortcutStore | null = null;
+let loadPromise: Promise<ShortcutStore> | null = null;
+
+function normalizeQuery(q: string): string {
+  return q.trim().toLowerCase();
+}
+
+export async function loadShortcuts(): Promise<ShortcutStore> {
+  if (cache) return cache;
+  if (loadPromise) return loadPromise;
+  loadPromise = (async () => {
+    try {
+      const data = await chrome.storage.local.get(STORAGE_KEY);
+      cache = (data[STORAGE_KEY] as ShortcutStore) ?? {};
+    } catch {
+      cache = {};
+    }
+    return cache;
+  })();
+  return loadPromise;
+}
+
+/** Synchronous accessor; returns {} if not yet loaded. */
+export function getCachedShortcuts(): ShortcutStore {
+  return cache ?? {};
+}
+
+/** Record that the user selected `url` (with `title`) after typing `query`. */
+export async function recordShortcutSelection(query: string, url: string, title?: string): Promise<void> {
+  const q = normalizeQuery(query);
+  if (!q) return;
+  const key = canonicalUrl(url);
+  if (!key) return;
+
+  const store = await loadShortcuts();
+  const now = Date.now();
+  const existing = store[key];
+  const queries = existing?.queries ?? {};
+  const existingQ = queries[q];
+  queries[q] = {
+    hits: (existingQ?.hits ?? 0) + 1,
+    lastUsedAt: now,
+  };
+
+  // Cap per-entry queries (LRU on lastUsedAt)
+  const qKeys = Object.keys(queries);
+  if (qKeys.length > MAX_QUERIES_PER_ENTRY) {
+    const sorted = qKeys
+      .map((k) => [k, queries[k].lastUsedAt] as const)
+      .sort((a, b) => a[1] - b[1]);
+    const toDelete = sorted.slice(0, qKeys.length - MAX_QUERIES_PER_ENTRY);
+    for (const [k] of toDelete) delete queries[k];
+  }
+
+  store[key] = {
+    hits: (existing?.hits ?? 0) + 1,
+    lastUsedAt: now,
+    title: title ?? existing?.title,
+    url,
+    queries,
+  };
+
+  // Cap total entries (LRU on lastUsedAt)
+  const allKeys = Object.keys(store);
+  if (allKeys.length > MAX_ENTRIES) {
+    const sorted = allKeys
+      .map((k) => [k, store[k].lastUsedAt] as const)
+      .sort((a, b) => a[1] - b[1]);
+    const toDelete = sorted.slice(0, allKeys.length - MAX_ENTRIES);
+    for (const [k] of toDelete) delete store[k];
+  }
+
+  cache = store;
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY]: store });
+  } catch {
+    // best-effort write
+  }
+}
+
+/**
+ * Compute a boost for a candidate URL given the current query.
+ *
+ * Looks for any prior recorded query that the current `q` starts with (i.e.
+ * the user has typed past, or exactly equal to, what they typed before),
+ * and returns a non-negative boost roughly scaled by hit count and recency.
+ *
+ * Requires recorded queries to be at least 2 characters so a single typed
+ * character doesn't promote every URL the user ever picked.
+ *
+ * Returns 0 if no shortcut applies.
+ */
+export function shortcutBoost(currentQuery: string, url: string): number {
+  const q = normalizeQuery(currentQuery);
+  if (!q) return 0;
+  const store = getCachedShortcuts();
+  const entry = store[canonicalUrl(url)];
+  if (!entry) return 0;
+
+  let bestHits = 0;
+  let bestRecency = 0;
+  for (const [recordedQ, info] of Object.entries(entry.queries)) {
+    if (recordedQ.length < 2) continue;
+    if (!q.startsWith(recordedQ)) continue;
+    if (info.hits > bestHits) {
+      bestHits = info.hits;
+      bestRecency = info.lastUsedAt;
+    }
+  }
+
+  if (bestHits === 0) return 0;
+  const ageDays = Math.max((Date.now() - bestRecency) / (1000 * 60 * 60 * 24), 0.1);
+  const recencyFactor = 1 / (1 + Math.log10(1 + ageDays));
+  return Math.log(1 + bestHits) * 200 * recencyFactor;
+}
+
+/** Returns true if the URL has a recorded prefix-shortcut for the query. */
+export function isShortcutFor(currentQuery: string, url: string): boolean {
+  return shortcutBoost(currentQuery, url) > 0;
+}

--- a/src/entrypoints/overlay/search/tokenize.ts
+++ b/src/entrypoints/overlay/search/tokenize.ts
@@ -1,0 +1,43 @@
+/**
+ * Token splitting for queries and search targets.
+ *
+ * Splits on whitespace, slashes, dashes, dots, underscores, query punctuation,
+ * and empty groups. Returns lowercased tokens with empty strings filtered out.
+ */
+const TOKEN_SPLIT = /[\s\-_./?#=&:;,!@()[\]{}<>"'`~]+/;
+
+export function tokens(input: string): string[] {
+  if (!input) return [];
+  return input
+    .toLowerCase()
+    .split(TOKEN_SPLIT)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Find the start index of `needle` in `haystack` after lowercasing both.
+ * Returns -1 if not present.
+ */
+export function caseInsensitiveIndexOf(haystack: string, needle: string, fromIndex = 0): number {
+  if (!needle) return -1;
+  return haystack.toLowerCase().indexOf(needle.toLowerCase(), fromIndex);
+}
+
+/**
+ * Locate the host substring boundaries inside a URL string. Returns the
+ * [start, end) indices of the hostname inside the original URL, or null if
+ * the URL cannot be parsed.
+ */
+export function hostBoundsInUrl(url: string): [number, number] | null {
+  try {
+    const u = new URL(url);
+    const host = u.hostname;
+    if (!host) return null;
+    const lower = url.toLowerCase();
+    const idx = lower.indexOf(host.toLowerCase());
+    if (idx < 0) return null;
+    return [idx, idx + host.length];
+  } catch {
+    return null;
+  }
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       "alarms",
       "bookmarks",
       "history",
+      "sessions",
       "sidePanel",
       "scripting",
       "debugger",


### PR DESCRIPTION
Refactors the OverlayApp's command-palette / omnibox-style search to a single ranked Match list mixing tabs, cross-space tabs, favorites, bookmarks, history, and recently-closed tabs, with source-indicating badges and bolded match ranges. Replaces the old subsequence-fuzzy + category-first layout that suppressed strong cross-source hits.

- New search/ module:
  * canonical.ts — URL canonicalization for cross-source dedup
  * tokenize.ts — query/target tokenization with host bounds
  * score.ts — tokenized contiguous scoring + log-damped frecency
  * shortcuts.ts — bounded LRU (chrome.storage.local) learning of (query → URL) selections, used as a personalization boost
  * matches.ts — buildMatches() pipeline producing one ranked Match[]

- New components/match/ UI:
  * HighlightedText — bolds matched character ranges
  * MatchBadge — source labels (Current tab, Switch to tab, Switch to <space>, Favorited, Bookmark, Recently closed, History)
  * MatchRow / MatchList — flat ranked rendering

- OverlayApp: flat MatchList in flat mode (query non-empty OR history mode); legacy OverlayTabList only in empty default state. Shortcut selections recorded on accept; high-confidence inline autocomplete shown only for personalized Shortcut top hits.

- OverlayHeader: input wrapped with ghost-text overlay; Tab or caret-at-end ArrowRight accepts the autocomplete.

- background: GET_OVERLAY_TABS now sources recentlyClosed from chrome.sessions.getRecentlyClosed (real closed tabs, with sessionId); OVERLAY_OPEN_URL accepts sessionId and uses chrome.sessions.restore to preserve scroll/history; SEARCH_HISTORY pool 50→200 with startTime: 0 (full history, not just last 24h).

- wxt.config.ts: adds "sessions" permission.