### PR TITLE
feat(extension): add webFetch tool + provider/model UX fixes

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -82,6 +82,7 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
+    "turndown": "^7.2.4",
     "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.4",
     "zod": "^4.3.6"
@@ -91,6 +92,7 @@
     "@types/chrome": "^0.1.40",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/turndown": "^5.0.6",
     "@wxt-dev/module-react": "^1.1.5",
     "tsx": "^4.20.4",
     "typescript": "^5.9.3",

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -233,6 +233,55 @@ export function ChatView({
     settings.downloadedModels,
   ]);
 
+  // Auto-select a default model when none is set and at least one
+  // provider is now configured. Mirrors the same effect in LandingPage
+  // so that whichever surface the user lands on after entering their
+  // first API key gets a sensible model selected automatically.
+  //
+  // Without this, the model-selector trigger renders empty and the
+  // chat input stays disabled until the user manually picks a model,
+  // which made the post-config UX feel broken.
+  useEffect(() => {
+    if (agentSettings.agentModel) return;
+    if (providerModels.length === 0) return;
+
+    const isAvailable = (key: string) => {
+      const [pid, ...rest] = key.split(":");
+      const mid = rest.join(":");
+      return providerModels.some(
+        (g) => g.provider === pid && g.models.some((m) => m.id === mid),
+      );
+    };
+
+    let pick: string | null = null;
+
+    const favorite = settings.favoriteModels.find(isAvailable);
+    if (favorite) pick = favorite;
+
+    if (!pick) {
+      for (const group of providerModels) {
+        const rec = group.models.find((m) => m.recommended);
+        if (rec) {
+          pick = `${group.provider}:${rec.id}`;
+          break;
+        }
+      }
+    }
+
+    if (!pick) {
+      const group = providerModels[0];
+      const model = group?.models[0];
+      if (group && model) pick = `${group.provider}:${model.id}`;
+    }
+
+    if (pick) setAgentModel(pick);
+  }, [
+    providerModels,
+    agentSettings.agentModel,
+    settings.favoriteModels,
+    setAgentModel,
+  ]);
+
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [preEditInput, setPreEditInput] = useState("");
   const [activeTab, setActiveTab] = useState<{

--- a/apps/extension/src/components/chat/ToolCallBlock.tsx
+++ b/apps/extension/src/components/chat/ToolCallBlock.tsx
@@ -22,6 +22,7 @@ import {
 import { ScreenshotResult } from "./tool-results/screenshot";
 import { SkillResult } from "./tool-results/skill";
 import { SnapshotResult } from "./tool-results/snapshot";
+import { WebFetchResult } from "./tool-results/web-fetch";
 
 import { getToolPreview } from "./tool-previews";
 
@@ -43,6 +44,7 @@ const BUILTIN_RESULT_RENDERERS: Record<string, ResultRenderer> = {
   Grep: ({ args, result }) => <GrepResult args={args} result={result} />,
   LS: ({ args, result }) => <LSResult args={args} result={result} />,
   skill: ({ args, result }) => <SkillResult args={args} result={result} />,
+  webFetch: ({ args, result }) => <WebFetchResult args={args} result={result} />,
 };
 
 interface ToolCallBlockProps {
@@ -73,6 +75,7 @@ const TOOL_LABELS: Record<string, { pending: string; done: string }> = {
   LS: { pending: "Listing folder...", done: "Listed folder" },
   todoWrite: { pending: "Updating plan...", done: "Updated plan" },
   extract: { pending: "Extracting data...", done: "Extracted data" },
+  webFetch: { pending: "Fetching URL...", done: "Fetched URL" },
 
   // Skill tools
   skill: { pending: "Loading skill...", done: "Loaded skill" },
@@ -133,6 +136,33 @@ function parseMcpToolName(toolKey: string): string | null {
   return match[1].replace(/_/g, " ").replace(/-/g, " ");
 }
 
+/**
+ * Build a webFetch-specific label that includes the request URL's host
+ * (and path if short enough). Falls back to the static label when the
+ * URL isn't usable.
+ */
+function webFetchLabels(
+  args: Record<string, unknown>,
+  fallback: { pending: string; done: string },
+): { pending: string; done: string } {
+  const raw = typeof args.url === "string" ? args.url : "";
+  if (!raw) return fallback;
+  let target = raw;
+  try {
+    const u = new URL(raw.startsWith("http") ? raw : `https://${raw}`);
+    target = u.host + (u.pathname && u.pathname !== "/" ? u.pathname : "");
+    if (target.length > 48) target = target.slice(0, 47) + "…";
+  } catch {
+    // Keep the raw string if the URL was unparseable; the agent's
+    // wrapper validates URLs but render shouldn't crash on bad input.
+    if (target.length > 48) target = target.slice(0, 47) + "…";
+  }
+  return {
+    pending: `Fetching ${target}...`,
+    done: `Fetched ${target}`,
+  };
+}
+
 export function ToolCallBlock({
   toolName,
   toolCallId,
@@ -162,6 +192,12 @@ export function ToolCallBlock({
       done: mcpName ? mcpName : toolName,
     };
 
+  // For webFetch, splice in the requested URL's host so the collapsed
+  // row shows the user something concrete (e.g. "Fetching openbrowse.ai...")
+  // rather than a generic "Fetching URL...".
+  const dynamicLabels =
+    toolName === "webFetch" ? webFetchLabels(args, labels) : labels;
+
   const showTabBadge = TAB_TOOLS.has(toolName);
 
   // Denied: compact non-expandable row with a muted "Denied" suffix
@@ -170,7 +206,7 @@ export function ToolCallBlock({
       <div className="flex items-center gap-1.5 py-0.5 px-1 -mx-1 text-sm">
         <X className="size-3 shrink-0 text-muted-foreground/60" />
         <span className="text-muted-foreground/70 line-through">
-          {labels.done}
+          {dynamicLabels.done}
         </span>
         {showTabBadge && <TabBadge toolCallId={toolCallId} />}
         <span className="text-[11px] text-muted-foreground/60 ml-1">
@@ -214,7 +250,7 @@ export function ToolCallBlock({
                 <span className="size-1.5 rounded-full shrink-0 bg-muted-foreground/40" />
               )}
               <span className="text-sm text-muted-foreground">
-                {labels.done}
+                {dynamicLabels.done}
               </span>
               {showTabBadge && <TabBadge toolCallId={toolCallId} />}
               <ChevronRight
@@ -272,10 +308,10 @@ export function ToolCallBlock({
                 !mcpInfo && "animate-pulse",
               )}
             >
-              {labels.pending}
+              {dynamicLabels.pending}
             </span>
           ) : (
-            <span className="text-sm text-muted-foreground">{labels.done}</span>
+            <span className="text-sm text-muted-foreground">{dynamicLabels.done}</span>
           )}
           {showTabBadge && <TabBadge toolCallId={toolCallId} />}
           {!pending && (

--- a/apps/extension/src/components/chat/tool-results/web-fetch.tsx
+++ b/apps/extension/src/components/chat/tool-results/web-fetch.tsx
@@ -1,0 +1,145 @@
+import { ExternalLink, Globe } from "lucide-react";
+import Markdown from "react-markdown";
+
+interface WebFetchOutput {
+  url?: string;
+  status?: number;
+  contentType?: string;
+  format?: "markdown" | "text" | "html";
+  content?: string;
+  summarized?: boolean;
+  originalLength?: number;
+  redirected?: boolean;
+  redirectedFrom?: string;
+}
+
+interface Props {
+  args: Record<string, unknown>;
+  result: unknown;
+}
+
+function truncateMiddle(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return s.slice(0, head) + "…" + s.slice(s.length - tail);
+}
+
+function formatChars(n: number): string {
+  if (n < 1000) return `${n} chars`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}K chars`;
+  return `${(n / 1_000_000).toFixed(1)}M chars`;
+}
+
+function statusTone(status?: number): string {
+  if (status == null) return "text-muted-foreground bg-muted/60";
+  if (status >= 200 && status < 300)
+    return "text-green-600 bg-green-500/10 dark:text-green-400";
+  if (status >= 300 && status < 400)
+    return "text-blue-600 bg-blue-500/10 dark:text-blue-400";
+  if (status >= 400) return "text-red-600 bg-red-500/10 dark:text-red-400";
+  return "text-muted-foreground bg-muted/60";
+}
+
+function shortContentType(ct?: string): string | null {
+  if (!ct) return null;
+  // e.g. "text/html; charset=utf-8" → "text/html"
+  const semi = ct.indexOf(";");
+  return (semi === -1 ? ct : ct.slice(0, semi)).trim() || null;
+}
+
+export function WebFetchResult({ args, result }: Props) {
+  const out = (result ?? {}) as WebFetchOutput;
+  const requestedUrl =
+    typeof args.url === "string" ? (args.url as string) : "";
+  const finalUrl = out.url ?? requestedUrl;
+  const ct = shortContentType(out.contentType);
+  const charCount = typeof out.content === "string" ? out.content.length : 0;
+  const isMarkdown = out.format === "markdown";
+
+  return (
+    <div className="ml-3 mt-1 mb-1 rounded-md border border-border overflow-hidden text-xs">
+      {/* Header */}
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-muted/50 border-b border-border text-muted-foreground">
+        <Globe className="size-3 shrink-0" />
+        {finalUrl ? (
+          <a
+            href={finalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono truncate hover:text-foreground hover:underline underline-offset-2 inline-flex items-center gap-1 min-w-0"
+            title={finalUrl}
+          >
+            <span className="truncate">{truncateMiddle(finalUrl, 80)}</span>
+            <ExternalLink className="size-3 shrink-0 opacity-60" />
+          </a>
+        ) : (
+          <span className="font-mono truncate">webFetch</span>
+        )}
+      </div>
+
+      {/* Metadata badges */}
+      <div className="flex flex-wrap items-center gap-1.5 px-2.5 py-1.5 border-b border-border bg-background/50">
+        {out.status != null && (
+          <span
+            className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${statusTone(
+              out.status,
+            )}`}
+          >
+            {out.status}
+          </span>
+        )}
+        {ct && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-muted text-muted-foreground">
+            {ct}
+          </span>
+        )}
+        {out.format && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-muted text-muted-foreground">
+            {out.format}
+          </span>
+        )}
+        {charCount > 0 && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-muted text-muted-foreground">
+            {formatChars(charCount)}
+          </span>
+        )}
+        {out.summarized && (
+          <span
+            className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-amber-500/15 text-amber-700 dark:text-amber-400"
+            title={
+              out.originalLength != null
+                ? `Summarized from ${out.originalLength.toLocaleString()} chars`
+                : "Summarized"
+            }
+          >
+            summarized
+          </span>
+        )}
+        {out.redirected && out.redirectedFrom && (
+          <span
+            className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-blue-500/15 text-blue-700 dark:text-blue-400"
+            title={`Redirected from ${out.redirectedFrom}`}
+          >
+            redirected
+          </span>
+        )}
+      </div>
+
+      {/* Body */}
+      {out.content != null && (
+        <div className="bg-background/50 max-h-72 overflow-y-auto styled-scrollbar">
+          {isMarkdown ? (
+            <div className="px-3 py-2 prose prose-sm dark:prose-invert max-w-none text-foreground/80 prose-p:leading-snug prose-pre:bg-muted/50 prose-pre:text-[11px] prose-headings:text-foreground/90 prose-a:text-blue-600 dark:prose-a:text-blue-400">
+              <Markdown>{out.content}</Markdown>
+            </div>
+          ) : (
+            <pre className="px-3 py-2 whitespace-pre-wrap font-mono text-[11px] text-foreground/80">
+              {out.content}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -115,6 +115,60 @@ export function LandingPage({
     });
   }, [providerModels, agentSettings.agentModel]);
 
+  // Auto-select a default model when none is set and at least one
+  // provider is now configured. Without this, after the user enters
+  // their first API key in Settings, the model-selector trigger renders
+  // empty ("Select a model...") and `isConfigured` stays false, leaving
+  // the chat input disabled until the user manually picks a model.
+  //
+  // Selection priority:
+  //   1. The first user-favorited model that's actually available
+  //   2. The first model marked `recommended` in any enabled provider
+  //   3. The first model of the first enabled provider (last resort)
+  useEffect(() => {
+    if (agentSettings.agentModel) return;
+    if (providerModels.length === 0) return;
+
+    const isAvailable = (key: string) => {
+      const [pid, ...rest] = key.split(":");
+      const mid = rest.join(":");
+      return providerModels.some(
+        (g) => g.provider === pid && g.models.some((m) => m.id === mid),
+      );
+    };
+
+    let pick: string | null = null;
+
+    const favorite = settings.favoriteModels.find(isAvailable);
+    if (favorite) pick = favorite;
+
+    if (!pick) {
+      for (const group of providerModels) {
+        const rec = group.models.find((m) => m.recommended);
+        if (rec) {
+          pick = `${group.provider}:${rec.id}`;
+          break;
+        }
+      }
+    }
+
+    if (!pick) {
+      const group = providerModels[0];
+      const model = group?.models[0];
+      if (group && model) pick = `${group.provider}:${model.id}`;
+    }
+
+    if (pick) {
+      const updated = { ...agentSettings, agentModel: pick };
+      setAgentSettings(updated);
+      void storage.setAgentSettings(updated);
+    }
+  }, [
+    providerModels,
+    agentSettings,
+    settings.favoriteModels,
+  ]);
+
   const handleSubmit = useCallback(
     async (mentions: TabMentionAttrs[], images: ImagePreview[]) => {
       if (!input.trim() && images.length === 0) return;

--- a/apps/extension/src/hooks/useProviders.ts
+++ b/apps/extension/src/hooks/useProviders.ts
@@ -7,6 +7,7 @@ import {
 } from "@/registry/providers";
 import {
   getLastUpdated as fetchLastUpdated,
+  invalidateCache as invalidateCatalogCache,
 } from "@/registry/models-dev/catalog";
 
 export interface UseProvidersResult {
@@ -44,6 +45,11 @@ export function useProviders(): UseProvidersResult {
     ) => {
       if (area !== "local") return;
       if (!(STORAGE_KEYS.MODELS_DEV_CATALOG in changes)) return;
+      // Drop the in-memory cache so getCatalog() re-reads the freshly
+      // written value from storage. Without this it would short-circuit
+      // on the cached snapshot it loaded at first mount and consumers
+      // would never observe live-catalog updates that arrived after.
+      invalidateCatalogCache();
       void (async () => {
         const fresh = await getProviders();
         if (cancelled) return;

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -38,6 +38,7 @@ import {
   typeInElementTool,
   updateMemoryTool,
   snapshotTool,
+  webFetchTool,
 } from "./tools";
 import { createFsTools } from "./tools/fs";
 import { createPythonTool } from "./tools/execute-python";
@@ -77,6 +78,7 @@ Your current plan will be appended to your instructions at every turn. Keep it i
 5. Use \`extract\` to pull structured data (product lists, search results, table rows) from a page. Provide an instruction and optionally a JSON Schema. Mark URL fields as \`{"type": "string", "format": "uri"}\` for reliable link extraction — the tool substitutes URLs with numeric IDs to prevent hallucination and rehydrates them before returning. Use element selectors like \`"main"\` or \`".s-main-slot"\` (NOT \`[role="main"]\`).
 6. Use \`readPage\` when you need full text content (articles, long-form text).
 7. Use \`screenshot\` when visual context would help; add \`annotate: true\` to overlay color-coded @ref labels on interactive elements (buttons blue, links green, inputs orange, other gray).
+8. Use \`webFetch({ url, format? })\` to read a URL's contents (markdown / text / html) WITHOUT navigating the user's tab. Prefer this over \`navigate\` when you only need to read documentation or a referenced page and don't need to interact with it. Redirects are followed automatically; the response's \`url\` field reflects the final destination, and \`redirected: true\` flags when the host changed.
 
 ### Example: extracting a product list
 \`\`\`
@@ -740,6 +742,7 @@ export async function createAgentTransport(
     executeOnPage: toSDKTool(executeOnPageTool, "executeOnPage"),
     executePython: toSDKTool(pythonTool, "executePython"),
     extract: toSDKTool(extractTool, "extract"),
+    webFetch: toSDKTool(webFetchTool, "webFetch"),
     todoWrite: toSDKTool(createTodoWriteTool(conversationId), "todoWrite"),
     skill: toSDKTool(skillTool, "skill"),
     install_skill: toSDKTool(installSkillTool, "install_skill"),

--- a/apps/extension/src/lib/agent/tools/index.ts
+++ b/apps/extension/src/lib/agent/tools/index.ts
@@ -20,3 +20,4 @@ export { skillTool } from "./skill";
 export { readOpfsFileTool } from "./read-opfs-file";
 export { installSkillTool } from "./install-skill";
 export { createSkillTool } from "./create-skill";
+export { webFetchTool } from "./web-fetch";

--- a/apps/extension/src/lib/agent/tools/web-fetch.test.ts
+++ b/apps/extension/src/lib/agent/tools/web-fetch.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { webFetchTool } from "./web-fetch";
+
+// We test the parts of web-fetch that don't require a DOM:
+//   - URL validation, scheme blocking, HTTPS upgrade
+//   - Redirect handling (cross-host vs same-host)
+//   - Timeout via AbortController
+//   - Body byte cap
+//   - Content-type-based bypass of DOM parsing
+//   - format: "html" (raw passthrough)
+//
+// HTML → markdown / text conversion paths are exercised via manual smoke
+// testing in the loaded extension because the test env is "node" and we
+// don't ship DOM-test infrastructure in this repo.
+
+type MockResponseInit = {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string;
+  url?: string; // final URL after redirect
+};
+
+function makeResponse(init: MockResponseInit = {}): Response {
+  const status = init.status ?? 200;
+  const headers = new Headers(init.headers ?? {});
+  const body = init.body ?? "";
+  // Build a Response. We override `url` via a Proxy because Response.url is
+  // read-only in node's undici impl when constructed directly.
+  const base = new Response(body, { status, headers });
+  return new Proxy(base, {
+    get(target, prop, receiver) {
+      if (prop === "url") return init.url ?? "";
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("webFetch — URL validation & scheme blocking", () => {
+  it("rejects chrome:// URLs", async () => {
+    await expect(
+      webFetchTool.execute({ url: "chrome://settings" } as never),
+    ).rejects.toThrow(/blocked scheme|invalid|url/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects file:// URLs", async () => {
+    await expect(
+      webFetchTool.execute({ url: "file:///etc/passwd" } as never),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects javascript: URLs", async () => {
+    await expect(
+      webFetchTool.execute({ url: "javascript:alert(1)" } as never),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects data: URLs", async () => {
+    await expect(
+      webFetchTool.execute({ url: "data:text/plain,hello" } as never),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed URLs", async () => {
+    await expect(
+      webFetchTool.execute({ url: "not a url" } as never),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("webFetch — HTTPS upgrade", () => {
+  it("upgrades http:// to https:// before fetching", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+        body: "ok",
+        url: "https://example.com/",
+      }),
+    );
+
+    await webFetchTool.execute({
+      url: "http://example.com/",
+      format: "html",
+    } as never);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://example.com/");
+  });
+});
+
+describe("webFetch — non-2xx handling", () => {
+  it("throws on 404 with status in error message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 404,
+        headers: { "content-type": "text/html" },
+        body: "Not Found",
+        url: "https://example.com/missing",
+      }),
+    );
+
+    await expect(
+      webFetchTool.execute({
+        url: "https://example.com/missing",
+      } as never),
+    ).rejects.toThrow(/404/);
+  });
+
+  it("throws on 500", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 500,
+        headers: {},
+        body: "Server Error",
+        url: "https://example.com/",
+      }),
+    );
+
+    await expect(
+      webFetchTool.execute({ url: "https://example.com/" } as never),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("webFetch — redirect handling", () => {
+  it("follows cross-host redirects transparently and reports redirected=true", async () => {
+    // With redirect: "follow", fetch handles all hops; the final response
+    // arrives with response.url pointing at the destination host.
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        body: "destination body",
+        url: "https://www.example.com/landing",
+      }),
+    );
+
+    const result = (await webFetchTool.execute({
+      url: "https://example.com/",
+      format: "html",
+    } as never)) as {
+      url: string;
+      content: string;
+      status: number;
+      redirected?: boolean;
+      redirectedFrom?: string;
+    };
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe(200);
+    expect(result.url).toBe("https://www.example.com/landing");
+    expect(result.content).toBe("destination body");
+    expect(result.redirected).toBe(true);
+    expect(result.redirectedFrom).toBe("https://example.com/");
+  });
+
+  it("does not flag redirected=true when the final URL is on the same host", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        body: "final body",
+        url: "https://example.com/v2/page",
+      }),
+    );
+
+    const result = (await webFetchTool.execute({
+      url: "https://example.com/page",
+      format: "html",
+    } as never)) as {
+      content: string;
+      status: number;
+      redirected?: boolean;
+    };
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe(200);
+    expect(result.content).toBe("final body");
+    expect(result.redirected).toBeUndefined();
+  });
+
+  it("issues a single fetch — browser handles redirect chains internally", async () => {
+    // Sanity check that we are NOT manually walking redirect chains; the
+    // older redirect:"manual" implementation broke in real browsers
+    // because manual-mode responses are opaque (status: 0). With
+    // redirect:"follow", one fetch call yields the final response.
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        body: "ok",
+        url: "https://example.com/final",
+      }),
+    );
+
+    await webFetchTool.execute({
+      url: "https://example.com/start",
+      format: "html",
+    } as never);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.redirect).toBe("follow");
+  });
+});
+
+describe("webFetch — content-type handling", () => {
+  it("returns non-HTML bodies verbatim regardless of requested format", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"hello":"world"}',
+        url: "https://api.example.com/x",
+      }),
+    );
+
+    const result = (await webFetchTool.execute({
+      url: "https://api.example.com/x",
+      format: "markdown",
+    } as never)) as { content: string; contentType: string };
+
+    expect(result.content).toBe('{"hello":"world"}');
+    expect(result.contentType).toContain("application/json");
+  });
+
+  it("format='html' returns body verbatim", async () => {
+    const html = "<html><body><h1>Hi</h1></body></html>";
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: html,
+        url: "https://example.com/",
+      }),
+    );
+
+    const result = (await webFetchTool.execute({
+      url: "https://example.com/",
+      format: "html",
+    } as never)) as { content: string; format: string };
+
+    expect(result.format).toBe("html");
+    expect(result.content).toBe(html);
+  });
+});
+
+describe("webFetch — timeout", () => {
+  it("aborts after the configured timeout", async () => {
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+
+    await expect(
+      webFetchTool.execute({
+        url: "https://example.com/",
+        timeout: 1, // 1 second
+      } as never),
+    ).rejects.toThrow(/timed out|timeout|abort/i);
+  }, 5000);
+});
+
+describe("webFetch — body byte cap", () => {
+  it("rejects responses larger than the raw byte cap", async () => {
+    // 6 MB > 5 MB cap. Build a string and rely on the implementation's
+    // streaming reader to detect overflow.
+    const huge = "x".repeat(6 * 1024 * 1024);
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        status: 200,
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(huge.length),
+        },
+        body: huge,
+        url: "https://example.com/big",
+      }),
+    );
+
+    await expect(
+      webFetchTool.execute({
+        url: "https://example.com/big",
+        format: "html",
+      } as never),
+    ).rejects.toThrow(/too large|exceeded|5 ?MB/i);
+  });
+});
+
+describe("webFetch — tool metadata", () => {
+  it("declares the expected name", () => {
+    expect(webFetchTool.name).toBe("webFetch");
+  });
+
+  it("does not require approval", () => {
+    expect(webFetchTool.approval?.required ?? false).toBe(false);
+  });
+
+  it("has a description that mentions the format options", () => {
+    expect(webFetchTool.description).toMatch(/markdown/i);
+    expect(webFetchTool.description).toMatch(/text/i);
+    expect(webFetchTool.description).toMatch(/html/i);
+  });
+});

--- a/apps/extension/src/lib/agent/tools/web-fetch.ts
+++ b/apps/extension/src/lib/agent/tools/web-fetch.ts
@@ -1,0 +1,398 @@
+import { generateText } from "ai";
+import TurndownService from "turndown";
+import { z } from "zod";
+import type { BrowserTool } from "../types";
+
+// Lazy-loaded to avoid pulling agent-transport (and its chrome.* dependencies)
+// into module init for tests / non-runtime contexts.
+async function loadCurrentAgentModel() {
+  const mod = await import("../agent-transport");
+  return mod.getCurrentAgentModel();
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Hard ceiling on response body bytes read from the network. */
+const MAX_RAW_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/** Output character threshold above which we summarize via the agent's LLM. */
+const SUMMARIZATION_THRESHOLD = 100_000;
+
+const DEFAULT_TIMEOUT_S = 30;
+const MAX_TIMEOUT_S = 120;
+
+/** Schemes we refuse to fetch. */
+const BLOCKED_SCHEMES = new Set([
+  "chrome:",
+  "chrome-extension:",
+  "file:",
+  "javascript:",
+  "data:",
+  "about:",
+  "blob:",
+  "ftp:",
+  "view-source:",
+]);
+
+/**
+ * Content-types that we treat as "already text-shaped" and pass through
+ * without DOM parsing. Anything outside this set + not text/html is also
+ * passed through verbatim.
+ */
+const TEXTLIKE_NON_HTML = /^(application\/json|application\/xml|text\/(plain|csv|xml|markdown|css|javascript|x-[a-z]+))/i;
+
+const HTML_LIKE = /^(text\/html|application\/xhtml\+xml)/i;
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+const parameters = z.object({
+  url: z
+    .string()
+    .url()
+    .describe(
+      "URL to fetch. Must be a fully-formed URL (with scheme). http:// is auto-upgraded to https://.",
+    ),
+  format: z
+    .enum(["markdown", "text", "html"])
+    .optional()
+    .describe(
+      "Output format for HTML responses. 'markdown' (default) converts to GitHub-flavored markdown. 'text' returns plain text (innerText). 'html' returns the raw HTML body. Non-HTML responses (JSON, plain text, etc.) are returned verbatim regardless of this flag.",
+    ),
+  timeout: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_TIMEOUT_S)
+    .optional()
+    .describe(
+      `Request timeout in seconds. Default ${DEFAULT_TIMEOUT_S}, max ${MAX_TIMEOUT_S}.`,
+    ),
+});
+
+type Input = z.infer<typeof parameters>;
+
+type Output = {
+  url: string;
+  status: number;
+  contentType: string;
+  format: "markdown" | "text" | "html";
+  content: string;
+  summarized: boolean;
+  originalLength?: number;
+  /** True if the final URL ended up on a different host than requested. */
+  redirected?: boolean;
+  /** Original URL the request was sent to, present only when redirected. */
+  redirectedFrom?: string;
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function upgradeHttp(rawUrl: string): string {
+  if (rawUrl.startsWith("http://")) return "https://" + rawUrl.slice(7);
+  return rawUrl;
+}
+
+function assertSchemeAllowed(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`webFetch: invalid URL: ${rawUrl}`);
+  }
+  if (BLOCKED_SCHEMES.has(parsed.protocol)) {
+    throw new Error(
+      `webFetch: refusing to fetch blocked scheme '${parsed.protocol}': ${rawUrl}`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `webFetch: only http/https URLs are supported (got '${parsed.protocol}')`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Read a Response body, accumulating chunks up to MAX_RAW_BYTES. Throws if
+ * the body exceeds the cap. Returns the full text as a UTF-8 string.
+ *
+ * Falls back to res.text() when the body isn't streamable (e.g. in some
+ * test mocks). Even in the fallback path we still enforce the byte cap.
+ */
+async function readBodyCapped(res: Response): Promise<string> {
+  const contentLength = res.headers.get("content-length");
+  if (contentLength) {
+    const n = Number(contentLength);
+    if (Number.isFinite(n) && n > MAX_RAW_BYTES) {
+      throw new Error(
+        `webFetch: response too large (Content-Length ${n} > ${MAX_RAW_BYTES} bytes / 5MB cap)`,
+      );
+    }
+  }
+
+  const reader = res.body?.getReader?.();
+  if (!reader) {
+    const text = await res.text();
+    // Use TextEncoder for accurate byte count rather than char length.
+    const bytes = new TextEncoder().encode(text).byteLength;
+    if (bytes > MAX_RAW_BYTES) {
+      throw new Error(
+        `webFetch: response too large (${bytes} bytes exceeded ${MAX_RAW_BYTES} bytes / 5MB cap)`,
+      );
+    }
+    return text;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > MAX_RAW_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {}
+        throw new Error(
+          `webFetch: response too large (exceeded ${MAX_RAW_BYTES} bytes / 5MB cap during streaming read)`,
+        );
+      }
+      chunks.push(value);
+    }
+  }
+  // Concatenate and decode as UTF-8.
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  return new TextDecoder("utf-8").decode(merged);
+}
+
+/**
+ * Issue a fetch with `redirect: "follow"` and report whether the final
+ * URL ended up on a different host than the request.
+ *
+ * Why not `redirect: "manual"` for cross-host detection? In a browser
+ * context, manual-mode responses are opaque-redirect: status is 0, the
+ * `Location` header is unreadable, and the response body is empty. So
+ * we cannot inspect the redirect target before deciding whether to
+ * follow. Letting the browser follow handles the same-host hop limit
+ * for us, and `response.url` reflects the final destination — that's
+ * enough to inform the caller of any host change.
+ */
+async function fetchAndFollow(
+  initialUrl: string,
+  signal: AbortSignal,
+): Promise<{ response: Response; finalUrl: string; redirected: boolean }> {
+  let initialHost: string;
+  try {
+    initialHost = new URL(initialUrl).host;
+  } catch {
+    throw new Error(`webFetch: invalid URL: ${initialUrl}`);
+  }
+
+  const response = await fetch(initialUrl, {
+    redirect: "follow",
+    credentials: "omit",
+    signal,
+  });
+
+  const finalUrl = response.url || initialUrl;
+  let redirected = false;
+  try {
+    redirected = new URL(finalUrl).host !== initialHost;
+  } catch {
+    // Final URL was somehow unparseable; treat as not-redirected rather
+    // than throw — we still got a Response and can return its body.
+  }
+
+  return { response, finalUrl, redirected };
+}
+
+function stripNoiseTags(doc: Document): void {
+  doc
+    .querySelectorAll("script, style, noscript, iframe, svg")
+    .forEach((n) => n.remove());
+}
+
+function htmlToText(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  stripNoiseTags(doc);
+  const text = doc.body?.innerText ?? doc.body?.textContent ?? "";
+  return text.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function htmlToMarkdown(html: string): string {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  stripNoiseTags(doc);
+  const td = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+    bulletListMarker: "-",
+  });
+  return td.turndown(doc.body ?? doc.documentElement);
+}
+
+const SUMMARIZATION_SYSTEM_PROMPT = `You summarize fetched web pages for an AI agent that needs the contents but cannot fit the full page in its context.
+
+Rules:
+- Preserve URLs verbatim (do not omit or rewrite links).
+- Preserve headings, code blocks, and key technical details.
+- Preserve numerical facts, version numbers, and identifiers.
+- Be terse: drop boilerplate, navigation, ads, footer, and repeated content.
+- Output as markdown.
+- Do NOT add commentary about what you summarized — just emit the summary.`;
+
+async function summarizeIfNeeded(
+  content: string,
+  url: string,
+): Promise<{ content: string; summarized: boolean; originalLength?: number }> {
+  if (content.length <= SUMMARIZATION_THRESHOLD) {
+    return { content, summarized: false };
+  }
+
+  const model = await loadCurrentAgentModel();
+  if (!model) {
+    // Invariant violation: tool runs only while the agent runs. Fall back to
+    // truncation rather than failing — the agent still gets useful prefix.
+    const truncated =
+      content.slice(0, SUMMARIZATION_THRESHOLD) +
+      `\n\n[...content truncated; original ${content.length} chars; LLM summarization unavailable]`;
+    return {
+      content: truncated,
+      summarized: false,
+      originalLength: content.length,
+    };
+  }
+
+  try {
+    const { text } = await generateText({
+      model,
+      system: SUMMARIZATION_SYSTEM_PROMPT,
+      prompt: `Summarize the following page contents fetched from ${url}:\n\n${content}`,
+    });
+    return {
+      content: text,
+      summarized: true,
+      originalLength: content.length,
+    };
+  } catch (err) {
+    // Summarization failed — fall back to truncation with a note so the
+    // agent knows what happened.
+    const note = err instanceof Error ? err.message : String(err);
+    const truncated =
+      content.slice(0, SUMMARIZATION_THRESHOLD) +
+      `\n\n[...content truncated; original ${content.length} chars; summarization failed: ${note}]`;
+    return {
+      content: truncated,
+      summarized: false,
+      originalLength: content.length,
+    };
+  }
+}
+
+// ============================================================================
+// Tool
+// ============================================================================
+
+export const webFetchTool: BrowserTool<Input, Output> = {
+  name: "webFetch",
+  description:
+    "Fetch a URL and return its contents as markdown (default), plain text, or raw HTML. Use this to read documentation, articles, or APIs WITHOUT navigating the user's active tab. http:// URLs are auto-upgraded to https://. Redirects are followed automatically; if the final URL ends up on a different host, the response includes `redirected: true` and `redirectedFrom` so you can confirm the destination. Oversized responses are summarized via the agent's own model. Read-only — no side effects, no user cookies sent.",
+  parameters,
+  execute: async (input) => {
+    const parsed = parameters.parse(input);
+    const format = parsed.format ?? "markdown";
+    const timeoutS = parsed.timeout ?? DEFAULT_TIMEOUT_S;
+
+    // Validate scheme on the user-supplied URL first (before HTTPS upgrade)
+    // so that http: passes through to the upgrade step but everything else
+    // is rejected with a clear message.
+    assertSchemeAllowed(parsed.url);
+    const requestUrl = upgradeHttp(parsed.url);
+    // Re-validate after upgrade just to be safe.
+    assertSchemeAllowed(requestUrl);
+
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+      controller.abort();
+    }, timeoutS * 1000);
+
+    let response: Response;
+    let finalUrl: string;
+    let redirected: boolean;
+    try {
+      ({ response, finalUrl, redirected } = await fetchAndFollow(
+        requestUrl,
+        controller.signal,
+      ));
+    } catch (err) {
+      if (controller.signal.aborted) {
+        throw new Error(`webFetch: timed out after ${timeoutS}s`);
+      }
+      if (err instanceof Error && /aborted|AbortError/i.test(err.name + " " + err.message)) {
+        throw new Error(`webFetch: timed out after ${timeoutS}s`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `webFetch: HTTP ${response.status} ${response.statusText} for ${finalUrl}`,
+      );
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    const body = await readBodyCapped(response);
+
+    // Decide whether to DOM-parse this response.
+    const isHtml = HTML_LIKE.test(contentType);
+    let content: string;
+    let effectiveFormat: "markdown" | "text" | "html" = format;
+
+    if (format === "html" || !isHtml) {
+      // Either the user asked for raw HTML, or this isn't HTML at all
+      // (JSON, plain text, XML, etc.) — pass through verbatim.
+      content = body;
+      // Reflect the actual format we're emitting. If the user asked for
+      // markdown but we're returning JSON, we still call it "html" (the
+      // raw/passthrough mode) so the agent doesn't expect markdown.
+      if (!isHtml && format === "markdown") {
+        effectiveFormat = TEXTLIKE_NON_HTML.test(contentType) ? "text" : "html";
+      }
+    } else if (format === "text") {
+      content = htmlToText(body);
+    } else {
+      // format === "markdown" && isHtml
+      content = htmlToMarkdown(body);
+    }
+
+    const sized = await summarizeIfNeeded(content, finalUrl);
+
+    return {
+      url: finalUrl,
+      status: response.status,
+      contentType,
+      format: effectiveFormat,
+      content: sized.content,
+      summarized: sized.summarized,
+      ...(sized.originalLength != null
+        ? { originalLength: sized.originalLength }
+        : {}),
+      ...(redirected
+        ? { redirected: true, redirectedFrom: requestUrl }
+        : {}),
+    };
+  },
+};

--- a/apps/extension/src/lib/format-markdown.ts
+++ b/apps/extension/src/lib/format-markdown.ts
@@ -65,6 +65,71 @@ export function formatPartAsMarkdown(part: any): string | null {
       return `**Tool: install_skill**\n${inputStr}[Skill '${source}' installed]`;
     }
 
+    if (toolName === "webFetch") {
+      const reqUrl = typeof input?.url === "string" ? input.url : "";
+      const reqFormat =
+        typeof input?.format === "string" ? input.format : "markdown";
+      const inputStr = input
+        ? "```json\n" + JSON.stringify(input, null, 2) + "\n```\n"
+        : "";
+      const header = reqUrl
+        ? `**Tool: webFetch** — ${reqUrl}`
+        : `**Tool: webFetch**`;
+      if (!hasOutput) return `${header}\n${inputStr}`.trim();
+
+      const out = output as Record<string, unknown> | null;
+      const status =
+        typeof out?.status === "number" ? `HTTP ${out.status}` : "";
+      const contentType =
+        typeof out?.contentType === "string" && out.contentType
+          ? String(out.contentType)
+          : "";
+      const fmt =
+        typeof out?.format === "string" ? String(out.format) : reqFormat;
+      const content =
+        typeof out?.content === "string" ? (out.content as string) : "";
+      const summarized = out?.summarized === true;
+      const originalLength =
+        typeof out?.originalLength === "number" ? out.originalLength : null;
+      const redirected = out?.redirected === true;
+      const redirectedFrom =
+        typeof out?.redirectedFrom === "string"
+          ? (out.redirectedFrom as string)
+          : null;
+      const finalUrl =
+        typeof out?.url === "string" ? (out.url as string) : "";
+
+      const meta = [
+        status,
+        contentType,
+        `${content.length.toLocaleString()} chars`,
+        summarized && originalLength != null
+          ? `summarized from ${originalLength.toLocaleString()}`
+          : null,
+        redirected && redirectedFrom && finalUrl
+          ? `redirected ${redirectedFrom} → ${finalUrl}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+      // For markdown format we render the content directly so it stays
+      // readable. For html / text / passthrough modes we wrap in a fenced
+      // code block to avoid clobbering surrounding markdown.
+      const body =
+        fmt === "markdown"
+          ? content
+          : "```" +
+            (fmt === "html" ? "html" : "") +
+            "\n" +
+            content +
+            "\n```";
+
+      return [header, inputStr.trim(), meta, "", body]
+        .filter((s) => s !== null && s !== undefined)
+        .join("\n");
+    }
+
     if (toolName === "todoWrite") {
       const todos = (input?.todos as Array<Record<string, unknown>>) || [];
       if (todos.length === 0) {

--- a/apps/extension/src/registry/models-dev/catalog.ts
+++ b/apps/extension/src/registry/models-dev/catalog.ts
@@ -193,3 +193,19 @@ export function _resetCacheForTests(): void {
   memory.cached = null;
   memory.inflight = null;
 }
+
+/**
+ * Drops the in-memory cache so the next `getCatalog()` call re-reads
+ * from `chrome.storage.local`. Call this when the storage key is known
+ * to have changed in another context (e.g. a background refresh wrote
+ * a new live catalog while the page-context cache was holding the
+ * bundled snapshot).
+ *
+ * Without this, `getCatalog()` short-circuits on `memory.cached` for
+ * the lifetime of the page and consumers like `useProviders` never
+ * see catalog updates that landed after the first `getCatalog()` call.
+ */
+export function invalidateCache(): void {
+  memory.cached = null;
+  memory.inflight = null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.3.0
+      turndown:
+        specifier: ^7.2.4
+        version: 7.2.4
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -298,6 +301,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/turndown':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@wxt-dev/module-react':
         specifier: ^1.1.5
         version: 1.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))(wxt@0.20.24(@types/node@25.6.0)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3))
@@ -1430,6 +1436,9 @@ packages:
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
   '@mlc-ai/web-llm@0.2.82':
     resolution: {integrity: sha512-ONhW+28PPVSUI1m0RkJcm7suwc47b65i5b/rTEIADq5I22p1+9uf/CBbDPRkkjj1WJB9s8oFp0ywAW0NY1G6fg==}
@@ -3110,6 +3119,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/turndown@5.0.6':
+    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -6199,6 +6211,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  turndown@7.2.4:
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -7555,6 +7571,8 @@ snapshots:
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.3
+
+  '@mixmark-io/domino@2.2.0': {}
 
   '@mlc-ai/web-llm@0.2.82':
     dependencies:
@@ -9178,6 +9196,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/turndown@5.0.6': {}
 
   '@types/unist@2.0.11': {}
 
@@ -12860,6 +12880,10 @@ snapshots:
       esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  turndown@7.2.4:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
 
   tw-animate-css@1.4.0: {}
 


### PR DESCRIPTION
Adds a `webFetch` tool to the agent and fixes two provider/model issues that surfaced while testing it on a fresh install.

No version bump — leaving that to a coordinated `0.2.0` release once other work lands.

## Changes

### 1. `feat(extension): add webFetch tool` (ebc7087)

A new agent tool that fetches a URL and returns its contents as markdown (default), text, or raw HTML — without navigating the user's active tab. Mirrors OpenCode's `WebFetch` semantics.

**Tool behavior**
- Zod-validated `url`; blocked schemes (`chrome:`, `file:`, `javascript:`, `data:`, …) rejected with a clear error
- `http://` auto-upgraded to `https://`
- `redirect: \"follow\"` — browser handles the chain; `response.url` determines redirect-host detection. Sets `redirected: true` + `redirectedFrom` when the final host differs (informational, non-blocking)
- `credentials: \"omit\"` — no user cookies leak
- `timeout` (1–120s, default 30s) via `AbortController`
- 5 MB raw-body cap with streamed reader
- Non-HTML content types (JSON, plain text, XML) pass through verbatim
- HTML→Markdown via Turndown (new dep, ~10 KB gz); HTML→Text via `DOMParser + innerText` with `script/style/noscript/iframe/svg` stripped
- Oversized output (>100K chars) summarized via the agent's own model (`generateText`), with truncation fallback if the model is unavailable or summarization fails

**UI**
- Custom result renderer in `ToolCallBlock` with header link to the final URL, status / content-type / format / length / `summarized` / `redirected` badges, and markdown- or pre-rendered body
- Dynamic collapsed-row label includes the request URL host (e.g. \"Fetched openbrowse.ai\") instead of static \"webFetch\"
- `format-markdown.ts` gets a `webFetch` branch so chat history avoids the 50KB JSON-redaction trap

**Tests**
18 unit tests covering URL validation, scheme blocking, HTTPS upgrade, non-2xx errors, timeout, body cap, content-type bypass, redirect handling, and tool metadata.

### 2. `fix(extension): auto-select default model after first provider config` (a456113)

`DEFAULT_AGENT_SETTINGS.agentModel` is empty and the existing auto-select path in `SettingsPage.handleSave` only kicks in via the explicit Save button + when `favoriteModels` is non-empty — neither holds when a fresh-install user enters their first API key in the Models tab (which writes `providerConfigs` immediately, bypassing `handleSave`).

Result before this fix: model-selector trigger rendered the empty placeholder (\"Select a model…\") and `isConfigured` returned false, leaving the chat input disabled. Data was loaded correctly — the user just couldn't tell.

Adds a `useEffect` in both `LandingPage` and `ChatView` that auto-picks when no model is set:
1. First favorite that's still available
2. First model marked `recommended` in any enabled provider
3. First model of the first enabled provider

### 3. `fix(extension): invalidate provider catalog cache on storage change` (f357239)

`getCatalog()` unconditionally short-circuits on `memory.cached`, so once a page-context's cache is seeded, subsequent `chrome.storage.onChanged` events for `MODELS_DEV_CATALOG` don't refresh the provider list. Means pages can be stuck on the bundled snapshot for the entire session if they raced the background SW's startup refresh.

Adds `invalidateCache()` to `catalog.ts` and calls it from `useProviders`' change listener before re-running `getProviders()`.

## Verification

- `pnpm test` → **46/46 pass** (18 new + 28 pre-existing)
- `pnpm compile` (`tsc --noEmit`) → clean
- `pnpm build` → clean (~31.87 MB total)

## Smoke test

1. `chrome.storage.local.clear()` from extension devtools (simulate fresh install)
2. Open extension → confirm dropdown empty (no providers configured)
3. Open Settings → Models → configure any provider, save
4. Return to home/sidepanel → expect a real model name selected automatically; input enabled
5. Try `webFetch https://example.com` end-to-end
6. Try a URL that cross-host redirects (e.g. `openbrowse.ai` → `www.openbrowse.ai`) and confirm the result includes `redirected: true` instead of the old `HTTP 0` failure mode

## Notes

- Previous redirect approach (`redirect: \"manual\"` + Location-header inspection) was broken in real browsers because manual-mode responses are opaque (status 0, headers unreadable). Tests passed against synthetic mocks but the production behavior was wrong. Fixed in commit 1.
- DOM-conversion paths (`htmlToMarkdown` / `htmlToText`) are not unit-tested because the repo's Vitest env is `node` and there's no DOM test infrastructure. Verified via manual smoke testing.