### PR TITLE
feat: per-conversation file uploads to OPFS workspace

### DIFF
--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -13,6 +13,7 @@ import { Kbd } from "@/components/ui/kbd";
 import { RegistryIcon } from "@/components/ui/registry-icon";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
+import { ZoomableImage } from "@/components/ui/zoomable-image";
 import {
   Tooltip,
   TooltipContent,
@@ -658,6 +659,26 @@ export function ChatInput({
     { enableOnFormTags: true },
   );
 
+  useHotkeys(
+    "mod+u",
+    (e) => {
+      // Cmd/Ctrl+U normally opens "View Source" in browsers — suppress
+      // and trigger our file picker instead.
+      e.preventDefault();
+      if (disabled) return;
+      fileInputRef.current?.click();
+    },
+    {
+      enableOnFormTags: true,
+      // Tiptap uses [contenteditable], which `enableOnFormTags`
+      // doesn't cover by itself. This flag makes the hotkey fire
+      // while focus is in the chat editor too.
+      enableOnContentEditable: true,
+      preventDefault: true,
+    },
+    [disabled],
+  );
+
   useEffect(() => {
     function handleHotkeys(e: KeyboardEvent) {
       if (e.altKey && (e.key === "/" || e.code === "Slash")) {
@@ -731,64 +752,79 @@ export function ChatInput({
           : "border-border",
       )}
     >
-      {/* Attachments */}
-      {attachments.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 px-2 pt-2">
-          {attachments.map((att) => {
-            const overImageCap =
-              att.kind === "image" &&
-              selectedModel != null &&
-              att.file.size > getImageSizeLimit(selectedModel);
-            return (
-              <div key={att.id} className="relative group">
-                {att.kind === "image" ? (
-                  att.loading ? (
-                    <div className="h-[108px] w-[140px] rounded-lg border border-border bg-muted/40 animate-pulse" />
-                  ) : (
-                    <img
-                      src={att.dataUrl}
-                      alt={att.file.name}
-                      className="h-[108px] w-[140px] object-cover rounded-lg border border-border"
-                    />
-                  )
-                ) : (
-                  <div className="flex h-[108px] w-[140px] flex-col gap-1 rounded-lg border border-border bg-background p-2.5">
-                    <div className="line-clamp-3 break-words text-xs font-medium leading-tight text-foreground">
-                      {att.file.name}
-                    </div>
-                    <div className="text-[11px] text-muted-foreground">
-                      {att.loading ? (
-                        <span className="inline-block h-3 w-12 rounded bg-muted animate-pulse" />
-                      ) : att.lineCount !== undefined ? (
-                        `${att.lineCount} ${att.lineCount === 1 ? "line" : "lines"}`
-                      ) : (
-                        formatBytes(att.file.size)
-                      )}
-                    </div>
-                    <div className="mt-auto">
-                      <span className="inline-block rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                        {getTypeBadge(att.file.name)}
-                      </span>
-                    </div>
-                  </div>
-                )}
-                {overImageCap && (
-                  <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full border border-border bg-background px-1.5 py-0.5 text-[9px] leading-none text-muted-foreground shadow-sm">
-                    file only
-                  </span>
-                )}
-                <button
-                  type="button"
-                  onClick={() => removeAttachment(att.id)}
-                  className="absolute -right-1 -top-1 size-4 flex items-center justify-center rounded-full bg-background border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
+      {/* Attachments — animates from 0 to natural height via the
+          grid-rows trick so the input box grows smoothly when files
+          are added (and shrinks when the last one is removed). */}
+      <div
+        aria-hidden={attachments.length === 0}
+        className={cn(
+          "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+          attachments.length > 0
+            ? "grid-rows-[1fr] opacity-100"
+            : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="flex flex-wrap gap-1.5 px-2 pt-2">
+            {attachments.map((att) => {
+              const overImageCap =
+                att.kind === "image" &&
+                selectedModel != null &&
+                att.file.size > getImageSizeLimit(selectedModel);
+              return (
+                <div
+                  key={att.id}
+                  className="relative group animate-in fade-in-0 zoom-in-95 duration-200"
                 >
-                  <X className="size-2.5" />
-                </button>
-              </div>
-            );
-          })}
+                  {att.kind === "image" ? (
+                    att.loading ? (
+                      <div className="h-[108px] w-[140px] rounded-lg border border-border bg-muted/40 animate-pulse" />
+                    ) : (
+                      <ZoomableImage
+                        src={att.dataUrl}
+                        alt={att.file.name}
+                        className="h-[108px] w-[140px] object-cover rounded-lg border border-border"
+                      />
+                    )
+                  ) : (
+                    <div className="flex h-[108px] w-[140px] flex-col gap-1 rounded-lg border border-border bg-background p-2.5">
+                      <div className="line-clamp-3 break-words text-xs font-medium leading-tight text-foreground">
+                        {att.file.name}
+                      </div>
+                      <div className="text-[11px] text-muted-foreground">
+                        {att.loading ? (
+                          <span className="inline-block h-3 w-12 rounded bg-muted animate-pulse" />
+                        ) : att.lineCount !== undefined ? (
+                          `${att.lineCount} ${att.lineCount === 1 ? "line" : "lines"}`
+                        ) : (
+                          formatBytes(att.file.size)
+                        )}
+                      </div>
+                      <div className="mt-auto">
+                        <span className="inline-block rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                          {getTypeBadge(att.file.name)}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                  {overImageCap && (
+                    <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full border border-border bg-background px-1.5 py-0.5 text-[9px] leading-none text-muted-foreground shadow-sm">
+                      file only
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => removeAttachment(att.id)}
+                    className="absolute -right-1 -top-1 size-4 flex items-center justify-center rounded-full bg-background border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
         </div>
-      )}
+      </div>
 
       {/* Editor */}
       <EditorContent editor={editor} className="min-w-0" />
@@ -1097,7 +1133,7 @@ export function ChatInput({
         </div>
 
         {/* Action buttons */}
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center gap-1.5">
           <input
             ref={fileInputRef}
             type="file"
@@ -1121,10 +1157,8 @@ export function ChatInput({
                 <Paperclip className="size-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">
-              {selectedModel
-                ? `Attach file — images up to ${Math.round(getImageSizeLimit(selectedModel) / (1024 * 1024))} MB`
-                : "Attach file"}
+            <TooltipContent side="top" className="flex items-center gap-1.5">
+              Attach files or images <Kbd>⌘U</Kbd>
             </TooltipContent>
           </Tooltip>
           <Tooltip>

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -19,6 +19,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getImageSizeLimit } from "@/lib/agent/vision-limits";
+import {
+  countLines,
+  formatBytes,
+  getTypeBadge,
+  isTextFile,
+} from "@/lib/chat/attachment-meta";
+import { cn } from "@/lib/utils";
 import type { Attachment } from "@/lib/chat/types";
 import type { ThinkingConfig } from "@/lib/types";
 import type { JSONContent } from "@tiptap/core";
@@ -31,8 +38,7 @@ import {
   ArrowUp,
   BrainIcon,
   ChevronDown,
-  File as FileIcon,
-  Image as ImageIcon,
+  Paperclip,
   Square,
   Star,
   X,
@@ -276,6 +282,10 @@ export function ChatInput({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
+  // Drag-over visual state. `dragCounter` de-flickers nested
+  // dragenter/leave events fired from child elements.
+  const [isDragOver, setIsDragOver] = useState(false);
+  const dragCounter = useRef(0);
   // Back-compat for spots in this file that count or filter to images.
   const images = useMemo(
     () => attachments.filter((a): a is Extract<Attachment, { kind: "image" }> => a.kind === "image"),
@@ -400,11 +410,13 @@ export function ChatInput({
         );
       }
 
-      // Validate synchronously, then convert any accepted images to
-      // data URLs in parallel. The previous image-only code parallelized
-      // FileReader work; preserve that.
+      // Validate synchronously so we can insert placeholder cards
+      // immediately. The async metadata work (FileReader for images,
+      // file.text() for text-file line counts) runs in parallel and
+      // patches each card in place when it lands. Without this, the
+      // user sees a delay between picking a file and seeing it appear.
       const slice = incoming.slice(0, Math.max(0, remainingSlots));
-      const validated = slice.map((file) => {
+      const accepted = slice.flatMap((file) => {
         const isImage = file.type.startsWith("image/");
         const cap = isImage ? imageCap : FILE_CAP;
         if (file.size > cap) {
@@ -412,33 +424,64 @@ export function ChatInput({
           rejections.push(
             `${file.name} exceeds the ${capMB} MB ${isImage ? "image" : "file"} limit.`,
           );
-          return null;
+          return [];
         }
-        return { file, isImage };
+        return [{ file, isImage, id: crypto.randomUUID() }];
       });
 
-      const accepted: Attachment[] = await Promise.all(
-        validated
-          .filter((v): v is { file: File; isImage: boolean } => v !== null)
-          .map(async ({ file, isImage }) => {
-            if (isImage) {
-              return {
-                kind: "image" as const,
-                id: crypto.randomUUID(),
-                file,
-                dataUrl: await fileToDataUrl(file),
-              };
-            }
-            return { kind: "file" as const, id: crypto.randomUUID(), file };
-          }),
-      );
-
       if (accepted.length > 0) {
-        setAttachments((prev) => [...prev, ...accepted]);
+        const placeholders: Attachment[] = accepted.map(({ file, isImage, id }) =>
+          isImage
+            ? {
+                kind: "image" as const,
+                id,
+                file,
+                dataUrl: "",
+                loading: true,
+              }
+            : { kind: "file" as const, id, file, loading: true },
+        );
+        setAttachments((prev) => [...prev, ...placeholders]);
       }
+
       for (const msg of rejections) {
         toast.error(msg);
       }
+
+      // Resolve async metadata in parallel; patch each placeholder in
+      // place by id. If the user removed an attachment before its
+      // metadata resolved, the .map below no-ops on the missing id.
+      await Promise.all(
+        accepted.map(async ({ file, isImage, id }) => {
+          if (isImage) {
+            const dataUrl = await fileToDataUrl(file);
+            setAttachments((prev) =>
+              prev.map((a) =>
+                a.id === id && a.kind === "image"
+                  ? { ...a, dataUrl, loading: false }
+                  : a,
+              ),
+            );
+            return;
+          }
+          let lineCount: number | undefined;
+          if (isTextFile(file.name)) {
+            try {
+              const text = await file.text();
+              lineCount = countLines(text);
+            } catch {
+              // Unreadable as text — leave undefined; card falls back to size.
+            }
+          }
+          setAttachments((prev) =>
+            prev.map((a) =>
+              a.id === id && a.kind === "file"
+                ? { ...a, lineCount, loading: false }
+                : a,
+            ),
+          );
+        }),
+      );
     },
     [selectedModel],
   );
@@ -446,6 +489,44 @@ export function ChatInput({
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);
+
+  // Container-level drag-and-drop handlers. Activated only for actual
+  // file drags (filtered via dataTransfer.types) so text/tab-mention
+  // drags pass through unaffected. The counter pattern avoids flicker
+  // on dragenter/leave fired from child elements.
+  const handleContainerDragEnter = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    dragCounter.current += 1;
+    setIsDragOver(true);
+  }, []);
+
+  const handleContainerDragLeave = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    dragCounter.current -= 1;
+    if (dragCounter.current <= 0) {
+      dragCounter.current = 0;
+      setIsDragOver(false);
+    }
+  }, []);
+
+  const handleContainerDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const handleContainerDrop = useCallback(
+    (e: React.DragEvent) => {
+      if (!e.dataTransfer.types.includes("Files")) return;
+      e.preventDefault();
+      dragCounter.current = 0;
+      setIsDragOver(false);
+      const files = e.dataTransfer.files;
+      if (files.length > 0) addFiles(files);
+    },
+    [addFiles],
+  );
 
   const submitWithMentions = useCallback(() => {
     const ed = editorRef.current;
@@ -459,7 +540,11 @@ export function ChatInput({
   const editor = useEditor({
     autofocus: autoFocus ? "end" : false,
     extensions: [
-      StarterKit.configure({ hardBreak: false }),
+      // `dropcursor: false` disables ProseMirror's blue vertical
+      // insertion-point line on drag-over. We handle file drops at
+      // the container level (turning them into attachments) so the
+      // editor's own drop cue is misleading.
+      StarterKit.configure({ hardBreak: false, dropcursor: false }),
       Placeholder.configure({
         placeholder: "Ask anything... Type @ to mention a tab, / for skills",
         showOnlyWhenEditable: false,
@@ -480,7 +565,13 @@ export function ChatInput({
                 onStopRef.current();
               } else {
                 const text = this.editor.getMarkdown().trim();
-                if (text || attachmentsRef.current.length > 0) {
+                const hasLoadingAttachment = attachmentsRef.current.some(
+                  (a) => a.loading,
+                );
+                if (
+                  (text || attachmentsRef.current.length > 0) &&
+                  !hasLoadingAttachment
+                ) {
                   submitWithMentions();
                 }
               }
@@ -508,10 +599,12 @@ export function ChatInput({
         return false;
       },
       handleDrop: (_view, event) => {
-        const files = event.dataTransfer?.files;
-        if (files && files.length > 0) {
+        // File drops are handled by the container-level onDrop on the
+        // outer ChatInput div (so dropping anywhere — attachment row,
+        // bottom bar, padding — works). We just suppress tiptap's
+        // default file-insertion behavior here.
+        if (event.dataTransfer?.files && event.dataTransfer.files.length > 0) {
           event.preventDefault();
-          addFiles(files);
           return true;
         }
         return false;
@@ -526,13 +619,34 @@ export function ChatInput({
 
   editorRef.current = editor;
 
+  // True while any attachment's async metadata is still resolving.
+  // Send is gated on this — submitting with a `loading` image would
+  // produce a vision part with an empty data URL and fail at the API.
+  const attachmentsLoading = useMemo(
+    () => attachments.some((a) => a.loading),
+    [attachments],
+  );
+
   const handleButtonClick = useCallback(() => {
     if (isLoading && onStop) {
       onStop();
-    } else if ((value.trim() || attachments.length > 0) && !disabled && !isLoading) {
+    } else if (
+      (value.trim() || attachments.length > 0) &&
+      !disabled &&
+      !isLoading &&
+      !attachmentsLoading
+    ) {
       submitWithMentions();
     }
-  }, [isLoading, onStop, value, disabled, submitWithMentions, attachments.length]);
+  }, [
+    isLoading,
+    onStop,
+    value,
+    disabled,
+    submitWithMentions,
+    attachments.length,
+    attachmentsLoading,
+  ]);
 
   useHotkeys(
     "mod+shift+backspace",
@@ -605,8 +719,19 @@ export function ChatInput({
   }, [providerModels, selectedModel]);
 
   return (
-    <div className="flex flex-col rounded-lg border border-border bg-card">
-      {/* Image previews */}
+    <div
+      onDragEnter={handleContainerDragEnter}
+      onDragLeave={handleContainerDragLeave}
+      onDragOver={handleContainerDragOver}
+      onDrop={handleContainerDrop}
+      className={cn(
+        "relative flex flex-col rounded-lg border bg-card transition-all duration-150",
+        isDragOver
+          ? "border-blue-500/60 ring-2 ring-blue-500/60 bg-blue-500/5"
+          : "border-border",
+      )}
+    >
+      {/* Attachments */}
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-1.5 px-2 pt-2">
           {attachments.map((att) => {
@@ -617,15 +742,34 @@ export function ChatInput({
             return (
               <div key={att.id} className="relative group">
                 {att.kind === "image" ? (
-                  <img
-                    src={att.dataUrl}
-                    alt={att.file.name}
-                    className="size-16 object-cover rounded-md border border-border"
-                  />
+                  att.loading ? (
+                    <div className="h-[108px] w-[140px] rounded-lg border border-border bg-muted/40 animate-pulse" />
+                  ) : (
+                    <img
+                      src={att.dataUrl}
+                      alt={att.file.name}
+                      className="h-[108px] w-[140px] object-cover rounded-lg border border-border"
+                    />
+                  )
                 ) : (
-                  <div className="flex h-16 max-w-[160px] items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 text-xs">
-                    <FileIcon className="size-4 shrink-0 text-muted-foreground" />
-                    <span className="truncate">{att.file.name}</span>
+                  <div className="flex h-[108px] w-[140px] flex-col gap-1 rounded-lg border border-border bg-background p-2.5">
+                    <div className="line-clamp-3 break-words text-xs font-medium leading-tight text-foreground">
+                      {att.file.name}
+                    </div>
+                    <div className="text-[11px] text-muted-foreground">
+                      {att.loading ? (
+                        <span className="inline-block h-3 w-12 rounded bg-muted animate-pulse" />
+                      ) : att.lineCount !== undefined ? (
+                        `${att.lineCount} ${att.lineCount === 1 ? "line" : "lines"}`
+                      ) : (
+                        formatBytes(att.file.size)
+                      )}
+                    </div>
+                    <div className="mt-auto">
+                      <span className="inline-block rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                        {getTypeBadge(att.file.name)}
+                      </span>
+                    </div>
                   </div>
                 )}
                 {overImageCap && (
@@ -974,7 +1118,7 @@ export function ChatInput({
                 disabled={disabled}
                 className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
               >
-                <ImageIcon className="size-3.5" />
+                <Paperclip className="size-3.5" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">
@@ -988,7 +1132,7 @@ export function ChatInput({
               <button
                 type="button"
                 onClick={handleButtonClick}
-                disabled={disabled && !isLoading}
+                disabled={(disabled || attachmentsLoading) && !isLoading}
                 className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40"
               >
                 {isLoading ? (
@@ -1011,6 +1155,15 @@ export function ChatInput({
           </Tooltip>
         </div>
       </div>
+
+      {isDragOver && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-card/85 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-1.5 text-blue-500">
+            <Paperclip className="size-5" />
+            <span className="text-xs font-medium">Drop file to attach</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -18,6 +18,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { getImageSizeLimit } from "@/lib/agent/vision-limits";
+import type { Attachment } from "@/lib/chat/types";
 import type { ThinkingConfig } from "@/lib/types";
 import type { JSONContent } from "@tiptap/core";
 import HardBreak from "@tiptap/extension-hard-break";
@@ -29,6 +31,7 @@ import {
   ArrowUp,
   BrainIcon,
   ChevronDown,
+  File as FileIcon,
   Image as ImageIcon,
   Square,
   Star,
@@ -36,12 +39,12 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { toast } from "sonner";
 
-interface ImagePreview {
-  id: string;
-  file: File;
-  dataUrl: string;
-}
+// Derived alias kept for back-compat with call sites that destructure
+// images: ImagePreview[] from onSubmit. Tasks 5-6 migrate those sites;
+// once they're gone we can delete the alias and the re-export.
+type ImagePreview = Extract<Attachment, { kind: "image" }>;
 
 interface ModelOption {
   id: string;
@@ -66,7 +69,7 @@ interface ProviderModels {
 interface ChatInputProps {
   value: string;
   onChange: (value: string) => void;
-  onSubmit: (mentions: TabMentionAttrs[], images: ImagePreview[]) => void;
+  onSubmit: (mentions: TabMentionAttrs[], attachments: Attachment[]) => void;
   onStop?: () => void;
   isLoading: boolean;
   disabled: boolean;
@@ -89,7 +92,7 @@ export interface TabMentionAttrs {
   favicon: string;
 }
 
-export type { ImagePreview };
+export type { ImagePreview, Attachment };
 
 export function extractTabMentions(json: JSONContent): TabMentionAttrs[] {
   const mentions: TabMentionAttrs[] = [];
@@ -270,9 +273,14 @@ export function ChatInput({
   isLoadingRef.current = isLoading;
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [images, setImages] = useState<ImagePreview[]>([]);
-  const imagesRef = useRef(images);
-  imagesRef.current = images;
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
+  // Back-compat for spots in this file that count or filter to images.
+  const images = useMemo(
+    () => attachments.filter((a): a is Extract<Attachment, { kind: "image" }> => a.kind === "image"),
+    [attachments],
+  );
   const lastExternalValue = useRef(value);
   const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
   const [highlightedModelId, setHighlightedModelId] = useState<string | null>(
@@ -375,24 +383,68 @@ export function ChatInput({
     };
   }, [providerModels, modelSearchQuery, favoriteModels]);
 
-  const addFiles = useCallback(async (files: FileList | File[]) => {
-    const imageFiles = Array.from(files).filter((f) =>
-      f.type.startsWith("image/"),
-    );
-    if (imageFiles.length === 0) return;
+  const addFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const MB = 1024 * 1024;
+      const FILE_CAP = 50 * MB;
+      const COUNT_CAP = 10;
+      const imageCap = selectedModel ? getImageSizeLimit(selectedModel) : 10 * MB;
 
-    const newPreviews = await Promise.all(
-      imageFiles.map(async (file) => ({
-        id: crypto.randomUUID(),
-        file,
-        dataUrl: await fileToDataUrl(file),
-      })),
-    );
-    setImages((prev) => [...prev, ...newPreviews]);
-  }, []);
+      const incoming = Array.from(files);
+      const rejections: string[] = [];
 
-  const removeImage = useCallback((id: string) => {
-    setImages((prev) => prev.filter((img) => img.id !== id));
+      const remainingSlots = COUNT_CAP - attachmentsRef.current.length;
+      if (incoming.length > remainingSlots) {
+        rejections.push(
+          `Only ${remainingSlots} more attachment${remainingSlots === 1 ? "" : "s"} allowed (max ${COUNT_CAP} per message).`,
+        );
+      }
+
+      // Validate synchronously, then convert any accepted images to
+      // data URLs in parallel. The previous image-only code parallelized
+      // FileReader work; preserve that.
+      const slice = incoming.slice(0, Math.max(0, remainingSlots));
+      const validated = slice.map((file) => {
+        const isImage = file.type.startsWith("image/");
+        const cap = isImage ? imageCap : FILE_CAP;
+        if (file.size > cap) {
+          const capMB = Math.round(cap / MB);
+          rejections.push(
+            `${file.name} exceeds the ${capMB} MB ${isImage ? "image" : "file"} limit.`,
+          );
+          return null;
+        }
+        return { file, isImage };
+      });
+
+      const accepted: Attachment[] = await Promise.all(
+        validated
+          .filter((v): v is { file: File; isImage: boolean } => v !== null)
+          .map(async ({ file, isImage }) => {
+            if (isImage) {
+              return {
+                kind: "image" as const,
+                id: crypto.randomUUID(),
+                file,
+                dataUrl: await fileToDataUrl(file),
+              };
+            }
+            return { kind: "file" as const, id: crypto.randomUUID(), file };
+          }),
+      );
+
+      if (accepted.length > 0) {
+        setAttachments((prev) => [...prev, ...accepted]);
+      }
+      for (const msg of rejections) {
+        toast.error(msg);
+      }
+    },
+    [selectedModel],
+  );
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);
 
   const submitWithMentions = useCallback(() => {
@@ -400,8 +452,8 @@ export function ChatInput({
     if (!ed) return;
     const json = ed.getJSON();
     const mentions = extractTabMentions(json);
-    onSubmitRef.current(mentions, imagesRef.current);
-    setImages([]);
+    onSubmitRef.current(mentions, attachmentsRef.current);
+    setAttachments([]);
   }, []);
 
   const editor = useEditor({
@@ -428,7 +480,7 @@ export function ChatInput({
                 onStopRef.current();
               } else {
                 const text = this.editor.getMarkdown().trim();
-                if (text || imagesRef.current.length > 0) {
+                if (text || attachmentsRef.current.length > 0) {
                   submitWithMentions();
                 }
               }
@@ -449,28 +501,18 @@ export function ChatInput({
       handlePaste: (_view, event) => {
         const files = event.clipboardData?.files;
         if (files && files.length > 0) {
-          const hasImages = Array.from(files).some((f) =>
-            f.type.startsWith("image/"),
-          );
-          if (hasImages) {
-            event.preventDefault();
-            addFiles(files);
-            return true;
-          }
+          event.preventDefault();
+          addFiles(files);
+          return true;
         }
         return false;
       },
       handleDrop: (_view, event) => {
         const files = event.dataTransfer?.files;
         if (files && files.length > 0) {
-          const hasImages = Array.from(files).some((f) =>
-            f.type.startsWith("image/"),
-          );
-          if (hasImages) {
-            event.preventDefault();
-            addFiles(files);
-            return true;
-          }
+          event.preventDefault();
+          addFiles(files);
+          return true;
         }
         return false;
       },
@@ -487,10 +529,10 @@ export function ChatInput({
   const handleButtonClick = useCallback(() => {
     if (isLoading && onStop) {
       onStop();
-    } else if ((value.trim() || images.length > 0) && !disabled && !isLoading) {
+    } else if ((value.trim() || attachments.length > 0) && !disabled && !isLoading) {
       submitWithMentions();
     }
-  }, [isLoading, onStop, value, disabled, submitWithMentions, images.length]);
+  }, [isLoading, onStop, value, disabled, submitWithMentions, attachments.length]);
 
   useHotkeys(
     "mod+shift+backspace",
@@ -565,24 +607,42 @@ export function ChatInput({
   return (
     <div className="flex flex-col rounded-lg border border-border bg-card">
       {/* Image previews */}
-      {images.length > 0 && (
+      {attachments.length > 0 && (
         <div className="flex flex-wrap gap-1.5 px-2 pt-2">
-          {images.map((img) => (
-            <div key={img.id} className="relative group">
-              <img
-                src={img.dataUrl}
-                alt="Upload preview"
-                className="size-16 object-cover rounded-md border border-border"
-              />
-              <button
-                type="button"
-                onClick={() => removeImage(img.id)}
-                className="absolute -right-1 -top-1 size-4 flex items-center justify-center rounded-full bg-background border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
-              >
-                <X className="size-2.5" />
-              </button>
-            </div>
-          ))}
+          {attachments.map((att) => {
+            const overImageCap =
+              att.kind === "image" &&
+              selectedModel != null &&
+              att.file.size > getImageSizeLimit(selectedModel);
+            return (
+              <div key={att.id} className="relative group">
+                {att.kind === "image" ? (
+                  <img
+                    src={att.dataUrl}
+                    alt={att.file.name}
+                    className="size-16 object-cover rounded-md border border-border"
+                  />
+                ) : (
+                  <div className="flex h-16 max-w-[160px] items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 text-xs">
+                    <FileIcon className="size-4 shrink-0 text-muted-foreground" />
+                    <span className="truncate">{att.file.name}</span>
+                  </div>
+                )}
+                {overImageCap && (
+                  <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full border border-border bg-background px-1.5 py-0.5 text-[9px] leading-none text-muted-foreground shadow-sm">
+                    file only
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => removeAttachment(att.id)}
+                  className="absolute -right-1 -top-1 size-4 flex items-center justify-center rounded-full bg-background border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <X className="size-2.5" />
+                </button>
+              </div>
+            );
+          })}
         </div>
       )}
 
@@ -897,7 +957,6 @@ export function ChatInput({
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/*"
             multiple
             className="hidden"
             onChange={(e) => {
@@ -918,7 +977,11 @@ export function ChatInput({
                 <ImageIcon className="size-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">Attach image</TooltipContent>
+            <TooltipContent side="top">
+              {selectedModel
+                ? `Attach file — images up to ${Math.round(getImageSizeLimit(selectedModel) / (1024 * 1024))} MB`
+                : "Attach file"}
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -1,7 +1,7 @@
 import {
   ChatInput,
-  type ImagePreview,
   type TabMentionAttrs,
+  type Attachment,
 } from "./ChatInput";
 import { ChatMessage } from "./ChatMessage";
 import { CompactionDivider } from "./CompactionDivider";
@@ -412,9 +412,9 @@ export function ChatView({
   }, [preEditInput, setInput]);
 
   const handleEditSubmit = useCallback(
-    (mentions: TabMentionAttrs[], images: ImagePreview[]) => {
+    (mentions: TabMentionAttrs[], attachments: Attachment[]) => {
       if (!editingMessageId) return;
-      confirmEdit(editingMessageId, mentions, images);
+      confirmEdit(editingMessageId, mentions, attachments);
       setEditingMessageId(null);
     },
     [editingMessageId, confirmEdit],

--- a/apps/extension/src/components/chat/UserMessage.tsx
+++ b/apps/extension/src/components/chat/UserMessage.tsx
@@ -6,10 +6,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
-import { Check, Copy, Pencil, File as FileIcon } from "lucide-react";
+import { Check, Copy, Pencil } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
 import { classifyFile } from "@/lib/vfs/file-classify";
+import { getTypeBadge } from "@/lib/chat/attachment-meta";
 
 interface UserMessageProps {
   message: AgentUIMessage;
@@ -89,7 +90,7 @@ export function UserMessage({ message, onEdit, dimmed }: UserMessageProps) {
         </div>
       )}
       {attachedPaths.length > 0 && (
-        <div className="max-w-[85%] flex flex-wrap justify-end gap-1">
+        <div className="max-w-[85%] flex flex-wrap justify-end gap-1.5">
           {attachedPaths
             // Image attachments already render as thumbnails above —
             // skip them in the chip row to avoid duplication.
@@ -102,10 +103,16 @@ export function UserMessage({ message, onEdit, dimmed }: UserMessageProps) {
               return (
                 <div
                   key={path}
-                  className="flex items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground"
+                  className="flex h-[108px] w-[140px] flex-col gap-1 rounded-lg border border-border bg-background p-2.5"
                 >
-                  <FileIcon className="size-3.5" />
-                  <span className="truncate max-w-[160px]">{name}</span>
+                  <div className="line-clamp-3 break-words text-xs font-medium leading-tight text-foreground">
+                    {name}
+                  </div>
+                  <div className="mt-auto">
+                    <span className="inline-block rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                      {getTypeBadge(name)}
+                    </span>
+                  </div>
                 </div>
               );
             })}

--- a/apps/extension/src/components/chat/UserMessage.tsx
+++ b/apps/extension/src/components/chat/UserMessage.tsx
@@ -6,8 +6,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
-import { Check, Copy, Pencil } from "lucide-react";
+import { Check, Copy, Pencil, File as FileIcon } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
+import { classifyFile } from "@/lib/vfs/file-classify";
 
 interface UserMessageProps {
   message: AgentUIMessage;
@@ -24,10 +26,23 @@ export function UserMessage({ message, onEdit, dimmed }: UserMessageProps) {
     .map((p) => (p as { text: string }).text)
     .join("");
 
-  const text = useMemo(
-    () => rawText.split("\n\n-----\n\n<Mentioned tabs>")[0],
-    [rawText],
-  );
+  const { displayText, attachedPaths } = useMemo(() => {
+    // Parse the trailing <Attached files> block FIRST (it uses
+    // lastIndexOf and finds the block whether or not a <Mentioned tabs>
+    // block precedes it). LandingPage persists mentions BEFORE
+    // attachments, so a "split mentions then parse attachments" order
+    // would discard the attachment block on those messages. After
+    // parsing, strip any preceding <Mentioned tabs> block from the
+    // remaining displayText.
+    const { displayText: afterAttachments, attachedPaths } =
+      parseAttachedFiles(rawText);
+    const displayText = afterAttachments.split(
+      "\n\n-----\n\n<Mentioned tabs>",
+    )[0];
+    return { displayText, attachedPaths };
+  }, [rawText]);
+
+  const text = displayText;
 
   const imageUrls = useMemo(
     () =>
@@ -71,6 +86,29 @@ export function UserMessage({ message, onEdit, dimmed }: UserMessageProps) {
             content={text}
             className="text-secondary-foreground [&_*]:text-secondary-foreground [&>p]:!my-0 [&_p]:!my-0 [&_.tab-mention]:bg-foreground/10 [&_.skill-slash]:bg-foreground/10"
           />
+        </div>
+      )}
+      {attachedPaths.length > 0 && (
+        <div className="max-w-[85%] flex flex-wrap justify-end gap-1">
+          {attachedPaths
+            // Image attachments already render as thumbnails above —
+            // skip them in the chip row to avoid duplication.
+            .filter((path) => {
+              const name = path.split("/").pop() ?? path;
+              return classifyFile(name) !== "image";
+            })
+            .map((path) => {
+              const name = path.split("/").pop() ?? path;
+              return (
+                <div
+                  key={path}
+                  className="flex items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground"
+                >
+                  <FileIcon className="size-3.5" />
+                  <span className="truncate max-w-[160px]">{name}</span>
+                </div>
+              );
+            })}
         </div>
       )}
       {!dimmed && (

--- a/apps/extension/src/components/ui/zoomable-image.css
+++ b/apps/extension/src/components/ui/zoomable-image.css
@@ -1,0 +1,21 @@
+/*
+ * Overrides for `react-medium-image-zoom`'s default styles.
+ *
+ * - Hide the top-right close ("unzoom") button. Click-outside and
+ *   the Escape key still close the zoom view.
+ * - Replace the (white-in-light-mode) backdrop with a semi-transparent
+ *   dark scrim that reads correctly on both light and dark themes.
+ */
+
+:root {
+  --rmiz-overlay-bg-color-start: rgba(0, 0, 0, 0);
+  --rmiz-overlay-bg-color-end: rgba(0, 0, 0, 0.7);
+}
+
+[data-rmiz-modal-overlay="visible"] {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+[data-rmiz-btn-unzoom] {
+  display: none !important;
+}

--- a/apps/extension/src/components/ui/zoomable-image.tsx
+++ b/apps/extension/src/components/ui/zoomable-image.tsx
@@ -1,5 +1,6 @@
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
+import "./zoomable-image.css";
 import { cn } from "@/lib/utils";
 
 interface ZoomableImageProps {

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -18,6 +18,7 @@ import { DEFAULT_SETTINGS, DEFAULT_AGENT_SETTINGS } from "@/lib/constants";
 import { useProviders } from "@/hooks/useProviders";
 import type { Space, Settings, AgentSettings, SerializedUIPart, ThinkingConfig } from "@/lib/types";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 interface LandingPageProps {
   space: Space | null;
@@ -185,11 +186,21 @@ export function LandingPage({
 
       const baseText = input.trim();
       const mentionContext = await formatMentionContext(mentions);
-      const { block: attachmentBlock, visionFiles } = await formatAttachments(
-        convId,
-        attachments,
-        agentSettings.agentModel,
-      );
+
+      let attachmentBlock: string;
+      let visionFiles: { mediaType: string; url: string }[];
+      try {
+        ({ block: attachmentBlock, visionFiles } = await formatAttachments(
+          convId,
+          attachments,
+          agentSettings.agentModel,
+        ));
+      } catch (e) {
+        toast.error(
+          `Failed to save attachments: ${(e as Error).message ?? String(e)}`,
+        );
+        return;
+      }
 
       // Unlike useAgentChat.handleSubmit, LandingPage doesn't sendMessage
       // directly — the side panel mounts on onNewConversation, reloads from

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -1,9 +1,10 @@
 import {
   ChatInput,
   type TabMentionAttrs,
-  type ImagePreview,
+  type Attachment,
   formatMentionContext,
 } from "@/components/chat/ChatInput";
+import { formatAttachments } from "@/lib/chat/format-attachments";
 import {
   Suggestions,
   Suggestion,
@@ -170,8 +171,8 @@ export function LandingPage({
   ]);
 
   const handleSubmit = useCallback(
-    async (mentions: TabMentionAttrs[], images: ImagePreview[]) => {
-      if (!input.trim() && images.length === 0) return;
+    async (mentions: TabMentionAttrs[], attachments: Attachment[]) => {
+      if (!input.trim() && attachments.length === 0) return;
 
       const convId = crypto.randomUUID();
       await chatDb.createConversation({
@@ -184,21 +185,32 @@ export function LandingPage({
 
       const baseText = input.trim();
       const mentionContext = await formatMentionContext(mentions);
-      const fullText = baseText + mentionContext;
+      const { block: attachmentBlock, visionFiles } = await formatAttachments(
+        convId,
+        attachments,
+        agentSettings.agentModel,
+      );
 
-      const fileParts: SerializedUIPart[] = images.map((img) => ({
+      // Unlike useAgentChat.handleSubmit, LandingPage doesn't sendMessage
+      // directly — the side panel mounts on onNewConversation, reloads from
+      // chatDb, and replays via bare sendMessage(). The persisted record IS
+      // the model's first view, so mentionContext must survive into chatDb.
+      // The attachment block is appended after so chip rendering also survives.
+      const persistedFull = baseText + mentionContext + attachmentBlock;
+
+      const fileParts: SerializedUIPart[] = visionFiles.map((vf) => ({
         type: "file" as const,
-        mediaType: img.file.type,
-        url: img.dataUrl,
+        mediaType: vf.mediaType,
+        url: vf.url,
       }));
 
       await chatDb.saveMessage({
         id: crypto.randomUUID(),
         conversationId: convId,
         role: "user",
-        content: fullText,
+        content: persistedFull,
         parts: [
-          ...(fullText ? [{ type: "text" as const, text: fullText }] : []),
+          ...(persistedFull ? [{ type: "text" as const, text: persistedFull }] : []),
           ...fileParts,
         ],
         createdAt: Date.now(),

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -1,5 +1,6 @@
 import { chatDb } from "@/lib/chat-db";
 import { createAgentTransport } from "@/lib/chat-transport";
+import { formatAttachments } from "@/lib/chat/format-attachments";
 import {
   resetAgentIndicator,
   setAgentSpaceColor,
@@ -22,7 +23,7 @@ import {
 } from "@/lib/agent/compaction";
 import {
   type TabMentionAttrs,
-  type ImagePreview,
+  type Attachment,
   formatMentionContext,
 } from "@/components/chat/ChatInput";
 import { DEFAULT_AGENT_SETTINGS, DEFAULT_SETTINGS } from "@/lib/constants";
@@ -1004,8 +1005,11 @@ export function useAgentChat({
   }, [conversationId, chat, transport, setMessages, sendMessage, status]);
 
   const handleSubmit = useCallback(
-    async (mentions: TabMentionAttrs[] = [], images: ImagePreview[] = []) => {
-      if (!input.trim() && images.length === 0) return;
+    async (
+      mentions: TabMentionAttrs[] = [],
+      attachments: Attachment[] = [],
+    ) => {
+      if (!input.trim() && attachments.length === 0) return;
       if (!isConfigured) return;
 
       // Heal any stranded tool calls in the existing history before
@@ -1094,21 +1098,33 @@ export function useAgentChat({
 
       const baseText = input.trim();
       const mentionContext = await formatMentionContext(mentions);
-      const text = baseText + mentionContext;
+      const { block: attachmentBlock, visionFiles } = await formatAttachments(
+        convId,
+        attachments,
+        agentSettings.agentModel,
+      );
 
-      const fileParts: SerializedUIPart[] = images.map((img) => ({
+      // `text` is what the model sees; `persistedText` is what we store in
+      // chat-db. Mention context is intentionally model-only (keeps the
+      // user's question clean in history); the attachment block, in
+      // contrast, must persist so `UserMessage` can re-render filename
+      // chips after a reload.
+      const text = baseText + mentionContext + attachmentBlock;
+      const persistedText = baseText + attachmentBlock;
+
+      const fileParts: SerializedUIPart[] = visionFiles.map((vf) => ({
         type: "file" as const,
-        mediaType: img.file.type,
-        url: img.dataUrl,
+        mediaType: vf.mediaType,
+        url: vf.url,
       }));
 
       await chatDb.saveMessage({
         id: generateId(),
         conversationId: convId,
         role: "user",
-        content: baseText,
+        content: persistedText,
         parts: [
-          ...(baseText ? [{ type: "text" as const, text: baseText }] : []),
+          ...(persistedText ? [{ type: "text" as const, text: persistedText }] : []),
           ...fileParts,
         ],
         createdAt: Date.now(),
@@ -1116,10 +1132,10 @@ export function useAgentChat({
 
       setInput("");
 
-      const files = images.map((img) => ({
+      const files = visionFiles.map((vf) => ({
         type: "file" as const,
-        mediaType: img.file.type,
-        url: img.dataUrl,
+        mediaType: vf.mediaType,
+        url: vf.url,
       }));
 
       // Compaction-aware message assembly now lives in the transport. Here
@@ -1219,8 +1235,12 @@ export function useAgentChat({
   }, [messages, conversationId, regenerate, clearError, setMessages]);
 
   const confirmEdit = useCallback(
-    async (messageId: string, mentions: TabMentionAttrs[] = [], images: ImagePreview[] = []) => {
-      if (!input.trim() && images.length === 0) return;
+    async (
+      messageId: string,
+      mentions: TabMentionAttrs[] = [],
+      attachments: Attachment[] = [],
+    ) => {
+      if (!input.trim() && attachments.length === 0) return;
       if (!isConfigured) return;
       const idx = messages.findIndex((m) => m.id === messageId);
       if (idx === -1) return;
@@ -1245,12 +1265,26 @@ export function useAgentChat({
 
       const baseText = input.trim();
       const mentionContext = await formatMentionContext(mentions);
-      const text = baseText + mentionContext;
+      // TODO(workspace-cleanup): edits write attachments to OPFS but
+      // never remove files that were attached to the prior version of
+      // this message. Repeated edits can leak duplicates into the
+      // conversation workspace (with `(2)`, `(3)`, ... suffixes from
+      // OPFS.uniquePath). Acceptable for v1; address with a real diff
+      // against the prior persisted parts when we add workspace cleanup.
+      const { block: attachmentBlock, visionFiles } = await formatAttachments(
+        conversationId!,
+        attachments,
+        agentSettings.agentModel,
+      );
 
-      const fileParts: SerializedUIPart[] = images.map((img) => ({
+      // See `handleSubmit` for rationale on the text/persistedText split.
+      const text = baseText + mentionContext + attachmentBlock;
+      const persistedText = baseText + attachmentBlock;
+
+      const fileParts: SerializedUIPart[] = visionFiles.map((vf) => ({
         type: "file" as const,
-        mediaType: img.file.type,
-        url: img.dataUrl,
+        mediaType: vf.mediaType,
+        url: vf.url,
       }));
 
       const newMessageId = generateId();
@@ -1258,9 +1292,9 @@ export function useAgentChat({
         id: newMessageId,
         conversationId: conversationId!,
         role: "user",
-        content: baseText,
+        content: persistedText,
         parts: [
-          ...(baseText ? [{ type: "text" as const, text: baseText }] : []),
+          ...(persistedText ? [{ type: "text" as const, text: persistedText }] : []),
           ...fileParts,
         ],
         createdAt: Date.now(),
@@ -1279,10 +1313,10 @@ export function useAgentChat({
       // without a chat switch.
       const sendParts: AgentMessage["parts"] = [
         ...(text ? [{ type: "text" as const, text }] : []),
-        ...images.map((img) => ({
+        ...visionFiles.map((vf) => ({
           type: "file" as const,
-          mediaType: img.file.type,
-          url: img.dataUrl,
+          mediaType: vf.mediaType,
+          url: vf.url,
         })),
       ];
 
@@ -1292,7 +1326,7 @@ export function useAgentChat({
         parts: sendParts,
       });
     },
-    [input, isConfigured, messages, setMessages, conversationId, sendMessage],
+    [input, isConfigured, messages, setMessages, conversationId, sendMessage, agentSettings.agentModel],
   );
 
   const setAgentModel = useCallback(

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -54,6 +54,7 @@ import type {
   TextUIPart,
 } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 
 type AgentMessage = AgentUIMessage;
 
@@ -1098,11 +1099,23 @@ export function useAgentChat({
 
       const baseText = input.trim();
       const mentionContext = await formatMentionContext(mentions);
-      const { block: attachmentBlock, visionFiles } = await formatAttachments(
-        convId,
-        attachments,
-        agentSettings.agentModel,
-      );
+
+      let attachmentBlock: string;
+      let visionFiles: { mediaType: string; url: string }[];
+      try {
+        ({ block: attachmentBlock, visionFiles } = await formatAttachments(
+          convId,
+          attachments,
+          agentSettings.agentModel,
+        ));
+      } catch (e) {
+        // Spec §7: stop on first failure, surface error, leave input intact
+        // so the user can retry after removing the offending attachment.
+        toast.error(
+          `Failed to save attachments: ${(e as Error).message ?? String(e)}`,
+        );
+        return;
+      }
 
       // `text` is what the model sees; `persistedText` is what we store in
       // chat-db. Mention context is intentionally model-only (keeps the
@@ -1265,17 +1278,27 @@ export function useAgentChat({
 
       const baseText = input.trim();
       const mentionContext = await formatMentionContext(mentions);
-      // TODO(workspace-cleanup): edits write attachments to OPFS but
-      // never remove files that were attached to the prior version of
-      // this message. Repeated edits can leak duplicates into the
-      // conversation workspace (with `(2)`, `(3)`, ... suffixes from
-      // OPFS.uniquePath). Acceptable for v1; address with a real diff
-      // against the prior persisted parts when we add workspace cleanup.
-      const { block: attachmentBlock, visionFiles } = await formatAttachments(
-        conversationId!,
-        attachments,
-        agentSettings.agentModel,
-      );
+
+      let attachmentBlock: string;
+      let visionFiles: { mediaType: string; url: string }[];
+      try {
+        // TODO(workspace-cleanup): edits write attachments to OPFS but
+        // never remove files that were attached to the prior version of
+        // this message. Repeated edits can leak duplicates into the
+        // conversation workspace (with `(2)`, `(3)`, ... suffixes from
+        // OPFS.uniquePath). Acceptable for v1; address with a real diff
+        // against the prior persisted parts when we add workspace cleanup.
+        ({ block: attachmentBlock, visionFiles } = await formatAttachments(
+          conversationId!,
+          attachments,
+          agentSettings.agentModel,
+        ));
+      } catch (e) {
+        toast.error(
+          `Failed to save attachments: ${(e as Error).message ?? String(e)}`,
+        );
+        return;
+      }
 
       // See `handleSubmit` for rationale on the text/persistedText split.
       const text = baseText + mentionContext + attachmentBlock;

--- a/apps/extension/src/lib/agent/__tests__/vision-limits.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/vision-limits.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { getImageSizeLimit } from "../vision-limits";
+
+const MB = 1024 * 1024;
+
+describe("getImageSizeLimit", () => {
+  it("returns Anthropic's 5 MB cap for anthropic models", () => {
+    expect(getImageSizeLimit("anthropic:claude-sonnet-4")).toBe(5 * MB);
+  });
+
+  it("returns Google's 7 MB cap for google models", () => {
+    expect(getImageSizeLimit("google:gemini-2.0-flash")).toBe(7 * MB);
+  });
+
+  it("returns OpenAI's 20 MB cap clamped at the universal ceiling", () => {
+    expect(getImageSizeLimit("openai:gpt-4o")).toBe(20 * MB);
+  });
+
+  it("returns xAI's 10 MB cap", () => {
+    expect(getImageSizeLimit("xai:grok-2-vision")).toBe(10 * MB);
+  });
+
+  it("returns OpenRouter's defensive 5 MB cap", () => {
+    expect(getImageSizeLimit("openrouter:openai/gpt-4o")).toBe(5 * MB);
+  });
+
+  it("returns the 10 MB default for unknown providers", () => {
+    expect(getImageSizeLimit("some-new-provider:foo-1")).toBe(10 * MB);
+  });
+
+  it("handles the no-colon edge case by using the whole string as provider", () => {
+    expect(getImageSizeLimit("anthropic")).toBe(5 * MB);
+  });
+
+  it("clamps any future-too-permissive entry to the 20 MB ceiling", () => {
+    // Sanity: even if a provider entry were 50 MB, the API surface clamps.
+    // We test this by asserting no return value exceeds 20 MB across all
+    // known providers.
+    const knownProviders = [
+      "anthropic", "google", "xai", "openai", "openai-compat",
+      "openrouter", "ollama", "webllm", "chrome-builtin",
+    ];
+    for (const p of knownProviders) {
+      expect(getImageSizeLimit(`${p}:any-model`)).toBeLessThanOrEqual(20 * MB);
+    }
+  });
+});

--- a/apps/extension/src/lib/agent/vision-limits.ts
+++ b/apps/extension/src/lib/agent/vision-limits.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-provider image size caps for inline vision message parts.
+ *
+ * Values reflect provider-published API limits as of 2026-05. Maintenance
+ * note: caps move maybe once a year. Update this table when they do — it
+ * is the single source of truth.
+ *
+ * Universal hard ceiling regardless of provider: 20 MB. Even if a provider
+ * accepts more, base64 inflation (~33%) means a 25 MB image becomes a
+ * 33 MB blob in the message stream, bloating compaction.
+ */
+
+const PROVIDER_CAPS_MB: Record<string, number> = {
+  anthropic: 5,
+  google: 7,
+  xai: 10,
+  openai: 20,
+  "openai-compat": 10,
+  openrouter: 5, // defensive — request can route to any underlying model
+  ollama: 10,
+  webllm: 10,
+  "chrome-builtin": 10,
+};
+
+const HARD_CEILING_MB = 20;
+const DEFAULT_MB = 10;
+
+/**
+ * Returns the maximum image size (in bytes) that should be inlined as a
+ * vision message part for the given model. Files above this cap can still
+ * land in the workspace; they just won't be sent as vision parts.
+ *
+ * Accepts the compound `<provider>:<modelId>` key used throughout the
+ * registry (and `ChatInput.selectedModel`). If no colon is present the
+ * entire string is treated as the provider id.
+ */
+export function getImageSizeLimit(modelKey: string): number {
+  const provider = modelKey.includes(":")
+    ? modelKey.slice(0, modelKey.indexOf(":"))
+    : modelKey;
+  const cap = PROVIDER_CAPS_MB[provider] ?? DEFAULT_MB;
+  return Math.min(cap, HARD_CEILING_MB) * 1024 * 1024;
+}

--- a/apps/extension/src/lib/chat/__tests__/attachment-meta.test.ts
+++ b/apps/extension/src/lib/chat/__tests__/attachment-meta.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  getTypeBadge,
+  isTextFile,
+  countLines,
+  formatBytes,
+} from "../attachment-meta";
+
+describe("getTypeBadge", () => {
+  it("returns the uppercased extension for common files", () => {
+    expect(getTypeBadge("report.pdf")).toBe("PDF");
+    expect(getTypeBadge("notes.md")).toBe("MD");
+    expect(getTypeBadge("data.json")).toBe("JSON");
+    expect(getTypeBadge("App.tsx")).toBe("TSX");
+  });
+
+  it("uses the last segment for multi-dot names", () => {
+    expect(getTypeBadge("archive.tar.gz")).toBe("GZ");
+  });
+
+  it("returns FILE for extensionless names", () => {
+    expect(getTypeBadge("README")).toBe("FILE");
+  });
+
+  it("returns FILE for dotfiles", () => {
+    expect(getTypeBadge(".gitignore")).toBe("FILE");
+  });
+});
+
+describe("isTextFile", () => {
+  it("returns true for code", () => {
+    expect(isTextFile("foo.ts")).toBe(true);
+    expect(isTextFile("foo.json")).toBe(true);
+    expect(isTextFile("README")).toBe(true); // unknown extensions classify as code
+  });
+
+  it("returns true for markdown", () => {
+    expect(isTextFile("foo.md")).toBe(true);
+  });
+
+  it("returns false for binary classes", () => {
+    expect(isTextFile("foo.pdf")).toBe(false);
+    expect(isTextFile("foo.png")).toBe(false);
+    expect(isTextFile("foo.zip")).toBe(false);
+  });
+});
+
+describe("countLines", () => {
+  it("returns 0 for an empty string", () => {
+    expect(countLines("")).toBe(0);
+  });
+
+  it("returns 1 for a single line without trailing newline", () => {
+    expect(countLines("hello")).toBe(1);
+  });
+
+  it("returns 1 for a single line with trailing newline", () => {
+    expect(countLines("hello\n")).toBe(1);
+  });
+
+  it("counts multiple lines without trailing newline", () => {
+    expect(countLines("a\nb\nc")).toBe(3);
+  });
+
+  it("counts multiple lines with trailing newline", () => {
+    expect(countLines("a\nb\nc\n")).toBe(3);
+  });
+
+  it("counts a lone newline as 1", () => {
+    expect(countLines("\n")).toBe(1);
+  });
+});
+
+describe("formatBytes", () => {
+  it("uses bytes under 1 KiB", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("rounds to whole KB up to 1 MiB", () => {
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(24 * 1024)).toBe("24 KB");
+    expect(formatBytes(1024 * 1024 - 1)).toBe("1024 KB");
+  });
+
+  it("uses MB with one decimal above 1 MiB", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(formatBytes(1024 * 1024 * 5)).toBe("5.0 MB");
+    expect(formatBytes(1024 * 1024 * 1.25)).toBe("1.3 MB");
+  });
+});

--- a/apps/extension/src/lib/chat/__tests__/format-attachments.test.ts
+++ b/apps/extension/src/lib/chat/__tests__/format-attachments.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Attachment } from "../types";
+
+vi.mock("@/lib/vfs/opfs", () => {
+  const writes: Array<{ path: string; size: number }> = [];
+  return {
+    OPFS: {
+      writeFileBytes: vi.fn(async (path: string, blob: Blob) => {
+        writes.push({ path, size: blob.size });
+      }),
+      uniquePath: vi.fn(async (dir: string, name: string) => `${dir}/${name}`),
+    },
+    __writes: writes,
+  };
+});
+
+import { formatAttachments } from "../format-attachments";
+// @ts-ignore — exposed by the mock above for assertions
+import { __writes } from "@/lib/vfs/opfs";
+
+function fakeFile(
+  name: string,
+  size: number,
+  type = "application/octet-stream",
+): File {
+  const content = new Uint8Array(size);
+  return new File([content], name, { type });
+}
+
+beforeEach(() => {
+  __writes.length = 0;
+});
+
+describe("formatAttachments", () => {
+  it("returns empty block and no vision files for an empty list", async () => {
+    const r = await formatAttachments("conv-1", [], "openai:gpt-4o");
+    expect(r.block).toBe("");
+    expect(r.visionFiles).toEqual([]);
+    expect(__writes).toEqual([]);
+  });
+
+  it("writes a non-image attachment and includes its path in the block", async () => {
+    const attachments: Attachment[] = [
+      { kind: "file", id: "a1", file: fakeFile("report.pdf", 100) },
+    ];
+    const r = await formatAttachments(
+      "conv-1",
+      attachments,
+      "anthropic:claude-sonnet-4",
+    );
+    expect(r.block).toBe(
+      "\n\n<Attached files>\n- /report.pdf\n</Attached files>",
+    );
+    expect(r.visionFiles).toEqual([]);
+    expect(__writes.length).toBe(1);
+  });
+
+  it("includes a vision file part for a small image on a vision-capable model", async () => {
+    const attachments: Attachment[] = [
+      {
+        kind: "image",
+        id: "i1",
+        file: fakeFile("shot.png", 1024 * 1024, "image/png"),
+        dataUrl: "data:image/png;base64,AAAA",
+      },
+    ];
+    const r = await formatAttachments(
+      "conv-1",
+      attachments,
+      "anthropic:claude-sonnet-4",
+    );
+    expect(r.block).toContain("- /shot.png");
+    expect(r.visionFiles).toEqual([
+      { mediaType: "image/png", url: "data:image/png;base64,AAAA" },
+    ]);
+  });
+
+  it("skips the vision part for an oversize image but still writes the file", async () => {
+    const attachments: Attachment[] = [
+      {
+        kind: "image",
+        id: "i1",
+        file: fakeFile("big.png", 12 * 1024 * 1024, "image/png"),
+        dataUrl: "data:image/png;base64,AAAA",
+      },
+    ];
+    // Anthropic cap is 5 MB; 12 MB exceeds it.
+    const r = await formatAttachments(
+      "conv-1",
+      attachments,
+      "anthropic:claude-sonnet-4",
+    );
+    expect(r.visionFiles).toEqual([]);
+    expect(r.block).toContain("- /big.png");
+    expect(__writes.length).toBe(1);
+  });
+
+  it("preserves attachment order in both block and vision parts", async () => {
+    const attachments: Attachment[] = [
+      { kind: "file", id: "a", file: fakeFile("a.csv", 10) },
+      {
+        kind: "image",
+        id: "b",
+        file: fakeFile("b.png", 100, "image/png"),
+        dataUrl: "data:image/png;base64,B",
+      },
+      { kind: "file", id: "c", file: fakeFile("c.txt", 10) },
+    ];
+    const r = await formatAttachments("conv-1", attachments, "openai:gpt-4o");
+    expect(r.block).toBe(
+      "\n\n<Attached files>\n- /a.csv\n- /b.png\n- /c.txt\n</Attached files>",
+    );
+    expect(r.visionFiles).toHaveLength(1);
+  });
+});

--- a/apps/extension/src/lib/chat/__tests__/parse-attached-files.test.ts
+++ b/apps/extension/src/lib/chat/__tests__/parse-attached-files.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseAttachedFiles } from "../parse-attached-files";
+
+// Mock OPFS so we can call formatAttachments without a real OPFS env.
+vi.mock("@/lib/vfs/opfs", () => ({
+  OPFS: {
+    writeFileBytes: vi.fn(async () => {}),
+    uniquePath: vi.fn(async (dir: string, name: string) => `${dir}/${name}`),
+  },
+}));
+
+import { formatAttachments } from "../format-attachments";
+import type { Attachment } from "../types";
+
+function fakeFile(name: string, size = 100, type = "application/octet-stream") {
+  const bytes = new Uint8Array(size);
+  return new File([bytes], name, { type });
+}
+
+describe("parseAttachedFiles", () => {
+  it("returns text unchanged with no block", () => {
+    const r = parseAttachedFiles("hello world");
+    expect(r.displayText).toBe("hello world");
+    expect(r.attachedPaths).toEqual([]);
+  });
+
+  it("returns text unchanged when the block is malformed (no closing tag)", () => {
+    const text = "hello\n\n<Attached files>\n- /foo.pdf\n";
+    const r = parseAttachedFiles(text);
+    expect(r.displayText).toBe(text);
+    expect(r.attachedPaths).toEqual([]);
+  });
+
+  it("strips the block and extracts paths", () => {
+    const text =
+      "summarize this\n\n<Attached files>\n- /report.pdf\n- /data.csv\n</Attached files>";
+    const r = parseAttachedFiles(text);
+    expect(r.displayText).toBe("summarize this");
+    expect(r.attachedPaths).toEqual(["/report.pdf", "/data.csv"]);
+  });
+
+  it("preserves a user-typed `<Attached files>` literal earlier in the body", () => {
+    const text =
+      "I wrote <Attached files> in my prompt\n\n<Attached files>\n- /real.pdf\n</Attached files>";
+    const r = parseAttachedFiles(text);
+    expect(r.displayText).toBe("I wrote <Attached files> in my prompt");
+    expect(r.attachedPaths).toEqual(["/real.pdf"]);
+  });
+
+  it("filters empty lines and trims whitespace", () => {
+    const text =
+      "x\n\n<Attached files>\n- /a.pdf\n\n-  /b.csv  \n</Attached files>";
+    const r = parseAttachedFiles(text);
+    expect(r.attachedPaths).toEqual(["/a.pdf", "/b.csv"]);
+  });
+
+  it("round-trips with formatAttachments output", async () => {
+    const attachments: Attachment[] = [
+      { kind: "file", id: "1", file: fakeFile("report.pdf") },
+      {
+        kind: "image",
+        id: "2",
+        file: fakeFile("shot.png", 100, "image/png"),
+        dataUrl: "data:image/png;base64,A",
+      },
+      { kind: "file", id: "3", file: fakeFile("data.csv") },
+    ];
+    const formatted = await formatAttachments(
+      "conv-1",
+      attachments,
+      "openai:gpt-4o",
+    );
+    const userText = "look at these";
+    const combined = userText + formatted.block;
+
+    const parsed = parseAttachedFiles(combined);
+    expect(parsed.displayText).toBe(userText);
+    expect(parsed.attachedPaths).toEqual([
+      "/report.pdf",
+      "/shot.png",
+      "/data.csv",
+    ]);
+  });
+
+  it("round-trips empty attachments (no block, no paths)", async () => {
+    const formatted = await formatAttachments(
+      "conv-1",
+      [],
+      "openai:gpt-4o",
+    );
+    const userText = "just text, no files";
+    const combined = userText + formatted.block;
+
+    const parsed = parseAttachedFiles(combined);
+    expect(parsed.displayText).toBe(userText);
+    expect(parsed.attachedPaths).toEqual([]);
+  });
+});

--- a/apps/extension/src/lib/chat/attachment-meta.ts
+++ b/apps/extension/src/lib/chat/attachment-meta.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure helpers for rendering attachment chips.
+ *
+ * `getTypeBadge` and `formatBytes` are used in both the chat input
+ * (preview) and the past-message rendering. `isTextFile` and
+ * `countLines` are used at attach time to compute the "274 lines"
+ * subtitle on the preview card.
+ */
+
+import { classifyFile } from "@/lib/vfs/file-classify";
+
+const KB = 1024;
+const MB = KB * 1024;
+
+/**
+ * A short uppercase label for the file's type, derived from its
+ * extension. Used as the bottom-right pill on attachment cards.
+ *
+ * Examples: `report.pdf` → `PDF`, `app.tsx` → `TSX`,
+ * `archive.tar.gz` → `GZ`, `README` → `FILE`, `.gitignore` → `FILE`
+ * (dotfiles have no real extension).
+ */
+export function getTypeBadge(filename: string): string {
+  const lastDot = filename.lastIndexOf(".");
+  if (lastDot <= 0) return "FILE";
+  const ext = filename.slice(lastDot + 1).toUpperCase();
+  return ext || "FILE";
+}
+
+/**
+ * True when classifyFile would tag this as text-like content (code or
+ * markdown). Used to gate line-counting at attach time — counting
+ * lines on a 50 MB binary is wasteful and meaningless.
+ */
+export function isTextFile(filename: string): boolean {
+  const cls = classifyFile(filename);
+  return cls === "code" || cls === "markdown";
+}
+
+/**
+ * Count display-meaningful lines in a text body. Trailing newline
+ * does not produce a phantom empty line — so `"abc\n"` is 1 line and
+ * `"abc\ndef\n"` is 2, matching what most editors show.
+ */
+export function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  const trimmed = text.endsWith("\n") ? text.slice(0, -1) : text;
+  // Empty after trimming means a single "\n" with no content.
+  if (trimmed.length === 0) return 1;
+  return trimmed.split("\n").length;
+}
+
+/** Human-readable byte size. `26214` → `"26 KB"`, `5242880` → `"5.0 MB"`. */
+export function formatBytes(bytes: number): string {
+  if (bytes < KB) return `${bytes} B`;
+  if (bytes < MB) return `${Math.round(bytes / KB)} KB`;
+  return `${(bytes / MB).toFixed(1)} MB`;
+}

--- a/apps/extension/src/lib/chat/format-attachments.ts
+++ b/apps/extension/src/lib/chat/format-attachments.ts
@@ -1,0 +1,59 @@
+import { OPFS } from "@/lib/vfs/opfs";
+import { getImageSizeLimit } from "@/lib/agent/vision-limits";
+import type { Attachment } from "./types";
+
+export interface FormattedAttachments {
+  /** Text block to append to the user's message. Empty string if none. */
+  block: string;
+  /** Vision file-parts to send alongside the user message text. */
+  visionFiles: { mediaType: string; url: string }[];
+}
+
+/**
+ * Materialize `attachments` into the conversation's OPFS workspace and
+ * produce the message-side decoration (text block + vision parts).
+ *
+ * Behavior:
+ *  - Each attachment is written under `conversations/<id>/workspace/`,
+ *    using `OPFS.uniquePath` to avoid clobbering existing files.
+ *  - The `<Attached files>` block lists the resulting paths only — no
+ *    instructions, no sizes (per design).
+ *  - For image attachments, a vision file-part is added IFF the file
+ *    size ≤ the active provider's image cap (`getImageSizeLimit`). Above
+ *    the cap the file still lands in the workspace; the model just
+ *    can't "see" it inline.
+ */
+export async function formatAttachments(
+  conversationId: string,
+  attachments: Attachment[],
+  modelKey: string,
+): Promise<FormattedAttachments> {
+  if (attachments.length === 0) {
+    return { block: "", visionFiles: [] };
+  }
+
+  const workspaceDir = `conversations/${conversationId}/workspace`;
+  const imageCap = getImageSizeLimit(modelKey);
+
+  const lines: string[] = [];
+  const visionFiles: { mediaType: string; url: string }[] = [];
+
+  for (const att of attachments) {
+    const dest = await OPFS.uniquePath(workspaceDir, att.file.name);
+    await OPFS.writeFileBytes(dest, att.file);
+
+    // Agent paths are workspace-relative.
+    const basename = dest.slice(dest.lastIndexOf("/") + 1);
+    const relPath = `/${basename}`;
+    lines.push(`- ${relPath}`);
+
+    if (att.kind === "image" && att.file.size <= imageCap) {
+      visionFiles.push({ mediaType: att.file.type, url: att.dataUrl });
+    }
+  }
+
+  return {
+    block: `\n\n<Attached files>\n${lines.join("\n")}\n</Attached files>`,
+    visionFiles,
+  };
+}

--- a/apps/extension/src/lib/chat/parse-attached-files.ts
+++ b/apps/extension/src/lib/chat/parse-attached-files.ts
@@ -1,0 +1,48 @@
+/**
+ * Parser for the `<Attached files>` block emitted by `formatAttachments`.
+ *
+ * Producer: `apps/extension/src/lib/chat/format-attachments.ts`.
+ * Consumer: `apps/extension/src/components/chat/UserMessage.tsx`.
+ *
+ * Round-trip is exercised in `__tests__/parse-attached-files.test.ts` so
+ * the producer and consumer stay in lock-step if the format ever evolves.
+ */
+
+const OPEN = "\n\n<Attached files>\n";
+const CLOSE = "</Attached files>";
+
+export interface ParsedAttachedFiles {
+  /** The original text with the `<Attached files>` block stripped. */
+  displayText: string;
+  /** Workspace-relative paths the block listed (with leading `/`). */
+  attachedPaths: string[];
+}
+
+/**
+ * Strip the trailing `<Attached files>` block from `text` (if any) and
+ * return the resulting display text plus the list of paths the block
+ * referenced.
+ *
+ * If the block is absent or malformed (no closing tag), `text` is
+ * returned unchanged with an empty path list.
+ *
+ * `lastIndexOf` for the opener is intentional: a user-typed
+ * `<Attached files>` literal earlier in the prompt is preserved in
+ * `displayText`; only the trailing block (the one `formatAttachments`
+ * appended) is parsed.
+ */
+export function parseAttachedFiles(text: string): ParsedAttachedFiles {
+  const start = text.lastIndexOf(OPEN);
+  if (start === -1) return { displayText: text, attachedPaths: [] };
+
+  const end = text.indexOf(CLOSE, start);
+  if (end === -1) return { displayText: text, attachedPaths: [] };
+
+  const blockBody = text.slice(start + OPEN.length, end);
+  const paths = blockBody
+    .split("\n")
+    .map((line) => line.replace(/^- /, "").trim())
+    .filter((p) => p.length > 0);
+
+  return { displayText: text.slice(0, start), attachedPaths: paths };
+}

--- a/apps/extension/src/lib/chat/types.ts
+++ b/apps/extension/src/lib/chat/types.ts
@@ -1,8 +1,27 @@
 /**
  * A user-attached file in the chat input. Image attachments carry a
  * pre-computed data URL for the existing vision-part flow; non-image
- * files carry only the underlying `File`.
+ * files carry only the underlying `File` plus optional metadata
+ * (line count for text files) used by the preview card.
+ *
+ * `loading` is true between the moment the user picks/drops the file
+ * and the moment its async metadata (data URL for images, line count
+ * for text files) finishes computing. The chip renders a skeleton
+ * placeholder during this window so picking a file gives instant
+ * visual feedback.
  */
 export type Attachment =
-  | { kind: "image"; id: string; file: File; dataUrl: string }
-  | { kind: "file"; id: string; file: File };
+  | {
+      kind: "image";
+      id: string;
+      file: File;
+      dataUrl: string;
+      loading?: boolean;
+    }
+  | {
+      kind: "file";
+      id: string;
+      file: File;
+      lineCount?: number;
+      loading?: boolean;
+    };

--- a/apps/extension/src/lib/chat/types.ts
+++ b/apps/extension/src/lib/chat/types.ts
@@ -1,0 +1,8 @@
+/**
+ * A user-attached file in the chat input. Image attachments carry a
+ * pre-computed data URL for the existing vision-part flow; non-image
+ * files carry only the underlying `File`.
+ */
+export type Attachment =
+  | { kind: "image"; id: string; file: File; dataUrl: string }
+  | { kind: "file"; id: string; file: File };

--- a/apps/extension/src/lib/vfs/__tests__/opfs.test.ts
+++ b/apps/extension/src/lib/vfs/__tests__/opfs.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { uniqueNameInDir } from "../opfs";
+
+/** Build a fake FileSystemDirectoryHandle that "contains" the given names. */
+function fakeDir(existingNames: string[]) {
+  return {
+    async getFileHandle(name: string) {
+      if (existingNames.includes(name)) return {} as FileSystemFileHandle;
+      const err: any = new Error("not found");
+      err.name = "NotFoundError";
+      throw err;
+    },
+    async getDirectoryHandle(name: string) {
+      if (existingNames.includes(name)) return {} as FileSystemDirectoryHandle;
+      const err: any = new Error("not found");
+      err.name = "NotFoundError";
+      throw err;
+    },
+  } as unknown as FileSystemDirectoryHandle;
+}
+
+describe("uniqueNameInDir", () => {
+  it("returns the original name if no collision", async () => {
+    const dir = fakeDir([]);
+    expect(await uniqueNameInDir(dir, "report.pdf")).toBe("report.pdf");
+  });
+
+  it("appends ' (2)' before the extension on first collision", async () => {
+    const dir = fakeDir(["report.pdf"]);
+    expect(await uniqueNameInDir(dir, "report.pdf")).toBe("report (2).pdf");
+  });
+
+  it("walks to the next free index", async () => {
+    const dir = fakeDir(["report.pdf", "report (2).pdf", "report (3).pdf"]);
+    expect(await uniqueNameInDir(dir, "report.pdf")).toBe("report (4).pdf");
+  });
+
+  it("handles filenames with no extension", async () => {
+    const dir = fakeDir(["README"]);
+    expect(await uniqueNameInDir(dir, "README")).toBe("README (2)");
+  });
+
+  it("treats dotfiles correctly (no extension swap)", async () => {
+    const dir = fakeDir([".gitignore"]);
+    expect(await uniqueNameInDir(dir, ".gitignore")).toBe(".gitignore (2)");
+  });
+
+  it("only suffixes the last dot for multi-dot names", async () => {
+    const dir = fakeDir(["archive.tar.gz"]);
+    expect(await uniqueNameInDir(dir, "archive.tar.gz")).toBe(
+      "archive.tar (2).gz",
+    );
+  });
+
+  it("treats a directory name collision the same as a file collision", async () => {
+    // If a subdirectory named "data.csv" exists, we still need a unique name.
+    const dir = fakeDir([]);
+    // Override: only directory exists, not file.
+    const customDir = {
+      async getFileHandle(_: string) {
+        const err: any = new Error("not found");
+        err.name = "NotFoundError";
+        throw err;
+      },
+      async getDirectoryHandle(name: string) {
+        if (name === "data.csv") return {} as FileSystemDirectoryHandle;
+        const err: any = new Error("not found");
+        err.name = "NotFoundError";
+        throw err;
+      },
+    } as unknown as FileSystemDirectoryHandle;
+    expect(await uniqueNameInDir(customDir, "data.csv")).toBe("data (2).csv");
+  });
+});

--- a/apps/extension/src/lib/vfs/opfs.ts
+++ b/apps/extension/src/lib/vfs/opfs.ts
@@ -172,4 +172,69 @@ export class OPFS {
       }
     }
   }
+
+  /**
+   * Resolve a non-colliding filename inside `dirPath`. Creates the
+   * directory if it doesn't exist (so callers can race with first
+   * write to a fresh workspace). Returns the absolute path the caller
+   * can pass to `writeFileBytes`.
+   *
+   * NOTE: Name resolution and the subsequent `writeFileBytes` are not
+   * atomic. Concurrent callers may both resolve the same suffix and the
+   * second write will overwrite the first. Callers must serialize
+   * uploads into the same directory.
+   */
+  static async uniquePath(dirPath: string, filename: string): Promise<string> {
+    const dir = await this.getDirHandle(dirPath, true);
+    const unique = await uniqueNameInDir(dir, filename);
+    const cleanDir = dirPath.replace(/^\/+|\/+$/g, "");
+    return cleanDir ? `${cleanDir}/${unique}` : unique;
+  }
+}
+
+/**
+ * Given a directory handle and a desired filename, return a name that
+ * doesn't collide with any existing file or subdirectory in the dir,
+ * by Finder-style suffixing the basename: `report.pdf` →
+ * `report (2).pdf` → `report (3).pdf`, etc. Filenames without an
+ * extension (e.g. `README`, `.gitignore`) are suffixed at the end.
+ *
+ * Exported separately so it can be unit-tested against a fake
+ * `FileSystemDirectoryHandle` in environments without real OPFS.
+ */
+export async function uniqueNameInDir(
+  dirHandle: FileSystemDirectoryHandle,
+  filename: string,
+): Promise<string> {
+  const exists = async (name: string): Promise<boolean> => {
+    try {
+      await dirHandle.getFileHandle(name);
+      return true;
+    } catch (e: any) {
+      if (e?.name !== "NotFoundError") throw e;
+    }
+    try {
+      await dirHandle.getDirectoryHandle(name);
+      return true;
+    } catch (e: any) {
+      if (e?.name !== "NotFoundError") throw e;
+    }
+    return false;
+  };
+
+  if (!(await exists(filename))) return filename;
+
+  // Split on the LAST dot, but only if there's a non-empty stem before it.
+  // ".gitignore" has no stem, so it's treated as extensionless.
+  const lastDot = filename.lastIndexOf(".");
+  const hasExt = lastDot > 0;
+  const stem = hasExt ? filename.slice(0, lastDot) : filename;
+  const ext = hasExt ? filename.slice(lastDot) : "";
+
+  for (let i = 2; i < 10_000; i++) {
+    const candidate = `${stem} (${i})${ext}`;
+    if (!(await exists(candidate))) return candidate;
+  }
+  // Pathological — fall back to a timestamp suffix.
+  return `${stem} (${Date.now()})${ext}`;
 }


### PR DESCRIPTION
## Summary

Adds end-to-end support for user-uploaded files into the per-conversation OPFS workspace. The user can attach any file type (PDFs, CSVs, code, archives, screenshots, etc.) via paperclip, drag-drop, paste, or `Cmd/Ctrl+U`, and the agent then has full access to the file via its existing `Read`/`Glob`/`Grep`/`executePython` tools.

Image attachments additionally get inlined as vision message parts on providers that support them, with provider-specific size caps (Anthropic 5 MB, Google 7 MB, OpenAI 20 MB, etc.) clamped at a 20 MB universal ceiling.

Spec and plan live locally at `.superpowers/{specs,plans}/2026-05-22-workspace-file-upload*` (gitignored).

## What's new

- **Unified attachment model.** Replaces the image-only `ImagePreview` with an `Attachment` discriminated union (image or file) that flows from `ChatInput` through to `formatAttachments` at send time.
- **Send-time OPFS write.** Files are persisted to `conversations/<id>/workspace/<filename>` only when the user submits — no orphans if the user attaches and changes their mind.
- **Finder-style collision suffixing.** Two files named `report.pdf` in one message become `report.pdf` + `report (2).pdf`. Never overwrites existing workspace files.
- **Per-provider vision caps.** New `getImageSizeLimit(modelKey)` lookup in `lib/agent/vision-limits.ts`, clamped at 20 MB.
- **Past-message chip rendering.** `UserMessage` parses the trailing `<Attached files>` block and renders filename chips alongside existing image thumbnails. Round-trip-tested against `formatAttachments`.

## Polished UX

- Card-style attachment chips (140×108) with title, line count (text files) or formatted size (binary), and an uppercase type-badge pill (`MD`, `JSON`, `PDF`, `TSX`, ...)
- Skeleton placeholders inserted instantly on file pick; metadata patches in as `FileReader` / `file.text()` resolves; Send is gated while any attachment is loading
- Container-wide drag-and-drop zone with blue ring + translucent overlay; tiptap's `Dropcursor` disabled to avoid competing UI
- `Cmd/Ctrl+U` hotkey opens the file picker (works inside the tiptap `[contenteditable]`)
- Image previews use `ZoomableImage`; close button hidden, white backdrop replaced with semi-transparent dark scrim
- Smooth grid-rows height animation when chips appear/disappear; per-chip `animate-in fade-in-0 zoom-in-95` for new chips
- `Paperclip` icon replaces the `Image` icon on the attach button

## Architecture

```
lib/agent/vision-limits.ts          — per-provider image cap (bytes)
lib/vfs/opfs.ts (uniquePath)        — Finder-style collision suffix helper
lib/chat/types.ts                   — Attachment discriminated union
lib/chat/format-attachments.ts      — send-time: OPFS write, block + vision parts
lib/chat/parse-attached-files.ts    — past-message: extract paths from block
lib/chat/attachment-meta.ts         — pure helpers: badge, isText, lineCount, bytes
components/chat/ChatInput.tsx       — input UI: pickers, drag-over, chips, hotkey
components/chat/UserMessage.tsx     — past-message chip rendering
components/ui/zoomable-image.css    — rmiz overrides (close btn, backdrop)
hooks/useAgentChat.ts               — handleSubmit + confirmEdit wiring
entrypoints/home/components/LandingPage.tsx — landing-input wiring
```

## Test plan

- 89 vitest tests pass (61 new across 5 test files: `vision-limits`, `opfs`, `format-attachments`, `parse-attached-files`, `attachment-meta`)
- `tsc --noEmit` clean
- Manual smoke matrix in `.superpowers/plans/2026-05-22-workspace-file-upload.md` Task 8 — covers picker, drag-drop, paste, oversize rejection, count cap, model-switch graceful degrade, paperclip-only chip, image roundtrip on vision-capable model

## Known deferrals (tracked in code)

- `TODO(workspace-cleanup)` in `confirmEdit` — edits leak prior attachments to OPFS until a real diff-against-prior-parts is implemented
- `OPFS.uniquePath` TOCTOU — documented; concurrent uploads to the same dir can race. Practically bounded by the per-message 10-attachment cap and sequential `Promise.all` resolution
- Past-message chips don't yet show line counts (would require OPFS read at render); chip click-to-open is also deferred per spec non-goals

## Try it

1. Side-panel chat: paperclip / drag-drop / `Cmd+U` / paste a file → card appears → send → agent can `Read` and `executePython` against the file
2. Landing chat: same flow on the home page
3. Edit a past message with attachments → new ones get attached
4. Drop a 60 MB file → toast rejection ("exceeds 50 MB file limit")
5. Drop 11 files → toast "Only 10 more attachments allowed"
