### PR TITLE
feat(extension): message queueing while agent is streaming

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -99,6 +99,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/turndown": "^5.0.6",
     "@wxt-dev/module-react": "^1.1.5",
+    "fake-indexeddb": "^6.2.5",
     "tsx": "^4.20.4",
     "typescript": "^5.9.3",
     "vitest": "^2.1.8",

--- a/apps/extension/src/components/ai-elements/queue.tsx
+++ b/apps/extension/src/components/ai-elements/queue.tsx
@@ -1,0 +1,294 @@
+// Adapted from Vercel's `ai-elements/queue` component
+// (https://ai-sdk.dev/elements/components/queue).
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, PaperclipIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+
+export type QueueMessagePart = {
+  type: string;
+  text?: string;
+  url?: string;
+  filename?: string;
+  mediaType?: string;
+};
+
+export type QueueMessage = {
+  id: string;
+  parts: QueueMessagePart[];
+};
+
+export type QueueTodo = {
+  id: string;
+  title: string;
+  description?: string;
+  status?: "pending" | "completed";
+};
+
+export type QueueItemProps = ComponentProps<"li">;
+
+export const QueueItem = ({ className, ...props }: QueueItemProps) => (
+  <li
+    className={cn(
+      "group flex items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-muted",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export type QueueItemIndicatorProps = ComponentProps<"span"> & {
+  completed?: boolean;
+};
+
+export const QueueItemIndicator = ({
+  completed = false,
+  className,
+  ...props
+}: QueueItemIndicatorProps) => (
+  <span
+    className={cn(
+      "inline-block size-2 shrink-0 rounded-full border",
+      completed
+        ? "border-muted-foreground/20 bg-muted-foreground/10"
+        : "border-muted-foreground/50",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export type QueueItemContentProps = ComponentProps<"span"> & {
+  completed?: boolean;
+};
+
+export const QueueItemContent = ({
+  completed = false,
+  className,
+  ...props
+}: QueueItemContentProps) => (
+  <span
+    className={cn(
+      "line-clamp-1 grow break-words text-xs",
+      completed
+        ? "text-muted-foreground/50 line-through"
+        : "text-foreground",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export type QueueItemDescriptionProps = ComponentProps<"div"> & {
+  completed?: boolean;
+};
+
+export const QueueItemDescription = ({
+  completed = false,
+  className,
+  ...props
+}: QueueItemDescriptionProps) => (
+  <div
+    className={cn(
+      "ml-6 text-xs",
+      completed
+        ? "text-muted-foreground/40 line-through"
+        : "text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export type QueueItemActionsProps = ComponentProps<"div">;
+
+export const QueueItemActions = ({
+  className,
+  ...props
+}: QueueItemActionsProps) => (
+  <div className={cn("flex shrink-0 gap-0.5", className)} {...props} />
+);
+
+export type QueueItemActionProps = Omit<
+  ComponentProps<typeof Button>,
+  "variant" | "size"
+>;
+
+export const QueueItemAction = ({
+  className,
+  ...props
+}: QueueItemActionProps) => (
+  <Button
+    className={cn(
+      "size-6 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted-foreground/10 hover:text-foreground group-hover:opacity-100",
+      className,
+    )}
+    size="icon"
+    type="button"
+    variant="ghost"
+    {...props}
+  />
+);
+
+export type QueueItemAttachmentProps = ComponentProps<"div">;
+
+export const QueueItemAttachment = ({
+  className,
+  ...props
+}: QueueItemAttachmentProps) => (
+  // No `mt-*`: the upstream ai-elements/queue assumed a column layout
+  // (text stacked above attachments) where a top margin separated the
+  // two rows. Our QueueItem is row-flex with `items-center`, so any
+  // top margin on a flex child offsets it from the row's centerline
+  // and pushes thumbnails visibly below the action buttons.
+  <div className={cn("flex flex-wrap gap-1", className)} {...props} />
+);
+
+export type QueueItemImageProps = ComponentProps<"img">;
+
+export const QueueItemImage = ({
+  className,
+  ...props
+}: QueueItemImageProps) => (
+  <img
+    alt=""
+    className={cn("size-6 rounded border object-cover", className)}
+    height={24}
+    width={24}
+    {...props}
+  />
+);
+
+export type QueueItemFileProps = ComponentProps<"span">;
+
+export const QueueItemFile = ({
+  children,
+  className,
+  ...props
+}: QueueItemFileProps) => (
+  <span
+    className={cn(
+      "flex items-center gap-1 rounded border bg-muted px-1.5 py-0.5 text-xs",
+      className,
+    )}
+    {...props}
+  >
+    <PaperclipIcon size={10} />
+    <span className="max-w-[100px] truncate">{children}</span>
+  </span>
+);
+
+export type QueueListProps = ComponentProps<typeof ScrollArea>;
+
+export const QueueList = ({
+  children,
+  className,
+  ...props
+}: QueueListProps) => (
+  // No `-mb-1`: the parent QueueSectionContent uses `overflow-hidden`
+  // (for the collapse animation), and a negative bottom margin on the
+  // ScrollArea reduces the parent's effective content height by 4px.
+  // That clipped the bottom 4px of the LAST queued item, including its
+  // hover background — the children sat at y=4..28 inside a 32px LI,
+  // but only y=0..28 was visible, so the hover bg looked like it had
+  // 4px of breathing room on top and 0px on the bottom.
+  <ScrollArea className={cn("mt-1", className)} {...props}>
+    {/* No right padding: in this compact panel the queue rarely
+        scrolls, and the original `pr-4` (carried over from the
+        upstream ai-elements/queue) left a conspicuous empty gutter
+        on the right of every row. */}
+    <div className="max-h-40">
+      <ul className="space-y-0.5">{children}</ul>
+    </div>
+  </ScrollArea>
+);
+
+export type QueueSectionProps = ComponentProps<typeof Collapsible>;
+
+export const QueueSection = ({
+  className,
+  defaultOpen = true,
+  ...props
+}: QueueSectionProps) => (
+  <Collapsible className={cn(className)} defaultOpen={defaultOpen} {...props} />
+);
+
+export type QueueSectionTriggerProps = ComponentProps<"button">;
+
+export const QueueSectionTrigger = ({
+  children,
+  className,
+  ...props
+}: QueueSectionTriggerProps) => (
+  <CollapsibleTrigger asChild>
+    <button
+      className={cn(
+        "group flex w-full items-center justify-between rounded-md px-2 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-muted",
+        className,
+      )}
+      type="button"
+      {...props}
+    >
+      {children}
+    </button>
+  </CollapsibleTrigger>
+);
+
+export type QueueSectionLabelProps = ComponentProps<"span"> & {
+  count?: number;
+  label: string;
+  icon?: React.ReactNode;
+};
+
+export const QueueSectionLabel = ({
+  count,
+  label,
+  icon,
+  className,
+  ...props
+}: QueueSectionLabelProps) => (
+  <span className={cn("flex items-center gap-1.5", className)} {...props}>
+    <ChevronDownIcon className="group-data-[state=closed]:-rotate-90 size-3 transition-transform" />
+    {icon}
+    <span>
+      {count} {label}
+    </span>
+  </span>
+);
+
+export type QueueSectionContentProps = ComponentProps<typeof CollapsibleContent>;
+
+export const QueueSectionContent = ({
+  className,
+  ...props
+}: QueueSectionContentProps) => (
+  // The `overflow-hidden` + `animate-collapsible-{up,down}` recipe is
+  // the same one used by chain-of-thought, task, ToolCallBlock, etc.
+  // Driven by Radix's `--radix-collapsible-content-height` CSS var,
+  // which the Tailwind keyframes resolve in `app.css`.
+  <CollapsibleContent
+    className={cn(
+      "overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export type QueueProps = ComponentProps<"div">;
+
+export const Queue = ({ className, ...props }: QueueProps) => (
+  <div
+    className={cn(
+      "flex flex-col gap-1 rounded-md border border-border bg-background/50 px-1.5 py-1.5",
+      className,
+    )}
+    {...props}
+  />
+);

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -40,6 +40,7 @@ import {
   BrainIcon,
   ChevronDown,
   Paperclip,
+  Plus,
   Square,
   Star,
   X,
@@ -47,6 +48,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
+import { computeButtonMode } from "./chat-input-mode";
 
 // Derived alias kept for back-compat with call sites that destructure
 // images: ImagePreview[] from onSubmit. Tasks 5-6 migrate those sites;
@@ -77,7 +79,27 @@ interface ChatInputProps {
   value: string;
   onChange: (value: string) => void;
   onSubmit: (mentions: TabMentionAttrs[], attachments: Attachment[]) => void;
+  /**
+   * Optional handler for "queue this message instead of sending now".
+   * When provided AND `isLoading` is true AND the input has content, the
+   * Send button morphs into a Queue (＋) button and Enter routes here
+   * instead of triggering Stop. The hook persists the message in
+   * queue-db; the auto-flush watcher dispatches it once the current
+   * turn ends.
+   */
+  onQueue?: (mentions: TabMentionAttrs[], attachments: Attachment[]) => void;
   onStop?: () => void;
+  /**
+   * When true, the input is being used to edit an existing message
+   * (either a sent message or a queued one). The primary button is
+   * forced to "Save" mode regardless of `isLoading`, and Enter commits
+   * via `onSubmit` instead of branching into queue/stop.
+   *
+   * The Cmd+Shift+Backspace stop hotkey is preserved (it reads
+   * `isLoading` directly), so a user mid-edit can still abort the
+   * agent's in-flight turn from the keyboard if they really want to.
+   */
+  editMode?: boolean;
   isLoading: boolean;
   disabled: boolean;
   providerModels?: ProviderModels[];
@@ -257,7 +279,9 @@ export function ChatInput({
   value,
   onChange,
   onSubmit,
+  onQueue,
   onStop,
+  editMode = false,
   isLoading,
   disabled,
   providerModels,
@@ -274,10 +298,14 @@ export function ChatInput({
 }: ChatInputProps) {
   const onSubmitRef = useRef(onSubmit);
   onSubmitRef.current = onSubmit;
+  const onQueueRef = useRef(onQueue);
+  onQueueRef.current = onQueue;
   const onStopRef = useRef(onStop);
   onStopRef.current = onStop;
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
+  const editModeRef = useRef(editMode);
+  editModeRef.current = editMode;
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -538,6 +566,17 @@ export function ChatInput({
     setAttachments([]);
   }, []);
 
+  const queueWithMentions = useCallback(() => {
+    const handler = onQueueRef.current;
+    if (!handler) return;
+    const ed = editorRef.current;
+    if (!ed) return;
+    const json = ed.getJSON();
+    const mentions = extractTabMentions(json);
+    handler(mentions, attachmentsRef.current);
+    setAttachments([]);
+  }, []);
+
   const editor = useEditor({
     autofocus: autoFocus ? "end" : false,
     extensions: [
@@ -562,19 +601,39 @@ export function ChatInput({
             },
             "Shift-Enter": () => this.editor.commands.setHardBreak(),
             Enter: () => {
-              if (isLoadingRef.current && onStopRef.current) {
-                onStopRef.current();
-              } else {
-                const text = this.editor.getMarkdown().trim();
-                const hasLoadingAttachment = attachmentsRef.current.some(
-                  (a) => a.loading,
-                );
-                if (
-                  (text || attachmentsRef.current.length > 0) &&
-                  !hasLoadingAttachment
-                ) {
+              const text = this.editor.getMarkdown().trim();
+              const hasLoadingAttachment = attachmentsRef.current.some(
+                (a) => a.loading,
+              );
+              const hasContent =
+                (text || attachmentsRef.current.length > 0) &&
+                !hasLoadingAttachment;
+
+              // Edit mode: Enter commits the edit via onSubmit, regardless
+              // of whether the agent is streaming. Save shouldn't morph
+              // into Stop or Queue just because there's an in-flight turn.
+              if (editModeRef.current) {
+                if (hasContent) {
                   submitWithMentions();
                 }
+                return true;
+              }
+
+              // Queue while streaming when there's content AND a queue
+              // handler is wired up. Falls back to Stop when the input
+              // is empty (preserves the prior "Enter on empty = stop"
+              // gesture) or when no queue handler is provided.
+              if (isLoadingRef.current) {
+                if (hasContent && onQueueRef.current) {
+                  queueWithMentions();
+                } else if (onStopRef.current) {
+                  onStopRef.current();
+                }
+                return true;
+              }
+
+              if (hasContent) {
+                submitWithMentions();
               }
               return true;
             },
@@ -628,25 +687,53 @@ export function ChatInput({
     [attachments],
   );
 
+  const hasContent =
+    (value.trim().length > 0 || attachments.length > 0) && !attachmentsLoading;
+
+  /**
+   * Tri-state primary button:
+   *  - Edit mode (any kind)                     → save  (ArrowUp icon, "Save" tooltip)
+   *  - Streaming + has content + onQueue wired  → queue (Plus icon)
+   *  - Streaming                                → stop  (Square icon)
+   *  - Ready + has content + not disabled       → send  (ArrowUp icon)
+   *
+   * Edit mode wins outright over streaming so a Save button can't
+   * silently morph into Stop while the user is typing changes — even
+   * if the agent's stream ended-and-re-started during the edit (e.g.,
+   * because the queue auto-flushed an unrelated item).
+   *
+   * Logic is extracted into `computeButtonMode` for unit testing.
+   */
+  const buttonMode = computeButtonMode({
+    editMode,
+    isLoading,
+    hasContent,
+    hasOnQueue: !!onQueue,
+  });
+
   const handleButtonClick = useCallback(() => {
-    if (isLoading && onStop) {
-      onStop();
-    } else if (
-      (value.trim() || attachments.length > 0) &&
-      !disabled &&
-      !isLoading &&
-      !attachmentsLoading
-    ) {
+    if (editMode) {
+      if (hasContent && !disabled) submitWithMentions();
+      return;
+    }
+    if (isLoading) {
+      if (hasContent && onQueueRef.current) {
+        queueWithMentions();
+        return;
+      }
+      onStopRef.current?.();
+      return;
+    }
+    if (hasContent && !disabled) {
       submitWithMentions();
     }
   }, [
+    editMode,
     isLoading,
-    onStop,
-    value,
+    hasContent,
     disabled,
     submitWithMentions,
-    attachments.length,
-    attachmentsLoading,
+    queueWithMentions,
   ]);
 
   useHotkeys(
@@ -1166,25 +1253,39 @@ export function ChatInput({
               <button
                 type="button"
                 onClick={handleButtonClick}
-                disabled={(disabled || attachmentsLoading) && !isLoading}
+                disabled={
+                  buttonMode === "send" && (disabled || !hasContent)
+                  || (buttonMode === "queue" && !hasContent)
+                }
                 className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40"
               >
-                {isLoading ? (
-                  <Square className="size-3" />
-                ) : (
-                  <ArrowUp className="size-3.5" />
-                )}
+                {buttonMode === "stop" && <Square className="size-3" />}
+                {buttonMode === "queue" && <Plus className="size-3.5" />}
+                {buttonMode === "send" && <ArrowUp className="size-3.5" />}
               </button>
             </TooltipTrigger>
             <TooltipContent side="top" className="flex items-center gap-1.5">
-              {isLoading ? (
+              {buttonMode === "stop" && (
                 <>
                   Stop
                   <Kbd>⌘⇧⌫</Kbd>
                 </>
-              ) : (
-                "Send"
               )}
+              {buttonMode === "queue" && (
+                <>
+                  Queue
+                  <Kbd>⏎</Kbd>
+                </>
+              )}
+              {buttonMode === "send" &&
+                (editMode ? (
+                  <>
+                    Save
+                    <Kbd>⏎</Kbd>
+                  </>
+                ) : (
+                  "Send"
+                ))}
             </TooltipContent>
           </Tooltip>
         </div>

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -10,10 +10,28 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
+import {
+  Queue,
+  QueueItem,
+  QueueItemAction,
+  QueueItemActions,
+  QueueItemAttachment,
+  QueueItemContent,
+  QueueItemFile,
+  QueueItemImage,
+  QueueItemIndicator,
+  QueueList,
+  QueueSection,
+  QueueSectionContent,
+  QueueSectionLabel,
+  QueueSectionTrigger,
+} from "@/components/ai-elements/queue";
 import { Logo } from "@/components/ui/logo";
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { useProviders } from "@/hooks/useProviders";
+import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
 import { cn } from "@/lib/utils";
+import { classifyFile } from "@/lib/vfs/file-classify";
 import {
   AlertCircle,
   ArrowLeft,
@@ -21,6 +39,7 @@ import {
   HelpCircle,
   Link,
   MessageSquarePlus,
+  Pencil,
   RefreshCw,
   Settings2,
   Sparkles,
@@ -138,6 +157,12 @@ export function ChatView({
     stop,
     error,
     clearError,
+    queue,
+    queueMessage,
+    removeQueued,
+    updateQueued,
+    clearQueue,
+    setQueueEditing,
   } = useAgentChat({
     conversationId,
     spaceId,
@@ -282,7 +307,15 @@ export function ChatView({
     setAgentModel,
   ]);
 
-  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  /**
+   * Editing state. `kind === "sent"` edits a message already in the
+   * transcript (writes through `confirmEdit` → chatDb). `kind === "queued"`
+   * edits a queued-but-not-yet-sent message (writes through
+   * `updateQueued` → queueDb). Mutually exclusive — one editor, one mode.
+   */
+  const [editing, setEditing] = useState<
+    { kind: "sent" | "queued"; id: string } | null
+  >(null);
   const [preEditInput, setPreEditInput] = useState("");
   const [activeTab, setActiveTab] = useState<{
     title: string;
@@ -400,24 +433,52 @@ export function ChatView({
         .join("")
         .split("\n\n-----\n\n<Mentioned tabs>")[0];
       setPreEditInput(input);
-      setEditingMessageId(messageId);
+      setEditing({ kind: "sent", id: messageId });
       setInput(text);
     },
     [messages, input, setInput],
   );
 
+  const startEditQueued = useCallback(
+    (queuedId: string) => {
+      const item = queue.find((q) => q.id === queuedId);
+      if (!item) return;
+      setPreEditInput(input);
+      setEditing({ kind: "queued", id: queuedId });
+      // The QueuedMessage's `text` is the user's raw input pre-mention,
+      // pre-attachment-block — exactly what we want to repopulate.
+      setInput(item.text);
+      // Pause auto-flush so the item we're editing isn't drained out
+      // from under us between status flipping to ready and the user
+      // clicking Save. Cleared on cancel/save.
+      setQueueEditing(queuedId);
+    },
+    [queue, input, setInput, setQueueEditing],
+  );
+
   const cancelEdit = useCallback(() => {
-    setEditingMessageId(null);
+    setEditing(null);
     setInput(preEditInput);
-  }, [preEditInput, setInput]);
+    setQueueEditing(null);
+  }, [preEditInput, setInput, setQueueEditing]);
 
   const handleEditSubmit = useCallback(
     (mentions: TabMentionAttrs[], attachments: Attachment[]) => {
-      if (!editingMessageId) return;
-      confirmEdit(editingMessageId, mentions, attachments);
-      setEditingMessageId(null);
+      if (!editing) return;
+      if (editing.kind === "sent") {
+        confirmEdit(editing.id, mentions, attachments);
+      } else {
+        // Queue edits update the persisted text only. Re-attaching files
+        // or changing mentions on a queued item is a v2 concern — for
+        // now, the queued mention/attachment snapshot is preserved as
+        // captured at queue time. The new text replaces the old text.
+        updateQueued(editing.id, { text: input.trim() });
+      }
+      setEditing(null);
+      setInput(preEditInput);
+      setQueueEditing(null);
     },
-    [editingMessageId, confirmEdit],
+    [editing, confirmEdit, updateQueued, input, preEditInput, setInput, setQueueEditing],
   );
 
   function openSettings() {
@@ -430,9 +491,14 @@ export function ChatView({
     messages.length > 0 &&
     messages[messages.length - 1].role === "user";
 
-  const editingIndex = editingMessageId
-    ? messages.findIndex((m) => m.id === editingMessageId)
-    : -1;
+  // Sent-message edits dim everything below the edited row. Queued
+  // edits don't affect the transcript, so they don't dim anything.
+  const editingIndex =
+    editing?.kind === "sent"
+      ? messages.findIndex((m) => m.id === editing.id)
+      : -1;
+
+  const isEditing = editing !== null;
 
   return (
     <div className={cn("flex flex-col h-full pt-1", className)}>
@@ -581,7 +647,7 @@ export function ChatView({
                 !messages.slice(i + 1).some((m) => m.role === "assistant");
               const isDimmed = editingIndex !== -1 && i >= editingIndex;
               return (
-                <ChatMessage
+                 <ChatMessage
                   key={message.id}
                   message={message}
                   isStreaming={isLastAssistant}
@@ -589,13 +655,13 @@ export function ChatView({
                   onRegenerate={
                     message.role === "assistant" &&
                     !isLoading &&
-                    !editingMessageId
+                    !isEditing
                       ? () => handleRegenerate(message.id)
                       : undefined
                   }
                   onToolApproval={addToolApprovalResponse}
                   onEdit={
-                    message.role === "user" && !isLoading && !editingMessageId
+                    message.role === "user" && !isLoading && !isEditing
                       ? () => startEdit(message.id)
                       : undefined
                   }
@@ -623,7 +689,7 @@ export function ChatView({
             <span>Compacting context...</span>
           </div>
         )}
-        {activeTab && messages.length === 0 && !editingMessageId && (
+        {activeTab && messages.length === 0 && !isEditing && (
           <div className="flex items-center gap-2 px-2 py-1.5 mb-1.5 rounded-md bg-accent/50">
             {activeTab.favicon && (
               <img
@@ -644,9 +710,13 @@ export function ChatView({
             </button>
           </div>
         )}
-        {editingMessageId && (
+        {editing && (
           <div className="flex items-center justify-between px-2 py-1 mb-1.5 rounded-md bg-accent/50 text-xs text-muted-foreground">
-            <span>Editing message</span>
+            <span>
+              {editing.kind === "queued"
+                ? "Editing queued message"
+                : "Editing message"}
+            </span>
             <button
               type="button"
               onClick={cancelEdit}
@@ -657,10 +727,115 @@ export function ChatView({
             </button>
           </div>
         )}
+        {queue.length > 0 && (
+          <Queue className="mb-1.5">
+            <QueueSection defaultOpen>
+              <QueueSectionTrigger>
+                <QueueSectionLabel
+                  count={queue.length}
+                  label={queue.length === 1 ? "Queued" : "Queued"}
+                />
+                {/* Clear-queue affordance: only meaningful when there are
+                    actually multiple items, but render unconditionally so the
+                    surface is discoverable even with a single queued item. */}
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    clearQueue();
+                  }}
+                  className="rounded px-1 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+                  title="Clear queue"
+                >
+                  Clear
+                </button>
+              </QueueSectionTrigger>
+              <QueueSectionContent>
+                <QueueList>
+                  {queue.map((item) => {
+                    const isThisEdited =
+                      editing?.kind === "queued" && editing.id === item.id;
+                    // Image vision-files render as thumbnails directly from
+                    // their data URLs. Non-image attachments come out of the
+                    // `<Attached files>` block we synthesized at queue time;
+                    // we filter classified-image paths because those are
+                    // already covered by visionFiles (and an image that
+                    // exceeds the vision cap is intentionally dropped — same
+                    // behavior as UserMessage's chip row).
+                    const { attachedPaths } = parseAttachedFiles(
+                      item.attachmentBlock,
+                    );
+                    const nonImagePaths = attachedPaths.filter((p) => {
+                      const name = p.split("/").pop() ?? p;
+                      return classifyFile(name) !== "image";
+                    });
+                    const hasAttachments =
+                      item.visionFiles.length > 0 || nonImagePaths.length > 0;
+                    return (
+                      <QueueItem
+                        key={item.id}
+                        className={
+                          isThisEdited
+                            ? "bg-accent/40 ring-1 ring-primary/30"
+                            : undefined
+                        }
+                      >
+                        <QueueItemIndicator />
+                        {item.text && (
+                          <QueueItemContent>{item.text}</QueueItemContent>
+                        )}
+                        {hasAttachments && (
+                          <QueueItemAttachment>
+                            {item.visionFiles.map((vf, i) => (
+                              <QueueItemImage
+                                key={`img-${i}`}
+                                src={vf.url}
+                              />
+                            ))}
+                            {nonImagePaths.map((path) => {
+                              const name = path.split("/").pop() ?? path;
+                              return (
+                                <QueueItemFile key={path}>{name}</QueueItemFile>
+                              );
+                            })}
+                          </QueueItemAttachment>
+                        )}
+                        <QueueItemActions>
+                          {isThisEdited ? (
+                            <span className="text-[10px] text-muted-foreground italic px-1">
+                              editing
+                            </span>
+                          ) : (
+                            <>
+                              <QueueItemAction
+                                onClick={() => startEditQueued(item.id)}
+                                title="Edit"
+                              >
+                                <Pencil className="size-3" />
+                              </QueueItemAction>
+                              <QueueItemAction
+                                onClick={() => removeQueued(item.id)}
+                                title="Remove"
+                              >
+                                <X className="size-3" />
+                              </QueueItemAction>
+                            </>
+                          )}
+                        </QueueItemActions>
+                      </QueueItem>
+                    );
+                  })}
+                </QueueList>
+              </QueueSectionContent>
+            </QueueSection>
+          </Queue>
+        )}
         <ChatInput
           value={input}
           onChange={setInput}
-          onSubmit={editingMessageId ? handleEditSubmit : handleSubmit}
+          onSubmit={isEditing ? handleEditSubmit : handleSubmit}
+          onQueue={isEditing ? undefined : queueMessage}
+          editMode={isEditing}
           onStop={stop}
           isLoading={isLoading}
           disabled={!isConfigured}
@@ -687,7 +862,7 @@ export function ChatView({
               })?.capabilities
           }
           autoFocus
-          focusTrigger={`${conversationId ?? "new"}-${editingMessageId ?? ""}`}
+          focusTrigger={`${conversationId ?? "new"}-${editing?.id ?? ""}`}
         />
       </div>
     </div>

--- a/apps/extension/src/components/chat/__tests__/chat-input-mode.test.ts
+++ b/apps/extension/src/components/chat/__tests__/chat-input-mode.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { computeButtonMode } from "../chat-input-mode";
+
+/**
+ * Pure-logic tests for the tri-state Send / Stop / Queue button.
+ *
+ * The full ChatInput component test would require RTL + jsdom which
+ * the project hasn't pulled in yet. The branching matrix is the
+ * interesting bit, so we test it directly via the exported helper.
+ */
+describe("computeButtonMode", () => {
+  describe("not loading (status = ready)", () => {
+    it("returns 'send' regardless of content", () => {
+      expect(
+        computeButtonMode({
+          editMode: false,
+          isLoading: false,
+          hasContent: false,
+          hasOnQueue: true,
+        }),
+      ).toBe("send");
+      expect(
+        computeButtonMode({
+          editMode: false,
+          isLoading: false,
+          hasContent: true,
+          hasOnQueue: false,
+        }),
+      ).toBe("send");
+    });
+  });
+
+  describe("loading (streaming/submitted)", () => {
+    it("returns 'stop' when input is empty (preserves prior gesture)", () => {
+      expect(
+        computeButtonMode({
+          editMode: false,
+          isLoading: true,
+          hasContent: false,
+          hasOnQueue: true,
+        }),
+      ).toBe("stop");
+    });
+
+    it("returns 'queue' when there is content AND onQueue is wired", () => {
+      expect(
+        computeButtonMode({
+          editMode: false,
+          isLoading: true,
+          hasContent: true,
+          hasOnQueue: true,
+        }),
+      ).toBe("queue");
+    });
+
+    it("falls back to 'stop' when onQueue is not wired (e.g., editing)", () => {
+      // This is the situation that caused the original bug: editing a
+      // queued message during streaming. With editMode now overriding
+      // first, this fallback only matters for callers that intentionally
+      // disable queue (currently none; defensive).
+      expect(
+        computeButtonMode({
+          editMode: false,
+          isLoading: true,
+          hasContent: true,
+          hasOnQueue: false,
+        }),
+      ).toBe("stop");
+    });
+  });
+
+  describe("editMode (regression: the reported bug)", () => {
+    it("forces 'send' even while streaming with no onQueue", () => {
+      // This is the exact branch that produced the buggy "Stop" button
+      // when the user started editing a queued message during streaming.
+      expect(
+        computeButtonMode({
+          editMode: true,
+          isLoading: true,
+          hasContent: true,
+          hasOnQueue: false,
+        }),
+      ).toBe("send");
+    });
+
+    it("forces 'send' even while streaming with onQueue wired", () => {
+      // Defensive: editMode + onQueue should not silently fall through
+      // to "queue" semantics — Save means save.
+      expect(
+        computeButtonMode({
+          editMode: true,
+          isLoading: true,
+          hasContent: true,
+          hasOnQueue: true,
+        }),
+      ).toBe("send");
+    });
+
+    it("returns 'send' on empty input too (button is disabled by hasContent gating elsewhere)", () => {
+      expect(
+        computeButtonMode({
+          editMode: true,
+          isLoading: false,
+          hasContent: false,
+          hasOnQueue: false,
+        }),
+      ).toBe("send");
+    });
+  });
+});

--- a/apps/extension/src/components/chat/chat-input-mode.ts
+++ b/apps/extension/src/components/chat/chat-input-mode.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure-logic helpers for the chat input UI. Extracted from
+ * `ChatInput.tsx` so they can be unit tested without dragging the
+ * full React + tiptap + chrome bundle into the test environment.
+ */
+
+export type ChatInputButtonMode = "send" | "stop" | "queue";
+
+/**
+ * Computes the primary action button's mode from the input state.
+ *
+ * Precedence (top wins):
+ *  1. `editMode` → always "send" (renders as a Save button).
+ *     This branch is what guarantees the Save button can't morph into
+ *     Stop while the user is editing a queued message during streaming.
+ *  2. `isLoading + hasContent + hasOnQueue` → "queue".
+ *  3. `isLoading` → "stop".
+ *  4. otherwise → "send".
+ */
+export function computeButtonMode({
+  editMode,
+  isLoading,
+  hasContent,
+  hasOnQueue,
+}: {
+  editMode: boolean;
+  isLoading: boolean;
+  hasContent: boolean;
+  hasOnQueue: boolean;
+}): ChatInputButtonMode {
+  if (editMode) return "send";
+  if (isLoading) {
+    return hasContent && hasOnQueue ? "queue" : "stop";
+  }
+  return "send";
+}

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -1,6 +1,7 @@
 import { chatDb } from "@/lib/chat-db";
 import { createAgentTransport } from "@/lib/chat-transport";
 import { formatAttachments } from "@/lib/chat/format-attachments";
+import { queueDb, subscribeQueueChange } from "@/lib/queue-db";
 import {
   resetAgentIndicator,
   setAgentSpaceColor,
@@ -33,6 +34,7 @@ import { providers as registryProviders } from "@/registry/providers";
 import type {
   AgentSettings,
   CloudProvider,
+  QueuedMessage,
   SerializedToolPart,
   SerializedUIPart,
   Settings,
@@ -501,6 +503,37 @@ export function useAgentChat({
   const conversationIdRef = useRef(conversationId);
   conversationIdRef.current = conversationId;
 
+  /**
+   * Per-conversation FIFO queue of un-sent user messages. Items here
+   * exist in `queue-db` but NOT in `chat-db`; they migrate at flush
+   * time. State is hydrated on convId change and refreshed by the
+   * `QUEUE_CHANGED` runtime broadcast emitted by `queue-db` mutations.
+   *
+   * The flush mutex (claim/release) lives in `queue-db` so multiple
+   * panel contexts (sidepanel + detached popup) rendering the same
+   * conversation can't double-send.
+   */
+  const [queue, setQueue] = useState<QueuedMessage[]>([]);
+  const queueRef = useRef(queue);
+  queueRef.current = queue;
+
+  /**
+   * Pauses the auto-flush watcher when a queued message is currently
+   * being edited in the UI. Prevents the watcher from draining the
+   * very item the user is editing — which would silently turn a Save
+   * click into a no-op against `queue-db.update` (the row would be
+   * gone). Set/cleared by the consumer (`ChatView`) via the
+   * `setQueueEditing` callback below.
+   *
+   * Stored as a ref because the watcher already depends on `queue`
+   * and `status`; we don't need re-runs purely from this flag, only
+   * for the existing deps to re-evaluate against the latest value.
+   */
+  const queueEditingIdRef = useRef<string | null>(null);
+  const setQueueEditing = useCallback((id: string | null) => {
+    queueEditingIdRef.current = id;
+  }, []);
+
   useEffect(() => {
     storage.getSettings().then(setSettings);
     storage.getAgentSettings().then(setAgentSettings);
@@ -517,6 +550,49 @@ export function useAgentChat({
     chrome.storage.onChanged.addListener(listener);
     return () => chrome.storage.onChanged.removeListener(listener);
   }, []);
+
+  /**
+   * Hydrate the per-conversation queue and keep it in sync with both
+   * local mutations (this same panel calling enqueue/remove/etc.) and
+   * cross-context mutations (a sibling panel mutating the same convId).
+   *
+   * We subscribe to BOTH because `chrome.runtime.sendMessage` does not
+   * deliver to its own sender — without the in-process pubsub, the
+   * panel that just called `queueMessage` would never refresh its own
+   * `queue` state, and the auto-flush watcher's `[queue]` dependency
+   * would never re-fire. Cross-context still goes through
+   * `chrome.runtime.onMessage` so a popup mutating the same convId
+   * also lands here.
+   */
+  useEffect(() => {
+    if (!conversationId) {
+      setQueue([]);
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      const items = await queueDb.list(conversationId);
+      if (!cancelled) setQueue(items);
+    };
+    refresh();
+
+    const unsubLocal = subscribeQueueChange((cid) => {
+      if (cid === conversationId) refresh();
+    });
+
+    const onMessage = (msg: { type: string; conversationId?: string }) => {
+      if (msg.type === "QUEUE_CHANGED" && msg.conversationId === conversationId) {
+        refresh();
+      }
+    };
+    chrome.runtime.onMessage.addListener(onMessage);
+
+    return () => {
+      cancelled = true;
+      unsubLocal();
+      chrome.runtime.onMessage.removeListener(onMessage);
+    };
+  }, [conversationId]);
 
   const mcpConnectionKey = settings.mcpServers
     .filter((s) => s.enabled)
@@ -925,6 +1001,145 @@ export function useAgentChat({
     }
   }, [error, conversationId, messages, clearError, runCompaction]);
 
+  /**
+   * Auto-flush queued user messages once the agent's current turn ends.
+   *
+   * Triggers whenever the status, queue, or compaction flag changes
+   * such that a flush is now safe:
+   *
+   *  - status is back to `ready` (not `streaming` or `submitted`)
+   *  - queue is non-empty for the current conversation
+   *  - no compaction is in flight (compaction sends its own synthetic
+   *    "Continue..." message; we don't want to race it)
+   *  - the last assistant message isn't sitting in `approval-requested`
+   *    state — that's the user's turn to respond, not ours
+   *  - there's no unhandled error (existing error banner takes over)
+   *
+   * Cross-panel coordination is handled by `queueDb.claimHead`'s lock
+   * row. If a sibling panel claimed first, `claimHead` returns null
+   * and this one sits out the round.
+   *
+   * The flushed message is persisted to chat-db with the same shape as
+   * `handleSubmit` produces, then dispatched via `sendMessage`. The
+   * usual `healPendingTools` runs first so a denied/aborted tool call
+   * in the prior turn doesn't trip `MissingToolResultsError` on send.
+   */
+  const isFlushingRef = useRef(false);
+  useEffect(() => {
+    if (!conversationId) return;
+    if (status !== "ready") return;
+    if (isCompacting) return;
+    if (error) return;
+    if (queue.length === 0) return;
+    if (isFlushingRef.current) return;
+    // Pause if the user is actively editing a queued item — draining
+    // it would invalidate their pending edit. The watcher will retry
+    // when `setQueueEditing(null)` is called and any of the existing
+    // deps change (typically the queue itself, after the edit lands).
+    if (queueEditingIdRef.current !== null) return;
+
+    // Defer to user when an approval is pending. Detects via the same
+    // shape used elsewhere — last assistant message containing a tool
+    // part in `approval-requested` state.
+    const lastAssistant = [...messages]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    if (lastAssistant) {
+      const hasPendingApproval = lastAssistant.parts.some(
+        (p) =>
+          (p.type === "dynamic-tool" ||
+            (typeof p.type === "string" && p.type.startsWith("tool-"))) &&
+          (p as { state?: string }).state === "approval-requested",
+      );
+      if (hasPendingApproval) return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      isFlushingRef.current = true;
+      let claimed: QueuedMessage | null = null;
+      try {
+        claimed = await queueDb.claimHead(conversationId);
+        if (!claimed || cancelled) return;
+
+        // Heal any stranded tool calls before adding the queued message.
+        // Same rationale as in handleSubmit.
+        const { healed, healedMessages } = healPendingTools(
+          messages,
+          "Superseded by queued user message",
+        );
+        if (healedMessages.length > 0) {
+          setMessages(healed);
+          await persistHealedMessages(conversationId, healedMessages);
+        }
+
+        const persistedText = claimed.text + claimed.attachmentBlock;
+        const fileParts: SerializedUIPart[] = claimed.visionFiles.map((vf) => ({
+          type: "file" as const,
+          mediaType: vf.mediaType,
+          url: vf.url,
+        }));
+        await chatDb.saveMessage({
+          id: generateId(),
+          conversationId,
+          role: "user",
+          content: persistedText,
+          parts: [
+            ...(persistedText
+              ? [{ type: "text" as const, text: persistedText }]
+              : []),
+            ...fileParts,
+          ],
+          createdAt: Date.now(),
+        });
+
+        // Bind the panel's host tab so the agent has a working target on
+        // its first tab tool call.
+        resolveHostTabId().then((hostTabId) => {
+          setAgentContext(conversationId, hostTabId);
+        });
+
+        const text = claimed.text + claimed.mentionContext + claimed.attachmentBlock;
+        const files = claimed.visionFiles.map((vf) => ({
+          type: "file" as const,
+          mediaType: vf.mediaType,
+          url: vf.url,
+        }));
+        if (text) {
+          sendMessage({ text, files: files.length > 0 ? files : undefined });
+        } else {
+          sendMessage({ files });
+        }
+
+        await queueDb.releaseHead(conversationId, claimed.id, true);
+      } catch (err) {
+        console.error("[queue] flush failed:", err);
+        if (claimed) {
+          // Keep the queued item; release the lock so the next attempt
+          // can retry rather than hanging indefinitely.
+          await queueDb.releaseHead(conversationId, claimed.id, false).catch(
+            () => {},
+          );
+        }
+      } finally {
+        isFlushingRef.current = false;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    status,
+    conversationId,
+    queue,
+    isCompacting,
+    error,
+    messages,
+    setMessages,
+    sendMessage,
+    resolveHostTabId,
+  ]);
+
   // Track what triggered the load effect to avoid overwriting in-memory approval state.
   //
   // We key the "already loaded" guard off the Chat INSTANCE identity (not a
@@ -1172,6 +1387,108 @@ export function useAgentChat({
     [input, isConfigured, spaceId, onNewConversation, sendMessage, agentSettings.agentModel, settings.providerConfigs, messages, setMessages],
   );
 
+  /**
+   * Enqueue a user message instead of sending it. Mirrors handleSubmit's
+   * preflight (conversation creation if needed, mention/attachment
+   * snapshotting) but persists into queue-db rather than calling
+   * sendMessage. The auto-flush watcher below picks it up once the
+   * agent's current turn ends.
+   *
+   * Snapshot semantics: `formatMentionContext` is awaited NOW (so tab
+   * snapshots reflect what the user saw at queue time) and
+   * `formatAttachments` is also awaited NOW (so attachment bytes hit
+   * OPFS immediately, tied to convId).
+   */
+  const queueMessage = useCallback(
+    async (
+      mentions: TabMentionAttrs[] = [],
+      attachments: Attachment[] = [],
+    ) => {
+      if (!input.trim() && attachments.length === 0) return;
+      if (!isConfigured) return;
+
+      let convId = conversationIdRef.current;
+      let isNew = false;
+      if (!convId) {
+        // Mirror handleSubmit's new-conversation branch. We still need a
+        // convId to key the queue and the OPFS workspace.
+        convId = generateId();
+        isNew = true;
+        const truncatedTitle = input.trim().slice(0, 100) || "Image";
+        await chatDb.createConversation({
+          id: convId,
+          title: truncatedTitle,
+          spaceId,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+      }
+
+      const baseText = input.trim();
+      const mentionContext = await formatMentionContext(mentions);
+
+      let attachmentBlock = "";
+      let visionFiles: { mediaType: string; url: string }[] = [];
+      try {
+        ({ block: attachmentBlock, visionFiles } = await formatAttachments(
+          convId,
+          attachments,
+          agentSettings.agentModel,
+        ));
+      } catch (e) {
+        toast.error(
+          `Failed to save attachments: ${(e as Error).message ?? String(e)}`,
+        );
+        return;
+      }
+
+      await queueDb.enqueue({
+        id: generateId(),
+        conversationId: convId,
+        text: baseText,
+        mentionContext,
+        attachmentBlock,
+        visionFiles,
+        createdAt: Date.now(),
+      });
+
+      setInput("");
+
+      if (isNew) {
+        // Make the brand-new conversation visible so its queue panel
+        // and (eventually) the flush-side user message render in the
+        // correct chat view.
+        onNewConversation(convId);
+      }
+    },
+    [input, isConfigured, spaceId, agentSettings.agentModel, onNewConversation],
+  );
+
+  const removeQueued = useCallback(async (id: string) => {
+    await queueDb.remove(id);
+  }, []);
+
+  const updateQueued = useCallback(
+    async (
+      id: string,
+      patch: Partial<
+        Pick<
+          QueuedMessage,
+          "text" | "mentionContext" | "attachmentBlock" | "visionFiles"
+        >
+      >,
+    ) => {
+      await queueDb.update(id, patch);
+    },
+    [],
+  );
+
+  const clearQueue = useCallback(async () => {
+    const cid = conversationIdRef.current;
+    if (!cid) return;
+    await queueDb.clear(cid);
+  }, []);
+
   const handleNew = useCallback(() => {
     onNewConversation("");
     setMessages([]);
@@ -1410,5 +1727,18 @@ export function useAgentChat({
     stop,
     error,
     clearError,
+    // Message queue: see `queueMessage` JSDoc and the auto-flush watcher.
+    queue,
+    queueMessage,
+    removeQueued,
+    updateQueued,
+    clearQueue,
+    /**
+     * Tell the hook a queued message is being edited (or stop telling
+     * it). Pauses the auto-flush watcher while set so the row the
+     * user is editing isn't drained out from under them. Pass `null`
+     * to resume normal flushing.
+     */
+    setQueueEditing,
   };
 }

--- a/apps/extension/src/lib/__tests__/queue-db.test.ts
+++ b/apps/extension/src/lib/__tests__/queue-db.test.ts
@@ -1,0 +1,232 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queueDb, subscribeQueueChange } from "../queue-db";
+import type { QueuedMessage } from "../types";
+
+function makeItem(
+  conversationId: string,
+  id: string,
+  text: string,
+  createdAt: number,
+): QueuedMessage {
+  return {
+    id,
+    conversationId,
+    text,
+    mentionContext: "",
+    attachmentBlock: "",
+    visionFiles: [],
+    createdAt,
+  };
+}
+
+describe("queue-db", () => {
+  beforeEach(async () => {
+    // Reset both fake IndexedDB and the cached connection so each test
+    // starts from an empty database.
+    indexedDB = new IDBFactory();
+    queueDb._resetForTests();
+  });
+
+  afterEach(() => {
+    queueDb._resetForTests();
+  });
+
+  describe("enqueue/list", () => {
+    it("returns items sorted by createdAt for the requested conversation only", async () => {
+      const convA = "conv-a";
+      const convB = "conv-b";
+      await queueDb.enqueue(makeItem(convA, "a1", "first", 100));
+      await queueDb.enqueue(makeItem(convA, "a3", "third", 300));
+      await queueDb.enqueue(makeItem(convA, "a2", "second", 200));
+      await queueDb.enqueue(makeItem(convB, "b1", "other", 150));
+
+      const items = await queueDb.list(convA);
+      expect(items.map((i) => i.id)).toEqual(["a1", "a2", "a3"]);
+
+      const otherItems = await queueDb.list(convB);
+      expect(otherItems.map((i) => i.id)).toEqual(["b1"]);
+    });
+  });
+
+  describe("update", () => {
+    it("merges patch fields and leaves others intact", async () => {
+      const conv = "c1";
+      await queueDb.enqueue(makeItem(conv, "i1", "before", 100));
+      await queueDb.update("i1", { text: "after", mentionContext: "ctx" });
+      const [item] = await queueDb.list(conv);
+      expect(item.text).toBe("after");
+      expect(item.mentionContext).toBe("ctx");
+      expect(item.createdAt).toBe(100);
+    });
+
+    it("is a no-op for an unknown id", async () => {
+      await queueDb.update("ghost", { text: "x" });
+      const items = await queueDb.list("anywhere");
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe("remove/clear", () => {
+    it("removes a single item", async () => {
+      const conv = "c1";
+      await queueDb.enqueue(makeItem(conv, "i1", "a", 100));
+      await queueDb.enqueue(makeItem(conv, "i2", "b", 200));
+      await queueDb.remove("i1");
+      const items = await queueDb.list(conv);
+      expect(items.map((i) => i.id)).toEqual(["i2"]);
+    });
+
+    it("clears all items for a conversation but leaves others", async () => {
+      await queueDb.enqueue(makeItem("a", "a1", "x", 100));
+      await queueDb.enqueue(makeItem("a", "a2", "y", 200));
+      await queueDb.enqueue(makeItem("b", "b1", "z", 100));
+      await queueDb.clear("a");
+      expect(await queueDb.list("a")).toEqual([]);
+      expect((await queueDb.list("b")).map((i) => i.id)).toEqual(["b1"]);
+    });
+  });
+
+  describe("claimHead/releaseHead", () => {
+    it("returns null on an empty queue", async () => {
+      expect(await queueDb.claimHead("empty")).toBeNull();
+    });
+
+    it("returns the oldest item and locks the conversation", async () => {
+      const conv = "c1";
+      await queueDb.enqueue(makeItem(conv, "i2", "second", 200));
+      await queueDb.enqueue(makeItem(conv, "i1", "first", 100));
+      const claimed = await queueDb.claimHead(conv);
+      expect(claimed?.id).toBe("i1");
+
+      // A second concurrent claimer must back off until the first releases.
+      const reentrant = await queueDb.claimHead(conv);
+      expect(reentrant).toBeNull();
+    });
+
+    it("on success-release removes the item AND lets the next claim proceed", async () => {
+      const conv = "c1";
+      await queueDb.enqueue(makeItem(conv, "i1", "first", 100));
+      await queueDb.enqueue(makeItem(conv, "i2", "second", 200));
+      const claimed = await queueDb.claimHead(conv);
+      expect(claimed?.id).toBe("i1");
+      await queueDb.releaseHead(conv, "i1", true);
+
+      const remaining = await queueDb.list(conv);
+      expect(remaining.map((i) => i.id)).toEqual(["i2"]);
+
+      const next = await queueDb.claimHead(conv);
+      expect(next?.id).toBe("i2");
+    });
+
+    it("on failure-release keeps the item and frees the lock for retry", async () => {
+      const conv = "c1";
+      await queueDb.enqueue(makeItem(conv, "i1", "first", 100));
+      const claimed = await queueDb.claimHead(conv);
+      expect(claimed?.id).toBe("i1");
+      await queueDb.releaseHead(conv, "i1", false);
+
+      const items = await queueDb.list(conv);
+      expect(items.map((i) => i.id)).toEqual(["i1"]);
+
+      const reclaimed = await queueDb.claimHead(conv);
+      expect(reclaimed?.id).toBe("i1");
+    });
+
+    it("ignores release calls from a stale claimer", async () => {
+      const conv = "c1";
+      await queueDb.enqueue(makeItem(conv, "i1", "first", 100));
+      await queueDb.claimHead(conv);
+      // Some other actor with a stale id calls release — must not unlock.
+      await queueDb.releaseHead(conv, "different-id", true);
+      const blocked = await queueDb.claimHead(conv);
+      expect(blocked).toBeNull();
+    });
+  });
+
+  describe("subscribeQueueChange (in-process pubsub)", () => {
+    it("fires the local listener on enqueue/remove/update/clear", async () => {
+      const listener = vi.fn();
+      const unsub = subscribeQueueChange(listener);
+
+      await queueDb.enqueue(makeItem("c1", "i1", "a", 100));
+      expect(listener).toHaveBeenLastCalledWith("c1");
+
+      await queueDb.update("i1", { text: "b" });
+      expect(listener).toHaveBeenLastCalledWith("c1");
+
+      await queueDb.remove("i1");
+      expect(listener).toHaveBeenLastCalledWith("c1");
+
+      await queueDb.enqueue(makeItem("c2", "i2", "x", 200));
+      expect(listener).toHaveBeenLastCalledWith("c2");
+
+      await queueDb.clear("c2");
+      expect(listener).toHaveBeenLastCalledWith("c2");
+
+      // 5 mutations should have produced 5 notifications.
+      expect(listener).toHaveBeenCalledTimes(5);
+
+      unsub();
+    });
+
+    it("fires on releaseHead so callers refresh after a flush", async () => {
+      const listener = vi.fn();
+      const unsub = subscribeQueueChange(listener);
+      try {
+        await queueDb.enqueue(makeItem("c1", "i1", "a", 100));
+        listener.mockClear();
+        await queueDb.claimHead("c1");
+        await queueDb.releaseHead("c1", "i1", true);
+        expect(listener).toHaveBeenCalledWith("c1");
+      } finally {
+        unsub();
+      }
+    });
+
+    it("supports multiple concurrent listeners", async () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      const unsubA = subscribeQueueChange(a);
+      const unsubB = subscribeQueueChange(b);
+      try {
+        await queueDb.enqueue(makeItem("c1", "i1", "a", 100));
+        expect(a).toHaveBeenCalledWith("c1");
+        expect(b).toHaveBeenCalledWith("c1");
+      } finally {
+        unsubA();
+        unsubB();
+      }
+    });
+
+    it("stops firing after unsubscribe", async () => {
+      const listener = vi.fn();
+      const unsub = subscribeQueueChange(listener);
+      await queueDb.enqueue(makeItem("c1", "i1", "a", 100));
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsub();
+      await queueDb.enqueue(makeItem("c1", "i2", "b", 200));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("isolates throwing listeners from other listeners", async () => {
+      const good = vi.fn();
+      const bad = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const unsubBad = subscribeQueueChange(bad);
+      const unsubGood = subscribeQueueChange(good);
+      try {
+        // Mutation must succeed even if a listener throws.
+        await queueDb.enqueue(makeItem("c1", "i1", "a", 100));
+        expect(bad).toHaveBeenCalled();
+        expect(good).toHaveBeenCalled();
+        expect(await queueDb.list("c1")).toHaveLength(1);
+      } finally {
+        unsubBad();
+        unsubGood();
+      }
+    });
+  });
+});

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -1,4 +1,5 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import { queueDb } from "./queue-db";
 import type { SerializedUIPart, TodoItem } from "./types";
 import { OPFS } from "./vfs/opfs";
 
@@ -252,6 +253,15 @@ export const chatDb = {
     }
     
     await tx.done;
+
+    // Cascade-clear any queued (un-sent) messages for this conversation.
+    // Without this, a deleted conversation would resurrect dangling
+    // queue rows the next time anything iterates the queue.
+    try {
+      await queueDb.clear(id);
+    } catch (e) {
+      console.warn("Failed to clear message queue for deleted conversation", e);
+    }
 
     // Clean up ephemeral VFS container
     try {

--- a/apps/extension/src/lib/queue-db.ts
+++ b/apps/extension/src/lib/queue-db.ts
@@ -1,0 +1,259 @@
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import type { QueuedMessage } from "./types";
+
+/**
+ * IndexedDB-backed message queue.
+ *
+ * Lives in a separate DB from `chat-db` so its schema can evolve
+ * independently and so wiping the queue (e.g. for tests) doesn't risk
+ * touching the conversation transcript.
+ *
+ * Both renderer contexts (sidepanel/home/popup) and the background
+ * service worker open the same DB by name; the underlying IndexedDB is
+ * shared at the extension origin. Mutations broadcast a
+ * `QUEUE_CHANGED` runtime message so other open contexts can re-fetch.
+ *
+ * The `flushClaims` store implements the per-conversation flush mutex
+ * (see `claimHead` / `releaseHead`). Only one panel may flush a given
+ * conversation's head at a time; the row contains the queue id under
+ * flush plus a timestamp so a stale claim (panel crash mid-flush) can
+ * be reaped after a timeout.
+ */
+
+interface QueueDB extends DBSchema {
+  queue: {
+    key: string;
+    value: QueuedMessage;
+    indexes: {
+      "by-conversation": string;
+    };
+  };
+  flushClaims: {
+    key: string; // conversationId
+    value: {
+      conversationId: string;
+      queuedMessageId: string;
+      claimedAt: number;
+    };
+  };
+}
+
+const DB_NAME = "openbrowse-queue";
+const DB_VERSION = 1;
+const STALE_CLAIM_MS = 60_000;
+
+let dbPromise: Promise<IDBPDatabase<QueueDB>> | null = null;
+
+function getDb(): Promise<IDBPDatabase<QueueDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<QueueDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains("queue")) {
+          const store = db.createObjectStore("queue", { keyPath: "id" });
+          store.createIndex("by-conversation", "conversationId");
+        }
+        if (!db.objectStoreNames.contains("flushClaims")) {
+          db.createObjectStore("flushClaims", { keyPath: "conversationId" });
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+/**
+ * Broadcast a queue mutation to all extension contexts.
+ *
+ * `chrome.runtime.sendMessage` does NOT deliver back to its sender, so a
+ * cross-context broadcast alone leaves the calling panel out of the
+ * loop. We fix that by running an in-process pubsub first
+ * ({@link subscribeQueueChange}), then doing the runtime broadcast for
+ * sibling contexts. Local listeners fire synchronously so React state
+ * updates land in the same tick as the mutation; failure to deliver
+ * the cross-context message (no listener, non-extension test context)
+ * is silent.
+ */
+type QueueChangeListener = (conversationId: string) => void;
+const localListeners = new Set<QueueChangeListener>();
+
+/**
+ * Subscribe to queue mutations originating in the current JS context.
+ * Returns an unsubscribe function. Listeners are called synchronously
+ * after every successful mutation, before the cross-context runtime
+ * broadcast goes out.
+ *
+ * Use this from the renderer hook so the panel that just called
+ * `enqueue`/`remove`/`update`/`clear`/`releaseHead` actually sees the
+ * resulting change in its own queue state. Cross-context delivery is
+ * still handled by `chrome.runtime.onMessage` for `QUEUE_CHANGED`.
+ */
+export function subscribeQueueChange(
+  listener: QueueChangeListener,
+): () => void {
+  localListeners.add(listener);
+  return () => {
+    localListeners.delete(listener);
+  };
+}
+
+function notify(conversationId: string): void {
+  for (const l of localListeners) {
+    try {
+      l(conversationId);
+    } catch (err) {
+      console.warn("[queue-db] local listener threw:", err);
+    }
+  }
+  try {
+    chrome.runtime
+      ?.sendMessage?.({ type: "QUEUE_CHANGED", conversationId })
+      ?.catch?.(() => {});
+  } catch {
+    /* non-extension context; ignore */
+  }
+}
+
+export const queueDb = {
+  async list(conversationId: string): Promise<QueuedMessage[]> {
+    const db = await getDb();
+    const items = await db.getAllFromIndex(
+      "queue",
+      "by-conversation",
+      conversationId,
+    );
+    return items.sort((a, b) => a.createdAt - b.createdAt);
+  },
+
+  async enqueue(item: QueuedMessage): Promise<void> {
+    const db = await getDb();
+    await db.put("queue", item);
+    notify(item.conversationId);
+  },
+
+  async update(
+    id: string,
+    patch: Partial<
+      Pick<
+        QueuedMessage,
+        "text" | "mentionContext" | "attachmentBlock" | "visionFiles"
+      >
+    >,
+  ): Promise<void> {
+    const db = await getDb();
+    const existing = await db.get("queue", id);
+    if (!existing) return;
+    const next: QueuedMessage = { ...existing, ...patch };
+    await db.put("queue", next);
+    notify(existing.conversationId);
+  },
+
+  async remove(id: string): Promise<void> {
+    const db = await getDb();
+    const existing = await db.get("queue", id);
+    if (!existing) return;
+    await db.delete("queue", id);
+    notify(existing.conversationId);
+  },
+
+  async clear(conversationId: string): Promise<void> {
+    const db = await getDb();
+    const tx = db.transaction(["queue", "flushClaims"], "readwrite");
+    const idx = tx.objectStore("queue").index("by-conversation");
+    let cursor = await idx.openCursor(conversationId);
+    while (cursor) {
+      await cursor.delete();
+      cursor = await cursor.continue();
+    }
+    await tx.objectStore("flushClaims").delete(conversationId);
+    await tx.done;
+    notify(conversationId);
+  },
+
+  /**
+   * Atomically claim the head of `conversationId`'s queue for flushing.
+   *
+   * Returns the head item plus a unique claim id, or `null` if the queue
+   * is empty or another flusher is already running for this conversation.
+   *
+   * Stale claims (older than {@link STALE_CLAIM_MS}) are reaped here so a
+   * crashed flusher can't lock the queue indefinitely.
+   */
+  async claimHead(
+    conversationId: string,
+  ): Promise<QueuedMessage | null> {
+    const db = await getDb();
+    const tx = db.transaction(["queue", "flushClaims"], "readwrite");
+    const claimsStore = tx.objectStore("flushClaims");
+    const existingClaim = await claimsStore.get(conversationId);
+    const now = Date.now();
+    if (existingClaim && now - existingClaim.claimedAt < STALE_CLAIM_MS) {
+      // Another flusher is active.
+      await tx.done;
+      return null;
+    }
+
+    const queueIdx = tx.objectStore("queue").index("by-conversation");
+    let cursor = await queueIdx.openCursor(conversationId);
+    let head: QueuedMessage | null = null;
+    while (cursor) {
+      const v = cursor.value;
+      if (head === null || v.createdAt < head.createdAt) head = v;
+      cursor = await cursor.continue();
+    }
+    if (!head) {
+      // No work; clear any stale claim row we may have just observed.
+      if (existingClaim) await claimsStore.delete(conversationId);
+      await tx.done;
+      return null;
+    }
+
+    await claimsStore.put({
+      conversationId,
+      queuedMessageId: head.id,
+      claimedAt: now,
+    });
+    await tx.done;
+    return head;
+  },
+
+  /**
+   * Release the flush claim for `conversationId`.
+   *
+   * If `success === true`, the queued message is also removed from the
+   * queue (the caller successfully drained it into `chat-db` and called
+   * `sendMessage`). If `success === false`, the message stays at the
+   * head and only the claim is released, so the next flush attempt can
+   * retry.
+   */
+  async releaseHead(
+    conversationId: string,
+    queuedMessageId: string,
+    success: boolean,
+  ): Promise<void> {
+    const db = await getDb();
+    const tx = db.transaction(["queue", "flushClaims"], "readwrite");
+    const claim = await tx.objectStore("flushClaims").get(conversationId);
+    // Only release if the claim still references the same id we held —
+    // otherwise we'd be deleting some other flusher's claim.
+    if (claim && claim.queuedMessageId === queuedMessageId) {
+      await tx.objectStore("flushClaims").delete(conversationId);
+      if (success) {
+        await tx.objectStore("queue").delete(queuedMessageId);
+      }
+    } else if (success) {
+      // Defensive: if the claim is gone (timed out and reaped) but the
+      // caller still managed to flush, drop the queue row anyway.
+      await tx.objectStore("queue").delete(queuedMessageId);
+    }
+    await tx.done;
+    notify(conversationId);
+  },
+
+  /**
+   * Test/debug helper. Reset the in-memory db handle so a fresh
+   * `indexedDB` (e.g. fake-indexeddb in tests) is opened on next call.
+   */
+  _resetForTests(): void {
+    dbPromise = null;
+  },
+};

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -224,3 +224,38 @@ export interface HistoryItem {
   lastVisitTime: number;
   visitCount: number;
 }
+
+/**
+ * A user message that the user typed while the agent was already streaming
+ * the previous turn. Persisted in IndexedDB so the queue survives reloads
+ * and is shared across panel contexts (sidepanel, detached popup, home).
+ *
+ * Snapshot semantics:
+ *  - `mentionContext` is `formatMentionContext` output captured at queue
+ *    time so the agent sees the tab snapshots the user saw.
+ *  - `attachmentBlock` + `visionFiles` come from `formatAttachments`,
+ *    which already wrote the bytes to the conversation's OPFS workspace
+ *    when the user enqueued. The flush path doesn't re-touch OPFS.
+ *
+ * Drained messages move from `queue-db` into `chat-db` as ordinary user
+ * messages just before `sendMessage` is dispatched; they never appear
+ * in both stores at once.
+ */
+export interface QueuedMessage {
+  id: string;
+  conversationId: string;
+  /**
+   * The user-typed text BEFORE mention context or attachment block is
+   * appended. Kept raw so an "edit queued message" flow can pre-fill
+   * the input with what the user typed, not the synthesized blocks.
+   */
+  text: string;
+  /** `formatMentionContext` output captured at queue time. */
+  mentionContext: string;
+  /** `<Attached files>` block (or empty string) from `formatAttachments`. */
+  attachmentBlock: string;
+  /** Vision file-parts (data URLs) ready to ship with `sendMessage`. */
+  visionFiles: { mediaType: string; url: string }[];
+  createdAt: number;
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       '@wxt-dev/module-react':
         specifier: ^1.1.5
         version: 1.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))(wxt@0.20.24(@types/node@25.6.0)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       tsx:
         specifier: ^4.20.4
         version: 4.22.3
@@ -4239,6 +4242,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -10551,6 +10558,8 @@ snapshots:
   exsolve@1.0.8: {}
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 


### PR DESCRIPTION
## Summary

Lets the user type and submit additional messages while the agent is mid-stream. Queued messages persist across reloads and dispatch automatically when the current turn ends.

Send button morphs into ＋ (Queue) while streaming with text in the input. Queued items appear in a compact panel above the input, with their text + thumbnails for image attachments + paperclip chips for non-image files. Editing a queued item pauses auto-flush so the row can't be drained mid-edit.

## Architecture

### Storage — `lib/queue-db.ts`
- Separate IndexedDB database with claim/release flush mutex (60s stale-claim reaping) so multiple panel contexts (sidepanel + detached popup) can't double-send.
- In-process pubsub (\`subscribeQueueChange\`) fires synchronously in the same context that mutated, before the cross-context \`QUEUE_CHANGED\` runtime broadcast. This is required because \`chrome.runtime.sendMessage\` doesn't deliver to its sender — without it, the panel that called \`enqueue\` would never refresh its own \`queue\` state.
- Cascade-clears on conversation delete (\`chat-db.ts\`).

### Hook — `hooks/useAgentChat.ts`
- \`queueMessage\` mirrors \`handleSubmit\`'s preflight (mention/attachment snapshotting via \`formatMentionContext\` + \`formatAttachments\` to OPFS) but persists to queue-db instead of dispatching. Snapshot semantics: mention/attachment resolution happens at queue time.
- Auto-flush watcher: when status returns to \`ready\` and queue is non-empty (and not compacting, no error, no pending approval, no queue edit in progress), claims the head, persists to chatDb, sendMessage, releaseHead. OpenCode-style stop preserved via the natural status flip triggering the same watcher.
- \`setQueueEditing(id|null)\` pauses the flusher while the user is editing a queued item, preventing the row from being drained between status flip and Save click.

### UI — `components/ai-elements/queue.tsx`, `components/chat/*`
- Adopts Vercel \`ai-elements/queue\` primitives, restyled for the extension's compact aesthetic with smooth Radix Collapsible animations.
- Tri-state primary button: Send / Stop / Queue / Save. Logic extracted into \`computeButtonMode\` (\`chat-input-mode.ts\`) for unit testing. \`editMode\` prop forces Save state regardless of streaming.
- Edit-with-kind discriminator: editing state is \`{ kind: "sent" | "queued"; id }\`. Sent edits go through \`confirmEdit\`/chatDb; queued edits go through \`updateQueued\`/queue-db.
- Queued items render attachments inline-trailing: image thumbnails from \`visionFiles\`, paperclip-chips for non-image paths parsed from \`attachmentBlock\` (filtering classified-image paths to avoid duplication).

## Tests

- 15 queue-db unit tests covering CRUD, claim/release lifecycle, stale-claim reaping, and the in-process pubsub (multi-listener, unsubscribe, throwing-listener isolation).
- 7 button-mode tests covering every cell of the Send/Stop/Queue/Save matrix, including a regression test for the "edit-during-stream produced Stop button" bug.

\`pnpm test\`: 11 files / 93 tests pass.
\`pnpm compile\`: clean.
\`pnpm build\`: chrome-mv3 bundle succeeds.

## Notable layout fixes worth calling out
- Removed \`-mb-1\` from \`QueueList\`: combined with \`overflow-hidden\` on the parent CollapsibleContent (used for the collapse animation), the negative bottom margin clipped the bottom 4px of the last LI — visually breaking its hover-bg vertical centering.
- Removed \`mt-1\` from \`QueueItemAttachment\`: upstream ai-elements assumed a column layout (text above attachments). Our QueueItem is row-flex with \`items-center\`, so any top margin offset thumbnails below the row centerline.
- Removed \`pr-4\` from \`QueueList\`'s ScrollArea: scrollbar gutter carry-over that left a conspicuous empty gap on the right of every row in this compact panel.

## Dependencies

Adds \`fake-indexeddb\` as a devDependency for queue-db tests.