### PR TITLE
fix(agent): message-based compaction + reduce mid-task reluctance

### DIFF
--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import type { UIMessage } from "@ai-sdk/react";
+import type { AgentUIMessage } from "@/lib/types";
 import { Reasoning } from "@/components/ai-elements/reasoning";
 import { Markdown } from "./Markdown";
 import { MessageActions } from "./MessageActions";
@@ -9,7 +9,7 @@ import { capturedToolOrigins, allowToolOnSite } from "@/lib/agent/agent-transpor
 import "@/components/chat/tool-previews";
 
 interface AssistantMessageProps {
-  message: UIMessage;
+  message: AgentUIMessage;
   isStreaming?: boolean;
   onRegenerate?: () => void;
   onToolApproval?: (opts: { id: string; approved: boolean }) => void;

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,9 +1,9 @@
-import type { UIMessage } from "@ai-sdk/react";
+import type { AgentUIMessage } from "@/lib/types";
 import { AssistantMessage } from "./AssistantMessage";
 import { UserMessage } from "./UserMessage";
 
 interface ChatMessageProps {
-  message: UIMessage;
+  message: AgentUIMessage;
   isStreaming?: boolean;
   onRegenerate?: () => void;
   onToolApproval?: (opts: { id: string; approved: boolean }) => void;

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,5 +1,6 @@
 import { ChatInput, type TabMentionAttrs, type ImagePreview } from "./ChatInput";
 import { ChatMessage } from "./ChatMessage";
+import { CompactionDivider } from "./CompactionDivider";
 import { Logo } from "@/components/ui/logo";
 import {
   Conversation,
@@ -375,6 +376,59 @@ const providerModels = useMemo(() => {
               </div>
             )}
             {messages.map((message, i) => {
+              // Compaction-user message: replace the bubble with a
+              // CompactionDivider. The next assistant message in the
+              // stream is the summary; we render its text inside the
+              // divider's expand panel.
+              const compactionPart = message.parts.find(
+                (p) =>
+                  (p as Record<string, unknown>).type === "compaction",
+              ) as
+                | {
+                    type: "compaction";
+                    auto: boolean;
+                    overflow?: boolean;
+                  }
+                | undefined;
+              if (message.role === "user" && compactionPart) {
+                const next = messages[i + 1];
+                const summaryText =
+                  next?.role === "assistant"
+                    ? next.parts
+                        .filter(
+                          (p): p is { type: "text"; text: string } =>
+                            (p as { type: string }).type === "text",
+                        )
+                        .map((p) => p.text)
+                        .join("\n")
+                        .trim()
+                    : "";
+                return (
+                  <CompactionDivider
+                    key={message.id}
+                    summary={summaryText}
+                    hiddenCount={i}
+                    auto={compactionPart.auto}
+                    overflow={compactionPart.overflow}
+                  />
+                );
+              }
+
+              // Assistant summary message: hide from the main chat. Its
+              // content is shown via the divider's expand toggle. We
+              // detect it structurally — the previous message is a
+              // compaction-user.
+              const prev = messages[i - 1];
+              const prevIsCompactionUser =
+                prev?.role === "user" &&
+                prev.parts.some(
+                  (p) =>
+                    (p as Record<string, unknown>).type === "compaction",
+                );
+              if (message.role === "assistant" && prevIsCompactionUser) {
+                return null;
+              }
+
               const isLastAssistant =
                 message.role === "assistant" &&
                 isStreaming &&

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -24,7 +24,6 @@ import {
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TodoPanel } from "./TodoPanel";
-import type { CompactionPart } from "@/lib/types";
 
 interface ChatViewProps {
   conversationId: string | null;
@@ -35,6 +34,18 @@ interface ChatViewProps {
   showBackButton?: boolean;
   onBack?: () => void;
   showHeader?: boolean;
+  /**
+   * Optional handler for the header's settings button. Only relevant when
+   * `showHeader` is true; the button is rendered unconditionally inside the
+   * header but is a no-op without this handler.
+   */
+  onSettingsClick?: () => void;
+  /**
+   * Optional handler for the header's close button. The button only renders
+   * when this prop is supplied (header use cases without a close action,
+   * e.g. embedded panes, simply omit it).
+   */
+  onClose?: () => void;
   /**
    * Whether this ChatView is being rendered inside a detached popover window.
    * When true, the "Sharing [tab]" pill is anchored to the origin tab the
@@ -68,6 +79,8 @@ export function ChatView({
   showBackButton,
   onBack,
   showHeader = true,
+  onSettingsClick,
+  onClose,
   isPopupMode = false,
   originWindowId,
   originTabId,
@@ -304,14 +317,16 @@ const providerModels = useMemo(() => {
             >
               <MessageSquarePlus className="size-3.5" />
             </button>
-            <button
-              type="button"
-              onClick={onSettingsClick}
-              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-              title="Settings"
-            >
-              <Settings2 className="size-3.5" />
-            </button>
+            {onSettingsClick && (
+              <button
+                type="button"
+                onClick={onSettingsClick}
+                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                title="Settings"
+              >
+                <Settings2 className="size-3.5" />
+              </button>
+            )}
             {onClose && (
               <button
                 type="button"
@@ -381,18 +396,15 @@ const providerModels = useMemo(() => {
               // CompactionDivider. The next assistant message in the
               // stream is the summary; we render its text inside the
               // divider's expand panel.
-              const compactionPart = (
-                message.parts as unknown as CompactionPart[]
-              ).find((p) => p.type === "data-compaction");
+              const compactionPart = message.parts.find(
+                (p) => p.type === "data-compaction",
+              );
               if (message.role === "user" && compactionPart) {
                 const next = messages[i + 1];
                 const summaryText =
                   next?.role === "assistant"
                     ? next.parts
-                        .filter(
-                          (p): p is { type: "text"; text: string } =>
-                            (p as { type: string }).type === "text",
-                        )
+                        .filter((p) => p.type === "text")
                         .map((p) => p.text)
                         .join("\n")
                         .trim()

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -24,6 +24,7 @@ import {
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TodoPanel } from "./TodoPanel";
+import type { CompactionPart } from "@/lib/types";
 
 interface ChatViewProps {
   conversationId: string | null;
@@ -380,16 +381,9 @@ const providerModels = useMemo(() => {
               // CompactionDivider. The next assistant message in the
               // stream is the summary; we render its text inside the
               // divider's expand panel.
-              const compactionPart = message.parts.find(
-                (p) =>
-                  (p as Record<string, unknown>).type === "compaction",
-              ) as
-                | {
-                    type: "compaction";
-                    auto: boolean;
-                    overflow?: boolean;
-                  }
-                | undefined;
+              const compactionPart = (
+                message.parts as unknown as CompactionPart[]
+              ).find((p) => p.type === "data-compaction");
               if (message.role === "user" && compactionPart) {
                 const next = messages[i + 1];
                 const summaryText =
@@ -408,8 +402,8 @@ const providerModels = useMemo(() => {
                     key={message.id}
                     summary={summaryText}
                     hiddenCount={i}
-                    auto={compactionPart.auto}
-                    overflow={compactionPart.overflow}
+                    auto={compactionPart.data.auto}
+                    overflow={compactionPart.data.overflow}
                   />
                 );
               }
@@ -421,10 +415,7 @@ const providerModels = useMemo(() => {
               const prev = messages[i - 1];
               const prevIsCompactionUser =
                 prev?.role === "user" &&
-                prev.parts.some(
-                  (p) =>
-                    (p as Record<string, unknown>).type === "compaction",
-                );
+                prev.parts.some((p) => p.type === "data-compaction");
               if (message.role === "assistant" && prevIsCompactionUser) {
                 return null;
               }

--- a/src/components/chat/CompactionDivider.tsx
+++ b/src/components/chat/CompactionDivider.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Scissors } from "lucide-react";
+import { Markdown } from "./Markdown";
+
+interface CompactionDividerProps {
+  /**
+   * Plain-text summary that the LLM sees in place of the compacted head.
+   * Empty string is acceptable (e.g. if the compaction was triggered by a
+   * pruning-only fast path with no LLM-generated narrative).
+   */
+  summary: string;
+  /** Number of messages that came before the compaction boundary. */
+  hiddenCount: number;
+  /** True when the compaction was auto-triggered by the token threshold. */
+  auto: boolean;
+  /** True when triggered by a context-overflow API error path. */
+  overflow?: boolean;
+}
+
+/**
+ * Visual marker shown in the chat stream where the conversation was
+ * compacted. The full message history remains in the UI; this divider
+ * indicates which messages have been replaced by a summary in what gets
+ * sent to the model.
+ *
+ * Click the band to expand and read the summary that the LLM now sees in
+ * place of the compacted head.
+ *
+ * The same component renders for every trigger source (auto post-turn,
+ * mid-stream, manual /compact, overflow recovery) — only the small
+ * subtitle next to the count changes, so users always see a consistent
+ * UI.
+ */
+export function CompactionDivider({
+  summary,
+  hiddenCount,
+  auto,
+  overflow,
+}: CompactionDividerProps) {
+  const [expanded, setExpanded] = useState(false);
+  const countLabel =
+    hiddenCount === 1
+      ? "Compacted 1 earlier message"
+      : `Compacted ${hiddenCount} earlier messages`;
+  const reasonLabel = overflow
+    ? "context overflow"
+    : auto
+      ? "auto"
+      : "manual";
+  const hasSummary = summary.trim().length > 0;
+
+  return (
+    <div className="my-3">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="group flex w-full items-center gap-2 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+        aria-expanded={expanded}
+        aria-label={
+          expanded ? "Hide compaction summary" : "Show compaction summary"
+        }
+      >
+        <div className="h-px flex-1 bg-border transition-colors group-hover:bg-foreground/30" />
+        <Scissors className="size-3 shrink-0" />
+        <span className="whitespace-nowrap">
+          {countLabel} <span className="opacity-60">({reasonLabel})</span>
+        </span>
+        {expanded ? (
+          <ChevronUp className="size-3 shrink-0" />
+        ) : (
+          <ChevronDown className="size-3 shrink-0" />
+        )}
+        <div className="h-px flex-1 bg-border transition-colors group-hover:bg-foreground/30" />
+      </button>
+      {expanded && (
+        <div className="mt-2 rounded-md border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+            Summary sent to the model
+          </div>
+          {hasSummary ? (
+            <Markdown
+              source={summary}
+              className="text-xs [&_h2]:!text-xs [&_h2]:!font-semibold [&_h2]:!mt-2 [&_h2]:!mb-1 [&_ul]:!my-1 [&_p]:!my-1"
+            />
+          ) : (
+            <p className="italic text-muted-foreground/70">
+              No summary text — the head was reduced by pruning oversized
+              tool outputs only.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/MessageActions.tsx
+++ b/src/components/chat/MessageActions.tsx
@@ -1,4 +1,4 @@
-import type { UIMessage } from "@ai-sdk/react";
+import type { AgentUIMessage } from "@/lib/types";
 import { Check, Copy, RefreshCw } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 
 interface MessageActionsProps {
-  message: UIMessage;
+  message: AgentUIMessage;
   onRegenerate?: () => void;
 }
 

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -1,4 +1,4 @@
-import type { UIMessage } from "@ai-sdk/react";
+import type { AgentUIMessage } from "@/lib/types";
 import { Check, Copy, Pencil } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -6,7 +6,7 @@ import { ReadOnlyEditor } from "@/components/tiptap/ReadOnlyEditor";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 
 interface UserMessageProps {
-  message: UIMessage;
+  message: AgentUIMessage;
   onEdit?: () => void;
   dimmed?: boolean;
 }

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -20,7 +20,6 @@ import {
   shouldDebounceCompaction,
   MIN_MESSAGES_FOR_COMPACTION,
 } from "@/lib/agent/compaction";
-import type { CompactionPart } from "@/lib/types";
 import {
   type TabMentionAttrs,
   type ImagePreview,
@@ -37,6 +36,8 @@ import type {
   SerializedUIPart,
   Settings,
   ThinkingConfig,
+  AgentUIMessage,
+  CompactionPart,
 } from "@/lib/types";
 import { Chat, useChat } from "@ai-sdk/react";
 import {
@@ -50,11 +51,10 @@ import type {
   SourceUrlUIPart,
   StepStartUIPart,
   TextUIPart,
-  UIMessage,
 } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-type AgentMessage = UIMessage;
+type AgentMessage = AgentUIMessage;
 
 interface UseAgentChatOptions {
   conversationId: string | null;
@@ -94,6 +94,9 @@ function serializeParts(parts: AgentMessage["parts"]): SerializedUIPart[] {
         ];
       case "step-start":
         return [{ type: "step-start" }];
+      case "data-compaction":
+        // `part.data` is `CompactionData` thanks to AgentDataParts.
+        return [{ type: "data-compaction", data: part.data }];
       case "dynamic-tool":
         return [
           {
@@ -164,6 +167,10 @@ function deserializePart(
       } satisfies SourceUrlUIPart;
     case "step-start":
       return { type: "step-start" } satisfies StepStartUIPart;
+    case "data-compaction":
+      // Reuse the shared `CompactionPart` shape — by construction it
+      // matches the data-compaction variant of `AgentMessage["parts"][number]`.
+      return { type: "data-compaction", data: p.data } satisfies CompactionPart;
     case "dynamic-tool":
       return deserializeToolPart(p);
     default:

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -8,7 +8,6 @@ import {
   resetTokenTracking,
   getCurrentModelDef,
   setCurrentModelDef,
-  assembleMessagesForLLM,
 } from "@/lib/agent/agent-transport";
 import { setAgentActive, setAgentInactive } from "@/lib/active-agents";
 import {
@@ -17,11 +16,13 @@ import {
   buildCompactionPrompt,
   getCompactionSystemPrompt,
   prepareMessagesForSummarization,
-  shouldStopCompacting,
+  estimateMessageTokens,
+  findCompactionEvents,
+  shouldDebounceCompaction,
   MIN_MESSAGES_FOR_COMPACTION,
   getUsableTokens,
 } from "@/lib/agent/compaction";
-import type { CompactionState } from "@/lib/types";
+import type { CompactionPart } from "@/lib/types";
 import {
   type TabMentionAttrs,
   type ImagePreview,
@@ -314,6 +315,10 @@ export function useAgentChat({
     }
   }, []);
   const [isCompacting, setIsCompacting] = useState(false);
+  // AbortController for the in-flight compaction summary call. The chat's
+  // `stop()` cancels the agent stream; this cancels the summarization
+  // LLM call separately.
+  const compactionAbortRef = useRef<AbortController | null>(null);
   const conversationIdRef = useRef(conversationId);
   conversationIdRef.current = conversationId;
 
@@ -437,25 +442,53 @@ export function useAgentChat({
     sendMessage,
     regenerate,
     status,
-    stop,
+    stop: chatStop,
     error,
     clearError,
     addToolApprovalResponse,
   } = useChat<AgentMessage>({ chat });
+
+  // Wrap the chat's stop() so it also aborts any in-flight compaction
+  // summarization call. Without this, clicking Stop while a summary is
+  // generating would silently let the LLM call continue and write a
+  // compaction event into the chat after the user thought they had
+  // cancelled.
+  const stop = useCallback(() => {
+    compactionAbortRef.current?.abort();
+    chatStop();
+  }, [chatStop]);
 
   const isLoading = status === "submitted" || status === "streaming";
   const isStreaming = status === "streaming";
   const wasStreamingRef = useRef(false);
 
   const runCompaction = useCallback(
-    async (convId: string, msgs: AgentMessage[]) => {
+    async (
+      convId: string,
+      msgs: AgentMessage[],
+      opts?: { auto?: boolean; overflow?: boolean },
+    ) => {
       if (msgs.length < MIN_MESSAGES_FOR_COMPACTION) return;
 
-      const existingState = await chatDb.getCompactionState(convId);
-      if (shouldStopCompacting(existingState)) return;
+      // Time-based debounce thrash detection. If we just compacted within
+      // COMPACTION_DEBOUNCE_MS, don't compact again — covers the case
+      // where the produced summary itself overflows and would otherwise
+      // loop. Reads directly from the visible message list, so the UI
+      // and the runtime agree on what counts.
+      const dbMessages = await chatDb.getMessages(convId);
+      const events = findCompactionEvents(dbMessages);
+      if (shouldDebounceCompaction(events)) return;
 
+      const auto = opts?.auto ?? true;
+      const overflow = opts?.overflow ?? false;
+
+      const abortController = new AbortController();
+      compactionAbortRef.current = abortController;
       setIsCompacting(true);
       try {
+        // Build prunable view of the current chat for tail selection +
+        // summary input. We don't apply the result back to the chat —
+        // pruning at send time happens in CompactingChatTransport.
         const prunableMessages = msgs.map((m) => ({
           id: m.id,
           role: m.role,
@@ -466,74 +499,202 @@ export function useAgentChat({
         const { pruned, freedTokens } = pruneMessageParts(prunableMessages);
         const modelDef = getCurrentModelDef();
 
-        // Check if pruning alone is enough
+        // Phase 1 fast path: if pruning oversized tool outputs alone gets
+        // us comfortably under the threshold, skip the LLM summary call
+        // entirely. We still write a CompactionPart marker so the UI
+        // renders a divider AND the transport's send-time pruning takes
+        // effect. The marker carries an empty/sentinel summary in this
+        // case (assistant message has empty text); the divider expand
+        // will show that pruning happened without an LLM-generated
+        // narrative.
+        let summaryText = "";
+        let prunedOnly = false;
         if (freedTokens > 0) {
           const currentTokens = prunableMessages.reduce(
-            (sum, m) => sum + m.parts.reduce((s, p) => s + (p.type === "text" ? p.text.length / 4 : 50), 0),
+            (sum, m) => sum + estimateMessageTokens(m.parts),
             0,
           );
-          const estimatedAfterPrune = currentTokens - freedTokens;
           const usable = getUsableTokens(modelDef);
-          if (estimatedAfterPrune < usable) {
-            const state: CompactionState = {
-              conversationId: convId,
-              summary: existingState?.summary ?? "",
-              tailStartMessageId: pruned[pruned.length - 1]?.id ?? "",
-              previousSummary: existingState?.previousSummary,
-              compactedAt: Date.now(),
-              attempts: existingState ? existingState.attempts : 0,
-            };
-            await chatDb.saveCompactionState(state);
-            return;
+          if (currentTokens - freedTokens < usable) {
+            prunedOnly = true;
           }
         }
 
-        // Phase 2: Summarize via LLM
+        // Compute tail boundary in either path — needed both to skip the
+        // summary on the prune-only path AND to write a meaningful
+        // tailStartMessageId on the CompactionPart so future compactions
+        // can stack on top.
         const { headMessages, tailStartId } = selectTail(pruned, modelDef);
         if (!tailStartId || headMessages.length === 0) return;
 
-        const conversationText = prepareMessagesForSummarization(headMessages);
-        const userPrompt = buildCompactionPrompt(existingState?.summary);
+        if (!prunedOnly) {
+          const conversationText = prepareMessagesForSummarization(headMessages);
+          // Carry the previous summary forward so the new one is an
+          // anchored update, not a fresh start. OpenCode does the same
+          // via `previousSummary` in their compaction prompt.
+          const previousSummary = events.at(-1)?.summaryText;
+          const userPrompt = buildCompactionPrompt(previousSummary);
 
-        const { generateText } = await import("ai");
-        const agentSettingsForCompaction = await storage.getAgentSettings();
-        const settingsForCompaction = await storage.getSettings();
-        const compactionModelId = agentSettingsForCompaction.compactionModel || agentSettingsForCompaction.agentModel;
+          const { generateText } = await import("ai");
+          const agentSettingsForCompaction = await storage.getAgentSettings();
+          const settingsForCompaction = await storage.getSettings();
+          const compactionModelId =
+            agentSettingsForCompaction.compactionModel ||
+            agentSettingsForCompaction.agentModel;
 
-        // Resolve provider and create model
-        const { providers } = await import("@/registry/providers");
-        const provider = providers.find((p) => p.models.some((m) => m.id === compactionModelId));
-        if (!provider) return;
+          const { providers } = await import("@/registry/providers");
+          const provider = providers.find((p) =>
+            p.models.some((m) => m.id === compactionModelId),
+          );
+          if (!provider) return;
 
-        const config = settingsForCompaction.providerConfigs[provider.id] ?? {};
-        const compactionModel = provider.createLanguageModel(config, compactionModelId);
+          const config =
+            settingsForCompaction.providerConfigs[provider.id] ?? {};
+          const compactionModel = provider.createLanguageModel(
+            config,
+            compactionModelId,
+          );
 
-        const result = await generateText({
-          model: compactionModel,
-          system: getCompactionSystemPrompt(),
-          prompt: conversationText + "\n\n" + userPrompt,
+          const result = await generateText({
+            model: compactionModel,
+            system: getCompactionSystemPrompt(),
+            prompt: conversationText + "\n\n" + userPrompt,
+            abortSignal: abortController.signal,
+          });
+          summaryText = result.text;
+        }
+
+        // If the user aborted while the summary call was in flight, bail
+        // before persisting anything.
+        if (abortController.signal.aborted) return;
+
+        // Persist the compaction event as two messages.
+        const now = Date.now();
+        const compactionUserId = generateId();
+        const summaryAssistantId = generateId();
+
+        const compactionPart: CompactionPart = {
+          type: "compaction",
+          auto,
+          ...(overflow ? { overflow: true } : {}),
+          tailStartMessageId: tailStartId,
+        };
+
+        await chatDb.saveMessage({
+          id: compactionUserId,
+          conversationId: convId,
+          role: "user",
+          content: "",
+          parts: [compactionPart],
+          createdAt: now,
         });
 
-        const summary = result.text;
-        const state: CompactionState = {
+        const summaryParts: SerializedUIPart[] = summaryText
+          ? [{ type: "text", text: summaryText }]
+          : [];
+        await chatDb.saveMessage({
+          id: summaryAssistantId,
           conversationId: convId,
-          summary,
-          tailStartMessageId: tailStartId,
-          previousSummary: existingState?.summary,
-          compactedAt: Date.now(),
-          attempts: existingState ? existingState.attempts + 1 : 0,
-        };
-        await chatDb.saveCompactionState(state);
+          role: "assistant",
+          content: summaryText,
+          parts: summaryParts,
+          createdAt: now + 1,
+          summary: true,
+        });
 
-        // Silent continue
-        sendMessage({ text: "Continue where you left off, or ask for clarification if unsure how to proceed." });
+        // Reflect both new messages in the chat instance so the UI
+        // updates immediately and so `sendMessage("Continue...")` below
+        // sees them in the messages array.
+        const compactionUiMsg: AgentMessage = {
+          id: compactionUserId,
+          role: "user",
+          parts: [
+            // The CompactionPart is a custom marker, not part of the AI
+            // SDK's UIMessage union. We carry it through the transport
+            // and the UI as an opaque part — both sides know to look
+            // for `type === "compaction"`.
+            compactionPart as unknown as AgentMessage["parts"][number],
+          ],
+        };
+        const summaryUiMsg: AgentMessage = {
+          id: summaryAssistantId,
+          role: "assistant",
+          parts: summaryText
+            ? [{ type: "text", text: summaryText }]
+            : [],
+        };
+        setMessages([...msgs, compactionUiMsg, summaryUiMsg]);
+
+        // Auto-continue: send a synthetic user message asking the agent
+        // to resume. Manual /compact (follow-up) would skip this. The
+        // wording matches OpenCode's continue prompt.
+        if (auto) {
+          // Auto-deny any pending approvals that would otherwise leave
+          // the conversation in an invalid tool_use-without-tool_result
+          // state when we send the continue message. Mirrors the same
+          // logic in handleSubmit.
+          const hasPending = msgs.some((m) =>
+            m.parts.some(
+              (p) =>
+                ((p as Record<string, unknown>).type === "dynamic-tool" ||
+                  (typeof (p as Record<string, unknown>).type === "string" &&
+                    ((p as Record<string, unknown>).type as string).startsWith(
+                      "tool-",
+                    ))) &&
+                (p as Record<string, unknown>).state === "approval-requested",
+            ),
+          );
+          if (hasPending) {
+            const reason = "Superseded by auto-compaction continue";
+            setMessages((prev) =>
+              prev.map((msg) => ({
+                ...msg,
+                parts: msg.parts.map((part) => {
+                  const p = part as Record<string, unknown>;
+                  const isTool =
+                    p.type === "dynamic-tool" ||
+                    (typeof p.type === "string" &&
+                      (p.type as string).startsWith("tool-"));
+                  if (isTool && p.state === "approval-requested" && p.approval) {
+                    const approval = p.approval as { id: string };
+                    return {
+                      ...part,
+                      state: "output-denied",
+                      approval: {
+                        id: approval.id,
+                        approved: false,
+                        reason,
+                      },
+                    } as typeof part;
+                  }
+                  return part;
+                }),
+              })),
+            );
+          }
+
+          const continueText = overflow
+            ? "The previous request exceeded the context window. The conversation was compacted. Continue where you left off, or ask for clarification if unsure how to proceed."
+            : "Continue where you left off, or ask for clarification if unsure how to proceed.";
+          sendMessage({ text: continueText });
+        }
       } catch (err) {
+        if (
+          (err as { name?: string })?.name === "AbortError" ||
+          abortController.signal.aborted
+        ) {
+          // User-initiated stop — silent.
+          return;
+        }
         console.error("[compaction] failed:", err);
       } finally {
+        if (compactionAbortRef.current === abortController) {
+          compactionAbortRef.current = null;
+        }
         setIsCompacting(false);
       }
     },
-    [sendMessage],
+    [sendMessage, setMessages],
   );
 
   useEffect(() => {
@@ -545,9 +706,14 @@ export function useAgentChat({
       resetAgentIndicator();
       if (conversationId) setAgentInactive(conversationId);
 
-      // Check if compaction is needed after response completes
+      // Check if compaction is needed after response completes. This
+      // covers both true inter-turn compaction and mid-stream compaction
+      // (where `stopWhen` in agent-transport caused the agent loop to
+      // exit early at a step boundary because tokens crossed the
+      // threshold). Either way, status flips out of streaming and we
+      // land here.
       if (conversationId && needsCompaction() && messages.length >= MIN_MESSAGES_FOR_COMPACTION) {
-        runCompaction(conversationId, messages);
+        runCompaction(conversationId, messages, { auto: true });
       }
     }
   }, [status, conversationId, messages, runCompaction]);
@@ -570,7 +736,13 @@ export function useAgentChat({
     return () => chrome.runtime.onMessage.removeListener(listener);
   }, [isLoading, stop]);
 
-  // Detect context overflow errors and auto-trigger compaction
+  // Detect context overflow errors and auto-trigger compaction.
+  //
+  // Thrash detection is done inside `runCompaction` itself
+  // (`shouldDebounceCompaction`), which reads the latest completed
+  // compaction event from the visible message list. So no per-state
+  // counter to track here — if a compaction just completed and another
+  // overflow fires, the debounce will skip the retry.
   useEffect(() => {
     if (!error || !conversationId) return;
     const msg = error.message?.toLowerCase() ?? "";
@@ -582,7 +754,7 @@ export function useAgentChat({
       msg.includes("exceeds");
     if (isOverflow && messages.length >= MIN_MESSAGES_FOR_COMPACTION) {
       clearError();
-      runCompaction(conversationId, messages);
+      runCompaction(conversationId, messages, { auto: true, overflow: true });
     }
   }, [error, conversationId, messages, clearError, runCompaction]);
 
@@ -598,6 +770,19 @@ export function useAgentChat({
   // Keying off `chat` identity guarantees we reload from DB whenever a new
   // Chat instance is selected.
   const prevLoadedChatRef = useRef<Chat<AgentMessage> | null>(null);
+
+  // Reset per-conversation tracking when the active conversation changes.
+  // Token tracking lives in agent-transport as a module global; without
+  // this reset, switching conversations carries the previous
+  // conversation's last-step token count into needsCompaction() until the
+  // next streaming step overwrites it.
+  //
+  // Compaction state itself is no longer cached in React state — the
+  // renderer derives it from the messages array via `findCompactionEvents`,
+  // and `runCompaction` reads from the DB on demand for thrash debounce.
+  useEffect(() => {
+    resetTokenTracking();
+  }, [conversationId]);
 
   // Load messages from DB when conversation changes
   useEffect(() => {
@@ -621,13 +806,13 @@ export function useAgentChat({
         setMessages(uiMsgs);
         const lastMsg = uiMsgs[uiMsgs.length - 1];
         if (lastMsg.role === "user" && transport) {
-          const conversationTexts = msgs
-            .map((m) => m.content)
-            .filter(Boolean);
-          assembleMessagesForLLM(conversationId, conversationTexts).then((assembled) => {
-            resolveHostTabId().then((hostTabId) => {
-              setAgentContext(conversationId, assembled, hostTabId);
-            });
+          // Bind the panel's host tab so the agent has a working target on
+          // its first tab tool call. Compaction-aware message assembly now
+          // lives in the transport, so we no longer prefilter the message
+          // list here — the wrapper reads chatDb compaction state at
+          // send-time.
+          resolveHostTabId().then((hostTabId) => {
+            setAgentContext(conversationId, hostTabId);
           });
           sendMessage();
         }
@@ -763,13 +948,10 @@ export function useAgentChat({
         url: img.dataUrl,
       }));
 
-      const existingMessages = messages
-        .map((m) => m.parts.filter((p) => p.type === "text").map((p) => (p as { text: string }).text).join(""))
-        .filter(Boolean);
-      assembleMessagesForLLM(convId, [...existingMessages, baseText]).then((assembled) => {
-        resolveHostTabId().then((hostTabId) => {
-          setAgentContext(convId, assembled, hostTabId);
-        });
+      // Compaction-aware message assembly now lives in the transport. Here
+      // we just bind the host tab so tool calls have a default target.
+      resolveHostTabId().then((hostTabId) => {
+        setAgentContext(convId, hostTabId);
       });
 
       if (isNew) {

--- a/src/hooks/useAgentChat.ts
+++ b/src/hooks/useAgentChat.ts
@@ -16,11 +16,9 @@ import {
   buildCompactionPrompt,
   getCompactionSystemPrompt,
   prepareMessagesForSummarization,
-  estimateMessageTokens,
   findCompactionEvents,
   shouldDebounceCompaction,
   MIN_MESSAGES_FOR_COMPACTION,
-  getUsableTokens,
 } from "@/lib/agent/compaction";
 import type { CompactionPart } from "@/lib/types";
 import {
@@ -215,7 +213,7 @@ const chatInstances = new Map<string, ChatInstance>();
 
 function getOrCreateChat(
   conversationId: string,
-  transport: ChatTransport<UIMessage> | null,
+  transport: ChatTransport<AgentMessage> | null,
   origin: "sidepanel" | "home" = "sidepanel",
 ): Chat<AgentMessage> {
   const existing = chatInstances.get(conversationId);
@@ -280,7 +278,7 @@ function getOrCreateChat(
 }
 
 // A "null" chat for when there's no active conversation
-function createNullChat(transport: ChatTransport<UIMessage> | null): Chat<AgentMessage> {
+function createNullChat(transport: ChatTransport<AgentMessage> | null): Chat<AgentMessage> {
   return new Chat<AgentMessage>({
     transport: transport ?? undefined,
     generateId,
@@ -402,7 +400,7 @@ export function useAgentChat({
     });
   }, [agentSettings.agentModel]);
 
-  const [transport, setTransport] = useState<ChatTransport<UIMessage> | null>(null);
+  const [transport, setTransport] = useState<ChatTransport<AgentMessage> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -496,77 +494,77 @@ export function useAgentChat({
           createdAt: 0,
         }));
 
-        const { pruned, freedTokens } = pruneMessageParts(prunableMessages);
+        const { pruned } = pruneMessageParts(prunableMessages);
         const modelDef = getCurrentModelDef();
 
-        // Phase 1 fast path: if pruning oversized tool outputs alone gets
-        // us comfortably under the threshold, skip the LLM summary call
-        // entirely. We still write a CompactionPart marker so the UI
-        // renders a divider AND the transport's send-time pruning takes
-        // effect. The marker carries an empty/sentinel summary in this
-        // case (assistant message has empty text); the divider expand
-        // will show that pruning happened without an LLM-generated
-        // narrative.
-        let summaryText = "";
-        let prunedOnly = false;
-        if (freedTokens > 0) {
-          const currentTokens = prunableMessages.reduce(
-            (sum, m) => sum + estimateMessageTokens(m.parts),
-            0,
-          );
-          const usable = getUsableTokens(modelDef);
-          if (currentTokens - freedTokens < usable) {
-            prunedOnly = true;
-          }
-        }
-
-        // Compute tail boundary in either path — needed both to skip the
-        // summary on the prune-only path AND to write a meaningful
-        // tailStartMessageId on the CompactionPart so future compactions
-        // can stack on top.
+        // Compute the tail boundary. The CompactionPart will anchor here so
+        // the transport's filterCompactedMessages knows where to keep the
+        // verbatim tail and where to drop the head.
         const { headMessages, tailStartId } = selectTail(pruned, modelDef);
         if (!tailStartId || headMessages.length === 0) return;
 
-        if (!prunedOnly) {
-          const conversationText = prepareMessagesForSummarization(headMessages);
-          // Carry the previous summary forward so the new one is an
-          // anchored update, not a fresh start. OpenCode does the same
-          // via `previousSummary` in their compaction prompt.
-          const previousSummary = events.at(-1)?.summaryText;
-          const userPrompt = buildCompactionPrompt(previousSummary);
+        // Always run summarization. We previously had a "prune-only fast
+        // path" that skipped the LLM call when pruning would free enough
+        // tokens, writing a compaction event with an empty summary
+        // assistant message. That broke the AI SDK's Zod validation
+        // ("Message must contain at least one part") on the next send and
+        // produced no real benefit — `prunePartsAtSendTime` already runs
+        // unconditionally on every send via the transport, more
+        // aggressively than `pruneMessages` (no PRUNE_PROTECT budget). So
+        // the only effect of the fast path was a useless empty message.
+        //
+        // OpenCode treats pruning as a separate, silent operation from
+        // compaction events; we now match that. If the threshold check
+        // triggered runCompaction, we always summarize.
+        const conversationText = prepareMessagesForSummarization(headMessages);
+        // Carry the previous summary forward so the new one is an
+        // anchored update, not a fresh start. OpenCode does the same
+        // via `previousSummary` in their compaction prompt.
+        const previousSummary = events.at(-1)?.summaryText;
+        const userPrompt = buildCompactionPrompt(previousSummary);
 
-          const { generateText } = await import("ai");
-          const agentSettingsForCompaction = await storage.getAgentSettings();
-          const settingsForCompaction = await storage.getSettings();
-          const compactionModelId =
-            agentSettingsForCompaction.compactionModel ||
-            agentSettingsForCompaction.agentModel;
+        const { generateText } = await import("ai");
+        const agentSettingsForCompaction = await storage.getAgentSettings();
+        const settingsForCompaction = await storage.getSettings();
+        const compactionModelId =
+          agentSettingsForCompaction.compactionModel ||
+          agentSettingsForCompaction.agentModel;
 
-          const { providers } = await import("@/registry/providers");
-          const provider = providers.find((p) =>
-            p.models.some((m) => m.id === compactionModelId),
-          );
-          if (!provider) return;
+        const { providers } = await import("@/registry/providers");
+        const provider = providers.find((p) =>
+          p.models.some((m) => m.id === compactionModelId),
+        );
+        if (!provider) return;
 
-          const config =
-            settingsForCompaction.providerConfigs[provider.id] ?? {};
-          const compactionModel = provider.createLanguageModel(
-            config,
-            compactionModelId,
-          );
+        const config =
+          settingsForCompaction.providerConfigs[provider.id] ?? {};
+        const compactionModel = provider.createLanguageModel(
+          config,
+          compactionModelId,
+        );
 
-          const result = await generateText({
-            model: compactionModel,
-            system: getCompactionSystemPrompt(),
-            prompt: conversationText + "\n\n" + userPrompt,
-            abortSignal: abortController.signal,
-          });
-          summaryText = result.text;
-        }
+        const result = await generateText({
+          model: compactionModel,
+          system: getCompactionSystemPrompt(),
+          prompt: conversationText + "\n\n" + userPrompt,
+          abortSignal: abortController.signal,
+        });
+        const summaryText = result.text.trim();
 
         // If the user aborted while the summary call was in flight, bail
         // before persisting anything.
         if (abortController.signal.aborted) return;
+
+        // Defensive: if the model returned empty text, don't persist a
+        // compaction event with an empty assistant message — that would
+        // fail Zod validation on subsequent sends. Just abort the
+        // compaction silently; the next overflow trigger will retry.
+        if (!summaryText) {
+          console.warn(
+            "[compaction] summary model returned empty text; skipping event",
+          );
+          return;
+        }
 
         // Persist the compaction event as two messages.
         const now = Date.now();
@@ -574,10 +572,12 @@ export function useAgentChat({
         const summaryAssistantId = generateId();
 
         const compactionPart: CompactionPart = {
-          type: "compaction",
-          auto,
-          ...(overflow ? { overflow: true } : {}),
-          tailStartMessageId: tailStartId,
+          type: "data-compaction",
+          data: {
+            auto,
+            ...(overflow ? { overflow: true } : {}),
+            tailStartMessageId: tailStartId,
+          },
         };
 
         await chatDb.saveMessage({
@@ -589,9 +589,9 @@ export function useAgentChat({
           createdAt: now,
         });
 
-        const summaryParts: SerializedUIPart[] = summaryText
-          ? [{ type: "text", text: summaryText }]
-          : [];
+        const summaryParts: SerializedUIPart[] = [
+          { type: "text", text: summaryText },
+        ];
         await chatDb.saveMessage({
           id: summaryAssistantId,
           conversationId: convId,
@@ -608,20 +608,12 @@ export function useAgentChat({
         const compactionUiMsg: AgentMessage = {
           id: compactionUserId,
           role: "user",
-          parts: [
-            // The CompactionPart is a custom marker, not part of the AI
-            // SDK's UIMessage union. We carry it through the transport
-            // and the UI as an opaque part — both sides know to look
-            // for `type === "compaction"`.
-            compactionPart as unknown as AgentMessage["parts"][number],
-          ],
+          parts: [compactionPart],
         };
         const summaryUiMsg: AgentMessage = {
           id: summaryAssistantId,
           role: "assistant",
-          parts: summaryText
-            ? [{ type: "text", text: summaryText }]
-            : [],
+          parts: [{ type: "text", text: summaryText }],
         };
         setMessages([...msgs, compactionUiMsg, summaryUiMsg]);
 

--- a/src/lib/agent/agent-transport.ts
+++ b/src/lib/agent/agent-transport.ts
@@ -6,7 +6,7 @@ import type {
   ToolSet,
   UIMessage,
 } from "ai";
-import { DirectChatTransport, ToolLoopAgent, tool } from "ai";
+import { ToolLoopAgent, tool } from "ai";
 import { z } from "zod";
 import { chatDb } from "../chat-db";
 import { getMcpRegistry } from "../mcp";
@@ -14,6 +14,7 @@ import { sendMcpMessage } from "../mcp/messages";
 import { memoryDb } from "../memory-db";
 import type { Settings } from "../types";
 import { shouldCompact } from "./compaction";
+import { CompactingChatTransport } from "./compacting-transport";
 import { clearHandles } from "./tab-handles";
 import {
   clickElementTool,
@@ -40,6 +41,16 @@ const SYSTEM_PROMPT = `You are OpenBrowse, an AI browser agent. You help users u
 
 You have tools to interact with the user's browser tabs. Tools automatically target the user's active browsing tab — you do NOT need to select or switch tabs unless the user asks to work with a different one.
 
+## Working autonomously
+
+Long tasks are normal — many browser tasks take 20+ tool calls. Plan with todoWrite, then work through the plan to completion.
+
+Do the task as asked. Do not propose a simpler version, do not offer "a quicker alternative", and do not substitute a less thorough approach to save effort. If the task is genuinely ambiguous, pick the most reasonable interpretation and proceed.
+
+Do not ask permission questions like "should I continue?", "want me to keep going?", or "would you like me to do X instead?". Pick the next step and take it. Course-correct if it turns out wrong.
+
+When you announce a tool call, make the tool call. Don't describe what you'd do and end your turn.
+
 ## Planning with todoWrite
 For tasks that require multiple steps or distinct objectives, call \`todoWrite\` BEFORE acting to lay out your steps.
 As you work:
@@ -49,7 +60,7 @@ As you work:
 - Cancel items that become irrelevant rather than silently skipping them
 - Before providing your final text response to the user, you MUST ensure all tasks in your plan are marked "completed" or "cancelled" via a final \`todoWrite\` call.
 
-Your current plan will be appended to your instructions at every turn. Keep it in sync with reality. You may skip this for trivial, single-action requests.
+Your current plan will be appended to your instructions at every turn. Keep it in sync with reality. You may skip this for trivial, single-action requests. For non-trivial tasks, expect 5-15 todo items shaped around outcomes (e.g. "Find the cheapest mechanical keyboard under $150") rather than individual clicks. Long plans are fine.
 
 ## Page Interaction Workflow
 
@@ -92,10 +103,10 @@ extract({
 - CSS selectors are a fallback only when refs are unavailable
 - Tabs are identified by handles (t1, t2, ...) from listTabs — use these with selectTab
 - Use scrollPage to see more content, then snapshot again to get updated refs
-- Do NOT call selectTab or navigate unless the user explicitly asks to switch pages or go somewhere
-- Do NOT navigate to URLs you have invented or guessed. If you don't know the exact URL, ask the user or interact with the page to find it.
-- If snapshot returns an empty result or refCount: 0, retry once; if still empty, fall back to screenshot for visual context
-- Be concise. Prefer tool calls over guessing.
+- Navigate when the task requires it. Don't switch tabs gratuitously, but don't refuse to navigate just because the user didn't say "navigate".
+- Don't navigate to URLs you have invented or guessed. Find the URL by searching on the page, following links, or running a Google query. Asking the user is a fallback, not the first step.
+- If snapshot returns an empty result or refCount: 0, try another approach: switch \`mode\` (viewport ↔ interactive), scope to a different selector, scrollPage and re-snapshot, or take a screenshot. Don't give up after a single retry.
+- Be concise in your text replies to the user. Take as many tool calls as the task needs.
 
 ## Code Execution
 
@@ -104,7 +115,16 @@ You have two tools for running JavaScript:
 - \`executeCode\`: Runs in an isolated sandbox. Use for computation, data transforms, API calls (fetch). No DOM access. Pass data via \`input\` parameter, access it as \`__input\` in your code. Use \`return\` to produce output.
 - \`executeOnPage\`: Runs in the active tab with full DOM/page access. Requires user approval. Use when you need to read or modify the page beyond what snapshot/clickElement/typeInElement provide — for example, scraping structured data from a product grid, or reading \`data-*\` attributes that don't appear in the accessibility tree.
 
-Prefer the existing browser tools (snapshot, clickElement, etc.) for simple interactions. Use executeOnPage only when you need complex multi-step DOM manipulation or need to access page JavaScript variables/state.`;
+Prefer the existing browser tools (snapshot, clickElement, etc.) for simple interactions. Use executeOnPage only when you need complex multi-step DOM manipulation or need to access page JavaScript variables/state.
+
+## Recovering from problems
+
+The biggest failure mode is giving up too early. Default to trying one more thing before reporting failure.
+
+- A click or type returned \`diff: null\` (no visible change): re-snapshot for fresh refs, then try a different element or selector.
+- The page is still loading: scroll or screenshot to wait, don't bail.
+- A tool errored: if the error looks transient, retry; if structural, change approach.
+- Don't retry the same exact tool call with the same input more than 2-3 times.`;
 
 const MEMORY_INSTRUCTIONS = `
 
@@ -339,7 +359,6 @@ let currentSpaceColor: string | null = null;
 let indicatorQueue: Promise<void> = Promise.resolve();
 
 let agentConversationId: string | null = null;
-let agentConversationMessages: string[] = [];
 // Tab id of the panel/popover that initiated this agent run. Used as the
 // implicit host tab to bind to a fresh conversation on the first tab tool
 // call (so the agent has a target without the user manually clicking
@@ -387,25 +406,21 @@ export function resetTokenTracking() {
 
 export function setAgentContext(
   conversationId: string | null,
-  messages: string[],
   hostTabId: number | null = null,
 ) {
   if (agentConversationId && agentConversationId !== conversationId) {
     clearHandles(agentConversationId);
   }
   agentConversationId = conversationId;
-  agentConversationMessages = messages;
   agentHostTabId = hostTabId;
 }
 
 export function getAgentContext(): {
   conversationId: string | null;
-  messages: string[];
   hostTabId: number | null;
 } {
   return {
     conversationId: agentConversationId,
-    messages: agentConversationMessages,
     hostTabId: agentHostTabId,
   };
 }
@@ -619,33 +634,6 @@ export function resetAgentIndicator() {
   }
 }
 
-export async function assembleMessagesForLLM(
-  conversationId: string,
-  messages: string[],
-): Promise<string[]> {
-  const compactionState = await chatDb.getCompactionState(conversationId);
-  if (!compactionState || !compactionState.summary) {
-    return messages;
-  }
-
-  const dbMessages = await chatDb.getMessages(conversationId);
-  const tailStartIdx = dbMessages.findIndex(
-    (m) => m.id === compactionState.tailStartMessageId,
-  );
-
-  if (tailStartIdx === -1) {
-    return messages;
-  }
-
-  const summaryContext = `[Previous conversation summary]\n${compactionState.summary}`;
-  const tailMessages = dbMessages
-    .slice(tailStartIdx)
-    .map((m) => m.content)
-    .filter(Boolean);
-
-  return [summaryContext, ...tailMessages];
-}
-
 export async function createAgentTransport(
   settings: Settings,
   agentModel: string,
@@ -828,6 +816,13 @@ export async function createAgentTransport(
     }
   }
 
+  // Per-stream "needs mid-stream compaction" signal. Set by `onStepFinish`
+  // when token usage crosses the threshold; read by `stopWhen` to break
+  // the loop after the current step completes (matching OpenCode's
+  // step-boundary behavior). Cleared at the start of each `sendMessages`
+  // by the wrapper transport so a previous turn's signal doesn't leak.
+  let needsMidStreamCompaction = false;
+
   const agent = new ToolLoopAgent({
     model,
     tools,
@@ -838,8 +833,21 @@ export async function createAgentTransport(
       if (usage.inputTokens != null || usage.outputTokens != null) {
         lastTotalTokens = (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
       }
+      // Once needsCompaction() reports true, set the flag so stopWhen
+      // breaks the loop at the next step boundary. We don't unset on a
+      // false read — once we've decided to compact, see the decision
+      // through.
+      if (needsCompaction()) {
+        needsMidStreamCompaction = true;
+      }
     },
+    stopWhen: () => needsMidStreamCompaction,
   });
 
-  return new DirectChatTransport({ agent }) as ChatTransport<UIMessage>;
+  return new CompactingChatTransport({
+    agent,
+    onSendStart: () => {
+      needsMidStreamCompaction = false;
+    },
+  }) as unknown as ChatTransport<UIMessage>;
 }

--- a/src/lib/agent/agent-transport.ts
+++ b/src/lib/agent/agent-transport.ts
@@ -849,5 +849,5 @@ export async function createAgentTransport(
     onSendStart: () => {
       needsMidStreamCompaction = false;
     },
-  }) as unknown as ChatTransport<UIMessage>;
+  });
 }

--- a/src/lib/agent/agent-transport.ts
+++ b/src/lib/agent/agent-transport.ts
@@ -4,7 +4,6 @@ import type {
   LanguageModel,
   ToolLoopAgentSettings,
   ToolSet,
-  UIMessage,
 } from "ai";
 import { ToolLoopAgent, tool } from "ai";
 import { z } from "zod";
@@ -12,7 +11,7 @@ import { chatDb } from "../chat-db";
 import { getMcpRegistry } from "../mcp";
 import { sendMcpMessage } from "../mcp/messages";
 import { memoryDb } from "../memory-db";
-import type { Settings } from "../types";
+import type { AgentUIMessage, Settings } from "../types";
 import { shouldCompact } from "./compaction";
 import { CompactingChatTransport } from "./compacting-transport";
 import { clearHandles } from "./tab-handles";
@@ -643,7 +642,7 @@ export async function createAgentTransport(
     enabled: boolean;
     config?: import("../types").ThinkingConfig;
   },
-): Promise<ChatTransport<UIMessage> | null> {
+): Promise<ChatTransport<AgentUIMessage> | null> {
   if (!agentModel) return null;
 
   const { providers } = await import("@/registry/providers");

--- a/src/lib/agent/compacting-transport.ts
+++ b/src/lib/agent/compacting-transport.ts
@@ -1,0 +1,175 @@
+import type {
+  Agent,
+  ChatTransport,
+  ToolSet,
+  UIMessage,
+  UIMessageChunk,
+} from "ai";
+import { DirectChatTransport } from "ai";
+import type { CompactionPart, SerializedUIPart } from "../types";
+import {
+  COMPACTION_USER_PROMPT,
+  prunePartsAtSendTime,
+} from "./compaction";
+
+interface Options {
+  // Use `any` for the agent generics: the wrapper does not consume any of
+  // the agent's per-call options, tool inferences, or output schema — it
+  // only delegates `sendMessages`/`reconnectToStream` through to a
+  // `DirectChatTransport` typed at the same UIMessage boundary the rest of
+  // the codebase uses.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  agent: Agent<any, ToolSet, any>;
+  /**
+   * Called once at the top of each `sendMessages`. The agent layer uses
+   * this to clear the per-stream "needs mid-stream compaction" signal so
+   * the next step's onStepFinish can re-trigger it cleanly.
+   */
+  onSendStart?: () => void;
+}
+
+/**
+ * A `ChatTransport` wrapper that applies auto-compaction at send time.
+ *
+ * Compaction events live as messages in the chat history (a user message
+ * carrying a `CompactionPart`, immediately followed by an assistant
+ * message containing the summary text). For every outbound request:
+ *
+ * 1. Walk the message list to find the latest completed compaction event
+ *    (compaction-user immediately followed by an assistant whose first
+ *    part-pair signature matches a summary). If found, drop the head and
+ *    keep `[compaction-user, summary, ...retained-tail, ...post-event]`.
+ *    The retained tail is anchored at `compactionPart.tailStartMessageId`
+ *    when set; otherwise it falls back to "everything after the
+ *    compaction event."
+ * 2. Substitute the `CompactionPart` with a synthetic user text
+ *    ("What did we do so far?") so the model sees a normal Q/A flow:
+ *    user asks, assistant summarizes, user (auto-continue) says "continue
+ *    where you left off."
+ * 3. Apply per-part pruning (truncate oversized tool outputs, drop
+ *    screenshot data) so even the live tail can't ship hundreds of KB of
+ *    stale payload.
+ * 4. Delegate the rewritten list to a `DirectChatTransport`.
+ *
+ * The Chat instance's in-memory messages are never mutated — the UI keeps
+ * showing the full conversation; only what the LLM sees is compacted.
+ *
+ * If no compaction events exist, the wrapper still applies send-time
+ * pruning (idempotent, near-zero overhead for short conversations).
+ */
+export class CompactingChatTransport implements ChatTransport<UIMessage> {
+  private readonly inner: ChatTransport<UIMessage>;
+  private readonly onSendStart?: () => void;
+
+  constructor({ agent, onSendStart }: Options) {
+    this.inner = new DirectChatTransport({
+      agent,
+    }) as unknown as ChatTransport<UIMessage>;
+    this.onSendStart = onSendStart;
+  }
+
+  async sendMessages(
+    args: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0],
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    this.onSendStart?.();
+    const rewritten = rewriteForLLM(args.messages);
+    return this.inner.sendMessages({ ...args, messages: rewritten });
+  }
+
+  reconnectToStream(
+    args: Parameters<ChatTransport<UIMessage>["reconnectToStream"]>[0],
+  ): Promise<ReadableStream<UIMessageChunk> | null> {
+    return this.inner.reconnectToStream(args);
+  }
+}
+
+/**
+ * Pure function: takes the chat's full UIMessage list and produces the
+ * list to send to the model. Exported for testing and so other callers
+ * (e.g. eventual `prepareStep` integrations) can share the logic.
+ */
+export function rewriteForLLM(messages: UIMessage[]): UIMessage[] {
+  let working = messages;
+
+  const event = findLatestCompactionEvent(messages);
+  if (event) {
+    const tailStartId = event.compactionPart.tailStartMessageId;
+    const tailIdx = tailStartId
+      ? messages.findIndex((m) => m.id === tailStartId)
+      : -1;
+    const retainedTailStart =
+      tailIdx >= 0 && tailIdx < event.userIndex ? tailIdx : event.userIndex;
+
+    working = [
+      // The compaction-user marker — substituted to "What did we do so far?"
+      // before sending (see substituteCompactionPart below).
+      messages[event.userIndex],
+      // The summary assistant message.
+      messages[event.summaryIndex],
+      // Retained tail (messages from tailStartMessageId up to but not
+      // including the compaction-user).
+      ...messages.slice(retainedTailStart, event.userIndex),
+      // Everything after the summary (auto-continue + subsequent turns).
+      ...messages.slice(event.summaryIndex + 1),
+    ];
+  }
+
+  return working.map((m) => {
+    let parts = m.parts as unknown as SerializedUIPart[];
+    parts = substituteCompactionPart(parts);
+    parts = prunePartsAtSendTime(parts);
+    if (parts === (m.parts as unknown as SerializedUIPart[])) return m;
+    return {
+      ...m,
+      parts: parts as unknown as UIMessage["parts"],
+    };
+  });
+}
+
+/**
+ * Mirrors `findCompactionEvents` but operates on the SDK's UIMessage
+ * (which does not carry our `summary: true` flag). We treat the assistant
+ * message immediately following a user-with-CompactionPart as the summary.
+ * Persistence layer guarantees this pairing exists once a compaction is
+ * complete.
+ */
+function findLatestCompactionEvent(messages: UIMessage[]):
+  | {
+      userIndex: number;
+      summaryIndex: number;
+      compactionPart: CompactionPart;
+    }
+  | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role !== "user") continue;
+    const part = (m.parts as unknown as SerializedUIPart[]).find(
+      (p): p is CompactionPart => p.type === "compaction",
+    );
+    if (!part) continue;
+    const next = messages[i + 1];
+    if (!next || next.role !== "assistant") continue;
+    return { userIndex: i, summaryIndex: i + 1, compactionPart: part };
+  }
+  return undefined;
+}
+
+/**
+ * Replaces any `CompactionPart` on a parts array with a synthetic text
+ * part for the model. Returns the same reference when nothing changed.
+ */
+function substituteCompactionPart(
+  parts: SerializedUIPart[],
+): SerializedUIPart[] {
+  let changed = false;
+  const out: SerializedUIPart[] = [];
+  for (const p of parts) {
+    if (p.type === "compaction") {
+      out.push({ type: "text", text: COMPACTION_USER_PROMPT });
+      changed = true;
+    } else {
+      out.push(p);
+    }
+  }
+  return changed ? out : parts;
+}

--- a/src/lib/agent/compacting-transport.ts
+++ b/src/lib/agent/compacting-transport.ts
@@ -89,13 +89,23 @@ export class CompactingChatTransport implements ChatTransport<UIMessage> {
  * (e.g. eventual `prepareStep` integrations) can share the logic.
  */
 export function rewriteForLLM(messages: UIMessage[]): UIMessage[] {
-  let working = messages;
+  // Step 1: repair legacy broken compaction events. An earlier version of
+  // `runCompaction` had a "prune-only fast path" that wrote a compaction
+  // event with an empty summary assistant. Sending that message fails the
+  // AI SDK's Zod validation ("Message must contain at least one part").
+  // We detect those broken events (compaction-user immediately followed
+  // by an assistant with no parts) and excise the whole event — the
+  // user-with-CompactionPart, the empty summary, and any adjacent
+  // synthetic auto-continue user that followed. Stale-data only; new code
+  // never produces this shape.
+  const repaired = excludeBrokenCompactionEvents(messages);
+  let working = repaired;
 
-  const event = findLatestCompactionEvent(messages);
+  const event = findLatestCompactionEvent(repaired);
   if (event) {
-    const tailStartId = event.compactionPart.tailStartMessageId;
+    const tailStartId = event.compactionPart.data.tailStartMessageId;
     const tailIdx = tailStartId
-      ? messages.findIndex((m) => m.id === tailStartId)
+      ? repaired.findIndex((m) => m.id === tailStartId)
       : -1;
     const retainedTailStart =
       tailIdx >= 0 && tailIdx < event.userIndex ? tailIdx : event.userIndex;
@@ -103,27 +113,76 @@ export function rewriteForLLM(messages: UIMessage[]): UIMessage[] {
     working = [
       // The compaction-user marker — substituted to "What did we do so far?"
       // before sending (see substituteCompactionPart below).
-      messages[event.userIndex],
+      repaired[event.userIndex],
       // The summary assistant message.
-      messages[event.summaryIndex],
+      repaired[event.summaryIndex],
       // Retained tail (messages from tailStartMessageId up to but not
       // including the compaction-user).
-      ...messages.slice(retainedTailStart, event.userIndex),
+      ...repaired.slice(retainedTailStart, event.userIndex),
       // Everything after the summary (auto-continue + subsequent turns).
-      ...messages.slice(event.summaryIndex + 1),
+      ...repaired.slice(event.summaryIndex + 1),
     ];
   }
 
-  return working.map((m) => {
-    let parts = m.parts as unknown as SerializedUIPart[];
+  const rewritten = working.map((m) => {
+    let parts = asExtendedParts(m.parts);
     parts = substituteCompactionPart(parts);
     parts = prunePartsAtSendTime(parts);
-    if (parts === (m.parts as unknown as SerializedUIPart[])) return m;
+    if (parts === asExtendedParts(m.parts)) return m;
     return {
       ...m,
-      parts: parts as unknown as UIMessage["parts"],
+      parts: asUIParts(parts),
     };
   });
+
+  // Final safety net: drop any message that still ended up with empty
+  // parts after substitution + pruning. Should be unreachable now that
+  // `excludeBrokenCompactionEvents` runs first, but cheap insurance.
+  return rewritten.filter((m) => m.parts.length > 0);
+}
+
+/**
+ * Removes broken auto-compaction events (compaction-user immediately
+ * followed by an assistant with no parts). Also strips the synthetic
+ * auto-continue user message that typically follows the broken pair, to
+ * avoid leaving the conversation with adjacent user messages that
+ * Anthropic rejects.
+ *
+ * The "Continue where you left off..." text is the canonical auto-continue
+ * sentinel; we match by exact prefix to keep the heuristic conservative.
+ */
+const AUTO_CONTINUE_PREFIX = "Continue where you left off";
+
+function excludeBrokenCompactionEvents(messages: UIMessage[]): UIMessage[] {
+  const skipIds = new Set<string>();
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (m.role !== "user") continue;
+    const hasCompactionPart = asExtendedParts(m.parts).some(
+      (p) => p.type === "data-compaction",
+    );
+    if (!hasCompactionPart) continue;
+    const next = messages[i + 1];
+    if (!next || next.role !== "assistant") continue;
+    if (next.parts.length > 0) continue;
+
+    skipIds.add(m.id);
+    skipIds.add(next.id);
+
+    const after = messages[i + 2];
+    if (after && after.role === "user") {
+      const text = asExtendedParts(after.parts)
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("");
+      if (text.startsWith(AUTO_CONTINUE_PREFIX)) {
+        skipIds.add(after.id);
+      }
+    }
+  }
+
+  if (skipIds.size === 0) return messages;
+  return messages.filter((m) => !skipIds.has(m.id));
 }
 
 /**
@@ -143,8 +202,8 @@ function findLatestCompactionEvent(messages: UIMessage[]):
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
     if (m.role !== "user") continue;
-    const part = (m.parts as unknown as SerializedUIPart[]).find(
-      (p): p is CompactionPart => p.type === "compaction",
+    const part = asExtendedParts(m.parts).find(
+      (p): p is CompactionPart => p.type === "data-compaction",
     );
     if (!part) continue;
     const next = messages[i + 1];
@@ -164,7 +223,7 @@ function substituteCompactionPart(
   let changed = false;
   const out: SerializedUIPart[] = [];
   for (const p of parts) {
-    if (p.type === "compaction") {
+    if (p.type === "data-compaction") {
       out.push({ type: "text", text: COMPACTION_USER_PROMPT });
       changed = true;
     } else {
@@ -172,4 +231,16 @@ function substituteCompactionPart(
     }
   }
   return changed ? out : parts;
+}
+
+// Helper to convert the AI SDK's strict parts union to our wider
+// SerializedUIPart union (which adds CompactionPart) without sprinkling
+// `as unknown as` everywhere. The chat library accepts our custom
+// DataUIPart client-side so it flows through the array seamlessly.
+function asExtendedParts(parts: UIMessage["parts"]): SerializedUIPart[] {
+  return parts as unknown as SerializedUIPart[];
+}
+
+function asUIParts(parts: SerializedUIPart[]): UIMessage["parts"] {
+  return parts as unknown as UIMessage["parts"];
 }

--- a/src/lib/agent/compacting-transport.ts
+++ b/src/lib/agent/compacting-transport.ts
@@ -1,25 +1,18 @@
-import type {
-  Agent,
-  ChatTransport,
-  ToolSet,
-  UIMessage,
-  UIMessageChunk,
-} from "ai";
-import { DirectChatTransport } from "ai";
-import type { CompactionPart, SerializedUIPart } from "../types";
 import {
-  COMPACTION_USER_PROMPT,
-  prunePartsAtSendTime,
-} from "./compaction";
+  convertToModelMessages,
+  validateUIMessages,
+  type Agent,
+  type ChatTransport,
+  type InferUITools,
+  type ToolSet,
+  type UIMessage,
+  type UIMessageChunk,
+} from "ai";
+import type { AgentDataParts, AgentUIMessage, CompactionPart } from "../types";
+import { COMPACTION_USER_PROMPT, prunePartsAtSendTime } from "./compaction";
 
-interface Options {
-  // Use `any` for the agent generics: the wrapper does not consume any of
-  // the agent's per-call options, tool inferences, or output schema — it
-  // only delegates `sendMessages`/`reconnectToStream` through to a
-  // `DirectChatTransport` typed at the same UIMessage boundary the rest of
-  // the codebase uses.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  agent: Agent<any, ToolSet, any>;
+interface Options<TOOLS extends ToolSet> {
+  agent: Agent<never, TOOLS, never>;
   /**
    * Called once at the top of each `sendMessages`. The agent layer uses
    * this to clear the per-stream "needs mid-stream compaction" signal so
@@ -49,37 +42,75 @@ interface Options {
  * 3. Apply per-part pruning (truncate oversized tool outputs, drop
  *    screenshot data) so even the live tail can't ship hundreds of KB of
  *    stale payload.
- * 4. Delegate the rewritten list to a `DirectChatTransport`.
+ * 4. We skip `DirectChatTransport` and manually convert and stream via the
+ *    underlying Agent. `DirectChatTransport`'s class signature constrains
+ *    `UI_MESSAGE extends UIMessage<unknown, never, ...>` — i.e. forbids any
+ *    extended `DATA_PARTS` — which would reject our `AgentDataParts`.
+ *    Inlining the four-line equivalent (validate → convert → stream →
+ *    toUIMessageStream) lets us flow `AgentUIMessage` end-to-end without
+ *    type assertions.
  *
  * The Chat instance's in-memory messages are never mutated — the UI keeps
  * showing the full conversation; only what the LLM sees is compacted.
  *
  * If no compaction events exist, the wrapper still applies send-time
  * pruning (idempotent, near-zero overhead for short conversations).
+ *
+ * @typeParam TOOLS - The agent's tool set; flows through to
+ *   `validateUIMessages` so tool-call shapes are validated against the
+ *   agent's actual tools at the type level. Mirrors `DirectChatTransport`'s
+ *   `TOOLS` parameter.
  */
-export class CompactingChatTransport implements ChatTransport<UIMessage> {
-  private readonly inner: ChatTransport<UIMessage>;
+export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
+  implements ChatTransport<AgentUIMessage>
+{
+  private readonly agent: Agent<never, TOOLS, never>;
   private readonly onSendStart?: () => void;
 
-  constructor({ agent, onSendStart }: Options) {
-    this.inner = new DirectChatTransport({
-      agent,
-    }) as unknown as ChatTransport<UIMessage>;
+  constructor({ agent, onSendStart }: Options<TOOLS>) {
+    this.agent = agent;
     this.onSendStart = onSendStart;
   }
 
-  async sendMessages(
-    args: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0],
-  ): Promise<ReadableStream<UIMessageChunk>> {
+  async sendMessages({
+    messages,
+    abortSignal,
+  }: Parameters<ChatTransport<AgentUIMessage>["sendMessages"]>[0]): Promise<
+    ReadableStream<UIMessageChunk>
+  > {
     this.onSendStart?.();
-    const rewritten = rewriteForLLM(args.messages);
-    return this.inner.sendMessages({ ...args, messages: rewritten });
+    const rewritten = rewriteForLLM(messages);
+
+    // Tie validateUIMessages' inferred UI_MESSAGE to *this transport's*
+    // TOOLS so its `tools` parameter resolves to the same shape as
+    // `agent.tools` (i.e. the precise tools the agent was constructed
+    // with). Without this hint TS defaults to the wide `UITools` map and
+    // rejects the assignment.
+    type ToolBoundUIMessage = UIMessage<
+      unknown,
+      AgentDataParts,
+      InferUITools<TOOLS>
+    >;
+    const validatedMessages = await validateUIMessages<ToolBoundUIMessage>({
+      messages: rewritten,
+      tools: this.agent.tools,
+    });
+
+    const modelMessages = await convertToModelMessages(validatedMessages, {
+      tools: this.agent.tools,
+    });
+
+    const result = await this.agent.stream({
+      prompt: modelMessages,
+      abortSignal,
+    });
+
+    return result.toUIMessageStream();
   }
 
-  reconnectToStream(
-    args: Parameters<ChatTransport<UIMessage>["reconnectToStream"]>[0],
-  ): Promise<ReadableStream<UIMessageChunk> | null> {
-    return this.inner.reconnectToStream(args);
+  reconnectToStream(): Promise<ReadableStream<UIMessageChunk> | null> {
+    // Reconnection is not supported for in-process direct agent transport.
+    return Promise.resolve(null);
   }
 }
 
@@ -87,8 +118,12 @@ export class CompactingChatTransport implements ChatTransport<UIMessage> {
  * Pure function: takes the chat's full UIMessage list and produces the
  * list to send to the model. Exported for testing and so other callers
  * (e.g. eventual `prepareStep` integrations) can share the logic.
+ *
+ * Operates on `AgentUIMessage` directly — its `DATA_PARTS = AgentDataParts`
+ * gives us a real `data-compaction` variant in the parts union, so all the
+ * helpers below narrow on `p.type === "data-compaction"` without casts.
  */
-export function rewriteForLLM(messages: UIMessage[]): UIMessage[] {
+export function rewriteForLLM(messages: AgentUIMessage[]): AgentUIMessage[] {
   // Step 1: repair legacy broken compaction events. An earlier version of
   // `runCompaction` had a "prune-only fast path" that wrote a compaction
   // event with an empty summary assistant. Sending that message fails the
@@ -125,14 +160,11 @@ export function rewriteForLLM(messages: UIMessage[]): UIMessage[] {
   }
 
   const rewritten = working.map((m) => {
-    let parts = asExtendedParts(m.parts);
+    let parts = m.parts;
     parts = substituteCompactionPart(parts);
     parts = prunePartsAtSendTime(parts);
-    if (parts === asExtendedParts(m.parts)) return m;
-    return {
-      ...m,
-      parts: asUIParts(parts),
-    };
+    if (parts === m.parts) return m;
+    return { ...m, parts };
   });
 
   // Final safety net: drop any message that still ended up with empty
@@ -153,12 +185,14 @@ export function rewriteForLLM(messages: UIMessage[]): UIMessage[] {
  */
 const AUTO_CONTINUE_PREFIX = "Continue where you left off";
 
-function excludeBrokenCompactionEvents(messages: UIMessage[]): UIMessage[] {
+function excludeBrokenCompactionEvents(
+  messages: AgentUIMessage[],
+): AgentUIMessage[] {
   const skipIds = new Set<string>();
   for (let i = 0; i < messages.length; i++) {
     const m = messages[i];
     if (m.role !== "user") continue;
-    const hasCompactionPart = asExtendedParts(m.parts).some(
+    const hasCompactionPart = m.parts.some(
       (p) => p.type === "data-compaction",
     );
     if (!hasCompactionPart) continue;
@@ -171,8 +205,8 @@ function excludeBrokenCompactionEvents(messages: UIMessage[]): UIMessage[] {
 
     const after = messages[i + 2];
     if (after && after.role === "user") {
-      const text = asExtendedParts(after.parts)
-        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      const text = after.parts
+        .filter((p) => p.type === "text")
         .map((p) => p.text)
         .join("");
       if (text.startsWith(AUTO_CONTINUE_PREFIX)) {
@@ -192,7 +226,7 @@ function excludeBrokenCompactionEvents(messages: UIMessage[]): UIMessage[] {
  * Persistence layer guarantees this pairing exists once a compaction is
  * complete.
  */
-function findLatestCompactionEvent(messages: UIMessage[]):
+function findLatestCompactionEvent(messages: AgentUIMessage[]):
   | {
       userIndex: number;
       summaryIndex: number;
@@ -202,13 +236,18 @@ function findLatestCompactionEvent(messages: UIMessage[]):
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
     if (m.role !== "user") continue;
-    const part = asExtendedParts(m.parts).find(
-      (p): p is CompactionPart => p.type === "data-compaction",
-    );
+    // `find` narrows `part` to the data-compaction variant of
+    // `UIMessagePart<AgentDataParts, ...>`, which is structurally
+    // identical to `CompactionPart`.
+    const part = m.parts.find((p) => p.type === "data-compaction");
     if (!part) continue;
     const next = messages[i + 1];
     if (!next || next.role !== "assistant") continue;
-    return { userIndex: i, summaryIndex: i + 1, compactionPart: part };
+    return {
+      userIndex: i,
+      summaryIndex: i + 1,
+      compactionPart: part,
+    };
   }
   return undefined;
 }
@@ -218,12 +257,14 @@ function findLatestCompactionEvent(messages: UIMessage[]):
  * part for the model. Returns the same reference when nothing changed.
  */
 function substituteCompactionPart(
-  parts: SerializedUIPart[],
-): SerializedUIPart[] {
+  parts: AgentUIMessage["parts"],
+): AgentUIMessage["parts"] {
   let changed = false;
-  const out: SerializedUIPart[] = [];
+  const out: AgentUIMessage["parts"] = [];
   for (const p of parts) {
     if (p.type === "data-compaction") {
+      // TextUIPart is a member of `AgentUIMessage["parts"][number]`, so
+      // pushing it widens to the union with no cast.
       out.push({ type: "text", text: COMPACTION_USER_PROMPT });
       changed = true;
     } else {
@@ -231,16 +272,4 @@ function substituteCompactionPart(
     }
   }
   return changed ? out : parts;
-}
-
-// Helper to convert the AI SDK's strict parts union to our wider
-// SerializedUIPart union (which adds CompactionPart) without sprinkling
-// `as unknown as` everywhere. The chat library accepts our custom
-// DataUIPart client-side so it flows through the array seamlessly.
-function asExtendedParts(parts: UIMessage["parts"]): SerializedUIPart[] {
-  return parts as unknown as SerializedUIPart[];
-}
-
-function asUIParts(parts: SerializedUIPart[]): UIMessage["parts"] {
-  return parts as unknown as UIMessage["parts"];
 }

--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -1,5 +1,10 @@
 // src/lib/agent/compaction.ts
-import type { SerializedUIPart, CompactionPart, ChatMessage } from "../types";
+import type {
+  AgentUIMessage,
+  ChatMessage,
+  CompactionPart,
+  SerializedUIPart,
+} from "../types";
 import type { ModelDefinition } from "@/registry/providers/types";
 
 // Constants
@@ -132,19 +137,20 @@ export interface PrunableMessage {
  *
  * Returns the same array reference when nothing changed (cheap fast-path for
  * messages with no large outputs).
+ *
+ * Operates on the SDK's `UIMessagePart` union directly via
+ * `AgentUIMessage["parts"]` so callers (the transport) don't have to
+ * convert to/from our `SerializedUIPart` shape. Only `dynamic-tool` parts
+ * are inspected; everything else passes through unchanged.
  */
 export function prunePartsAtSendTime(
-  parts: SerializedUIPart[],
-): SerializedUIPart[] {
+  parts: AgentUIMessage["parts"],
+): AgentUIMessage["parts"] {
   let changed = false;
-  const out: SerializedUIPart[] = [];
+  const out: AgentUIMessage["parts"] = [];
 
   for (const part of parts) {
-    if (
-      part.type !== "dynamic-tool" ||
-      part.state !== "output-available" ||
-      part.output === undefined
-    ) {
+    if (part.type !== "dynamic-tool" || part.state !== "output-available") {
       out.push(part);
       continue;
     }

--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -423,13 +423,15 @@ export interface CompactionEvent {
  * immediately followed by an assistant with `summary: true`. Returns
  * events in chronological order.
  */
-export function findCompactionEvents(messages: ChatMessage[]): CompactionEvent[] {
+export function findCompactionEvents(
+  messages: { role: string; parts: any[]; summary?: boolean; createdAt?: number }[],
+): CompactionEvent[] {
   const events: CompactionEvent[] = [];
   for (let i = 0; i < messages.length; i++) {
     const m = messages[i];
     if (m.role !== "user") continue;
     const part = m.parts.find(
-      (p): p is CompactionPart => p.type === "compaction",
+      (p): p is CompactionPart => p.type === "data-compaction",
     );
     if (!part) continue;
     const next = messages[i + 1];
@@ -444,7 +446,7 @@ export function findCompactionEvents(messages: ChatMessage[]): CompactionEvent[]
       summaryIndex: i + 1,
       part,
       summaryText,
-      completedAt: next.createdAt,
+      completedAt: next.createdAt ?? 0,
     });
   }
   return events;
@@ -475,13 +477,15 @@ export function shouldDebounceCompaction(
  * Returns the original array (unchanged) if there are no completed
  * compactions.
  */
-export function filterCompactedMessages<T extends ChatMessage>(messages: T[]): T[] {
+export function filterCompactedMessages<
+  T extends { id: string; role: string; parts: any[] },
+>(messages: T[]): T[] {
   const events = findCompactionEvents(messages);
   const last = events.at(-1);
   if (!last) return messages;
 
-  const tailStartId = last.part.tailStartMessageId;
-  const tailIndex = tailStartId
+  const tailStartId = last.part.data.tailStartMessageId;
+  const tailIdx = tailStartId
     ? messages.findIndex((m) => m.id === tailStartId)
     : -1;
 
@@ -490,7 +494,7 @@ export function filterCompactedMessages<T extends ChatMessage>(messages: T[]): T
   // message), or it's missing/stale (defensive: fall back to dropping
   // everything before the compaction event itself).
   const retainedTailStart =
-    tailIndex >= 0 && tailIndex < last.userIndex ? tailIndex : last.userIndex;
+    tailIdx >= 0 && tailIdx < last.userIndex ? tailIdx : last.userIndex;
 
   return [
     // 1. The compaction-user marker (the transport substitutes its

--- a/src/lib/agent/compaction.ts
+++ b/src/lib/agent/compaction.ts
@@ -1,5 +1,5 @@
 // src/lib/agent/compaction.ts
-import type { SerializedUIPart, CompactionState } from "../types";
+import type { SerializedUIPart, CompactionPart, ChatMessage } from "../types";
 import type { ModelDefinition } from "@/registry/providers/types";
 
 // Constants
@@ -11,8 +11,18 @@ export const PROTECTED_TURNS = 2;
 export const TAIL_TURNS = 2;
 export const MIN_PRESERVE_RECENT_TOKENS = 2_000;
 export const MAX_PRESERVE_RECENT_TOKENS = 8_000;
-export const MAX_THRASH_ATTEMPTS = 3;
 export const MIN_MESSAGES_FOR_COMPACTION = 4;
+/**
+ * Time-based debounce for thrash detection. If the latest completed
+ * compaction in the conversation finished less than this many milliseconds
+ * ago, skip running another compaction. This prevents the
+ * compaction-summarizes-but-summary-still-overflows infinite loop without
+ * keeping a hidden attempts counter.
+ *
+ * 30s is a sane default — covers a runaway summary cycle but doesn't block
+ * a genuinely long agent run that crosses the threshold a second time.
+ */
+export const COMPACTION_DEBOUNCE_MS = 30_000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_OUTPUT = 8_000;
 
@@ -107,6 +117,65 @@ export interface PrunableMessage {
   role: "user" | "assistant" | "system";
   parts: SerializedUIPart[];
   createdAt: number;
+}
+
+/**
+ * Per-message-part pruner used by the compacting transport at send time.
+ *
+ * Differs from `pruneMessages`:
+ * - Operates on a single message's `parts` (no protected-tail logic — the
+ *   transport already preserves the verbatim tail above this layer).
+ * - Always trims oversized tool outputs (no `PRUNE_PROTECT` cumulative budget
+ *   — that gates the *decision* to compact in `runCompaction`, not what we
+ *   send to the model).
+ * - Idempotent — running it twice produces identical output.
+ *
+ * Returns the same array reference when nothing changed (cheap fast-path for
+ * messages with no large outputs).
+ */
+export function prunePartsAtSendTime(
+  parts: SerializedUIPart[],
+): SerializedUIPart[] {
+  let changed = false;
+  const out: SerializedUIPart[] = [];
+
+  for (const part of parts) {
+    if (
+      part.type !== "dynamic-tool" ||
+      part.state !== "output-available" ||
+      part.output === undefined
+    ) {
+      out.push(part);
+      continue;
+    }
+
+    const outputStr =
+      typeof part.output === "string"
+        ? part.output
+        : JSON.stringify(part.output);
+
+    if (
+      part.toolName === "screenshot" ||
+      part.toolName === "screenshotPage"
+    ) {
+      out.push({ ...part, output: "[screenshot removed during compaction]" });
+      changed = true;
+      continue;
+    }
+
+    if (outputStr.length > TOOL_OUTPUT_MAX_CHARS) {
+      out.push({
+        ...part,
+        output: outputStr.substring(0, TOOL_OUTPUT_MAX_CHARS) + "...",
+      });
+      changed = true;
+      continue;
+    }
+
+    out.push(part);
+  }
+
+  return changed ? out : parts;
 }
 
 export function pruneMessages(
@@ -324,24 +393,125 @@ export function prepareMessagesForSummarization(
   return formatted.join("\n\n");
 }
 
-// Anti-Thrashing Helpers
+// Compaction-event helpers (message-based architecture)
 
-export function shouldStopCompacting(
-  state: CompactionState | undefined
+/**
+ * A "completed compaction" is a user message containing a `CompactionPart`
+ * immediately followed by an assistant message marked `summary: true`.
+ *
+ * The pair represents one auto- or manually-triggered compaction event.
+ * The pre-compaction head can be safely dropped from the LLM view; the
+ * UI keeps the full history.
+ */
+export interface CompactionEvent {
+  /** Index of the user message carrying the CompactionPart. */
+  userIndex: number;
+  /** Index of the assistant message carrying the summary text. */
+  summaryIndex: number;
+  /** The CompactionPart on the user message (carries `tailStartMessageId`). */
+  part: CompactionPart;
+  /** Plain-text summary extracted from the assistant message. */
+  summaryText: string;
+  /** Timestamp the assistant summary was created at (ms). */
+  completedAt: number;
+}
+
+/**
+ * Walks `messages` in order and identifies completed compaction events.
+ *
+ * A compaction is "completed" when the user-with-CompactionPart is
+ * immediately followed by an assistant with `summary: true`. Returns
+ * events in chronological order.
+ */
+export function findCompactionEvents(messages: ChatMessage[]): CompactionEvent[] {
+  const events: CompactionEvent[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (m.role !== "user") continue;
+    const part = m.parts.find(
+      (p): p is CompactionPart => p.type === "compaction",
+    );
+    if (!part) continue;
+    const next = messages[i + 1];
+    if (!next || next.role !== "assistant" || !next.summary) continue;
+    const summaryText = next.parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("\n")
+      .trim();
+    events.push({
+      userIndex: i,
+      summaryIndex: i + 1,
+      part,
+      summaryText,
+      completedAt: next.createdAt,
+    });
+  }
+  return events;
+}
+
+/**
+ * Time-based debounce: returns true if a recent compaction event finished
+ * within `COMPACTION_DEBOUNCE_MS`, indicating we shouldn't run another one
+ * yet. Replaces the legacy `attempts` counter.
+ */
+export function shouldDebounceCompaction(
+  events: CompactionEvent[],
+  nowMs: number = Date.now(),
 ): boolean {
-  return state !== undefined && state.attempts >= MAX_THRASH_ATTEMPTS;
+  const last = events.at(-1);
+  if (!last) return false;
+  return nowMs - last.completedAt < COMPACTION_DEBOUNCE_MS;
 }
 
-export function incrementAttempts(state: CompactionState): CompactionState {
-  return {
-    ...state,
-    attempts: state.attempts + 1,
-  };
+/**
+ * Reorders messages for the LLM view. For the latest completed compaction,
+ * the pre-event head is dropped; the compaction-user message is kept (its
+ * CompactionPart will be replaced with synthetic prompt text by the
+ * transport before sending), followed by the summary assistant, the
+ * retained tail (anchored at `tailStartMessageId` if present, else the
+ * messages immediately after the event), and any post-event messages.
+ *
+ * Returns the original array (unchanged) if there are no completed
+ * compactions.
+ */
+export function filterCompactedMessages<T extends ChatMessage>(messages: T[]): T[] {
+  const events = findCompactionEvents(messages);
+  const last = events.at(-1);
+  if (!last) return messages;
+
+  const tailStartId = last.part.tailStartMessageId;
+  const tailIndex = tailStartId
+    ? messages.findIndex((m) => m.id === tailStartId)
+    : -1;
+
+  // Tail boundary either points back to a message in the pre-compaction
+  // head (the normal case — we drop everything before it but keep that
+  // message), or it's missing/stale (defensive: fall back to dropping
+  // everything before the compaction event itself).
+  const retainedTailStart =
+    tailIndex >= 0 && tailIndex < last.userIndex ? tailIndex : last.userIndex;
+
+  return [
+    // 1. The compaction-user marker (the transport substitutes its
+    //    CompactionPart with a "What did we do so far?" text part for the
+    //    model view).
+    messages[last.userIndex],
+    // 2. The summary assistant message.
+    messages[last.summaryIndex],
+    // 3. The retained tail — messages from the tail boundary up to (but
+    //    not including) the compaction-user message.
+    ...messages.slice(retainedTailStart, last.userIndex),
+    // 4. Everything after the summary message (auto-continue + subsequent
+    //    turns).
+    ...messages.slice(last.summaryIndex + 1),
+  ];
 }
 
-export function resetAttempts(state: CompactionState): CompactionState {
-  return {
-    ...state,
-    attempts: 0,
-  };
-}
+/**
+ * Compose the prompt content the model sees in place of a CompactionPart.
+ * Keeping this as a single source of truth avoids drift between the
+ * transport (which substitutes at send time) and any future consumer.
+ */
+export const COMPACTION_USER_PROMPT = "What did we do so far?";
+

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -28,20 +28,15 @@ interface ChatDB extends DBSchema {
       content: string;
       parts: SerializedUIPart[];
       createdAt: number;
+      /**
+       * True for assistant messages that are auto-compaction summaries.
+       * The preceding user message is the compaction marker. See
+       * `CompactionPart` in types.ts.
+       */
+      summary?: boolean;
     };
     indexes: {
       "by-conversation": string;
-    };
-  };
-  compaction: {
-    key: string;
-    value: {
-      conversationId: string;
-      summary: string;
-      tailStartMessageId: string;
-      previousSummary?: string;
-      compactedAt: number;
-      attempts: number;
     };
   };
 }
@@ -50,7 +45,10 @@ let dbPromise: Promise<IDBPDatabase<ChatDB>> | null = null;
 
 function getDb(): Promise<IDBPDatabase<ChatDB>> {
   if (!dbPromise) {
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 5, {
+    // v6: drops the legacy `compaction` object store. Compaction events
+    // now live as messages in the `messages` store (see CompactionPart and
+    // the `summary` flag on assistant messages).
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 6, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -85,7 +83,9 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
         }
 
         if (oldVersion < 3) {
-          db.createObjectStore("compaction", { keyPath: "conversationId" });
+          // The `compaction` store was created here historically. We no
+          // longer need it (compaction is message-based), so we don't
+          // create it. v6 below removes any pre-existing copy.
         }
 
         if (oldVersion < 4) {
@@ -115,6 +115,14 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
             }
           };
           migrateConversationsTodos();
+        }
+
+        if (oldVersion < 6) {
+          // Drop the legacy `compaction` object store. Compaction events
+          // are now persisted as regular messages in the `messages` store.
+          if (db.objectStoreNames.contains("compaction" as never)) {
+            db.deleteObjectStore("compaction" as never);
+          }
         }
       },
     });
@@ -169,9 +177,8 @@ export const chatDb = {
 
   async deleteConversation(id: string): Promise<void> {
     const db = await getDb();
-    const tx = db.transaction(["conversations", "messages", "compaction"], "readwrite");
+    const tx = db.transaction(["conversations", "messages"], "readwrite");
     await tx.objectStore("conversations").delete(id);
-    await tx.objectStore("compaction").delete(id);
     const msgIndex = tx.objectStore("messages").index("by-conversation");
     let cursor = await msgIndex.openCursor(id);
     while (cursor) {
@@ -225,20 +232,5 @@ export const chatDb = {
       await tx.store.delete(msg.id);
     }
     await tx.done;
-  },
-
-  async getCompactionState(conversationId: string): Promise<ChatDB["compaction"]["value"] | undefined> {
-    const db = await getDb();
-    return db.get("compaction", conversationId);
-  },
-
-  async saveCompactionState(state: ChatDB["compaction"]["value"]): Promise<void> {
-    const db = await getDb();
-    await db.put("compaction", state);
-  },
-
-  async deleteCompactionState(conversationId: string): Promise<void> {
-    const db = await getDb();
-    await db.delete("compaction", conversationId);
   },
 };

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -45,10 +45,10 @@ let dbPromise: Promise<IDBPDatabase<ChatDB>> | null = null;
 
 function getDb(): Promise<IDBPDatabase<ChatDB>> {
   if (!dbPromise) {
-    // v6: drops the legacy `compaction` object store. Compaction events
-    // now live as messages in the `messages` store (see CompactionPart and
-    // the `summary` flag on assistant messages).
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 6, {
+    // v7: migrates legacy `{ type: "compaction", auto, ... }` parts
+    // to the AI SDK's DataUIPart contract:
+    // `{ type: "data-compaction", data: { auto, ... } }`.
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 7, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -123,6 +123,32 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
           if (db.objectStoreNames.contains("compaction" as never)) {
             db.deleteObjectStore("compaction" as never);
           }
+        }
+        if (oldVersion < 7) {
+          const msgStore = transaction.objectStore("messages");
+          const migrateCompactionParts = async () => {
+            let cursor = await msgStore.openCursor();
+            while (cursor) {
+              const record = cursor.value as Record<string, unknown>;
+              let changed = false;
+              if (Array.isArray(record.parts)) {
+                const newParts = record.parts.map((p) => {
+                  if (p && typeof p === "object" && p.type === "compaction") {
+                    changed = true;
+                    const { type: _type, ...data } = p as any;
+                    return { type: "data-compaction", data };
+                  }
+                  return p;
+                });
+                if (changed) {
+                  record.parts = newParts;
+                  cursor.update(record as ChatDB["messages"]["value"]);
+                }
+              }
+              cursor = await cursor.continue();
+            }
+          };
+          migrateCompactionParts();
         }
       },
     });

--- a/src/lib/chat-db.ts
+++ b/src/lib/chat-db.ts
@@ -133,9 +133,10 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
               let changed = false;
               if (Array.isArray(record.parts)) {
                 const newParts = record.parts.map((p) => {
-                  if (p && typeof p === "object" && p.type === "compaction") {
+                  if (p && typeof p === "object" && "type" in p && p.type === "compaction") {
                     changed = true;
-                    const { type: _type, ...data } = p as any;
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { type: _type, ...data } = p as Record<string, unknown>;
                     return { type: "data-compaction", data };
                   }
                   return p;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,4 @@
+import type { DataUIPart } from "ai";
 import type { McpServerConfig } from "./mcp/types";
 
 export interface FavoriteTab {
@@ -141,10 +142,12 @@ export type SerializedUIPart =
  *   the model view.
  */
 export interface CompactionPart {
-  type: "compaction";
-  auto: boolean;
-  overflow?: boolean;
-  tailStartMessageId?: string;
+  type: "data-compaction";
+  data: {
+    auto: boolean;
+    overflow?: boolean;
+    tailStartMessageId?: string;
+  };
 }
 
 export interface SerializedToolPart {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,6 +105,17 @@ export interface ChatMessage {
   content: string;
   parts: SerializedUIPart[];
   createdAt: number;
+  /**
+   * True for assistant messages that are an auto-compaction summary. The
+   * compaction-user message that triggered this summary is the message
+   * immediately preceding it (its `parts` contain a `CompactionPart`).
+   *
+   * Set on the assistant message instead of the user message because the
+   * "completed compaction" predicate (used by `filterCompactedMessages`)
+   * needs to know the summary is fully written; the assistant message's
+   * presence + this flag is the natural signal.
+   */
+  summary?: boolean;
 }
 
 export type SerializedUIPart =
@@ -113,7 +124,28 @@ export type SerializedUIPart =
   | { type: "file"; mediaType: string; url: string }
   | { type: "source-url"; sourceId: string; url: string; title?: string }
   | { type: "step-start" }
+  | CompactionPart
   | SerializedToolPart;
+
+/**
+ * Marker part that lives on a synthetic user message inserted into the chat
+ * stream when the conversation is compacted. The next assistant message in
+ * the stream carries the summary text (with `summary: true` on the message
+ * record).
+ *
+ * - `auto`: true when triggered by the token threshold; false for manual
+ *   `/compact` (follow-up).
+ * - `overflow`: true when triggered by a context-overflow API error path.
+ * - `tailStartMessageId`: id of the first message in the verbatim tail. The
+ *   transport's `filterCompactedMessages` uses this to drop the head from
+ *   the model view.
+ */
+export interface CompactionPart {
+  type: "compaction";
+  auto: boolean;
+  overflow?: boolean;
+  tailStartMessageId?: string;
+}
 
 export interface SerializedToolPart {
   type: "dynamic-tool";
@@ -226,15 +258,6 @@ export interface AutoTidyNotification {
   archivedCount: number;
   sectionCount: number;
   tabCount: number;
-}
-
-export interface CompactionState {
-  conversationId: string;
-  summary: string;
-  tailStartMessageId: string;
-  previousSummary?: string;
-  compactedAt: number;
-  attempts: number;
 }
 
 export interface HistoryItem {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { DataUIPart } from "ai";
+import type { UIMessage } from "ai";
 import type { McpServerConfig } from "./mcp/types";
 
 export interface FavoriteTab {
@@ -143,12 +143,39 @@ export type SerializedUIPart =
  */
 export interface CompactionPart {
   type: "data-compaction";
-  data: {
-    auto: boolean;
-    overflow?: boolean;
-    tailStartMessageId?: string;
-  };
+  data: CompactionData;
 }
+
+export interface CompactionData {
+  auto: boolean;
+  overflow?: boolean;
+  tailStartMessageId?: string;
+}
+
+/**
+ * Custom `DATA_PARTS` map for our `UIMessage`. Keying `compaction` here
+ * registers a `data-compaction` variant on `UIMessagePart<AgentDataParts, ...>`
+ * with `data: CompactionData`. This is what lets us narrow on
+ * `p.type === "data-compaction"` without any casts.
+ *
+ * The SDK type machinery generates the variant from this map; if you add a
+ * new application-specific data part, add it here and the rest of the
+ * codebase will pick it up via `AgentUIMessage`.
+ */
+export type AgentDataParts = {
+  compaction: CompactionData;
+};
+
+/**
+ * The `UIMessage` flavor we use throughout the app. The default `metadata`
+ * generic (`unknown`) and tool generic (`UITools`) are kept; only the
+ * `DATA_PARTS` slot is narrowed to our `AgentDataParts`.
+ *
+ * Component code, the chat hook, and the `CompactingChatTransport` all
+ * type-check against this so the discriminated union of `parts` includes
+ * `{ type: "data-compaction"; data: CompactionData; id?: string }`.
+ */
+export type AgentUIMessage = UIMessage<unknown, AgentDataParts>;
 
 export interface SerializedToolPart {
   type: "dynamic-tool";


### PR DESCRIPTION
## Summary

Auto-compaction was structurally broken — the summary was generated and saved to a side IndexedDB row, but nothing wired that summary into the actual LLM request. Every send still shipped the full conversation history, so context never shrank and long sessions hit the model's window. This PR fixes it by mirroring OpenCode's message-based architecture, adds mid-stream compaction support, and tightens the system prompt to reduce agent reluctance on long-horizon tasks.

## Compaction architecture

Compaction events are now first-class messages in the chat history. A user message with a `CompactionPart` is immediately followed by an assistant message marked `summary: true`. Same UI for every trigger source (post-turn, mid-stream, manual `/compact` follow-up, overflow recovery).

- **`CompactingChatTransport`** wraps `DirectChatTransport`. At send time, it walks the messages array, finds the latest compaction event, drops the pre-event head, substitutes the `CompactionPart` with a synthetic "What did we do so far?" prompt for the model, and applies per-part pruning of oversized tool outputs. UI keeps the full history; only the LLM sees the compacted view.
- **`stopWhen`** on `ToolLoopAgent` breaks the loop at the next step boundary when `needsCompaction()` crosses, enabling mid-stream compaction during multi-tool agent runs. Matches OpenCode's `Stream.takeUntil(needsCompaction)` behavior.
- **`AbortController`** on the in-flight summarization so the user's Stop button cancels the summary call cleanly.
- **30s time-based debounce** replaces the legacy attempts counter for thrash detection. Reads directly from the visible message list.
- **IndexedDB v5 → v6**: drops the legacy `compaction` object store. Schema migration safe since this was unshipped.
- New `CompactionDivider` component renders a click-to-expand divider for every compaction event.

## Prompt changes

Tightens `SYSTEM_PROMPT` to address agent reluctance on long-horizon tasks. Inspired by comparing our prompt against OpenCode's `beast.txt` and `codex.txt` — ours had no persistence framing and three lines that primed the model to give up early.

- New "Working autonomously" section: explicit "do the task as asked, do not propose simpler alternatives, do not ask permission questions"
- Reframed "ask the user" → "find it yourself" (search the page, follow links, run a Google query)
- Removed the "retry once" hard cap on snapshot failures, lists alternative recovery strategies instead
- "Be concise" clarified to apply to text replies, not tool calls
- Permission for long todoWrite plans (5–15 items)
- New "Recovering from problems" section codifying recovery strategies

## How to test

1. **Inter-turn compaction:** several back-and-forth turns until tokens cross threshold. Divider appears between turns at the appropriate boundary, click expands the summary, agent auto-continues.
2. **Mid-stream compaction:** stress prompt that does many tool calls in one turn (e.g. "Open these 4 Wikipedia articles, readPage + screenshot + interactive snapshot each, then write a comparative essay"). Agent pauses at a step boundary, divider + summary appear, agent resumes.
3. **Multiple compactions:** keep going until a second compaction fires. Two dividers visible in chat, each independently expandable.
4. **Stop during summary:** click Stop while "Compacting context..." spinner shows. AbortController cancels the LLM call, no partial messages persist.
5. **Overflow recovery:** force a context-overflow API error. Divider labeled "(context overflow)".
6. **DB inspection:** IndexedDB → openbrowse-chat v6 → confirm no `compaction` store, messages contain `CompactionPart` entries, summary assistant messages have `summary: true`.
7. **Network tab:** outbound LLM request after compaction starts with `[user] "What did we do so far?"` → `[assistant] summary` → retained tail.

## Files changed

- New: `src/lib/agent/compacting-transport.ts`, `src/components/chat/CompactionDivider.tsx`
- Modified: `src/lib/types.ts`, `src/lib/chat-db.ts`, `src/lib/agent/compaction.ts`, `src/lib/agent/agent-transport.ts`, `src/hooks/useAgentChat.ts`, `src/components/chat/ChatView.tsx`

8 files changed, +862 / −163 lines.

## Deferred to follow-ups

- Manual `/compact` slash command
- Per-conversation `lastTotalTokens` map (still global; mitigated by `resetTokenTracking()` on conversation change)
- Per-provider system prompt variants (we use one prompt for all models; OpenCode splits by model family)
- Tests + Vitest infrastructure