### PR TITLE
fix(bench): drop deprecated baseUrl from tsconfig

### DIFF
--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@agent/*": ["../../apps/extension/src/lib/agent/*"]
     },


### PR DESCRIPTION
## What this does

Removes `baseUrl` from `packages/bench/tsconfig.json`. TypeScript 6.0 emits TS5101 deprecating the option, and TypeScript 7.0 will remove it entirely.

The `paths` glob in this tsconfig is already fully relative (`../../apps/extension/src/lib/agent/*`), so it resolves correctly without `baseUrl` — TS 5.4+ resolves `paths` relative to the tsconfig.json containing them when `baseUrl` is unset.

## Why this is its own PR

Unblocks #36 (TS 5.9 → 6.0 dependabot bump) without taking ownership of the dependabot branch. After this lands, `@dependabot rebase` on #36 picks up the fix and CI passes there.

## Testing

- `pnpm compile` clean on TS 5.9.3 (current main)
- `pnpm compile` clean on TS 6.0.3 (PR #36's target)
- `pnpm test` — 93/93 pass on both
