### PR TITLE
chore(release): bump extension to v0.2.0

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
   "name": "openbrowse",
   "description": "The open source browser agent. A model-agnostic alternative to Claude for Chrome. Connect any local or cloud AI.",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
   manifest: ({ mode }) => ({
     name: "OpenBrowse",
     description: "The open source browser agent.",
-    version: "0.1.1",
+    version: "0.2.0",
     // Pins the extension ID to the Chrome Web Store listing. Required so
     // that storage from manual / unpacked installs (loaded from a release
     // zip) carries over to the Web Store install: same `key` -> same


### PR DESCRIPTION
Bumps the extension version from \`0.1.1\` to \`0.2.0\` in both:
- \`apps/extension/package.json\`
- \`apps/extension/wxt.config.ts\` (manifest source)

After merge, tag the merge commit \`v0.2.0\` and push the tag — that triggers \`.github/workflows/release.yml\` which verifies tag↔manifest version match, runs typecheck + tests, builds the chrome zip, asserts the manifest \`key\` is pinned, and publishes a GitHub Release with auto-generated notes.

```bash
git tag v0.2.0 <merge-commit-sha>
git push origin v0.2.0
```

## Notable changes since v0.1.1

- feat: message queueing while agent is streaming (#22)
- feat: OpenBrowse offline evaluation harness & runner hardening (#20)
- feat: working folder viewers, resizable side-panel, OPFS uploads (#21)
- feat: per-conversation file uploads to OPFS workspace (#18)
- feat: webFetch tool
- feat: dynamic provider registry powered by models.dev (#12)
- feat: pin extension key for stable ID across install methods
- fix: heal broken chat sessions and stranded tool calls (#16)
- fix: invalidate provider catalog cache on storage change
- fix: auto-select default model after first provider config
- fix: auto-update bundled skills when extension is upgraded

## Verification

- \`pnpm compile\`: clean
- \`pnpm test\`: 11 files, 93 tests pass
- \`pnpm zip\`: produces \`apps/extension/.output/openbrowse-0.2.0-chrome.zip\` (11.12 MB)
- Release workflow's tag↔manifest assertion will pass
- Release workflow's \`manifest.key\` pinned-field check will pass