### PR TITLE
fix: auto-update bundled skills when extension is upgraded

### DIFF
--- a/apps/extension/src/lib/skills/bundled.ts
+++ b/apps/extension/src/lib/skills/bundled.ts
@@ -21,9 +21,7 @@ export async function bootstrapBundledSkills(): Promise<void> {
     if (!manifest || manifest.length === 0) return;
 
     for (const bundledSkill of manifest) {
-      // Check if already installed
       const existing = await skillsDb.get(bundledSkill.name);
-      if (existing) continue;
 
       // Ensure SKILL.md exists in the bundle
       const skillMdUrl = chrome.runtime.getURL(`skills/${bundledSkill.name}/SKILL.md`);
@@ -31,6 +29,24 @@ export async function bootstrapBundledSkills(): Promise<void> {
       if (!skillMdResponse.ok) continue;
       
       const skillMdContent = await skillMdResponse.text();
+
+      if (existing) {
+        if (existing.source !== "bundled") {
+          // User installed a custom version, do not overwrite
+          continue;
+        }
+
+        try {
+          const existingContent = await OPFS.readFile(`skills/${bundledSkill.name}/SKILL.md`);
+          // If content hasn't changed, skip update
+          if (existingContent === skillMdContent) {
+            continue;
+          }
+        } catch {
+          // Could not read from OPFS, proceed with overwrite
+        }
+      }
+
       let frontmatter;
       try {
         const parsed = parseSkillFrontmatter(skillMdContent);


### PR DESCRIPTION
Fixes an issue where bundled skills (like `python-env` or `find-skills`) wouldn't update for existing users because the bootstrap script bailed if the skill was already in the database. Now it compares the bundled `SKILL.md` content with the OPFS content and overwrites it if there are changes.