### PR TITLE
fix(overlay/search): rank open tabs above frecent history

### DIFF
--- a/src/entrypoints/overlay/search/matches.ts
+++ b/src/entrypoints/overlay/search/matches.ts
@@ -136,11 +136,24 @@ interface RawCandidate {
   visitCount?: number;
 }
 
+/**
+ * Per-source ranking weights.
+ *
+ * The frecency multiplier (see `frecencyScore` callsite below) is bounded at
+ * 1.6× and is only applied to sources with visit-count/last-visit data
+ * (`history`, `closed`). To keep currently-open content ranked above heavily
+ * visited history for similar match scores, every "open tab" source weight
+ * is set safely above `history` × max-frecency-multiplier (1.0 × 1.6 = 1.6).
+ *
+ * This mirrors how Chrome's omnibox keeps the OpenTab provider scored above
+ * heavily-visited history entries even when canonical-URL dedup doesn't
+ * collapse them into a single row (e.g. `vercel.com/` vs `vercel.com/dash`).
+ */
 const SOURCE_WEIGHTS: Record<MatchSource, number> = {
-  tab: 1.4,
-  "favorite-open": 1.45,
+  tab: 2.0,
+  "favorite-open": 2.05,
   "favorite-closed": 1.3,
-  "tab-other-space": 1.2,
+  "tab-other-space": 1.8,
   bookmark: 1.1,
   closed: 1.05,
   history: 1.0,


### PR DESCRIPTION
## Problem

In the overlay search, a history result for a domain could rank above an open tab for the same domain when the canonical URLs differed (e.g. \`vercel.com/\` in history vs \`vercel.com/dashboard\` open in another space). Reproduced with a \"vercel\" search where a \"Vercel\" history row appeared above a \"Vercel\" open-tab row.

## Root cause

In \`buildMatches\` (\`src/entrypoints/overlay/search/matches.ts\`), every source gets a frecency multiplier capped at **1.6×**, but only \`history\` and \`closed\` actually carry visit-count/last-visit data — open tabs always score with multiplier 1.0×. The previous source weights were:

| source | weight | effective max |
|---|---|---|
| favorite-open | 1.45 | 1.45 |
| tab | 1.4 | 1.4 |
| favorite-closed | 1.3 | 1.3 |
| tab-other-space | 1.2 | 1.2 |
| bookmark | 1.1 | 1.1 |
| closed | 1.05 | 1.68 |
| history | 1.0 | **1.6** |

A heavily-visited history entry (1.0 × 1.6 = 1.6) overtook every \`tab-*\` source when the title-match score was similar.

## Fix

Bump \`tab\`, \`favorite-open\`, and \`tab-other-space\` weights so their floor sits safely above history's frecency ceiling:

| source | before | after |
|---|---|---|
| tab | 1.4 | **2.0** |
| favorite-open | 1.45 | **2.05** |
| tab-other-space | 1.2 | **1.8** |

This mirrors Chrome omnibox behavior: the OpenTab provider is scored above heavily-visited history so that currently-open content wins when canonical-URL dedup doesn't already collapse the rows.

## Out of scope

\`favorite-closed\` (1.3) and \`bookmark\` (1.1) can still be overtaken by max-frecency history (1.6). That is pre-existing behavior, separate from the reported issue, and worth a follow-up if curated-but-closed favorites/bookmarks should also beat frecency-heavy history.

## Test plan

1. With multiple spaces, have a tab open whose URL matches a frequently-visited history entry on a slightly different path.
2. Open the overlay and search for the shared keyword.
3. The open-tab row should now appear above the history row.

\`tsc --noEmit\` shows no new errors (3 pre-existing errors in \`ChatView.tsx\` are unchanged on \`main\`).