### PR TITLE
fix(extension): heal broken chat sessions and stranded tool calls

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
   "name": "openbrowse",
   "description": "The open source browser agent. A model-agnostic alternative to Claude for Chrome. Connect any local or cloud AI.",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -130,6 +130,7 @@ export function ChatView({
     handleSubmit,
     handleNew,
     handleRegenerate,
+    handleRetry,
     confirmEdit,
     addToolApprovalResponse,
     setAgentModel,
@@ -556,10 +557,7 @@ export function ChatView({
             {error && (
               <ErrorMessage
                 error={error}
-                onRetry={() => {
-                  clearError();
-                  handleSubmit();
-                }}
+                onRetry={handleRetry}
                 onDismiss={clearError}
               />
             )}

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -1826,8 +1826,8 @@ export default defineBackground({
           if (message.type === "CHECK_AVAILABILITY") {
             if (message.provider === "web-llm" && message.webllmModel) {
               const { storage } = await import("@/lib/storage");
-              const downloaded = await storage.getDownloadedModels();
-              if (downloaded.includes(message.webllmModel)) {
+              const { downloadedModels } = await storage.getSettings();
+              if (downloadedModels.includes(message.webllmModel)) {
                 reply({
                   provider: message.provider,
                   availability: "available",

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -150,6 +150,149 @@ function extractTextContent(parts: SerializedUIPart[]): string {
     .join("");
 }
 
+/**
+ * Whether `parts` represents an assistant turn worth persisting/showing.
+ *
+ * The AI SDK's `onFinish` callback fires for every terminal state —
+ * including errors that hit before the model produced any content. In
+ * that path `parts` ends up empty (or just a `step-start` marker). If
+ * we save such a message to chatDb anyway, the conversation gets
+ * stuck with a bare regenerate-icon bubble after the next page reload
+ * (the in-memory error banner from `useChat`'s `error` state doesn't
+ * survive refreshes).
+ *
+ * Returning false here from `onFinish` skips the save; on conversation
+ * load, a trailing message that fails this predicate is also self-
+ * healed out of chatDb so previously-broken chats recover automatically.
+ */
+function hasMeaningfulContent(parts: SerializedUIPart[]): boolean {
+  return parts.some((p) => {
+    if (p.type === "text" || p.type === "reasoning") return p.text.length > 0;
+    if (p.type === "dynamic-tool") return true;
+    if (p.type === "file" || p.type === "source-url") return true;
+    // step-start and data-compaction are markers, not user-visible content.
+    return false;
+  });
+}
+
+/**
+ * Heals "stranded" tool calls in `messages` so a subsequent prompt
+ * does not trip the AI SDK's `MissingToolResultsError`.
+ *
+ * Two states get healed:
+ *
+ * - `approval-requested` → `output-denied` with `approval.approved = false`.
+ *   Mirrors the pre-existing inline cleanup; see the long comment in
+ *   {@link handleSubmit} below for why we mutate state directly here
+ *   rather than calling `addToolApprovalResponse` / `addToolOutput`.
+ *
+ * - `input-available` → `output-error`. Happens when a tool call started
+ *   but its result was never recorded (page refreshed mid-stream, the
+ *   stream errored after emitting `tool-input-available` but before
+ *   `tool-output-available`, etc.). Synthesizing an `output-error` with
+ *   a clear errorText keeps the model in the loop — it sees the failed
+ *   attempt instead of an unexplained text gap, and can decide whether
+ *   to retry or proceed.
+ *
+ * Returns both the new full `messages` list and the subset that
+ * actually changed. Callers persist the changed subset to chatDb so
+ * the heal survives across reloads.
+ */
+const TOOL_HEAL_INTERRUPT_TEXT =
+  "Tool execution was interrupted before it returned a result";
+
+function healPendingTools(
+  messages: AgentMessage[],
+  denyReason: string,
+): { healed: AgentMessage[]; healedMessages: AgentMessage[] } {
+  const isPendingTool = (p: unknown): boolean => {
+    const pp = p as Record<string, unknown>;
+    const isTool =
+      pp.type === "dynamic-tool" ||
+      (typeof pp.type === "string" &&
+        (pp.type as string).startsWith("tool-"));
+    if (!isTool) return false;
+    return (
+      pp.state === "approval-requested" || pp.state === "input-available"
+    );
+  };
+
+  const anyPending = messages.some((m) => m.parts.some(isPendingTool));
+  if (!anyPending) return { healed: messages, healedMessages: [] };
+
+  const healedMessages: AgentMessage[] = [];
+  const healed = messages.map((msg) => {
+    let changed = false;
+    const newParts = msg.parts.map((part) => {
+      const p = part as Record<string, unknown>;
+      const isTool =
+        p.type === "dynamic-tool" ||
+        (typeof p.type === "string" &&
+          (p.type as string).startsWith("tool-"));
+      if (!isTool) return part;
+
+      if (p.state === "approval-requested" && p.approval) {
+        const approval = p.approval as { id: string };
+        changed = true;
+        return {
+          ...part,
+          state: "output-denied",
+          approval: { id: approval.id, approved: false, reason: denyReason },
+        } as typeof part;
+      }
+
+      if (p.state === "input-available") {
+        changed = true;
+        return {
+          ...part,
+          state: "output-error",
+          errorText: TOOL_HEAL_INTERRUPT_TEXT,
+        } as typeof part;
+      }
+
+      return part;
+    });
+    if (!changed) return msg;
+    const newMsg = { ...msg, parts: newParts };
+    healedMessages.push(newMsg);
+    return newMsg;
+  });
+
+  return { healed, healedMessages };
+}
+
+/**
+ * Writes the healed messages produced by {@link healPendingTools} back
+ * to chatDb so a subsequent reload reads the post-heal shape rather
+ * than the original stranded `input-available` / `approval-requested`.
+ *
+ * Reads existing rows first to preserve `createdAt` (chatDb sorts by
+ * it on load) and any other fields like `summary` that aren't part of
+ * `AgentUIMessage`.
+ */
+async function persistHealedMessages(
+  conversationId: string | null,
+  healedMessages: AgentMessage[],
+): Promise<void> {
+  if (!conversationId || healedMessages.length === 0) return;
+  const dbMsgs = await chatDb.getMessages(conversationId);
+  const byId = new Map(dbMsgs.map((m) => [m.id, m]));
+  const updates: Parameters<typeof chatDb.saveMessages>[0] = [];
+  for (const m of healedMessages) {
+    const existing = byId.get(m.id);
+    if (!existing) continue;
+    const parts = serializeParts(m.parts);
+    updates.push({
+      ...existing,
+      parts,
+      content: extractTextContent(parts),
+    });
+  }
+  if (updates.length > 0) {
+    await chatDb.saveMessages(updates);
+  }
+}
+
 function deserializePart(
   p: SerializedUIPart,
 ): AgentMessage["parts"][number] | null {
@@ -237,16 +380,38 @@ function getOrCreateChat(
     generateId,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onFinish: async ({ message }) => {
+      // Clear the cross-context "agent is running" indicator. onFinish
+      // fires for every terminal state (success, abort, disconnect,
+      // error), so this is the single point where the active-agents
+      // flag should be cleared regardless of whether the React hook
+      // for this conversation is currently mounted. Pending tool
+      // approval also flips status out of streaming and shouldn't
+      // surface as a "running" dot — the user needs to act before the
+      // agent continues.
+      setAgentInactive(conversationId);
+
       const parts = serializeParts(message.parts);
-      await chatDb.saveMessage({
-        id: message.id,
-        conversationId,
-        role: "assistant",
-        content: extractTextContent(parts),
-        parts,
-        createdAt: Date.now(),
-      });
-      await chatDb.updateConversation(conversationId, { updatedAt: Date.now() });
+
+      // Skip persisting an "empty turn" — fired when the agent errored
+      // before producing any content. Saving an empty assistant
+      // message would leave a bare regenerate-icon bubble in the
+      // conversation after a refresh (the in-memory error banner
+      // doesn't survive reloads). Partial content (mid-stream errors,
+      // user aborts) still persists because at least one meaningful
+      // part exists by then.
+      if (hasMeaningfulContent(parts)) {
+        await chatDb.saveMessage({
+          id: message.id,
+          conversationId,
+          role: "assistant",
+          content: extractTextContent(parts),
+          parts,
+          createdAt: Date.now(),
+        });
+        await chatDb.updateConversation(conversationId, {
+          updatedAt: Date.now(),
+        });
+      }
       const hasApprovalPending = parts.some(
         (p) => p.type === "dynamic-tool" && p.state === "approval-requested"
       );
@@ -666,48 +831,19 @@ export function useAgentChat({
         // to resume. Manual /compact (follow-up) would skip this. The
         // wording matches OpenCode's continue prompt.
         if (auto) {
-          // Auto-deny any pending approvals that would otherwise leave
-          // the conversation in an invalid tool_use-without-tool_result
-          // state when we send the continue message. Mirrors the same
-          // logic in handleSubmit.
-          const hasPending = msgs.some((m) =>
-            m.parts.some(
-              (p) =>
-                ((p as Record<string, unknown>).type === "dynamic-tool" ||
-                  (typeof (p as Record<string, unknown>).type === "string" &&
-                    ((p as Record<string, unknown>).type as string).startsWith(
-                      "tool-",
-                    ))) &&
-                (p as Record<string, unknown>).state === "approval-requested",
-            ),
+          // Heal pending tool calls in the pre-compaction tail so the
+          // continue message doesn't leave the conversation in an
+          // invalid tool_use-without-tool_result state. Mirrors
+          // `handleSubmit`. We pass `msgs` (the pre-compaction list)
+          // because the newly-added compaction marker + summary have
+          // no tool parts.
+          const { healed, healedMessages } = healPendingTools(
+            msgs,
+            "Superseded by auto-compaction continue",
           );
-          if (hasPending) {
-            const reason = "Superseded by auto-compaction continue";
-            setMessages((prev) =>
-              prev.map((msg) => ({
-                ...msg,
-                parts: msg.parts.map((part) => {
-                  const p = part as Record<string, unknown>;
-                  const isTool =
-                    p.type === "dynamic-tool" ||
-                    (typeof p.type === "string" &&
-                      (p.type as string).startsWith("tool-"));
-                  if (isTool && p.state === "approval-requested" && p.approval) {
-                    const approval = p.approval as { id: string };
-                    return {
-                      ...part,
-                      state: "output-denied",
-                      approval: {
-                        id: approval.id,
-                        approved: false,
-                        reason,
-                      },
-                    } as typeof part;
-                  }
-                  return part;
-                }),
-              })),
-            );
+          if (healedMessages.length > 0) {
+            setMessages([...healed, compactionUiMsg, summaryUiMsg]);
+            await persistHealedMessages(convId, healedMessages);
           }
 
           const continueText = overflow
@@ -754,14 +890,6 @@ export function useAgentChat({
       }
     }
   }, [status, conversationId, messages, runCompaction]);
-
-  useEffect(() => {
-    return () => {
-      if (wasStreamingRef.current && conversationId) {
-        setAgentInactive(conversationId);
-      }
-    };
-  }, [conversationId]);
 
   useEffect(() => {
     const listener = (message: { type: string }) => {
@@ -837,7 +965,25 @@ export function useAgentChat({
     if (prevLoadedChatRef.current === chat) return;
     prevLoadedChatRef.current = chat;
 
-    chatDb.getMessages(conversationId).then((msgs) => {
+    chatDb.getMessages(conversationId).then(async (initialMsgs) => {
+      // Self-heal: drop a trailing empty assistant message left over
+      // from an `onFinish`-on-error save that pre-dates the
+      // `hasMeaningfulContent` gate above. Without this, the user sees
+      // a bare regenerate-icon bubble after refreshing a chat that
+      // errored. After the delete, the conversation reads as if the
+      // user's last message is unanswered, so the auto-resume branch
+      // below (or a manual retry) takes over.
+      let msgs = initialMsgs;
+      const lastDb = msgs[msgs.length - 1];
+      if (
+        lastDb &&
+        lastDb.role === "assistant" &&
+        !hasMeaningfulContent(lastDb.parts)
+      ) {
+        await chatDb.deleteMessagesFrom(conversationId, lastDb.id);
+        msgs = msgs.slice(0, -1);
+      }
+
       if (msgs.length > 0) {
         const uiMsgs = msgs.map(dbMessageToUIMessage);
         setMessages(uiMsgs);
@@ -862,57 +1008,48 @@ export function useAgentChat({
       if (!input.trim() && images.length === 0) return;
       if (!isConfigured) return;
 
-      // Auto-deny any approval requests still pending when the user sends a
-      // new message.
+      // Heal any stranded tool calls in the existing history before
+      // we append a new user message:
       //
-      // Why we mutate state directly instead of using addToolApprovalResponse
-      // or addToolOutput:
+      //   - `approval-requested` parts get `output-denied` so they
+      //     produce a tool-result instead of leaving an unmatched
+      //     tool_use.
+      //   - `input-available` parts get `output-error` for the same
+      //     reason — without this, sending the new user message would
+      //     trip the AI SDK's `MissingToolResultsError` validation.
       //
-      // - `addToolApprovalResponse({ approved: false })` moves the part to
-      //   state `approval-responded` with `approval.approved = false`. But
-      //   the SDK's agent loop only processes denials via `collectToolApprovals`
-      //   which ONLY looks at the last message. Once we push a user message
-      //   on top, the denial is invisible and the call goes out with an
-      //   Anthropic tool_use lacking a matching tool_result → API rejects.
+      // Why we mutate state directly instead of `addToolApprovalResponse`
+      // or `addToolOutput`:
       //
-      // - `addToolOutput({ state: "output-error" })` produces a real tool-result,
-      //   but its Zod schema requires `approval.approved === true` for that
-      //   state. The stale `{ id }` approval fails validation and the message
-      //   falls through to the data-part schema → "Type must start with data-".
+      // - `addToolApprovalResponse({ approved: false })` moves the part
+      //   to `approval-responded` with `approval.approved = false`. The
+      //   SDK's agent loop only processes denials via
+      //   `collectToolApprovals`, which ONLY looks at the last message.
+      //   Once we push a user message on top, the denial is invisible
+      //   and the call goes out with an Anthropic tool_use lacking a
+      //   matching tool_result → API rejects.
       //
-      // - The correct target is `state: "output-denied"` with
-      //   `approval.approved = false`, but no public API writes that state
-      //   client-side. So we mutate via setMessages.
-      const hasPending = messages.some((m) =>
-        m.parts.some(
-          (p) =>
-            ((p as Record<string, unknown>).type === "dynamic-tool" ||
-              (typeof (p as Record<string, unknown>).type === "string" &&
-                ((p as Record<string, unknown>).type as string).startsWith("tool-"))) &&
-            (p as Record<string, unknown>).state === "approval-requested",
-        ),
+      // - `addToolOutput({ state: "output-error" })` produces a real
+      //   tool-result, but its Zod schema requires
+      //   `approval.approved === true` for that state. The stale
+      //   `{ id }` approval fails validation and the message falls
+      //   through to the data-part schema → "Type must start with data-".
+      //
+      // - The correct target for approvals is `output-denied` with
+      //   `approval.approved = false`, and the correct target for an
+      //   un-resolved input-available is plain `output-error`. Neither
+      //   has a public API that writes them client-side, so
+      //   `healPendingTools` mutates via `setMessages` and we persist
+      //   the change to chatDb to survive reloads.
+      const { healed, healedMessages } = healPendingTools(
+        messages,
+        "Superseded by new user message",
       );
-      if (hasPending) {
-        const reason = "Superseded by new user message";
-        setMessages(
-          messages.map((msg) => ({
-            ...msg,
-            parts: msg.parts.map((part) => {
-              const p = part as Record<string, unknown>;
-              const isTool =
-                p.type === "dynamic-tool" ||
-                (typeof p.type === "string" && (p.type as string).startsWith("tool-"));
-              if (isTool && p.state === "approval-requested" && p.approval) {
-                const approval = p.approval as { id: string };
-                return {
-                  ...part,
-                  state: "output-denied",
-                  approval: { id: approval.id, approved: false, reason },
-                } as typeof part;
-              }
-              return part;
-            }),
-          })),
+      if (healedMessages.length > 0) {
+        setMessages(healed);
+        await persistHealedMessages(
+          conversationIdRef.current,
+          healedMessages,
         );
       }
 
@@ -1022,6 +1159,65 @@ export function useAgentChat({
     [regenerate, conversationId],
   );
 
+  /**
+   * Retry the last attempt after an error. Used by the error banner's
+   * Retry button.
+   *
+   * Two cases:
+   *
+   * - Last message is the user's prompt (the agent errored before
+   *   producing any persistable assistant content — `onFinish`'s
+   *   `hasMeaningfulContent` gate skipped saving). We just call
+   *   `regenerate()` and the SDK runs a fresh attempt off that prompt.
+   *
+   * - Last message is a partial assistant message (mid-stream error
+   *   that produced *some* content). Heal any stranded tool calls in
+   *   the messages that will survive the regenerate slice, delete the
+   *   partial assistant from chatDb to keep it in sync with the
+   *   in-memory slice the SDK is about to take, then call
+   *   `regenerate({ messageId })`.
+   *
+   * The bare `clearError(); handleSubmit()` previously wired here
+   * silently no-op'd whenever the input field was empty (the common
+   * case when clicking Retry).
+   */
+  const handleRetry = useCallback(async () => {
+    clearError();
+    const last = messages[messages.length - 1];
+    if (!last) return;
+
+    if (last.role === "assistant") {
+      // Heal stranded tool calls in the surviving prefix so the
+      // regenerated request doesn't trip MissingToolResultsError.
+      const survivors = messages.slice(0, messages.length - 1);
+      const { healed, healedMessages } = healPendingTools(
+        survivors,
+        "Superseded by retry",
+      );
+      if (healedMessages.length > 0) {
+        setMessages([...healed, last]);
+        await persistHealedMessages(conversationId, healedMessages);
+      }
+      if (conversationId) {
+        await chatDb.deleteMessagesFrom(conversationId, last.id);
+      }
+      regenerate({ messageId: last.id });
+      return;
+    }
+
+    // Last message is a user prompt — heal any prior stranded tool
+    // calls and ask the SDK to generate an assistant response.
+    const { healed, healedMessages } = healPendingTools(
+      messages,
+      "Superseded by retry",
+    );
+    if (healedMessages.length > 0) {
+      setMessages(healed);
+      await persistHealedMessages(conversationId, healedMessages);
+    }
+    regenerate();
+  }, [messages, conversationId, regenerate, clearError, setMessages]);
+
   const confirmEdit = useCallback(
     async (messageId: string, mentions: TabMentionAttrs[] = [], images: ImagePreview[] = []) => {
       if (!input.trim() && images.length === 0) return;
@@ -1029,41 +1225,20 @@ export function useAgentChat({
       const idx = messages.findIndex((m) => m.id === messageId);
       if (idx === -1) return;
 
-      // Auto-deny any pending approval requests — see note in handleSubmit.
-      const hasPending = messages.some((m) =>
-        m.parts.some(
-          (p) =>
-            ((p as Record<string, unknown>).type === "dynamic-tool" ||
-              (typeof (p as Record<string, unknown>).type === "string" &&
-                ((p as Record<string, unknown>).type as string).startsWith("tool-"))) &&
-            (p as Record<string, unknown>).state === "approval-requested",
-        ),
+      // Heal any stranded tool calls that will survive the edit slice
+      // (everything at/after `idx` is about to be deleted anyway). See
+      // the long note in `handleSubmit`.
+      const survivors = messages.slice(0, idx);
+      const { healed, healedMessages } = healPendingTools(
+        survivors,
+        "Superseded by edited user message",
       );
-      if (hasPending) {
-        const reason = "Superseded by edited user message";
-        setMessages(
-          messages.map((msg) => ({
-            ...msg,
-            parts: msg.parts.map((part) => {
-              const p = part as Record<string, unknown>;
-              const isTool =
-                p.type === "dynamic-tool" ||
-                (typeof p.type === "string" && (p.type as string).startsWith("tool-"));
-              if (isTool && p.state === "approval-requested" && p.approval) {
-                const approval = p.approval as { id: string };
-                return {
-                  ...part,
-                  state: "output-denied",
-                  approval: { id: approval.id, approved: false, reason },
-                } as typeof part;
-              }
-              return part;
-            }),
-          })),
-        );
+      if (healedMessages.length > 0) {
+        setMessages(healed);
+        await persistHealedMessages(conversationId, healedMessages);
       }
 
-      setMessages(messages.slice(0, idx));
+      setMessages(survivors);
       if (conversationId) {
         await chatDb.deleteMessagesFrom(conversationId, messageId);
       }
@@ -1093,17 +1268,29 @@ export function useAgentChat({
 
       setInput("");
 
-      const files = images.map((img) => ({
-        type: "file" as const,
-        mediaType: img.file.type,
-        url: img.dataUrl,
-      }));
+      // Construct a full message payload (id + role + parts) instead of the
+      // `{ text, files, messageId }` shorthand. Passing `messageId` to the AI
+      // SDK's `sendMessage` instructs it to *replace* an existing message in
+      // state with that id — but we just sliced the original out via
+      // `setMessages(messages.slice(0, idx))`, and `newMessageId` is brand new,
+      // so the SDK throws `message with id <newMessageId> not found`. Pushing
+      // it as a new message keeps state aligned with chatDb (both keyed by
+      // `newMessageId`) and lets the UI re-render the edited bubble immediately
+      // without a chat switch.
+      const sendParts: AgentMessage["parts"] = [
+        ...(text ? [{ type: "text" as const, text }] : []),
+        ...images.map((img) => ({
+          type: "file" as const,
+          mediaType: img.file.type,
+          url: img.dataUrl,
+        })),
+      ];
 
-      if (text) {
-        sendMessage({ text, files: files.length > 0 ? files : undefined, messageId: newMessageId });
-      } else {
-        sendMessage({ files, messageId: newMessageId });
-      }
+      sendMessage({
+        id: newMessageId,
+        role: "user",
+        parts: sendParts,
+      });
     },
     [input, isConfigured, messages, setMessages, conversationId, sendMessage],
   );
@@ -1160,6 +1347,7 @@ export function useAgentChat({
     handleSubmit,
     handleNew,
     handleRegenerate,
+    handleRetry,
     confirmEdit,
     addToolApprovalResponse,
     stop,

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -628,8 +628,23 @@ function toSDKTool<TInput, TOutput>(
 
   const toModelOutput = isImageTool
     ? ({ output }: { output: TOutput }) => {
-        const { imageDataUrl } = output as { imageDataUrl: string };
-        const base64 = imageDataUrl.replace(/^data:image\/png;base64,/, "");
+        // Tool results that were elided by the compacting transport's
+        // screenshot stripping arrive here without `imageDataUrl`. Emit
+        // a text marker so the model still sees that a screenshot was
+        // taken and dropped, instead of throwing on `undefined.replace`.
+        const out = output as { imageDataUrl?: string; removed?: string };
+        if (typeof out.imageDataUrl !== "string") {
+          return {
+            type: "content" as const,
+            value: [
+              {
+                type: "text" as const,
+                text: out.removed ?? "[screenshot removed during compaction]",
+              },
+            ],
+          };
+        }
+        const base64 = out.imageDataUrl.replace(/^data:image\/png;base64,/, "");
         return {
           type: "content" as const,
           value: [

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -9,7 +9,13 @@ import {
   type UIMessageChunk,
 } from "ai";
 import type { AgentDataParts, AgentUIMessage, CompactionPart } from "../types";
-import { COMPACTION_USER_PROMPT, prunePartsAtSendTime } from "./compaction";
+import {
+  COMPACTION_USER_PROMPT,
+  SCREENSHOT_PROTECTED_TURNS,
+  findProtectedTailStart,
+  prunePartsAtSendTime,
+  stripScreenshotsFromParts,
+} from "./compaction";
 
 interface Options<TOOLS extends ToolSet> {
   agent: Agent<never, TOOLS, never>;
@@ -159,9 +165,23 @@ export function rewriteForLLM(messages: AgentUIMessage[]): AgentUIMessage[] {
     ];
   }
 
-  const rewritten = working.map((m) => {
+  const protectedStart = findProtectedTailStart(
+    working,
+    SCREENSHOT_PROTECTED_TURNS,
+  );
+
+  const rewritten = working.map((m, i) => {
     let parts = m.parts;
     parts = substituteCompactionPart(parts);
+    // Only strip screenshots from messages older than the last
+    // SCREENSHOT_PROTECTED_TURNS user turns. Recent screenshots ride
+    // along intact so the model retains visual recall across one user-
+    // input boundary; older ones become a typed placeholder that the
+    // screenshot tool's `toModelOutput` adapter renders as a text
+    // marker.
+    if (i < protectedStart) {
+      parts = stripScreenshotsFromParts(parts);
+    }
     parts = prunePartsAtSendTime(parts);
     if (parts === m.parts) return m;
     return { ...m, parts };

--- a/apps/extension/src/lib/agent/compaction.ts
+++ b/apps/extension/src/lib/agent/compaction.ts
@@ -13,6 +13,16 @@ export const PRUNE_MINIMUM = 20_000;
 export const PRUNE_PROTECT = 40_000;
 export const TOOL_OUTPUT_MAX_CHARS = 2_000;
 export const PROTECTED_TURNS = 2;
+/**
+ * How many recent user turns keep their `screenshot` tool outputs intact
+ * when the compacting transport ships the conversation to the model.
+ *
+ * Held separately from `PROTECTED_TURNS` (which governs the head-pruner's
+ * cumulative-output budget) because the two policies are conceptually
+ * independent — one tunes summarization input, the other tunes per-turn
+ * visual recall — and shouldn't drift together accidentally.
+ */
+export const SCREENSHOT_PROTECTED_TURNS = 2;
 export const TAIL_TURNS = 2;
 export const MIN_PRESERVE_RECENT_TOKENS = 2_000;
 export const MAX_PRESERVE_RECENT_TOKENS = 8_000;
@@ -142,6 +152,11 @@ export interface PrunableMessage {
  * `AgentUIMessage["parts"]` so callers (the transport) don't have to
  * convert to/from our `SerializedUIPart` shape. Only `dynamic-tool` parts
  * are inspected; everything else passes through unchanged.
+ *
+ * Screenshot-specific elision is *not* handled here — that policy needs
+ * cross-message context (which user turns to protect) and lives in the
+ * compacting transport via {@link stripScreenshotsFromParts} +
+ * {@link findProtectedTailStart}.
  */
 export function prunePartsAtSendTime(
   parts: AgentUIMessage["parts"],
@@ -160,15 +175,6 @@ export function prunePartsAtSendTime(
         ? part.output
         : JSON.stringify(part.output);
 
-    if (
-      part.toolName === "screenshot" ||
-      part.toolName === "screenshotPage"
-    ) {
-      out.push({ ...part, output: "[screenshot removed during compaction]" });
-      changed = true;
-      continue;
-    }
-
     if (outputStr.length > TOOL_OUTPUT_MAX_CHARS) {
       out.push({
         ...part,
@@ -182,6 +188,66 @@ export function prunePartsAtSendTime(
   }
 
   return changed ? out : parts;
+}
+
+/**
+ * Replaces the output of every completed `screenshot` tool call in
+ * `parts` with the typed placeholder shape (`{ removed: "..." }`) that
+ * the screenshot tool's `toModelOutput` adapter recognizes.
+ *
+ * Cross-message recency policy (which messages get their screenshots
+ * stripped vs. preserved) lives in the compacting transport — this
+ * helper is shape-only and idempotent.
+ */
+export function stripScreenshotsFromParts(
+  parts: AgentUIMessage["parts"],
+): AgentUIMessage["parts"] {
+  let changed = false;
+  const out: AgentUIMessage["parts"] = [];
+  for (const part of parts) {
+    if (
+      part.type === "dynamic-tool" &&
+      part.state === "output-available" &&
+      part.toolName === "screenshot"
+    ) {
+      out.push({
+        ...part,
+        output: { removed: "[screenshot removed during compaction]" },
+      });
+      changed = true;
+      continue;
+    }
+    out.push(part);
+  }
+  return changed ? out : parts;
+}
+
+/**
+ * Walks `messages` from the end, counting user-role messages, and
+ * returns the index of the first message that belongs to the
+ * "protected tail" of the most recent `keepUserTurns` user turns. Any
+ * message at index `< return value` is in the head and may have its
+ * screenshots elided; index `>= return value` is in the tail and
+ * should keep its screenshots intact.
+ *
+ * Mirrors the loop already used inside `pruneMessages` so both pruners
+ * share the same notion of "recent user turns."
+ */
+export function findProtectedTailStart<T extends { role: string }>(
+  messages: T[],
+  keepUserTurns: number,
+): number {
+  let userTurnsSeen = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== "user") continue;
+    userTurnsSeen++;
+    if (userTurnsSeen > keepUserTurns) {
+      return i + 1;
+    }
+  }
+  // Conversation has fewer than `keepUserTurns` user turns total — every
+  // message is in the protected tail.
+  return 0;
 }
 
 export function pruneMessages(
@@ -244,10 +310,7 @@ export function pruneMessages(
 
         // Beyond threshold, start pruning
         // Check if this is a screenshot tool
-        if (
-          part.toolName === "screenshot" ||
-          part.toolName === "screenshotPage"
-        ) {
+        if (part.toolName === "screenshot") {
           // Replace output with placeholder
           newParts.push({
             ...part,

--- a/apps/extension/src/lib/agent/tools/screenshot.ts
+++ b/apps/extension/src/lib/agent/tools/screenshot.ts
@@ -20,7 +20,21 @@ const parameters = z.object({
 type Input = z.infer<typeof parameters>;
 
 type Output = {
-  imageDataUrl: string;
+  /**
+   * Data URL of the captured PNG. Always set when the screenshot tool
+   * actually executes successfully. Marked optional because the
+   * compacting transport may strip the image when the tool result
+   * falls outside the protected tail of recent user turns; in that
+   * case `removed` carries the placeholder marker instead.
+   */
+  imageDataUrl?: string;
+  /**
+   * Set when this tool result was elided by send-time pruning. Used by
+   * the screenshot tool's `toModelOutput` to emit a text marker so the
+   * model still sees that a screenshot existed here and was removed,
+   * instead of crashing on a missing field.
+   */
+  removed?: string;
   /** Number of @refs that were rendered as labels on the image. */
   annotatedCount?: number;
   /** Set if annotation was requested but failed; helps the agent diagnose. */

--- a/apps/extension/src/lib/constants.ts
+++ b/apps/extension/src/lib/constants.ts
@@ -60,7 +60,6 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
 export const STORAGE_KEYS = {
   SPACES: "spaces",
   SETTINGS: "settings",
-  DOWNLOADED_MODELS: "downloaded-models",
   AGENT_SETTINGS: "agent-settings",
   MCP_SERVERS: "mcp-servers",
   AUTO_TIDY_NOTIFICATION: "auto-tidy-notification",

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -10,6 +10,28 @@ async function set<T>(key: string, value: T): Promise<void> {
   await chrome.storage.local.set({ [key]: value });
 }
 
+/**
+ * Serializes writes (and read-modify-write blocks) against the
+ * `settings` storage key. Without this, two callers that each do a
+ * `getSettings → mutate → setSettings` round-trip can lose each
+ * other's updates — for example, two near-simultaneous WebLLM
+ * downloads finishing and both calling `addDownloadedModel`. The
+ * Promise chain enforces sequential execution; reads outside the
+ * chain still observe the latest committed value because
+ * `chrome.storage.local` reads are atomic.
+ */
+let settingsWriteChain: Promise<void> = Promise.resolve();
+
+function lockSettings<T>(fn: () => Promise<T>): Promise<T> {
+  const run = settingsWriteChain.then(fn, fn);
+  // Keep the chain alive even if a caller's promise rejects.
+  settingsWriteChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
 export const storage = {
   async getSpaces(): Promise<Space[]> {
     const raw = (await get<any[]>(STORAGE_KEYS.SPACES)) ?? [];
@@ -52,80 +74,53 @@ export const storage = {
   },
 
   async getSettings(): Promise<Settings> {
-    const stored = await get<Record<string, unknown>>(STORAGE_KEYS.SETTINGS);
-    if (!stored) return { ...DEFAULT_SETTINGS };
-
-    // Already migrated (has new fields)
-    if ("providerConfigs" in stored && "enabledModels" in stored) {
-      return { ...DEFAULT_SETTINGS, ...stored } as Settings;
-    }
-
-    // Migrate old format
-    const migrated: Settings = { ...DEFAULT_SETTINGS };
-
-    // General settings
-    if (stored.themeMode) migrated.themeMode = stored.themeMode as Settings["themeMode"];
-    if (stored.autoTidyAfterMinutes) migrated.autoTidyAfterMinutes = stored.autoTidyAfterMinutes as number;
-    if (stored.agentGroupIdleHours) migrated.agentGroupIdleHours = stored.agentGroupIdleHours as number;
-    if (stored.archiveAggressiveness) migrated.archiveAggressiveness = stored.archiveAggressiveness as Settings["archiveAggressiveness"];
-    if (stored.mcpServers) migrated.mcpServers = stored.mcpServers as Settings["mcpServers"];
-
-    // Migrate cloud API keys to providerConfigs
-    const cloudApiKeys = (stored.cloudApiKeys || {}) as Record<string, string>;
-    const singleKey = stored.cloudApiKey as string | undefined;
-    const cloudProvider = stored.cloudProvider as string | undefined;
-
-    // Store single key under its provider if cloudApiKeys doesn't have it
-    if (singleKey && cloudProvider && !cloudApiKeys[cloudProvider]) {
-      cloudApiKeys[cloudProvider] = singleKey;
-    }
-
-    if (cloudApiKeys.openai) migrated.providerConfigs.openai = { apiKey: cloudApiKeys.openai };
-    if (cloudApiKeys.anthropic) migrated.providerConfigs.anthropic = { apiKey: cloudApiKeys.anthropic };
-    if (cloudApiKeys.google) migrated.providerConfigs.google = { apiKey: cloudApiKeys.google };
-    if (cloudApiKeys["openai-compatible"]) {
-      migrated.providerConfigs["openai-compatible"] = {
-        apiKey: cloudApiKeys["openai-compatible"],
-        baseUrl: (stored.cloudBaseUrl as string) || "",
-        modelId: (stored.cloudModel as string) || "",
-      };
-    }
-
-    // Migrate favorite model from old single-model selection
-    if (cloudProvider && stored.cloudModel && cloudProvider !== "openai-compatible") {
-      migrated.favoriteModels = [`${cloudProvider}:${stored.cloudModel}`];
-    }
-
-    // Migrate downloaded models from legacy separate storage key
-    const legacyDownloaded = await get<string[]>(STORAGE_KEYS.DOWNLOADED_MODELS);
-    if (legacyDownloaded && legacyDownloaded.length > 0) {
-      migrated.downloadedModels = legacyDownloaded;
-    }
-
-    return migrated;
+    const stored = await get<Partial<Settings>>(STORAGE_KEYS.SETTINGS);
+    return { ...DEFAULT_SETTINGS, ...stored };
   },
 
   async setSettings(settings: Settings): Promise<void> {
-    await set(STORAGE_KEYS.SETTINGS, settings);
+    await lockSettings(() => set(STORAGE_KEYS.SETTINGS, settings));
   },
 
-  async getDownloadedModels(): Promise<string[]> {
-    return (await get<string[]>(STORAGE_KEYS.DOWNLOADED_MODELS)) ?? [];
+  /**
+   * Read-modify-write helper for `Settings`. Serialized against
+   * `setSettings` and other `updateSettings` calls via a shared lock,
+   * which prevents lost-update races between callers like
+   * `addDownloadedModel` and the settings UI's auto-save paths.
+   *
+   * The updater receives the current persisted settings (with
+   * `DEFAULT_SETTINGS` filling any missing fields) and returns the
+   * next value. Returning the same reference is a valid no-op.
+   */
+  async updateSettings(
+    updater: (current: Settings) => Settings | Promise<Settings>,
+  ): Promise<Settings> {
+    return lockSettings(async () => {
+      const stored = await get<Partial<Settings>>(STORAGE_KEYS.SETTINGS);
+      const current = { ...DEFAULT_SETTINGS, ...stored };
+      const next = await updater(current);
+      if (next !== current) {
+        await set(STORAGE_KEYS.SETTINGS, next);
+      }
+      return next;
+    });
   },
 
   async addDownloadedModel(modelId: string): Promise<void> {
-    const models = await this.getDownloadedModels();
-    if (!models.includes(modelId)) {
-      await set(STORAGE_KEYS.DOWNLOADED_MODELS, [...models, modelId]);
-    }
+    await this.updateSettings((s) => {
+      if (s.downloadedModels.includes(modelId)) return s;
+      return { ...s, downloadedModels: [...s.downloadedModels, modelId] };
+    });
   },
 
   async removeDownloadedModel(modelId: string): Promise<void> {
-    const models = await this.getDownloadedModels();
-    await set(
-      STORAGE_KEYS.DOWNLOADED_MODELS,
-      models.filter((m) => m !== modelId),
-    );
+    await this.updateSettings((s) => {
+      if (!s.downloadedModels.includes(modelId)) return s;
+      return {
+        ...s,
+        downloadedModels: s.downloadedModels.filter((m) => m !== modelId),
+      };
+    });
   },
 
   async getAgentSettings(): Promise<AgentSettings> {

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
   manifest: ({ mode }) => ({
     name: "OpenBrowse",
     description: "The open source browser agent.",
-    version: "0.1.0",
+    version: "0.1.1",
     // Pins the extension ID to the Chrome Web Store listing. Required so
     // that storage from manual / unpacked installs (loaded from a release
     // zip) carries over to the Web Store install: same `key` -> same


### PR DESCRIPTION
Fixes several intertwined bugs that caused chats to get stuck after errors, page refreshes, or interrupted tool calls.

## Settings persistence + concurrency
- Replace broken legacy migration gate in `getSettings()` (required both `providerConfigs` AND `enabledModels` to be present, falling through on saves missing one) with a simple `DEFAULT_SETTINGS` spread.
- Drop dead pre-`d9b4b93` migration code and the legacy `STORAGE_KEYS.DOWNLOADED_MODELS` key; `downloadedModels` now lives in `Settings`.
- Add a `lockSettings` Promise chain to serialize read-modify-write blocks so concurrent WebLLM downloads / settings UI saves don't drop each other's writes.

## Active agent indicator
- Move `setAgentInactive()` out of `useAgentChat`'s unmount cleanup and into the `Chat` instance's `onFinish` callback. `onFinish` fires for every terminal state regardless of React mount state, so the blue dot now clears correctly across context boundaries.

## Screenshot pruning + toModelOutput crash
- Make screenshot `Output.imageDataUrl` optional and add a `removed` placeholder. `toModelOutput` now handles elided screenshots by emitting a text marker instead of crashing on `undefined.replace`.
- Move screenshot pruning out of `prunePartsAtSendTime` into `stripScreenshotsFromParts` + `findProtectedTailStart` in `compaction.ts`, driven from `rewriteForLLM` with `SCREENSHOT_PROTECTED_TURNS = 2` so recent screenshots ride along intact for visual recall.
- Drop dead `screenshotPage` references.

## Empty assistant bubbles after errors
- Add `hasMeaningfulContent()` and gate `chatDb.saveMessage` in `onFinish` on it, so terminal-on-error callbacks (which deliver empty parts) don't persist a blank assistant message that renders as a bare regenerate-icon bubble after refresh.
- Self-heal: drop a trailing empty assistant from chatDb on conversation load. Auto-resume then re-attempts off the last user message.

## Stranded tool-call healing
- Add `healPendingTools()` to convert stranded `approval-requested` -> `output-denied` and `input-available` -> `output-error` (with a clear `errorText`) before sending to the model, so a refresh or mid-stream error followed by a new user message no longer trips the AI SDK's `MissingToolResultsError`.
- Add `persistHealedMessages()` to write heals back to chatDb, preserving `createdAt` + `summary`, so reloads see the post-heal shape.
- Refactor three previously-duplicated approval-cleanup sites (`handleSubmit`, `confirmEdit`, `runCompaction` auto-continue) to use the helpers and persist their changes.

## Retry button
- Add `handleRetry` callback. If the last message is a partial assistant, heal the surviving prefix, delete the partial from chatDb, and `regenerate({ messageId })`. If the last message is the user prompt, heal prior history and call `regenerate()` (SDK picks the last message). Wire `ChatView`'s `<ErrorMessage>` `onRetry` to it, replacing the bare `clearError() + handleSubmit()` that silently no-op'd whenever the input was empty.

## Verification
- `pnpm --filter openbrowse compile` — clean.
- `pnpm --filter openbrowse test` — 28/28.