### PR TITLE
feat(landing): mono headline, refined widths, manual-install CTA

### DIFF
--- a/apps/docs/components/landing/hero.tsx
+++ b/apps/docs/components/landing/hero.tsx
@@ -4,24 +4,22 @@ import { AgentScene } from "./scenes/agent/AgentScene";
 export function Hero() {
   return (
     <section className="mx-auto max-w-6xl px-6 pt-24 pb-16 md:pt-32">
-      <div className="flex flex-col items-center text-center max-w-3xl mx-auto mb-16">
-        <h1 className="text-4xl font-bold tracking-tight md:text-6xl">
+      <div className="flex flex-col items-center text-center mb-16">
+        <h1 className="font-mono font-bold tracking-tight text-3xl md:text-5xl max-w-5xl">
           The open source browser agent.
         </h1>
-        <p className="mt-6 text-lg text-muted-foreground leading-relaxed">
+        <p className="mt-6 text-base md:text-lg text-muted-foreground leading-relaxed max-w-3xl">
           OpenBrowse reads pages, takes actions, and organizes your tabs.
           Use any model — cloud, self-hosted, or fully on-device.
         </p>
         <div className="mt-8 flex items-center justify-center gap-4">
-          <a
-            href="https://chromewebstore.google.com"
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            href="/docs/overview#install"
             className="inline-flex h-11 items-center gap-2 rounded-md bg-foreground px-8 text-sm font-medium text-background transition-opacity hover:opacity-90"
           >
             <ChromeIcon className="h-4 w-4" />
-            Add to Chrome
-          </a>
+            Install
+          </Link>
           <a
             href="https://github.com/openbrowse-ai/openbrowse"
             target="_blank"
@@ -31,8 +29,11 @@ export function Hero() {
             GitHub
           </a>
         </div>
+        <p className="mt-4 text-xs text-muted-foreground">
+          Chrome Web Store listing coming soon — install manually for now.
+        </p>
       </div>
-      
+
       <AgentScene />
     </section>
   );


### PR DESCRIPTION
## Summary

Tweaks the landing hero ahead of the Chrome Web Store listing going live:

- Headline switched to **`font-mono`** and downsized from `text-4xl md:text-6xl` to `text-3xl md:text-5xl` (mono reads denser, so a small size reduction balances visual weight).
- Headline and paragraph now have independent width caps — `max-w-5xl` for the h1 and `max-w-3xl` for the supporting copy (previously both shared a single `max-w-3xl` wrapper).
- Primary CTA repointed from the placeholder \`https://chromewebstore.google.com\` (\"Add to Chrome\") to an internal link to \`/docs/overview#install\`, labeled **Install**. The docs already document the manual unpacked-extension flow as the current install path.
- Added a small muted caption under the CTAs: _\"Chrome Web Store listing coming soon — install manually for now.\"_

## Why

Chrome Web Store listing isn't approved yet, but the manual install flow is documented and ready, so the hero CTA should drive there instead of a dead Web Store URL. We can flip this back when the listing goes live.

## Files changed

- \`apps/docs/components/landing/hero.tsx\`

## Verification

- \`tsc --noEmit\` passes for the docs project.
- Visual review at desktop + mobile widths recommended before merging.