### PR TITLE
feat: add Option+Space global chat popup with conversation/draft persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ web-ext.config.ts
 # Internal docs
 docs/superpowers/
 .superpowers/
+.worktrees/

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -47,6 +47,26 @@ export function ChatList({
     refresh();
   }, [refresh]);
 
+  // Cross-window conversation lifecycle: refetch when another extension
+  // context (popup, side panel, home tab) creates, updates, or deletes a
+  // conversation. Broadcasts are field-filtered at chatDb so this doesn't
+  // fire on per-message `updatedAt` bumps.
+  useEffect(() => {
+    function onMessage(msg: unknown) {
+      if (typeof msg !== "object" || msg === null) return;
+      const t = (msg as { type?: unknown }).type;
+      if (
+        t === "CONVERSATION_CREATED" ||
+        t === "CONVERSATION_UPDATED" ||
+        t === "CONVERSATION_DELETED"
+      ) {
+        refresh();
+      }
+    }
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [refresh]);
+
   function handleDeleteClick(e: React.MouseEvent, id: string) {
     e.stopPropagation();
     setDeleteTarget(id);

--- a/src/components/chat/ChatPicker.tsx
+++ b/src/components/chat/ChatPicker.tsx
@@ -77,6 +77,28 @@ export function ChatPicker({
     }
   }, [open, refresh]);
 
+  // Cross-window conversation lifecycle: refetch when another extension
+  // context (popup, side panel, home tab) creates, updates, or deletes a
+  // conversation. Only listens while the picker is open since the closed
+  // popover doesn't render the list. Broadcasts are field-filtered at
+  // chatDb so this doesn't fire on per-message `updatedAt` bumps.
+  useEffect(() => {
+    if (!open) return;
+    function onMessage(msg: unknown) {
+      if (typeof msg !== "object" || msg === null) return;
+      const t = (msg as { type?: unknown }).type;
+      if (
+        t === "CONVERSATION_CREATED" ||
+        t === "CONVERSATION_UPDATED" ||
+        t === "CONVERSATION_DELETED"
+      ) {
+        refresh();
+      }
+    }
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [open, refresh]);
+
   function formatTime(ts: number) {
     const d = new Date(ts);
     const now = new Date();

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -21,7 +21,7 @@ import {
   HelpCircle,
 } from "lucide-react";
 import { useAgentChat } from "@/hooks/useAgentChat";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TodoPanel } from "./TodoPanel";
 
 interface ChatViewProps {
@@ -39,6 +39,13 @@ interface ChatViewProps {
    * popover was detached from rather than the popover's own (extension) tab.
    */
   isPopupMode?: boolean;
+  /**
+   * Whether this ChatView is the global Option+Space popup. Distinct from
+   * `isPopupMode` (which also covers detached side panel popups). When true,
+   * the input draft is persisted to chrome.storage.session so it survives
+   * dismiss/reopen cycles via the global hotkey.
+   */
+  isGlobalChat?: boolean;
   /**
    * The browser window the popover was detached from. Used as a fallback
    * for resolving the origin tab if the original origin tab was closed.
@@ -67,6 +74,7 @@ export function ChatView({
   onBack,
   showHeader = true,
   isPopupMode = false,
+  isGlobalChat = false,
   originWindowId,
   originTabId,
   originUrl,
@@ -110,6 +118,47 @@ export function ChatView({
     // window (which, in per-tab mode, IS the host tab).
     hostTabIdOverride: isPopupMode ? liveOriginTabId : undefined,
   });
+
+  // Global Option+Space popup: persist unsent draft text across dismiss/reopen
+  // cycles using chrome.storage.session. Hydrate once on mount; debounce-write
+  // on subsequent changes. Storage is cleared automatically when the input is
+  // emptied (e.g. after a successful send).
+  const draftHydratedRef = useRef(false);
+  useEffect(() => {
+    if (!isGlobalChat) return;
+    if (draftHydratedRef.current) return;
+    chrome.storage.session
+      .get("globalChatDraft")
+      .then((stored) => {
+        const v = stored.globalChatDraft;
+        if (typeof v === "string" && v.length > 0) setInput(v);
+      })
+      .catch((err) => {
+        console.warn("[global-chat] failed to hydrate draft:", err);
+      })
+      .finally(() => {
+        draftHydratedRef.current = true;
+      });
+  }, [isGlobalChat, setInput]);
+
+  useEffect(() => {
+    if (!isGlobalChat) return;
+    if (!draftHydratedRef.current) return; // skip until hydration ran
+    const timer = setTimeout(() => {
+      if (input && input.length > 0) {
+        chrome.storage.session
+          .set({ globalChatDraft: input })
+          .catch((err) => {
+            console.warn("[global-chat] failed to persist draft:", err);
+          });
+      } else {
+        chrome.storage.session.remove("globalChatDraft").catch((err) => {
+          console.warn("[global-chat] failed to clear draft:", err);
+        });
+      }
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [isGlobalChat, input]);
 
 const providerModels = useMemo(() => {
     return providers

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,6 +1,7 @@
 import type { TidyState, SortResult, ModelStatus } from "@/lib/types";
 import { markUserOpenedSidePanel, markUserClosedSidePanel, isUserOpenedSidePanel } from "./tab-scoping";
 import { openHomePage } from "./messages";
+import { chatDb } from "@/lib/chat-db";
 
 function getTidyState(data: Record<string, unknown>, key: string): TidyState {
   return (data[key] as TidyState) ?? {
@@ -34,6 +35,10 @@ export default defineBackground({
     let lastFocusedWindowId: number | undefined;
     let agentWorkingTabId: number | null | undefined = null;
     let agentWorkingColor: string | null = null;
+    let globalChatPopupWindowId: number | null = null;
+    // Serializes Option+Space toggles so rapid presses can't race and spawn
+    // orphan popups (or attempt to remove a window twice).
+    let globalChatToggleInFlight: Promise<void> | null = null;
     const pendingNotifications = new Map<string, { conversationId: string; origin: "sidepanel" | "home" }>();
 
     // windowId → active tabId. Maintained synchronously off chrome.tabs events
@@ -110,6 +115,9 @@ export default defineBackground({
 
     chrome.windows.onRemoved.addListener((windowId) => {
       activeTabByWindow.delete(windowId);
+      if (windowId === globalChatPopupWindowId) {
+        globalChatPopupWindowId = null;
+      }
     });
 
     // Connect MCP servers on startup
@@ -144,6 +152,85 @@ export default defineBackground({
     });
 
     chrome.commands.onCommand.addListener((command) => {
+      if (command === "open-global-chat") {
+        // Coalesce concurrent presses: if a toggle is already running, ignore
+        // additional presses until it resolves. This prevents two presses
+        // both observing globalChatPopupWindowId == null and spawning two
+        // popups, or two presses both calling chrome.windows.remove on the
+        // same id.
+        if (globalChatToggleInFlight) return;
+        globalChatToggleInFlight = (async () => {
+          // If a global popup already exists, toggle it: close when focused,
+          // refocus when visible-but-unfocused.
+          if (globalChatPopupWindowId != null) {
+            try {
+              const win = await chrome.windows.get(globalChatPopupWindowId);
+              if (win.focused) {
+                await chrome.windows.remove(globalChatPopupWindowId);
+                globalChatPopupWindowId = null;
+              } else {
+                await chrome.windows.update(globalChatPopupWindowId, {
+                  focused: true,
+                });
+              }
+              return;
+            } catch {
+              // Window no longer exists; fall through to create a new one.
+              globalChatPopupWindowId = null;
+            }
+          }
+
+          // Restore the last conversation viewed in the global popup, if any,
+          // so reopening drops the user back into the same chat. Validate
+          // the conversation still exists so a deleted conversation can't
+          // come back from the dead.
+          let lastConversationId: string | null = null;
+          try {
+            const stored = await chrome.storage.session.get(
+              "globalChatLastConversationId",
+            );
+            const v = stored.globalChatLastConversationId;
+            if (typeof v === "string" && v) {
+              const conv = await chatDb.getConversation(v);
+              if (conv) {
+                lastConversationId = v;
+              } else {
+                // Stale id (deleted conversation). Clear it so we don't
+                // resurrect it on the next open.
+                await chrome.storage.session
+                  .remove("globalChatLastConversationId")
+                  .catch(() => {});
+              }
+            }
+          } catch (err) {
+            console.warn("[global-chat] failed to read last conversation:", err);
+          }
+
+          const params = new URLSearchParams({
+            mode: "popup",
+            globalChat: "true",
+          });
+          if (lastConversationId) {
+            params.set("conversationId", lastConversationId);
+          }
+
+          const created = await chrome.windows.create({
+            url: chrome.runtime.getURL(`/sidepanel.html?${params.toString()}`),
+            type: "popup",
+            width: 420,
+            height: 700,
+            focused: true,
+          });
+          if (created?.id != null) globalChatPopupWindowId = created.id;
+        })()
+          .catch((err) => {
+            console.warn("[global-chat] toggle failed:", err);
+          })
+          .finally(() => {
+            globalChatToggleInFlight = null;
+          });
+        return;
+      }
       if (command === "open-chat") {
         const windowId = lastFocusedWindowId;
 

--- a/src/entrypoints/home/components/HomeSidebar.tsx
+++ b/src/entrypoints/home/components/HomeSidebar.tsx
@@ -260,6 +260,26 @@ export function HomeSidebar({
     };
   }, []);
 
+  // Cross-window conversation lifecycle: refetch when another extension
+  // context (popup, side panel, etc.) creates, updates, or deletes a
+  // conversation. The broadcast is field-filtered at the source so this
+  // doesn't fire on per-message `updatedAt` bumps.
+  useEffect(() => {
+    function onMessage(msg: unknown) {
+      if (typeof msg !== "object" || msg === null) return;
+      const t = (msg as { type?: unknown }).type;
+      if (
+        t === "CONVERSATION_CREATED" ||
+        t === "CONVERSATION_UPDATED" ||
+        t === "CONVERSATION_DELETED"
+      ) {
+        refresh();
+      }
+    }
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [refresh]);
+
   useEffect(() => {
     function handleKeydown(e: KeyboardEvent) {
       if (e.altKey && !e.shiftKey && !e.metaKey && !e.ctrlKey && e.code === "KeyN") {

--- a/src/entrypoints/settings/GeneralTab.tsx
+++ b/src/entrypoints/settings/GeneralTab.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -158,6 +159,42 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
             ))}
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="space-y-4 pt-4 border-t">
+        <h3 className="text-sm font-medium">Keyboard Shortcuts</h3>
+        <p className="text-xs text-muted-foreground">
+          OpenBrowse ships with two AI chat shortcuts:
+        </p>
+        <ul className="list-disc list-inside text-xs text-muted-foreground space-y-1">
+          <li>
+            <strong>Alt + I</strong> (Option + I on Mac) — toggles the chat in the
+            current tab&apos;s side panel.
+          </li>
+          <li>
+            <strong>Alt + Space</strong> (Option + Space on Mac) — opens the chat
+            in a standalone popup window.
+          </li>
+        </ul>
+        <div className="bg-secondary/50 p-4 rounded-md border text-sm">
+          <p className="font-medium mb-2">Want to launch the popup from anywhere on your computer (even when Chrome isn&apos;t focused)?</p>
+          <ol className="list-decimal list-inside space-y-1 mb-3 text-muted-foreground text-xs">
+            <li>Click the link below to open Chrome&apos;s shortcut settings</li>
+            <li>Find the <strong>&quot;Open Global AI chat popup&quot;</strong> shortcut</li>
+            <li>Change the dropdown from <strong>&quot;In Chrome&quot;</strong> to <strong>&quot;Global&quot;</strong></li>
+          </ol>
+          <a
+            href="chrome://extensions/shortcuts"
+            onClick={(e) => {
+              e.preventDefault();
+              chrome.tabs.create({ url: "chrome://extensions/shortcuts" });
+            }}
+            className="inline-flex items-center text-primary hover:underline font-medium text-xs cursor-pointer"
+          >
+            Open Chrome Shortcut Settings
+            <ExternalLink className="ml-1 h-3 w-3" />
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -24,6 +24,7 @@ function readPopupParams() {
   if (typeof window === "undefined") {
     return {
       isPopupMode: false,
+      isGlobalChat: false,
       originWindowId: null,
       originTabId: null,
       originUrl: null,
@@ -32,12 +33,14 @@ function readPopupParams() {
   }
   const params = new URLSearchParams(window.location.search);
   const isPopupMode = params.get("mode") === "popup";
+  const isGlobalChat = params.get("globalChat") === "true";
   const owid = params.get("originWindowId");
   const otid = params.get("originTabId");
   const ourl = params.get("originUrl");
   const cid = params.get("conversationId");
   return {
     isPopupMode,
+    isGlobalChat,
     originWindowId: owid ? Number(owid) : null,
     originTabId: otid ? Number(otid) : null,
     originUrl: ourl && ourl.length > 0 ? ourl : null,
@@ -47,7 +50,7 @@ function readPopupParams() {
 
 export default function App() {
   useTheme();
-  const { isPopupMode, originWindowId, originTabId, originUrl, initialConversationId } = readPopupParams();
+  const { isPopupMode, isGlobalChat, originWindowId, originTabId, originUrl, initialConversationId } = readPopupParams();
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(initialConversationId);
@@ -141,9 +144,55 @@ export default function App() {
       return;
     }
     chatDb.getConversation(activeConversationId).then((conv) => {
-      setConversationTitle(conv?.title ?? null);
+      if (!conv) {
+        // Defense in depth: the background command handler validates the
+        // last-conversation id at launch time, and the broadcast listener
+        // below handles live deletes from other windows. This catches any
+        // remaining edge case where the conversation already disappeared
+        // before the listener could fire (e.g. a concurrent delete during
+        // popup launch).
+        setActiveConversationId(null);
+        setConversationTitle(null);
+        return;
+      }
+      setConversationTitle(conv.title ?? null);
     });
   }, [activeConversationId]);
+
+  // Live cross-window deletion: when another extension context (home tab,
+  // detached popup, side panel) deletes a conversation, chatDb broadcasts
+  // CONVERSATION_DELETED via chrome.runtime. If the deleted id is the one
+  // we're currently viewing, reset to a fresh chat so the user doesn't end
+  // up writing to a stale id that would silently resurrect the deleted row.
+  useEffect(() => {
+    function onMessage(msg: unknown) {
+      if (
+        typeof msg === "object" &&
+        msg !== null &&
+        (msg as { type?: unknown }).type === "CONVERSATION_DELETED"
+      ) {
+        const deletedId = (msg as { conversationId?: unknown }).conversationId;
+        if (
+          typeof deletedId === "string" &&
+          deletedId === activeConversationIdRef.current
+        ) {
+          setActiveConversationId(null);
+          setConversationTitle(null);
+        }
+      }
+    }
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, []);
+
+  // Mirror the active conversation title to document.title so popup windows
+  // (both global and detached) show a meaningful name in their OS title bar
+  // instead of a static "OpenBrowse". Side-panel mode doesn't render a
+  // window title bar, so the effect is scoped to popup mode.
+  useEffect(() => {
+    if (!isPopupMode) return;
+    document.title = conversationTitle ?? "OpenBrowse";
+  }, [isPopupMode, conversationTitle]);
 
   useEffect(() => {
     function onGenerating(e: Event) {
@@ -178,6 +227,27 @@ export default function App() {
   const handleNew = useCallback(() => {
     setActiveConversationId(null);
   }, []);
+
+  // When this popup is the global-hotkey chat, persist the active
+  // conversation id to session storage so the next press of Option+Space
+  // restores the same conversation. Scoped to globalChat=true to avoid
+  // colliding with the regular detached side panel popup.
+  useEffect(() => {
+    if (!isGlobalChat) return;
+    if (activeConversationId) {
+      chrome.storage.session
+        .set({ globalChatLastConversationId: activeConversationId })
+        .catch((err) => {
+          console.warn("[global-chat] failed to persist conversation id:", err);
+        });
+    } else {
+      chrome.storage.session
+        .remove("globalChatLastConversationId")
+        .catch((err) => {
+          console.warn("[global-chat] failed to clear conversation id:", err);
+        });
+    }
+  }, [isGlobalChat, activeConversationId]);
 
   const handleOpenFullView = useCallback(async () => {
     const currentWindow = await chrome.windows.getCurrent();
@@ -279,9 +349,19 @@ export default function App() {
 
   // The tab id we want to reattach to, kept up to date so the click handler
   // can call chrome.sidePanel.open({tabId}) synchronously off the user
-  // gesture. Falls through origin tab → active tab in origin window → active
-  // tab in last focused normal window. Only maintained in popup mode.
+  // gesture. Reattach only targets the exact origin tab the popup was
+  // detached from. The global Option+Space popup has no origin tab, so
+  // its reattach target is always null and the reattach button is rendered
+  // disabled with an explanatory tooltip. We do NOT fall back to "active
+  // tab in last-focused window" — that would silently attach to whichever
+  // tab the user happens to have in front, which is surprising behavior.
+  //
+  // The ref is read synchronously inside the click handler (Chrome requires
+  // a sync gesture for chrome.sidePanel.open). The parallel state mirrors
+  // the same value to drive the button's disabled prop and tooltip text,
+  // since refs don't trigger re-renders.
   const reattachTargetRef = useRef<number | null>(originTabId ?? null);
+  const [canReattach, setCanReattach] = useState<boolean>(originTabId != null);
 
   useEffect(() => {
     if (!isPopupMode) return;
@@ -293,25 +373,14 @@ export default function App() {
         try {
           const t = await chrome.tabs.get(originTabId);
           if (t.id != null) next = t.id;
-        } catch {}
+        } catch {
+          // Origin tab was closed since detach; no fallback target.
+        }
       }
-      if (next == null && originWindowId != null) {
-        try {
-          await chrome.windows.get(originWindowId);
-          const [t] = await chrome.tabs.query({ active: true, windowId: originWindowId });
-          if (t?.id != null) next = t.id;
-        } catch {}
+      if (!cancelled) {
+        reattachTargetRef.current = next;
+        setCanReattach(next != null);
       }
-      if (next == null) {
-        try {
-          const w = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
-          if (w.id != null) {
-            const [t] = await chrome.tabs.query({ active: true, windowId: w.id });
-            if (t?.id != null) next = t.id;
-          }
-        } catch {}
-      }
-      if (!cancelled) reattachTargetRef.current = next;
     }
 
     compute();
@@ -325,60 +394,54 @@ export default function App() {
       chrome.tabs.onRemoved.removeListener(refresh);
       chrome.windows.onFocusChanged.removeListener(refresh);
     };
-  }, [isPopupMode, originTabId, originWindowId]);
+  }, [isPopupMode, originTabId]);
 
   const handleReattach = useCallback(() => {
     // chrome.sidePanel.open() requires a synchronous user gesture. Read the
     // precomputed target from the ref and call open() inline — no awaits or
     // .then() continuations before it.
+    //
+    // Reattach is only valid when this popup was detached from a specific
+    // tab that still exists. The button is rendered disabled when
+    // reattachTargetRef is null, so this guard is unreachable in practice
+    // — kept as a defensive no-op in case a stale gesture races the state.
     const tabId = reattachTargetRef.current;
-    if (tabId != null) {
-      // Register the panel for this tab and open it. The manifest has no
-      // default global panel, so setOptions is required before open().
-      // Fire-and-forget; Chrome processes these sequentially.
-      chrome.sidePanel.setOptions({ tabId, path: "sidepanel.html", enabled: true }).catch(() => {});
-      chrome.sidePanel.open({ tabId }).catch(() => {});
-    }
+    if (tabId == null) return;
+    // Register the panel for this tab and open it. The manifest has no
+    // default global panel, so setOptions is required before open().
+    // Fire-and-forget; Chrome processes these sequentially.
+    chrome.sidePanel.setOptions({ tabId, path: "sidepanel.html", enabled: true }).catch(() => {});
+    chrome.sidePanel.open({ tabId }).catch(() => {});
 
     // Async cleanup: activate the target tab, focus its window, and close
     // the popup. Safe to do off-gesture since none of these require user
     // activation.
     void (async () => {
-      if (tabId != null) {
-        chrome.runtime.sendMessage({ type: "MARK_USER_OPENED_SIDEPANEL", tabId }).catch(() => {});
-        // Activate the target tab so the just-opened panel is visible.
-        // Without this, if the user navigated to a different tab in the
-        // origin window before reattaching, focusing the window alone
-        // would leave that other tab active and the panel hidden (since
-        // we registered the panel only for tabId).
-        chrome.tabs.update(tabId, { active: true }).catch(() => {});
-      }
-      let targetWindowId: number | undefined;
-      if (originWindowId != null) {
-        try {
-          const w = await chrome.windows.get(originWindowId);
-          if (w.type === "normal") targetWindowId = w.id;
-        } catch {
-          // origin gone
+      chrome.runtime.sendMessage({ type: "MARK_USER_OPENED_SIDEPANEL", tabId }).catch(() => {});
+      // Activate the target tab so the just-opened panel is visible.
+      // Without this, if the user navigated to a different tab in the
+      // origin window before reattaching, focusing the window alone
+      // would leave that other tab active and the panel hidden (since
+      // we registered the panel only for tabId).
+      chrome.tabs.update(tabId, { active: true }).catch(() => {});
+      // Focus the window that owns the target tab. Read it from the tab
+      // itself — relying on originWindowId can be stale (the tab may have
+      // been moved between windows since detach), and we deliberately
+      // avoid a "last focused window" fallback to keep behavior tied to
+      // the actual origin.
+      try {
+        const t = await chrome.tabs.get(tabId);
+        if (t.windowId != null) {
+          chrome.windows.update(t.windowId, { focused: true }).catch(() => {});
         }
-      }
-      if (targetWindowId == null) {
-        try {
-          const w = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
-          if (w.id != null) targetWindowId = w.id;
-        } catch {}
-      }
-
-      if (targetWindowId != null) {
-        chrome.windows.update(targetWindowId, { focused: true }).catch(() => {});
-      }
+      } catch {}
 
       try {
         const popup = await chrome.windows.getCurrent();
         if (popup.id != null) await chrome.windows.remove(popup.id);
       } catch {}
     })();
-  }, [originWindowId]);
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -441,12 +504,17 @@ export default function App() {
               <button
                 type="button"
                 onClick={handleReattach}
-                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                disabled={!canReattach}
+                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <PanelRight className="size-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Reattach to side panel</TooltipContent>
+            <TooltipContent>
+              {canReattach
+                ? "Reattach to side panel"
+                : "Unable to attach. The original tab is closed or no active window is available."}
+            </TooltipContent>
           </Tooltip>
         )}
         <ChatPicker
@@ -492,6 +560,7 @@ export default function App() {
           onNewConversation={handleNewConversation}
           showHeader={false}
           isPopupMode={isPopupMode}
+          isGlobalChat={isGlobalChat}
           originWindowId={isPopupMode ? originWindowId : null}
           originTabId={isPopupMode ? originTabId : null}
           originUrl={isPopupMode ? originUrl : null}

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -154,6 +154,19 @@ export const chatDb = {
       todos: [],
       ...conv,
     });
+    // Broadcast so other extension contexts (home tab, side panels, popups)
+    // can refresh their conversation lists. Always sidebar-relevant.
+    try {
+      chrome.runtime
+        ?.sendMessage?.({
+          type: "CONVERSATION_CREATED",
+          conversationId: conv.id,
+          spaceId: conv.spaceId,
+        })
+        ?.catch?.(() => {});
+    } catch {
+      // Non-extension context (tests). Safe to ignore.
+    }
   },
 
   async updateConversation(
@@ -164,6 +177,27 @@ export const chatDb = {
     const existing = await db.get("conversations", id);
     if (existing) {
       await db.put("conversations", { ...existing, ...updates });
+    }
+    // Only broadcast for fields that materially affect conversation-list UIs.
+    // Excludes high-frequency churn like `updatedAt` (per message turn),
+    // `ownedTabIds`/`ownedGroupId` (tab-scoping reconciliation), and `todos`
+    // (per agent step). Same-window UIs don't refetch on those either, so
+    // broadcasting them would make cross-window behavior more aggressive
+    // than same-window — wrong direction.
+    const sidebarRelevant =
+      updates.title !== undefined || updates.spaceId !== undefined;
+    if (sidebarRelevant) {
+      try {
+        chrome.runtime
+          ?.sendMessage?.({
+            type: "CONVERSATION_UPDATED",
+            conversationId: id,
+            fields: Object.keys(updates),
+          })
+          ?.catch?.(() => {});
+      } catch {
+        // Non-extension context (tests). Safe to ignore.
+      }
     }
   },
 

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -179,6 +179,18 @@ export const chatDb = {
       cursor = await cursor.continue();
     }
     await tx.done;
+    // Broadcast so other extension contexts (popups, side panels, home tab)
+    // can react to a conversation disappearing — e.g. the global chat popup
+    // resetting to a fresh chat if the deleted conversation was active.
+    // chrome.runtime.sendMessage does not deliver to the sender, so the
+    // calling UI doesn't double-handle (it already refreshes locally).
+    try {
+      chrome.runtime
+        ?.sendMessage?.({ type: "CONVERSATION_DELETED", conversationId: id })
+        ?.catch?.(() => {});
+    } catch {
+      // Non-extension context (e.g. unit tests). Safe to ignore.
+    }
   },
 
   async getMessages(

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -78,6 +78,13 @@ export default defineConfig({
         },
         description: "Open search overlay",
       },
+      "open-global-chat": {
+        suggested_key: {
+          default: "Alt+Space",
+          mac: "Alt+Space",
+        },
+        description: "Open Global AI chat popup",
+      },
       "open-chat": {
         suggested_key: {
           default: "Alt+I",


### PR DESCRIPTION
## Summary

Adds a Gemini-style global AI chat popup triggered by **Option+Space** (Alt+Space). Pressing the shortcut toggles a 420×700 popup window: opens when none exists, closes when focused, refocuses when visible but unfocused. Concurrent presses are coalesced via an in-flight lock to prevent orphaned windows.

The popup reuses the existing `sidepanel.html` in popup mode but is distinguished from the existing detached side-panel popup by a new `globalChat=true` URL param. State is preserved across dismiss/reopen cycles via `chrome.storage.session`: the active conversation id and unsent draft text are persisted only when scoped to `globalChat=true`, so the regular detached popup is unaffected.

## How it works

| Press Option+Space when… | Result |
|---|---|
| No popup exists | Creates 420×700 popup, restoring the last conversation if any |
| Popup is focused | Closes the popup (true disappear, not minimize) |
| Popup is visible but unfocused | Brings popup to front |
| Popup was closed manually | Falls through to "no popup" path on next press |

## Defense in depth

- **Stale conversation ids:** background validates that the persisted conversation id still exists in `chatDb` before passing it to the popup. The sidepanel App also resets to a fresh chat if a deleted conversation id is observed mid-session (e.g. deleted from another window).
- **Race conditions:** rapid Option+Space presses are coalesced via an `inFlight` promise lock so they can't spawn orphan popups or double-remove the same window.
- **Storage namespace isolation:** session-storage keys (\`globalChatLastConversationId\`, \`globalChatDraft\`) are only written/read when \`globalChat=true\`, never colliding with the existing detached side-panel popup flow.

## UX details

- **Window title:** popup windows now mirror the active conversation title in the OS title bar (falls back to \`OpenBrowse\` for new chats).
- **Reattach button:** the existing reattach button works in the global popup too — it sends the chat into your last-focused normal Chrome window. If no valid target exists, a Gemini-style error toast appears: *"Unable to attach. The original tab is closed or no active window is available."*
- **Settings:** new Keyboard Shortcuts section in the Settings page enumerates both \`Alt+I\` (side panel toggle) and \`Alt+Space\` (global popup), with a deep link to \`chrome://extensions/shortcuts\` and instructions for upgrading the popup shortcut to **Global** scope (required because Chrome restricts default global shortcuts to \`Ctrl+Shift+digit\`).

## Test Plan

- [x] Press Option+Space on a fresh install → opens 420×700 popup
- [x] Press Option+Space again while popup is focused → popup vanishes
- [x] Press Option+Space again → popup reopens with same conversation and draft
- [x] Press Option+Space while focused on another app → popup gains focus
- [x] Type a draft, switch conversations, press Option+Space twice → draft persists
- [x] Send a message → draft clears (does NOT reappear on next reopen)
- [x] Delete the active conversation in another window → popup resets to fresh chat
- [x] Click reattach button when no normal window is open → toast error appears
- [x] Click reattach with a normal window open → chat moves to that window's side panel
- [x] Confirm side-panel toggle (Alt+I) still works independently
- [x] Confirm detached side-panel popup still works as before