### PR TITLE
feat: detachable side panel popover with per-tab scoping

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -33,6 +33,28 @@ interface ChatViewProps {
   showBackButton?: boolean;
   onBack?: () => void;
   showHeader?: boolean;
+  /**
+   * Whether this ChatView is being rendered inside a detached popover window.
+   * When true, the "Sharing [tab]" pill is anchored to the origin tab the
+   * popover was detached from rather than the popover's own (extension) tab.
+   */
+  isPopupMode?: boolean;
+  /**
+   * The browser window the popover was detached from. Used as a fallback
+   * for resolving the origin tab if the original origin tab was closed.
+   */
+  originWindowId?: number | null;
+  /**
+   * The tab the popover was detached from. The "Sharing [tab]" pill renders
+   * this tab. When the tab is closed, the pill hides; when a tab matching
+   * the origin URL reopens in the same window (e.g., user restores from
+   * history), the pill reappears.
+   */
+  originTabId?: number | null;
+  /**
+   * The URL of the origin tab at detach time, used to detect restoration.
+   */
+  originUrl?: string | null;
 }
 
 export function ChatView({
@@ -44,7 +66,20 @@ export function ChatView({
   showBackButton,
   onBack,
   showHeader = true,
+  isPopupMode = false,
+  originWindowId,
+  originTabId,
+  originUrl,
 }: ChatViewProps) {
+  // Track the live origin tab id in popup mode. May change if the original
+  // origin tab is closed and later restored from history (the URL matches a
+  // freshly-opened tab in the origin window). Side-panel mode ignores this.
+  const [liveOriginTabId, setLiveOriginTabId] = useState<number | null>(originTabId ?? null);
+
+  useEffect(() => {
+    setLiveOriginTabId(originTabId ?? null);
+  }, [originTabId]);
+
   const {
     messages,
     input,
@@ -65,7 +100,16 @@ export function ChatView({
     stop,
     error,
     clearError,
-  } = useAgentChat({ conversationId, spaceId, onNewConversation });
+  } = useAgentChat({
+    conversationId,
+    spaceId,
+    onNewConversation,
+    // In popup mode, host tab is the live origin tab (may be null if it
+    // was closed and not yet restored). In side-panel mode, defer to
+    // useAgentChat's auto-resolution from the active tab in the current
+    // window (which, in per-tab mode, IS the host tab).
+    hostTabIdOverride: isPopupMode ? liveOriginTabId : undefined,
+  });
 
 const providerModels = useMemo(() => {
     return providers
@@ -99,9 +143,68 @@ const providerModels = useMemo(() => {
   const [activeTab, setActiveTab] = useState<{ title: string; favicon: string; url: string } | null>(null);
 
   useEffect(() => {
-    async function getActiveTab() {
+    if (!isPopupMode) return;
+    if (originUrl == null || originWindowId == null) return;
+
+    // If the origin tab is gone (closed or never set), watch for a tab in
+    // the origin window matching originUrl — the user may restore via
+    // Cmd+Shift+T or history. Adopt the new tabId when it appears.
+    function adoptIfMatch(tab: chrome.tabs.Tab | undefined) {
+      if (!tab || tab.id == null) return false;
+      if (tab.windowId !== originWindowId) return false;
+      if (tab.url !== originUrl) return false;
+      setLiveOriginTabId(tab.id);
+      return true;
+    }
+
+    const onCreated = (tab: chrome.tabs.Tab) => {
+      if (liveOriginTabId != null) return; // still alive
+      adoptIfMatch(tab);
+    };
+    const onUpdated = (
+      _id: number,
+      _info: chrome.tabs.OnUpdatedInfo,
+      tab: chrome.tabs.Tab,
+    ) => {
+      if (liveOriginTabId != null) return;
+      adoptIfMatch(tab);
+    };
+    const onRemoved = (id: number) => {
+      if (id === liveOriginTabId) setLiveOriginTabId(null);
+    };
+
+    chrome.tabs.onCreated.addListener(onCreated);
+    chrome.tabs.onUpdated.addListener(onUpdated);
+    chrome.tabs.onRemoved.addListener(onRemoved);
+    return () => {
+      chrome.tabs.onCreated.removeListener(onCreated);
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      chrome.tabs.onRemoved.removeListener(onRemoved);
+    };
+  }, [isPopupMode, originUrl, originWindowId, liveOriginTabId]);
+
+  useEffect(() => {
+    async function refresh() {
       try {
-        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        let tab: chrome.tabs.Tab | undefined;
+        if (isPopupMode) {
+          // Popup pill is anchored to the origin tab. If origin tab is gone
+          // (and not yet restored), the pill hides — no fallback to the
+          // origin window's currently-active tab.
+          if (liveOriginTabId == null) {
+            setActiveTab(null);
+            return;
+          }
+          try {
+            tab = await chrome.tabs.get(liveOriginTabId);
+          } catch {
+            setLiveOriginTabId(null);
+            setActiveTab(null);
+            return;
+          }
+        } else {
+          [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        }
         if (tab?.url && !tab.url.startsWith("chrome://") && !tab.url.startsWith(chrome.runtime.getURL(""))) {
           setActiveTab({ title: tab.title ?? "Untitled", favicon: tab.favIconUrl ?? "", url: tab.url });
         } else {
@@ -111,16 +214,22 @@ const providerModels = useMemo(() => {
         setActiveTab(null);
       }
     }
-    getActiveTab();
-    const onActivated = () => getActiveTab();
-    const onUpdated = () => getActiveTab();
+    refresh();
+    const onActivated = () => refresh();
+    const onUpdated = (id: number) => {
+      if (isPopupMode) {
+        if (liveOriginTabId != null && id === liveOriginTabId) refresh();
+      } else {
+        refresh();
+      }
+    };
     chrome.tabs.onActivated.addListener(onActivated);
     chrome.tabs.onUpdated.addListener(onUpdated);
     return () => {
       chrome.tabs.onActivated.removeListener(onActivated);
       chrome.tabs.onUpdated.removeListener(onUpdated);
     };
-  }, []);
+  }, [isPopupMode, liveOriginTabId]);
 
   const startEdit = useCallback(
     (messageId: string) => {

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,5 +1,5 @@
 import type { TidyState, SortResult, ModelStatus } from "@/lib/types";
-import { isSidePanelOpenForWindow } from "./tab-scoping";
+import { markUserOpenedSidePanel, markUserClosedSidePanel, isUserOpenedSidePanel } from "./tab-scoping";
 import { openHomePage } from "./messages";
 
 function getTidyState(data: Record<string, unknown>, key: string): TidyState {
@@ -36,8 +36,80 @@ export default defineBackground({
     let agentWorkingColor: string | null = null;
     const pendingNotifications = new Map<string, { conversationId: string; origin: "sidepanel" | "home" }>();
 
-    chrome.windows.getLastFocused().then((w) => {
-      lastFocusedWindowId = w.id;
+    // windowId → active tabId. Maintained synchronously off chrome.tabs events
+    // so chrome.sidePanel.open({tabId}) can be called inline from a user
+    // gesture without breaking the activation chain by awaiting a tabs.query.
+    const activeTabByWindow = new Map<number, number>();
+
+    // Helper to dry up the gesture-sensitive side panel open paths.
+    // Because the manifest does not declare a `side_panel.default_path`,
+    // Chrome treats this extension as having NO global side panel by
+    // default. We register the panel per-tab here, giving us native
+    // per-tab scoping with no need to pre-disable other tabs.
+    function openSidePanelOnTab(tabId: number) {
+      // Eagerly mark as user-opened. This acts as a fallback for Chrome <141
+      // which doesn't support chrome.sidePanel.onOpened.
+      markUserOpenedSidePanel(tabId);
+      // Register the panel for this tab. Without this call, Chrome has no
+      // record of a panel for this tab and open() will reject.
+      chrome.sidePanel
+        .setOptions({ tabId, path: "sidepanel.html", enabled: true })
+        .catch(() => {});
+      chrome.sidePanel.open({ tabId }).catch(() => {});
+    }
+
+    // Chrome lifecycle events keep `userOpenedSidePanelTabs` in sync
+    // automatically when present. `onOpened` is Chrome 141+; `onClosed`
+    // is Chrome 142+. Both are feature-detected; callers also eagerly
+    // mark/unmark on user gestures as a fallback for older Chrome.
+    if (chrome.sidePanel.onOpened) {
+      chrome.sidePanel.onOpened.addListener((info) => {
+        if (info.tabId != null) markUserOpenedSidePanel(info.tabId);
+      });
+    }
+    if (chrome.sidePanel.onClosed) {
+      chrome.sidePanel.onClosed.addListener((info) => {
+        if (info.tabId != null) {
+          markUserClosedSidePanel(info.tabId);
+          chrome.sidePanel
+            .setOptions({ tabId: info.tabId, path: "sidepanel.html", enabled: false })
+            .catch(() => {});
+        }
+      });
+    }
+
+    // Track the most recently focused *normal* browser window. We
+    // deliberately exclude `popup`/`devtools` windows so that focusing
+    // the detached popover doesn't redirect gesture-bridged actions
+    // (Alt+I, search, notifications) to the popup's window — those
+    // need to target the user's real browsing window.
+    chrome.windows.getLastFocused({ windowTypes: ["normal"] }).then((w) => {
+      if (w.id != null) lastFocusedWindowId = w.id;
+    });
+
+    // Seed activeTabByWindow on startup. We no longer need to pre-disable
+    // every existing tab — without a default global panel, Chrome naturally
+    // shows nothing on tabs that haven't called setOptions.
+    chrome.windows.getAll({ populate: true }).then((wins) => {
+      for (const w of wins) {
+        if (w.id == null) continue;
+        const active = w.tabs?.find((t) => t.active);
+        if (active?.id != null) activeTabByWindow.set(w.id, active.id);
+      }
+    });
+
+    chrome.tabs.onActivated.addListener((info) => {
+      activeTabByWindow.set(info.windowId, info.tabId);
+    });
+
+    chrome.tabs.onCreated.addListener((tab) => {
+      if (tab.id != null && tab.windowId != null && tab.active) {
+        activeTabByWindow.set(tab.windowId, tab.id);
+      }
+    });
+
+    chrome.windows.onRemoved.addListener((windowId) => {
+      activeTabByWindow.delete(windowId);
     });
 
     // Connect MCP servers on startup
@@ -57,31 +129,48 @@ export default defineBackground({
           .catch(() => {});
       });
     });
-    chrome.windows.onFocusChanged.addListener((windowId) => {
-      if (windowId !== chrome.windows.WINDOW_ID_NONE) {
-        lastFocusedWindowId = windowId;
+    chrome.windows.onFocusChanged.addListener(async (windowId) => {
+      if (windowId === chrome.windows.WINDOW_ID_NONE) return;
+      // Only track focus on normal browser windows. Popup-type windows
+      // (such as our detached popover) and devtools windows must not
+      // override lastFocusedWindowId, otherwise gesture-bridged actions
+      // would target the popup instead of the user's real window.
+      try {
+        const w = await chrome.windows.get(windowId);
+        if (w.type === "normal") lastFocusedWindowId = windowId;
+      } catch {
+        // Window vanished between focus event and lookup — ignore.
       }
     });
 
     chrome.commands.onCommand.addListener((command) => {
       if (command === "open-chat") {
-        // chrome.sidePanel.open() requires a user gesture and must be called
-        // synchronously inside the command handler — no await before it.
         const windowId = lastFocusedWindowId;
+
+        const toggleOnTab = (tabId: number) => {
+          const opened = isUserOpenedSidePanel(tabId);
+          if (opened && chrome.sidePanel.close) {
+            markUserClosedSidePanel(tabId);
+            chrome.sidePanel.close({ tabId }).catch(() => {});
+            chrome.sidePanel
+              .setOptions({ tabId, path: "sidepanel.html", enabled: false })
+              .catch(() => {});
+          } else {
+            openSidePanelOnTab(tabId);
+          }
+        };
+
         if (windowId == null) {
-          // Best-effort: resolve the window then open. Will only work if Chrome
-          // still considers this a user-gesture context (it usually does for
-          // command events).
-          chrome.windows.getLastFocused().then((w) => {
-            if (w.id != null) chrome.sidePanel.open({ windowId: w.id });
+          chrome.windows.getLastFocused({ windowTypes: ["normal"] }).then((w) => {
+            if (w.id == null) return;
+            const tabId = activeTabByWindow.get(w.id);
+            if (tabId != null) toggleOnTab(tabId);
           });
           return;
         }
-        if (isSidePanelOpenForWindow(windowId) && chrome.sidePanel.close) {
-          chrome.sidePanel.close({ windowId });
-        } else {
-          chrome.sidePanel.open({ windowId });
-        }
+
+        const tabId = activeTabByWindow.get(windowId);
+        if (tabId != null) toggleOnTab(tabId);
         return;
       }
 
@@ -89,7 +178,7 @@ export default defineBackground({
         // openHomePage uses chrome.tabs APIs, which don't require a user
         // gesture, so we can safely await.
         (async () => {
-          const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused()).id;
+          const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
           if (windowId == null) return;
           await openHomePage(windowId);
         })();
@@ -98,7 +187,7 @@ export default defineBackground({
 
       if (command === "open-search") {
         (async () => {
-          const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused()).id;
+          const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
           if (!windowId) return;
 
           const [tab] = await chrome.tabs.query({ active: true, windowId });
@@ -361,9 +450,7 @@ export default defineBackground({
           try {
             const tabId = sender.tab?.id;
             if (tabId != null) {
-              await chrome.sidePanel.open({ tabId });
-            } else if (sender.tab?.windowId != null) {
-              await chrome.sidePanel.open({ windowId: sender.tab.windowId });
+              openSidePanelOnTab(tabId);
             }
             sendResponse({ ok: true });
           } catch (err) {
@@ -1252,13 +1339,79 @@ export default defineBackground({
         return true;
       }
 
+      if (message.type === "DETACH_SIDEPANEL") {
+        (async () => {
+          try {
+            const m = message as {
+              type: string;
+              activeConversationId?: string | null;
+              activeSpaceId?: string | null;
+              originWindowId?: number | null;
+              originTabId?: number | null;
+              originUrl?: string | null;
+            };
+            const originWindowId =
+              m.originWindowId ??
+              sender.tab?.windowId ??
+              lastFocusedWindowId ??
+              (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
+
+            // Resolve origin tab if not provided, by looking up the active
+            // tab in the origin window.
+            let originTabId = m.originTabId ?? null;
+            let originUrl = m.originUrl ?? null;
+            if (originTabId == null && originWindowId != null) {
+              try {
+                const [tab] = await chrome.tabs.query({ active: true, windowId: originWindowId });
+                if (tab?.id != null) {
+                  originTabId = tab.id;
+                  originUrl = tab.url ?? null;
+                }
+              } catch {}
+            }
+
+            // Close the side panel on the origin tab. With no global panel
+            // declared in the manifest, this is the only kind of panel that
+            // can exist for this extension.
+            const closePanel = chrome.sidePanel.close;
+            if (closePanel && originTabId != null) {
+              markUserClosedSidePanel(originTabId);
+              closePanel({ tabId: originTabId }).catch(() => {});
+              chrome.sidePanel
+                .setOptions({ tabId: originTabId, path: "sidepanel.html", enabled: false })
+                .catch(() => {});
+            }
+
+            const params = new URLSearchParams({ mode: "popup" });
+            if (originWindowId != null) params.set("originWindowId", String(originWindowId));
+            if (originTabId != null) params.set("originTabId", String(originTabId));
+            if (originUrl) params.set("originUrl", originUrl);
+            if (m.activeConversationId) params.set("conversationId", m.activeConversationId);
+
+            const popupWindow = await chrome.windows.create({
+              type: "popup",
+              url: chrome.runtime.getURL(`/sidepanel.html?${params.toString()}`),
+              width: 420,
+              height: 700,
+              focused: true,
+            });
+            void popupWindow;
+            sendResponse({ ok: true });
+          } catch (err) {
+            sendResponse({ ok: false, error: String(err) });
+          }
+        })();
+        return true;
+      }
+
       if (message.type === "OPEN_SIDEPANEL_SEARCH") {
         (async () => {
           try {
-            const windowId = sender.tab?.windowId ?? lastFocusedWindowId ?? (await chrome.windows.getLastFocused()).id;
+            const windowId = sender.tab?.windowId ?? lastFocusedWindowId ?? (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
             if (windowId) {
               chrome.storage.session.set({ focusSearch: true });
-              chrome.sidePanel.open({ windowId });
+              const tabId = sender.tab?.id ?? activeTabByWindow.get(windowId);
+              if (tabId != null) openSidePanelOnTab(tabId);
             }
             sendResponse({ ok: true });
           } catch (err) {
@@ -1268,11 +1421,18 @@ export default defineBackground({
         return true;
       }
 
+      if (message.type === "MARK_USER_OPENED_SIDEPANEL") {
+        const tabId = message.tabId as number | undefined;
+        if (tabId != null) markUserOpenedSidePanel(tabId);
+        sendResponse({ ok: true });
+        return false;
+      }
+
       if (message.type === "OPEN_NEW_SPACE_OVERLAY" || message.type === "OPEN_OVERLAY_ACTION") {
         const action = message.action ?? "new-space";
         (async () => {
           try {
-            const windowId = sender.tab?.windowId ?? lastFocusedWindowId ?? (await chrome.windows.getLastFocused()).id;
+            const windowId = sender.tab?.windowId ?? lastFocusedWindowId ?? (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
             if (!windowId) { sendResponse({ ok: false }); return; }
             const [tab] = await chrome.tabs.query({ active: true, windowId });
             if (!tab?.id) { sendResponse({ ok: false }); return; }
@@ -1346,7 +1506,8 @@ export default defineBackground({
               const spaces = await storage.getSpaces();
               const space = spaces.find((s) => s.id === message.spaceId);
               if (space?.windowId) {
-                await chrome.sidePanel.open({ windowId: space.windowId });
+                const tabId = activeTabByWindow.get(space.windowId);
+                if (tabId != null) openSidePanelOnTab(tabId);
               }
             }
             sendResponse({ ok: true });
@@ -1751,8 +1912,11 @@ export default defineBackground({
       pendingNotifications.delete(notificationId);
       chrome.notifications.clear(notificationId);
       if (info.origin === "sidepanel") {
-        const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused()).id;
-        if (windowId) chrome.sidePanel.open({ windowId });
+        const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
+        if (windowId) {
+          const tabId = activeTabByWindow.get(windowId);
+          if (tabId != null) openSidePanelOnTab(tabId);
+        }
       } else {
         const homeUrl = chrome.runtime.getURL("/home.html");
         const [existing] = await chrome.tabs.query({ url: homeUrl + "*" });

--- a/src/entrypoints/background/tab-scoping.ts
+++ b/src/entrypoints/background/tab-scoping.ts
@@ -4,6 +4,23 @@ const tabOwnership = new Map<number, string>();
 const groupOwnership = new Map<number, string>();
 const sidePanelOpenByWindow = new Map<number, boolean>();
 
+// Tabs the user explicitly opened the side panel on. Ephemeral (cleared on
+// extension reload). Chrome 141+ onOpened/onClosed syncs this automatically;
+// older versions rely on explicit helper calls on gesture.
+const userOpenedSidePanelTabs = new Set<number>();
+
+export function markUserOpenedSidePanel(tabId: number) {
+  userOpenedSidePanelTabs.add(tabId);
+}
+
+export function markUserClosedSidePanel(tabId: number) {
+  userOpenedSidePanelTabs.delete(tabId);
+}
+
+export function isUserOpenedSidePanel(tabId: number): boolean {
+  return userOpenedSidePanelTabs.has(tabId);
+}
+
 const DISMISSED_STORAGE_KEY = "agent_toast_dismissed_tabs";
 
 async function getDismissedTabs(): Promise<Set<number>> {
@@ -141,6 +158,19 @@ export function isSidePanelOpenForWindow(windowId: number): boolean {
   return sidePanelOpenByWindow.get(windowId) ?? false;
 }
 
+export function applyDesiredPanelState(tabId: number) {
+  // A tab should have the side panel registered (and enabled) if it's owned
+  // by a conversation (agent is active in the group) OR the user explicitly
+  // opened it there. Otherwise, leave it unregistered so Chrome shows
+  // nothing on that tab. The manifest declares no global side panel, so
+  // there's no default fallback to fight against.
+  const owned = tabOwnership.has(tabId);
+  const userOpened = userOpenedSidePanelTabs.has(tabId);
+  chrome.sidePanel
+    .setOptions({ tabId, path: "sidepanel.html", enabled: owned || userOpened })
+    .catch(() => {});
+}
+
 async function setPanelEnabledForTab(tabId: number, enabled: boolean) {
   try {
     if (enabled) {
@@ -222,7 +252,7 @@ async function clearTabOwnership(tabId: number) {
   const convId = tabOwnership.get(tabId);
   if (!convId) return;
   tabOwnership.delete(tabId);
-  setPanelEnabledForTab(tabId, false);
+  applyDesiredPanelState(tabId);
   emitToast(tabId, false);
 
   const conv = await chatDb.getConversation(convId);
@@ -239,7 +269,7 @@ async function clearGroupOwnership(groupId: number) {
   for (const [tabId, cid] of tabOwnership) {
     if (cid === convId) {
       tabOwnership.delete(tabId);
-      setPanelEnabledForTab(tabId, false);
+      applyDesiredPanelState(tabId);
       emitToast(tabId, false);
     }
   }
@@ -290,9 +320,10 @@ async function rebuildIndexesFromStorage() {
 
 function installListeners() {
   chrome.tabs.onActivated.addListener(async (info) => {
+    applyDesiredPanelState(info.tabId);
+    
     const convId = tabOwnership.get(info.tabId);
     if (convId) {
-      await setPanelEnabledForTab(info.tabId, true);
       if (sidePanelOpenByWindow.get(info.windowId)) {
         emitFocus(info.windowId, convId);
         emitToast(info.tabId, false);
@@ -300,12 +331,12 @@ function installListeners() {
         emitToast(info.tabId, true);
       }
     } else {
-      await setPanelEnabledForTab(info.tabId, false);
       emitToast(info.tabId, false);
     }
   });
 
   chrome.tabs.onRemoved.addListener((tabId) => {
+    userOpenedSidePanelTabs.delete(tabId);
     if (!tabOwnership.has(tabId)) return;
     clearTabOwnership(tabId);
   });

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ChatView } from "@/components/chat/ChatView";
 import { ChatPicker } from "@/components/chat/ChatPicker";
 import { SpaceSwitcher } from "./components/SpaceSwitcher";
-import { Download, ExternalLink, Link as LinkIcon, MessageSquarePlus, MoreVertical, Settings } from "lucide-react";
+import { Download, ExternalLink, MessageSquarePlus, MoreVertical, Settings, PictureInPicture, PanelRight } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -20,11 +20,37 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Kbd } from "@/components/ui/kbd";
 
+function readPopupParams() {
+  if (typeof window === "undefined") {
+    return {
+      isPopupMode: false,
+      originWindowId: null,
+      originTabId: null,
+      originUrl: null,
+      initialConversationId: null,
+    };
+  }
+  const params = new URLSearchParams(window.location.search);
+  const isPopupMode = params.get("mode") === "popup";
+  const owid = params.get("originWindowId");
+  const otid = params.get("originTabId");
+  const ourl = params.get("originUrl");
+  const cid = params.get("conversationId");
+  return {
+    isPopupMode,
+    originWindowId: owid ? Number(owid) : null,
+    originTabId: otid ? Number(otid) : null,
+    originUrl: ourl && ourl.length > 0 ? ourl : null,
+    initialConversationId: cid && cid.length > 0 ? cid : null,
+  };
+}
+
 export default function App() {
   useTheme();
+  const { isPopupMode, originWindowId, originTabId, originUrl, initialConversationId } = readPopupParams();
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
-  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(initialConversationId);
   const [conversationTitle, setConversationTitle] = useState<string | null>(null);
   const [generatingTitleIds, setGeneratingTitleIds] = useState<Set<string>>(new Set());
   const activeConversationIdRef = useRef(activeConversationId);
@@ -34,6 +60,21 @@ export default function App() {
     async function init() {
       const allSpaces = await storage.getSpaces();
       setSpaces(allSpaces);
+
+      // In popup mode, the popup's own window isn't a real space.
+      // Resolve the active space from the origin window if known, otherwise
+      // fall back to the first space.
+      if (isPopupMode) {
+        if (originWindowId != null) {
+          const space = await storage.getSpaceByWindowId(originWindowId);
+          if (space) {
+            setActiveSpaceId(space.id);
+            return;
+          }
+        }
+        if (allSpaces.length > 0) setActiveSpaceId(allSpaces[0].id);
+        return;
+      }
 
       const currentWindow = await chrome.windows.getCurrent();
       if (currentWindow.id) {
@@ -55,7 +96,7 @@ export default function App() {
             windowId: currentWindow.id,
           });
           if (owned?.ok && owned.conversationId) {
-            setActiveConversationId(owned.conversationId);
+            setActiveConversationId((prev) => prev ?? owned.conversationId);
           }
         } catch {}
         return;
@@ -71,7 +112,7 @@ export default function App() {
     };
     chrome.storage.onChanged.addListener(listener);
     return () => chrome.storage.onChanged.removeListener(listener);
-  }, []);
+  }, [isPopupMode, originWindowId]);
 
   useEffect(() => {
     let myWindowId: number | undefined;
@@ -138,40 +179,6 @@ export default function App() {
     setActiveConversationId(null);
   }, []);
 
-  const [activeTab, setActiveTab] = useState<{ tabId: number; pinned: boolean; windowId: number } | null>(null);
-  useEffect(() => {
-    async function refreshActiveTab() {
-      const w = await chrome.windows.getCurrent();
-      if (w.id == null) return;
-      const [tab] = await chrome.tabs.query({ active: true, windowId: w.id });
-      if (tab?.id != null) {
-        setActiveTab({ tabId: tab.id, pinned: tab.pinned === true, windowId: w.id });
-      } else {
-        setActiveTab(null);
-      }
-    }
-    refreshActiveTab();
-    const onActivated = () => refreshActiveTab();
-    const onUpdated = (_id: number, info: chrome.tabs.OnUpdatedInfo) => {
-      if (info.pinned != null || info.status === "complete") refreshActiveTab();
-    };
-    chrome.tabs.onActivated.addListener(onActivated);
-    chrome.tabs.onUpdated.addListener(onUpdated);
-    return () => {
-      chrome.tabs.onActivated.removeListener(onActivated);
-      chrome.tabs.onUpdated.removeListener(onUpdated);
-    };
-  }, []);
-
-  const handleBindActiveTab = useCallback(async () => {
-    if (!activeConversationId || !activeTab || activeTab.pinned) return;
-    await chrome.runtime.sendMessage({
-      type: "BIND_ACTIVE_TAB_TO_CONVERSATION",
-      conversationId: activeConversationId,
-      tabId: activeTab.tabId,
-    });
-  }, [activeConversationId, activeTab]);
-
   const handleOpenFullView = useCallback(async () => {
     const currentWindow = await chrome.windows.getCurrent();
     const hash = activeConversationId ? `#${activeConversationId}` : "";
@@ -179,9 +186,9 @@ export default function App() {
       type: "OVERLAY_GLOBAL_ACTION",
       action: "full-view",
       hash,
-      windowId: currentWindow.id,
+      windowId: isPopupMode && originWindowId != null ? originWindowId : currentWindow.id,
     });
-  }, [activeConversationId]);
+  }, [activeConversationId, isPopupMode, originWindowId]);
 
   const handleExportChat = useCallback(async () => {
     if (!activeConversationId) return;
@@ -249,6 +256,130 @@ export default function App() {
 
   const [pickerOpen, setPickerOpen] = useState(false);
 
+  const handleDetach = useCallback(async () => {
+    const w = await chrome.windows.getCurrent();
+    let tabId: number | null = null;
+    let url: string | null = null;
+    if (w.id != null) {
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, windowId: w.id });
+        tabId = tab?.id ?? null;
+        url = tab?.url ?? null;
+      } catch {}
+    }
+    await chrome.runtime.sendMessage({
+      type: "DETACH_SIDEPANEL",
+      activeConversationId,
+      activeSpaceId,
+      originWindowId: w.id ?? null,
+      originTabId: tabId,
+      originUrl: url,
+    });
+  }, [activeConversationId, activeSpaceId]);
+
+  // The tab id we want to reattach to, kept up to date so the click handler
+  // can call chrome.sidePanel.open({tabId}) synchronously off the user
+  // gesture. Falls through origin tab → active tab in origin window → active
+  // tab in last focused normal window. Only maintained in popup mode.
+  const reattachTargetRef = useRef<number | null>(originTabId ?? null);
+
+  useEffect(() => {
+    if (!isPopupMode) return;
+
+    let cancelled = false;
+    async function compute() {
+      let next: number | null = null;
+      if (originTabId != null) {
+        try {
+          const t = await chrome.tabs.get(originTabId);
+          if (t.id != null) next = t.id;
+        } catch {}
+      }
+      if (next == null && originWindowId != null) {
+        try {
+          await chrome.windows.get(originWindowId);
+          const [t] = await chrome.tabs.query({ active: true, windowId: originWindowId });
+          if (t?.id != null) next = t.id;
+        } catch {}
+      }
+      if (next == null) {
+        try {
+          const w = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
+          if (w.id != null) {
+            const [t] = await chrome.tabs.query({ active: true, windowId: w.id });
+            if (t?.id != null) next = t.id;
+          }
+        } catch {}
+      }
+      if (!cancelled) reattachTargetRef.current = next;
+    }
+
+    compute();
+    const refresh = () => compute();
+    chrome.tabs.onActivated.addListener(refresh);
+    chrome.tabs.onRemoved.addListener(refresh);
+    chrome.windows.onFocusChanged.addListener(refresh);
+    return () => {
+      cancelled = true;
+      chrome.tabs.onActivated.removeListener(refresh);
+      chrome.tabs.onRemoved.removeListener(refresh);
+      chrome.windows.onFocusChanged.removeListener(refresh);
+    };
+  }, [isPopupMode, originTabId, originWindowId]);
+
+  const handleReattach = useCallback(() => {
+    // chrome.sidePanel.open() requires a synchronous user gesture. Read the
+    // precomputed target from the ref and call open() inline — no awaits or
+    // .then() continuations before it.
+    const tabId = reattachTargetRef.current;
+    if (tabId != null) {
+      // Register the panel for this tab and open it. The manifest has no
+      // default global panel, so setOptions is required before open().
+      // Fire-and-forget; Chrome processes these sequentially.
+      chrome.sidePanel.setOptions({ tabId, path: "sidepanel.html", enabled: true }).catch(() => {});
+      chrome.sidePanel.open({ tabId }).catch(() => {});
+    }
+
+    // Async cleanup: activate the target tab, focus its window, and close
+    // the popup. Safe to do off-gesture since none of these require user
+    // activation.
+    void (async () => {
+      if (tabId != null) {
+        chrome.runtime.sendMessage({ type: "MARK_USER_OPENED_SIDEPANEL", tabId }).catch(() => {});
+        // Activate the target tab so the just-opened panel is visible.
+        // Without this, if the user navigated to a different tab in the
+        // origin window before reattaching, focusing the window alone
+        // would leave that other tab active and the panel hidden (since
+        // we registered the panel only for tabId).
+        chrome.tabs.update(tabId, { active: true }).catch(() => {});
+      }
+      let targetWindowId: number | undefined;
+      if (originWindowId != null) {
+        try {
+          const w = await chrome.windows.get(originWindowId);
+          if (w.type === "normal") targetWindowId = w.id;
+        } catch {
+          // origin gone
+        }
+      }
+      if (targetWindowId == null) {
+        try {
+          const w = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
+          if (w.id != null) targetWindowId = w.id;
+        } catch {}
+      }
+
+      if (targetWindowId != null) {
+        chrome.windows.update(targetWindowId, { focused: true }).catch(() => {});
+      }
+
+      try {
+        const popup = await chrome.windows.getCurrent();
+        if (popup.id != null) await chrome.windows.remove(popup.id);
+      } catch {}
+    })();
+  }, [originWindowId]);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.altKey && !e.shiftKey && !e.metaKey && !e.ctrlKey && e.code === "KeyN") {
@@ -275,20 +406,6 @@ export default function App() {
           </>
         )}
         <div className="flex-1" />
-        {activeConversationId && activeTab && !activeTab.pinned && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={handleBindActiveTab}
-                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                <LinkIcon className="size-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Work on this tab</TooltipContent>
-          </Tooltip>
-        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -304,6 +421,34 @@ export default function App() {
             <Kbd>⌥N</Kbd>
           </TooltipContent>
         </Tooltip>
+        {!isPopupMode && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleDetach}
+                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <PictureInPicture className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Detach to popover</TooltipContent>
+          </Tooltip>
+        )}
+        {isPopupMode && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleReattach}
+                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <PanelRight className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Reattach to side panel</TooltipContent>
+          </Tooltip>
+        )}
         <ChatPicker
           spaceId={activeSpaceId}
           activeConversationId={activeConversationId}
@@ -346,6 +491,10 @@ export default function App() {
           spaceId={activeSpaceId}
           onNewConversation={handleNewConversation}
           showHeader={false}
+          isPopupMode={isPopupMode}
+          originWindowId={isPopupMode ? originWindowId : null}
+          originTabId={isPopupMode ? originTabId : null}
+          originUrl={isPopupMode ? originUrl : null}
         />
       </div>
     </div>

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -5,14 +5,24 @@ import { Toaster } from "@/components/ui/sonner";
 import App from "./App";
 import "./app.css";
 
-const sidepanelPort = chrome.runtime.connect({ name: "sidepanel" });
-chrome.windows.getCurrent().then((w) => {
-  if (w.id != null) {
-    try {
-      sidepanelPort.postMessage({ type: "SIDEPANEL_HELLO", windowId: w.id });
-    } catch {}
-  }
-});
+// `sidepanel.html` is loaded both in Chrome's side panel and inside the
+// detached popup window. The "sidepanel" port + SIDEPANEL_HELLO is the
+// signal the background uses to populate `sidePanelOpenByWindow` for
+// toast / focus emission. The popup is not a real side panel, so skip
+// the port handshake when running in popup mode to avoid polluting
+// that map with the popup's window id.
+const isPopupMode = new URLSearchParams(window.location.search).get("mode") === "popup";
+
+if (!isPopupMode) {
+  const sidepanelPort = chrome.runtime.connect({ name: "sidepanel" });
+  chrome.windows.getCurrent().then((w) => {
+    if (w.id != null) {
+      try {
+        sidepanelPort.postMessage({ type: "SIDEPANEL_HELLO", windowId: w.id });
+      } catch {}
+    }
+  });
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -61,6 +61,14 @@ interface UseAgentChatOptions {
   conversationId: string | null;
   spaceId: string | null;
   onNewConversation: (id: string) => void;
+  /**
+   * Override for the host tab id used by the agent's implicit
+   * first-tool-call binding. When `undefined`, useAgentChat resolves the
+   * panel's host tab from the active tab in the current window. Pass an
+   * explicit value (or `null`) when the panel is rendered in a popover and
+   * `currentWindow` would resolve to the popup itself.
+   */
+  hostTabIdOverride?: number | null;
 }
 
 function generateId() {
@@ -282,12 +290,29 @@ export function useAgentChat({
   conversationId,
   spaceId,
   onNewConversation,
+  hostTabIdOverride,
 }: UseAgentChatOptions) {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [agentSettings, setAgentSettings] = useState<AgentSettings>(
     DEFAULT_AGENT_SETTINGS,
   );
   const [input, setInput] = useState("");
+
+  // Latest host tab override; the resolver below reads it via ref so
+  // resolveHostTabId() doesn't need to be a dep of every effect that uses it.
+  const hostTabOverrideRef = useRef<number | null | undefined>(hostTabIdOverride);
+  hostTabOverrideRef.current = hostTabIdOverride;
+
+  const resolveHostTabId = useCallback(async (): Promise<number | null> => {
+    const override = hostTabOverrideRef.current;
+    if (override !== undefined) return override;
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      return tab?.id ?? null;
+    } catch {
+      return null;
+    }
+  }, []);
   const [isCompacting, setIsCompacting] = useState(false);
   const conversationIdRef = useRef(conversationId);
   conversationIdRef.current = conversationId;
@@ -600,7 +625,9 @@ export function useAgentChat({
             .map((m) => m.content)
             .filter(Boolean);
           assembleMessagesForLLM(conversationId, conversationTexts).then((assembled) => {
-            setAgentContext(conversationId, assembled);
+            resolveHostTabId().then((hostTabId) => {
+              setAgentContext(conversationId, assembled, hostTabId);
+            });
           });
           sendMessage();
         }
@@ -740,7 +767,9 @@ export function useAgentChat({
         .map((m) => m.parts.filter((p) => p.type === "text").map((p) => (p as { text: string }).text).join(""))
         .filter(Boolean);
       assembleMessagesForLLM(convId, [...existingMessages, baseText]).then((assembled) => {
-        setAgentContext(convId, assembled);
+        resolveHostTabId().then((hostTabId) => {
+          setAgentContext(convId, assembled, hostTabId);
+        });
       });
 
       if (isNew) {

--- a/src/lib/agent/agent-transport.ts
+++ b/src/lib/agent/agent-transport.ts
@@ -340,6 +340,11 @@ let indicatorQueue: Promise<void> = Promise.resolve();
 
 let agentConversationId: string | null = null;
 let agentConversationMessages: string[] = [];
+// Tab id of the panel/popover that initiated this agent run. Used as the
+// implicit host tab to bind to a fresh conversation on the first tab tool
+// call (so the agent has a target without the user manually clicking
+// "Work on this tab").
+let agentHostTabId: number | null = null;
 
 let lastTotalTokens = 0;
 let currentModelDef: ModelDefinition | undefined;
@@ -383,21 +388,25 @@ export function resetTokenTracking() {
 export function setAgentContext(
   conversationId: string | null,
   messages: string[],
+  hostTabId: number | null = null,
 ) {
   if (agentConversationId && agentConversationId !== conversationId) {
     clearHandles(agentConversationId);
   }
   agentConversationId = conversationId;
   agentConversationMessages = messages;
+  agentHostTabId = hostTabId;
 }
 
 export function getAgentContext(): {
   conversationId: string | null;
   messages: string[];
+  hostTabId: number | null;
 } {
   return {
     conversationId: agentConversationId,
     messages: agentConversationMessages,
+    hostTabId: agentHostTabId,
   };
 }
 
@@ -484,6 +493,36 @@ function toSDKTool<TInput, TOutput>(
       setTargetTabId(pinnedTabId);
     }
     if (isTabTool) {
+      // Implicit host-tab binding: on the first tab-interacting tool call
+      // for a conversation that hasn't owned any tabs yet, bind the panel's
+      // host tab so the agent has a working target. Skipped when the host
+      // tab is unknown, an extension/chrome page, or already in the group.
+      if (agentConversationId && agentHostTabId != null && getTargetTabId() == null) {
+        try {
+          const conv = await chatDb.getConversation(agentConversationId);
+          if (conv && conv.ownedTabIds.length === 0) {
+            const hostTab = await chrome.tabs.get(agentHostTabId).catch(() => null);
+            const hostUrl = hostTab?.url ?? "";
+            const isInternal =
+              hostUrl.startsWith("chrome://") ||
+              hostUrl.startsWith("chrome-extension://") ||
+              hostUrl.startsWith("devtools://");
+            if (hostTab && !isInternal && !hostTab.pinned) {
+              await chrome.runtime
+                .sendMessage({
+                  type: "BIND_ACTIVE_TAB_TO_CONVERSATION",
+                  conversationId: agentConversationId,
+                  tabId: agentHostTabId,
+                })
+                .catch(() => {});
+              setTargetTabId(agentHostTabId);
+            }
+          }
+        } catch {
+          // Best-effort; the agent's own bootstrap fallback (getActiveUserTab)
+          // will pick up where this leaves off.
+        }
+      }
       try {
         const tab = await getActiveUserTab();
         if (tab.id && tab.title) {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -10,6 +10,18 @@ export default defineConfig({
   vite: () => ({
     plugins: [tailwindcss()],
   }),
+  hooks: {
+    // WXT auto-injects `side_panel.default_path` whenever a `sidepanel`
+    // entrypoint exists. We deliberately don't want that — declaring a
+    // global side panel makes Chrome show it on every tab by default,
+    // which fights against per-tab scoping (the global panel leaks
+    // onto other tabs in the window). Stripping this leaves Chrome
+    // with no default panel; we register per-tab via setOptions when
+    // the user explicitly opens it, giving us native per-tab isolation.
+    "build:manifestGenerated": (_wxt, manifest) => {
+      delete (manifest as { side_panel?: unknown }).side_panel;
+    },
+  },
   manifest: ({ mode }) => ({
     name: "OpenBrowse",
     description: "The open source browser agent.",
@@ -28,9 +40,6 @@ export default defineConfig({
       "128": "icon/128.png",
     },
     action: {},
-    side_panel: {
-      default_path: "sidepanel.html",
-    },
     permissions: [
       "tabs",
       "tabGroups",


### PR DESCRIPTION
## Summary

Adds a "Detach to popover" affordance that pops the side panel out into a floating Chrome window, with a "Reattach to side panel" button to put it back. While in there, also switches the side panel from window-scoped to per-tab-scoped (matching Gemini in Chrome / Claude for Chrome).

- **Detach** encodes `originWindowId`, `originTabId`, `originUrl`, and `conversationId` in the popup URL. **Reattach** opens the panel back on the exact origin tab, with synchronous fallback to the origin window's active tab → any normal window if that tab is gone.
- **"Sharing [tab]" pill** in the popover is anchored to the origin tab. If the origin tab is closed the pill hides; if a tab matching `originUrl` reopens in the origin window (e.g. Cmd+Shift+T from history), it rebinds.
- **Implicit host-tab binding** on the first tab-interacting tool call when the conversation has no owned tabs — replaces the manual "Work on this tab" link button. `BIND_ACTIVE_TAB_TO_CONVERSATION` is kept for the agent's `selectTab`.
- Detach uses `chrome.sidePanel.close({tabId})` (Chrome 141+) instead of `setOptions({enabled:false})` so we don't leave persistent disabled config on the tab.
- `tab-scoping` no longer disables the side panel for unowned tabs on activation/clear-ownership; the manifest default keeps the panel available everywhere so users can open a fresh chat from any tab.
- Gesture-sensitive entry points (Alt+I `open-chat` command, `OPEN_SIDEPANEL_SEARCH`, `SWITCH_SPACE.openSidePanel`, notification clicks) keep the synchronous `chrome.sidePanel.open({windowId})` call to preserve the user gesture; per-tab semantics still hold for owned tabs because `setOptions({tabId, path, enabled:true})` registers them as tab-specific instances.
- `handleReattach` precomputes its target tab in a ref, kept fresh via `chrome.tabs.onActivated`/`onRemoved` and `chrome.windows.onFocusChanged`, so the click handler can call `chrome.sidePanel.open({tabId})` synchronously off the gesture even if the origin tab has been closed.

## Test plan

1. Open the side panel via toolbar/Alt+I on a real web tab → panel opens.
2. Click the new picture-in-picture icon → popover detaches; side panel closes for that tab; popup window opens at 420×700 with the same conversation.
3. In the popover, switch tabs in the origin window → "Sharing [tab]" pill stays anchored to the origin tab.
4. Close the origin tab → pill disappears.
5. Cmd+Shift+T to restore the origin tab → pill rebinds.
6. Click the new PanelRight icon in the popover → side panel reopens on the origin tab with the same conversation; popover window closes.
7. Close the origin tab while popover is open, then click reattach → panel opens on a sensible fallback tab; popover still closes.
8. Send a chat message that triggers a tool ("summarize this page") in a fresh chat → host tab gets bound + grouped automatically (`OB | Title` group appears).
9. Pure Q&A chat (no tool calls) → no group created, no implicit binding.