### PR TITLE
fix(extension): rail layout mount and agent-transport compound keys

### DIFF
--- a/apps/extension/src/entrypoints/home/components/RightRail.tsx
+++ b/apps/extension/src/entrypoints/home/components/RightRail.tsx
@@ -88,8 +88,8 @@ export function RightRail({
    * drive subsequent size changes through the imperative handle below.
    * Using `useState` with an initializer pins the value to mount time.
    */
-  const [initialRailSize] = useState<number>(() => {
-    if (!isOpen) return 0;
+  const [initialRailSize] = useState<string>(() => {
+    if (!isOpen) return "0%";
     
     // We compute the initial size as a raw percentage rather than a pixel string
     // (e.g. "360px"). When `react-resizable-panels` parses a pixel string on mount,
@@ -112,8 +112,9 @@ export function RightRail({
     const estimatedContainerWidth = Math.max(800, vw - 260);
     const targetPx = getTargetPx();
     
-    // Return percentage (0..100)
-    return (targetPx / estimatedContainerWidth) * 100;
+    // Return percentage (0..100) string
+    const pct = (targetPx / estimatedContainerWidth) * 100;
+    return `${pct}%`;
   });
 
   // Drive the rail width from `isOpen` + `selectedFile`. Three target sizes:
@@ -124,15 +125,6 @@ export function RightRail({
     const handle = railPanelRef.current;
     if (!handle) return;
     
-    if (!hasInitializedRef.current) {
-      // First run after mount: trust the panel's `defaultSize`.
-      // By using a percentage for defaultSize, we bypass the library's
-      // pixel-conversion mount bug. The panel snaps instantly to the right
-      // width without an unwanted tween animation.
-      hasInitializedRef.current = true;
-      return;
-    }
-    
     const target = !isOpen
       ? 0
       : selectedFile !== null
@@ -141,6 +133,19 @@ export function RightRail({
           : fileWidthRef.current
         : WORKSPACE_WIDTH_PX;
         
+    if (!hasInitializedRef.current) {
+      // First run after mount: trust the panel's `defaultSize`.
+      // By using a percentage string for defaultSize, we bypass the library's
+      // pixel-conversion mount bug. We then wait one frame for ResizeObserver
+      // to establish the real container width, and snap to exact pixels.
+      hasInitializedRef.current = true;
+      const rafId = requestAnimationFrame(() => {
+        const h = railPanelRef.current;
+        if (h) h.resize(`${target}px`);
+      });
+      return () => cancelAnimationFrame(rafId);
+    }
+    
     const fromPx = handle.getSize?.()?.inPixels ?? 0;
     if (Math.abs(fromPx - target) < 0.5) return;
     

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -676,17 +676,27 @@ export async function createAgentTransport(
 ): Promise<ChatTransport<AgentUIMessage> | null> {
   if (!agentModel) return null;
 
+  // Parse compound "<providerId>:<modelId>" emitted by the chat UI; fall
+  // back to a flat lookup for legacy stored values that pre-date the
+  // compound format.
+  const [maybeProvider, ...modelIdParts] = agentModel.split(":");
+  const actualModelId =
+    modelIdParts.length > 0 ? modelIdParts.join(":") : agentModel;
+
   const { providers } = await import("@/registry/providers");
-  const provider = providers.find((p) =>
-    p.models.some((m) => m.id === agentModel),
-  );
+  const provider =
+    (modelIdParts.length > 0
+      ? providers.find((p) => p.id === maybeProvider)
+      : undefined) ??
+    providers.find((p) => p.models.some((m) => m.id === actualModelId));
+
   if (!provider) return null;
 
   const config = settings.providerConfigs[provider.id] ?? {};
   const requiredFields = provider.configSchema?.filter((f) => f.required) ?? [];
   if (!requiredFields.every((f) => !!config[f.key])) return null;
 
-  const model = await provider.createLanguageModel(config, agentModel);
+  const model = await provider.createLanguageModel(config, actualModelId);
   setCurrentAgentModel(model);
 
   const fsTools = createFsTools(conversationId);


### PR DESCRIPTION
Fixes two regressions:

1. **RightRail sliver on initial mount:** Passes a calculated percentage *string* (e.g. `"29.5%"`) to `react-resizable-panels`' `defaultSize` prop to bypass its buggy pixel-conversion path. Then uses a single `requestAnimationFrame` to snap the panel to the exact target px once the library's `ResizeObserver` has measured the true container width.
2. **`POST /api/chat ERR_FILE_NOT_FOUND`:** Restores the `[providerId, ...modelIdParts]` parsing in `createAgentTransport` that was lost in the eval harness PR. This allows compound stored keys like `"openai:gpt-4o"` to properly resolve the provider and model, preventing the chat from falling back to a null transport and the default HTTP endpoint.