### PR TITLE
feat(agent): explicit tab args + fix Always-allow-on-domain approval button

### DIFF
--- a/apps/docs/content/docs/basic-usage.mdx
+++ b/apps/docs/content/docs/basic-usage.mdx
@@ -47,9 +47,14 @@ A "Sharing [tab]" pill in the popover stays anchored to the original tab. If tha
 
 Click **Reattach to side panel** to put it back. The panel returns to the exact tab it came from, falling back to the origin window's active tab (or any normal window) if the original tab has since been closed.
 
-### Implicit host-tab binding
+### Acquiring a working tab
 
-The first time the agent calls a tab-interacting tool (`navigate`, `clickElement`, `readPage`, etc.) in a fresh conversation, the panel's current tab is automatically folded into the conversation's owned-tabs group. There's no manual "Work on this tab" button — binding happens on first use.
+Tab-interacting tools (`snapshot`, `clickElement`, `readPage`, etc.) require an explicit `tab` handle. The agent has two ways to get one:
+
+- **Bootstrap**: call `navigate({ url })` with no `tab` arg. This opens a new background tab, binds it into the conversation, and returns the new handle (e.g. `t1`) for subsequent tool calls.
+- **Bind an existing tab**: call `listTabs` to discover handles for tabs the user already has open, then `selectTab({ tab })` to fold one into the conversation.
+
+There's no implicit "the panel's current tab is yours" binding any more — every tab a conversation operates on is an explicit, named handle.
 
 ## Global chat popup
 

--- a/apps/docs/content/docs/contributing/architecture.mdx
+++ b/apps/docs/content/docs/contributing/architecture.mdx
@@ -55,10 +55,10 @@ Connector metadata lives in the `@openbrowse/connectors` workspace package and i
 ## Data Flow
 
 1. User interacts via the side panel (or popover, or overlay).
-2. The agent transport composes the system prompt (memory, todos, MCP tools) and the toolset.
+2. The agent transport composes the system prompt (memory, todos, MCP tools, the per-turn **tab legend**) and the toolset.
 3. Tool calls execute where they belong:
-   - Browser tools (`clickElement`, `readPage`, etc.) → content scripts via the background worker.
-   - `executeCode` / `executeOnPage` → workers / page context.
+   - Browser tools (`clickElement`, `readPage`, etc.) take a stable `tab` handle (e.g. `t1`) in their input. The transport resolves the handle via the conversation's persisted handle map (chatDb → `tab-handles.ts`) before dispatching to the content script.
+   - `executeCode` runs in an isolated worker; `executeOnPage` runs in the resolved tab's page context.
    - `executePython` → bundled Pyodide running in a sandboxed iframe (via the offscreen document).
    - Filesystem tools (`Read`, `Write`, `Edit`, `Glob`, `Grep`, `LS`) → per-conversation OPFS workspace.
    - MCP tools → the connector's MCP server.

--- a/apps/docs/content/docs/tools.mdx
+++ b/apps/docs/content/docs/tools.mdx
@@ -13,32 +13,40 @@ The agent comes equipped with a comprehensive suite of tools. When you ask it to
   streamline repeat workflows.
 </Callout>
 
+## Tab handles
+
+Every tab-interacting tool takes an explicit `tab` argument — a stable handle (`t1`, `t2`, ...) that identifies which tab the call should act on. Handles are minted by `navigate` (when it opens a new tab) and `selectTab` (when binding an external tab into the conversation). Once minted, a handle keeps referring to the same tab on subsequent turns and across service-worker restarts.
+
+The agent sees the live set of available handles in a `## Tabs in this conversation` block injected into its system prompt every turn. Calling `listTabs` returns the same shape and is the way to discover tabs the user has open elsewhere.
+
+To bootstrap a fresh conversation, the agent calls `navigate({ url })` with no `tab` arg — that opens a new background tab and returns the new handle in the response.
+
 ## Browsing & Interaction
 
-The agent navigates the web and interacts with elements just like a human user.
+The agent navigates the web and interacts with elements just like a human user. Each tool below requires `tab` (except `navigate`, where omitting `tab` opens a new tab).
 
 | Tool | Description |
 | --- | --- |
-| `navigate` | Navigate the active tab to a URL. |
-| `snapshot` | Capture a structural accessibility-tree snapshot of the active page. |
-| `readPage` | Extract text, links, and metadata from the page. |
-| `screenshot` | Capture a visual screenshot of the viewport. |
-| `scrollPage` | Scroll up, down, or to a specific position. |
-| `clickElement` | Click a specific element by its snapshot ref. |
-| `typeInElement` | Type text into an input field or textarea. |
+| `navigate` | `{ url, tab? }`. With `tab`: navigate that tab. Without `tab`: open a new background tab and return its handle. |
+| `snapshot` | `{ tab, mode?, selector?, diff? }`. Capture a structural accessibility-tree snapshot of a tab. |
+| `readPage` | `{ tab }`. Extract text, links, and metadata from a tab. |
+| `screenshot` | `{ tab, annotate?, fullPage? }`. Capture a visual screenshot of a tab. |
+| `scrollPage` | `{ tab, direction, amount? }`. Scroll up or down. |
+| `clickElement` | `{ tab, target }`. Click a specific element by its `@ref` (from a snapshot of THAT tab) or CSS selector. |
+| `typeInElement` | `{ tab, target, text, clearFirst?, submit? }`. Type into an input. `submit: true` presses Enter and waits for navigation. |
 
 ## Tab Management
 
 | Tool | Description |
 | --- | --- |
-| `listTabs` | List all open tabs across windows and spaces. |
-| `selectTab` | Switch focus to a specific tab. |
+| `listTabs` | List all open tabs across windows and spaces; emits handles. |
+| `selectTab` | `{ tab }`. Bind an external tab into this conversation so it appears in the legend and can be passed as `tab` to other tools. |
 
 ## Extraction
 
 | Tool | Description |
 | --- | --- |
-| `extract` | Extract structured data from the active page using its accessibility tree. Takes an instruction and an optional JSON Schema; preferred over raw DOM-scraping via `executeOnPage` for text-based data like search results, product lists, table rows, or articles. URL fields are substituted with numeric IDs and rehydrated to prevent hallucination. |
+| `extract` | `{ tab, instruction, selector?, schema? }`. Extract structured data from a tab using its accessibility tree. Preferred over raw DOM-scraping via `executeOnPage` for text-based data like search results, product lists, table rows, or articles. URL fields (`{ type: "string", format: "uri" }`) are substituted with numeric IDs and rehydrated to prevent hallucination. |
 
 ## Code Execution
 
@@ -47,7 +55,7 @@ The agent can execute code in three sandboxed environments depending on what it'
 | Tool | Description | Security |
 | --- | --- | --- |
 | `executeCode` | Run JavaScript in an isolated worker (no DOM access). Best for data processing. | Safe (Isolated) |
-| `executeOnPage` | Run JavaScript directly in the active page's context. Use when you need DOM access. | **Requires Approval** |
+| `executeOnPage` | `{ tab, code, args? }`. Run JavaScript directly in a tab's page context. Use when you need DOM access. | **Requires Approval** |
 | `executePython` | Run CPython 3 in [Pyodide](https://pyodide.org), bundled in a sandboxed iframe. The conversation's [workspace](/docs/workspace) is mounted at `/workspace`; `/skills` is mounted read-only. Optional network access via `pyfetch`. | Safe (Sandboxed) |
 
 For Python specifically, the agent loads the bundled [`python-env` skill](/docs/skills) on demand to pick up Pyodide-specific gotchas (no `subprocess`, mismatched import names like `import fitz` for `pymupdf`, top-level `await`, latin-1 PDF unicode pitfalls, etc.).

--- a/apps/extension/public/skills/find-skills/SKILL.md
+++ b/apps/extension/public/skills/find-skills/SKILL.md
@@ -16,8 +16,7 @@ This skill allows you to discover and install other agent skills from the [skill
 
 ## 1. Search the Registry
 
-Use the `executeOnPage` tool (or `navigate` then `readPage` if appropriate) to fetch data from the skills.sh API, or use a tool that can make HTTP requests if one is available.
-Wait, since you operate in a browser environment, you can use the `executeCode` tool to run a simple script to fetch the search results:
+The fastest path is the `executeCode` tool — it runs a script in an isolated worker (no DOM, no tab needed) and can hit the skills.sh API directly:
 
 ```javascript
 // Run this using executeCode
@@ -27,6 +26,8 @@ fetch('https://skills.sh/api/search?q=YOUR_SEARCH_QUERY')
 ```
 
 Replace `YOUR_SEARCH_QUERY` with the relevant terms.
+
+If `executeCode` is unavailable for some reason, fall back to `navigate({ url: 'https://skills.sh/...' })` followed by `readPage({ tab })` against the returned handle, or `executeOnPage({ tab, code })` for a more programmatic fetch from within the page context.
 
 ## 2. Present Results
 

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -167,11 +167,6 @@ export function ChatView({
     conversationId,
     spaceId,
     onNewConversation,
-    // In popup mode, host tab is the live origin tab (may be null if it
-    // was closed and not yet restored). In side-panel mode, defer to
-    // useAgentChat's auto-resolution from the active tab in the current
-    // window (which, in per-tab mode, IS the host tab).
-    hostTabIdOverride: isPopupMode ? liveOriginTabId : undefined,
     initialInput,
   });
 

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -1178,13 +1178,18 @@ export function useAgentChat({
       if (msgs.length > 0) {
         const uiMsgs = msgs.map(dbMessageToUIMessage);
         setMessages(uiMsgs);
+        // Hydrate the agent context (and tab handle map) for any
+        // subsequent action — retry, regenerate, approve a pending tool
+        // call, or auto-resume below. Doing it unconditionally on
+        // conversation load means resolveTabHandle has live state regardless
+        // of which path the user takes after opening the conversation.
+        setAgentContext(conversationId);
         const lastMsg = uiMsgs[uiMsgs.length - 1];
         if (lastMsg.role === "user" && transport) {
-          // Hydrate the conversation's tab handle map. Compaction-aware
-          // message assembly lives in the transport, so we no longer
-          // prefilter the message list here — the wrapper reads chatDb
-          // compaction state at send-time.
-          setAgentContext(conversationId);
+          // Auto-resume: an unanswered user message at the tail of the
+          // conversation. Compaction-aware message assembly lives in the
+          // transport, so we no longer prefilter the message list here —
+          // the wrapper reads chatDb compaction state at send-time.
           sendMessage();
         }
       }

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -65,14 +65,6 @@ interface UseAgentChatOptions {
   spaceId: string | null;
   onNewConversation: (id: string) => void;
   /**
-   * Override for the host tab id used by the agent's implicit
-   * first-tool-call binding. When `undefined`, useAgentChat resolves the
-   * panel's host tab from the active tab in the current window. Pass an
-   * explicit value (or `null`) when the panel is rendered in a popover and
-   * `currentWindow` would resolve to the popup itself.
-   */
-  hostTabIdOverride?: number | null;
-  /**
    * Initial value of the chat input editor. Used by the "Try in chat" flow
    * to pre-seed the input with a slash command when the home page opens
    * with a `?prefill=` URL parameter.
@@ -471,7 +463,6 @@ export function useAgentChat({
   conversationId,
   spaceId,
   onNewConversation,
-  hostTabIdOverride,
   initialInput,
 }: UseAgentChatOptions) {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
@@ -480,21 +471,6 @@ export function useAgentChat({
   );
   const [input, setInput] = useState(initialInput ?? "");
 
-  // Latest host tab override; the resolver below reads it via ref so
-  // resolveHostTabId() doesn't need to be a dep of every effect that uses it.
-  const hostTabOverrideRef = useRef<number | null | undefined>(hostTabIdOverride);
-  hostTabOverrideRef.current = hostTabIdOverride;
-
-  const resolveHostTabId = useCallback(async (): Promise<number | null> => {
-    const override = hostTabOverrideRef.current;
-    if (override !== undefined) return override;
-    try {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      return tab?.id ?? null;
-    } catch {
-      return null;
-    }
-  }, []);
   const [isCompacting, setIsCompacting] = useState(false);
   // AbortController for the in-flight compaction summary call. The chat's
   // `stop()` cancels the agent stream; this cancels the summarization
@@ -1093,11 +1069,10 @@ export function useAgentChat({
           createdAt: Date.now(),
         });
 
-        // Bind the panel's host tab so the agent has a working target on
-        // its first tab tool call.
-        resolveHostTabId().then((hostTabId) => {
-          setAgentContext(conversationId, hostTabId);
-        });
+        // Hydrate the conversation's tab handle map for the next agent
+        // run. Tools that need a target tab read explicit `tab` args, so
+        // there's no implicit "host tab" to pin any more.
+        setAgentContext(conversationId);
 
         const text = claimed.text + claimed.mentionContext + claimed.attachmentBlock;
         const files = claimed.visionFiles.map((vf) => ({
@@ -1137,7 +1112,6 @@ export function useAgentChat({
     messages,
     setMessages,
     sendMessage,
-    resolveHostTabId,
   ]);
 
   // Track what triggered the load effect to avoid overwriting in-memory approval state.
@@ -1206,14 +1180,11 @@ export function useAgentChat({
         setMessages(uiMsgs);
         const lastMsg = uiMsgs[uiMsgs.length - 1];
         if (lastMsg.role === "user" && transport) {
-          // Bind the panel's host tab so the agent has a working target on
-          // its first tab tool call. Compaction-aware message assembly now
-          // lives in the transport, so we no longer prefilter the message
-          // list here — the wrapper reads chatDb compaction state at
-          // send-time.
-          resolveHostTabId().then((hostTabId) => {
-            setAgentContext(conversationId, hostTabId);
-          });
+          // Hydrate the conversation's tab handle map. Compaction-aware
+          // message assembly lives in the transport, so we no longer
+          // prefilter the message list here — the wrapper reads chatDb
+          // compaction state at send-time.
+          setAgentContext(conversationId);
           sendMessage();
         }
       }
@@ -1366,11 +1337,10 @@ export function useAgentChat({
         url: vf.url,
       }));
 
-      // Compaction-aware message assembly now lives in the transport. Here
-      // we just bind the host tab so tool calls have a default target.
-      resolveHostTabId().then((hostTabId) => {
-        setAgentContext(convId, hostTabId);
-      });
+      // Compaction-aware message assembly now lives in the transport.
+      // We just register the conversation context here so the agent's
+      // tab-handle map is hydrated before tool calls run.
+      setAgentContext(convId);
 
       if (isNew) {
         // Set conversation ID first — the effect will load the user message

--- a/apps/extension/src/lib/agent/__tests__/tab-arg-schemas.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-arg-schemas.test.ts
@@ -1,0 +1,112 @@
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "vitest";
+import {
+  clickElementTool,
+  executeOnPageTool,
+  extractTool,
+  listTabsTool,
+  navigateTool,
+  readPageTool,
+  scrollPageTool,
+  screenshotTool,
+  snapshotTool,
+  typeInElementTool,
+  selectTabTool,
+} from "../tools";
+
+/**
+ * Schema-level tests for the explicit-`tab`-arg refactor. We don't exercise
+ * the tools' execute() paths here (those need a live BrowserDriver); we
+ * just verify the parameter contracts so the agent's tool calls are
+ * statically validated against the new requirement.
+ */
+describe("tab-arg schemas", () => {
+  describe("required `tab` arg on tab-interacting tools", () => {
+    const cases: Array<{ name: string; tool: { parameters: unknown }; extra?: Record<string, unknown> }> = [
+      { name: "snapshot", tool: snapshotTool },
+      { name: "readPage", tool: readPageTool },
+      { name: "screenshot", tool: screenshotTool },
+      { name: "scrollPage", tool: scrollPageTool, extra: { direction: "down" } },
+      {
+        name: "clickElement",
+        tool: clickElementTool,
+        extra: { target: "@e1" },
+      },
+      {
+        name: "typeInElement",
+        tool: typeInElementTool,
+        extra: { target: "@e1", text: "hi" },
+      },
+      {
+        name: "executeOnPage",
+        tool: executeOnPageTool,
+        extra: { code: "return 1" },
+      },
+      {
+        name: "extract",
+        tool: extractTool,
+        extra: { instruction: "x" },
+      },
+      { name: "selectTab", tool: selectTabTool },
+    ];
+
+    for (const { name, tool, extra } of cases) {
+      it(`${name} rejects input without \`tab\``, () => {
+        const schema = tool.parameters as { safeParse: (i: unknown) => { success: boolean } };
+        const result = schema.safeParse({ ...(extra ?? {}) });
+        expect(result.success).toBe(false);
+      });
+
+      it(`${name} accepts input with \`tab\``, () => {
+        const schema = tool.parameters as { safeParse: (i: unknown) => { success: boolean } };
+        const result = schema.safeParse({ tab: "t1", ...(extra ?? {}) });
+        expect(result.success).toBe(true);
+      });
+    }
+  });
+
+  describe("navigate accepts both with-tab and without-tab", () => {
+    it("accepts { url } alone (bootstrap path: create new tab)", () => {
+      const schema = navigateTool.parameters as {
+        safeParse: (i: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({ url: "https://example.com" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts { url, tab } (navigate existing tab)", () => {
+      const schema = navigateTool.parameters as {
+        safeParse: (i: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({
+        url: "https://example.com",
+        tab: "t1",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects unknown extra fields (`newTab` is gone)", () => {
+      const schema = navigateTool.parameters as {
+        safeParse: (i: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({
+        url: "https://example.com",
+        newTab: true,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("listTabs takes no args (still)", () => {
+    // listTabs is the discovery tool; it's the one tab-interacting tool that
+    // shouldn't require a `tab` arg because the whole point is to enumerate.
+    // Sanity assertion: if a future change adds `tab` to it, this test fails
+    // to force re-thinking the design.
+    it("listTabs accepts an empty input", () => {
+      const schema = listTabsTool.parameters as {
+        safeParse: (i: unknown) => { success: boolean };
+      };
+      expect(schema.safeParse({}).success).toBe(true);
+    });
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
@@ -149,6 +149,30 @@ describe("tab-handles", () => {
       expect(conv?.handleState?.counter).toBe(3);
     });
 
+    it("re-persists when an ephemeral handle's tab gets bound (selectTab flow)", async () => {
+      // Mint an ephemeral handle while ownedTabIds is empty.
+      await seedConv(CONV_A, []);
+      getOrCreateHandle(CONV_A, 555);
+      await flushPersist();
+
+      // chatDb should not contain the unowned handle yet.
+      let conv = await chatDb.getConversation(CONV_A);
+      expect(conv?.handleState?.handles).toEqual({});
+
+      // Simulate selectTab binding 555 into ownedTabIds.
+      await chatDb.updateConversation(CONV_A, { ownedTabIds: [555] });
+
+      // Re-call getOrCreateHandle for the same tabId. The function returns
+      // the existing handle BUT must also schedule a fresh persist so the
+      // now-owned handle lands in chatDb.
+      const handle = getOrCreateHandle(CONV_A, 555);
+      expect(handle).toBe("t1");
+      await flushPersist();
+
+      conv = await chatDb.getConversation(CONV_A);
+      expect(conv?.handleState?.handles).toEqual({ t1: 555 });
+    });
+
     it("persists newly-minted handles to chatDb (owned tabs)", async () => {
       await seedConv(CONV_A, [100, 200]);
       getOrCreateHandle(CONV_A, 100);

--- a/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
@@ -1,0 +1,306 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "../../chat-db";
+import {
+  clearHandles,
+  dropTab,
+  getOrCreateHandle,
+  listHandles,
+  loadHandlesForConversation,
+  resolveHandle,
+} from "../tab-handles";
+
+const CONV_A = "conv-a";
+const CONV_B = "conv-b";
+
+async function seedConv(id: string, ownedTabIds: number[] = []) {
+  await chatDb.createConversation({
+    id,
+    title: id,
+    spaceId: null,
+    ownedTabIds,
+    createdAt: 0,
+    updatedAt: 0,
+  });
+}
+
+/**
+ * Wait one microtask + one macrotask. The persistence write inside
+ * `getOrCreateHandle` is fire-and-forget; tests need a flush point so the
+ * chatDb write settles before they re-read.
+ */
+async function flushPersist() {
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  await Promise.resolve();
+}
+
+describe("tab-handles", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    clearHandles(CONV_A);
+    clearHandles(CONV_B);
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    clearHandles(CONV_A);
+    clearHandles(CONV_B);
+    vi.unstubAllGlobals();
+  });
+
+  describe("getOrCreateHandle", () => {
+    it("returns t1, t2, ... for new tabs and is stable per (conversation, tabId)", async () => {
+      await seedConv(CONV_A);
+      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+      expect(getOrCreateHandle(CONV_A, 200)).toBe("t2");
+      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+    });
+
+    it("scopes counter independently per conversation", async () => {
+      await seedConv(CONV_A);
+      await seedConv(CONV_B);
+      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+      expect(getOrCreateHandle(CONV_B, 999)).toBe("t1");
+      expect(getOrCreateHandle(CONV_A, 200)).toBe("t2");
+      expect(getOrCreateHandle(CONV_B, 888)).toBe("t2");
+    });
+  });
+
+  describe("resolveHandle", () => {
+    it("round-trips a handle to its tabId", async () => {
+      await seedConv(CONV_A);
+      getOrCreateHandle(CONV_A, 42);
+      expect(resolveHandle(CONV_A, "t1")).toBe(42);
+    });
+
+    it("returns undefined for unknown handle or unknown conversation", async () => {
+      await seedConv(CONV_A);
+      getOrCreateHandle(CONV_A, 42);
+      expect(resolveHandle(CONV_A, "t99")).toBeUndefined();
+      expect(resolveHandle("nope", "t1")).toBeUndefined();
+    });
+  });
+
+  describe("listHandles", () => {
+    it("emits all live (handle, tabId) pairs", async () => {
+      await seedConv(CONV_A);
+      getOrCreateHandle(CONV_A, 10);
+      getOrCreateHandle(CONV_A, 20);
+      const list = listHandles(CONV_A).sort((a, b) =>
+        a.handle.localeCompare(b.handle),
+      );
+      expect(list).toEqual([
+        { handle: "t1", tabId: 10 },
+        { handle: "t2", tabId: 20 },
+      ]);
+    });
+  });
+
+  describe("dropTab", () => {
+    it("removes the handle from every conversation that knew it", async () => {
+      await seedConv(CONV_A);
+      await seedConv(CONV_B);
+      getOrCreateHandle(CONV_A, 555);
+      getOrCreateHandle(CONV_B, 555);
+
+      dropTab(555);
+
+      expect(resolveHandle(CONV_A, "t1")).toBeUndefined();
+      expect(resolveHandle(CONV_B, "t1")).toBeUndefined();
+    });
+
+    it("is a no-op for unknown tab", async () => {
+      await seedConv(CONV_A);
+      getOrCreateHandle(CONV_A, 100);
+      expect(() => dropTab(99999)).not.toThrow();
+      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+    });
+  });
+
+  describe("clearHandles", () => {
+    it("drops the in-memory map but leaves persisted state intact", async () => {
+      await seedConv(CONV_A, [100]);
+      getOrCreateHandle(CONV_A, 100);
+      await flushPersist();
+
+      clearHandles(CONV_A);
+      expect(resolveHandle(CONV_A, "t1")).toBeUndefined();
+
+      // Persisted state survives → hydration restores it.
+      await loadHandlesForConversation(CONV_A);
+      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+    });
+  });
+
+  describe("persistence + hydration", () => {
+    it("only persists handles for tabs in ownedTabIds", async () => {
+      // Seed with 100 owned, 999 unowned.
+      await seedConv(CONV_A, [100]);
+      getOrCreateHandle(CONV_A, 100);
+      getOrCreateHandle(CONV_A, 999); // ephemeral (e.g. a listTabs preview)
+      await flushPersist();
+
+      const conv = await chatDb.getConversation(CONV_A);
+      expect(conv?.handleState?.handles).toEqual({ t1: 100 });
+      // counter still advances even for ephemeral handles
+      expect(conv?.handleState?.counter).toBe(3);
+    });
+
+    it("persists newly-minted handles to chatDb (owned tabs)", async () => {
+      await seedConv(CONV_A, [100, 200]);
+      getOrCreateHandle(CONV_A, 100);
+      getOrCreateHandle(CONV_A, 200);
+      await flushPersist();
+
+      const conv = await chatDb.getConversation(CONV_A);
+      expect(conv?.handleState).toBeDefined();
+      expect(conv?.handleState?.handles).toEqual({ t1: 100, t2: 200 });
+      expect(conv?.handleState?.counter).toBe(3);
+    });
+
+    it("restores counter so new handles don't collide with persisted ones", async () => {
+      await seedConv(CONV_A, [100, 200]);
+      getOrCreateHandle(CONV_A, 100);
+      getOrCreateHandle(CONV_A, 200);
+      await flushPersist();
+
+      // Simulate SW restart: in-memory map is cleared but chatDb survives.
+      clearHandles(CONV_A);
+
+      // `chrome.tabs.get` available → all persisted tabs are reported live.
+      vi.stubGlobal("chrome", {
+        tabs: {
+          get: vi.fn(async () => ({} as chrome.tabs.Tab)),
+        },
+      });
+
+      await loadHandlesForConversation(CONV_A);
+
+      // Existing handles still resolve.
+      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+      expect(resolveHandle(CONV_A, "t2")).toBe(200);
+
+      // New tab gets t3 (counter advanced past stored max).
+      expect(getOrCreateHandle(CONV_A, 300)).toBe("t3");
+    });
+
+    it("prunes dead tabs during hydration", async () => {
+      await seedConv(CONV_A, [100, 200, 300]);
+      getOrCreateHandle(CONV_A, 100);
+      getOrCreateHandle(CONV_A, 200);
+      getOrCreateHandle(CONV_A, 300);
+      await flushPersist();
+
+      clearHandles(CONV_A);
+
+      // Tab 200 is dead.
+      vi.stubGlobal("chrome", {
+        tabs: {
+          get: vi.fn(async (id: number) => {
+            if (id === 200) throw new Error("No tab with id 200");
+            return {} as chrome.tabs.Tab;
+          }),
+        },
+      });
+
+      await loadHandlesForConversation(CONV_A);
+
+      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+      expect(resolveHandle(CONV_A, "t2")).toBeUndefined();
+      expect(resolveHandle(CONV_A, "t3")).toBe(300);
+
+      // Pruned snapshot is written back.
+      await flushPersist();
+      const conv = await chatDb.getConversation(CONV_A);
+      expect(conv?.handleState?.handles).toEqual({ t1: 100, t3: 300 });
+    });
+
+    it("repairs counter if chatDb stored an inconsistent (low) counter", async () => {
+      await seedConv(CONV_A, [999]);
+      // Manually corrupt: stored counter is 1 but max suffix is t5.
+      await chatDb.updateConversation(CONV_A, {
+        handleState: {
+          handles: { t5: 999 },
+          counter: 1,
+        },
+      });
+
+      vi.stubGlobal("chrome", {
+        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+      });
+
+      await loadHandlesForConversation(CONV_A);
+
+      // Counter should advance past max seen suffix (5) → next handle is t6.
+      expect(getOrCreateHandle(CONV_A, 1000)).toBe("t6");
+    });
+
+    it("repairs counter if chatDb stored a non-finite value", async () => {
+      await seedConv(CONV_A);
+      await chatDb.updateConversation(CONV_A, {
+        handleState: {
+          handles: {},
+          counter: Number.NaN,
+        },
+      });
+      vi.stubGlobal("chrome", {
+        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+      });
+      await loadHandlesForConversation(CONV_A);
+      // Falls back to 1 (defensive), not NaN.
+      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+    });
+
+    it("treats a missing handleState as a fresh map", async () => {
+      await seedConv(CONV_A);
+      // No handleState written.
+      await loadHandlesForConversation(CONV_A);
+      expect(getOrCreateHandle(CONV_A, 42)).toBe("t1");
+    });
+
+    it("hydration's merge keeps live handles when a name collision happens", async () => {
+      // Pre-populate chatDb as if a previous session had t1→100 owned.
+      await seedConv(CONV_A, [100]);
+      await chatDb.updateConversation(CONV_A, {
+        handleState: { handles: { t1: 100 }, counter: 2 },
+      });
+
+      // Stub chrome so hydration's liveness check passes for any id.
+      vi.stubGlobal("chrome", {
+        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+      });
+
+      // Simulate the agent racing ahead and minting a handle BEFORE hydration
+      // lands. The fresh map starts at counter=1, so the freshly-minted
+      // handle for tabId=200 will also be "t1" — colliding with the
+      // persisted t1→100. The merge must keep the live binding (live wins),
+      // not silently overwrite it with the stale persisted value.
+      const freshHandle = getOrCreateHandle(CONV_A, 200);
+      expect(freshHandle).toBe("t1");
+
+      await loadHandlesForConversation(CONV_A);
+
+      // t1 still resolves to the live tab the agent already minted (200),
+      // not the stale persisted 100. The persisted entry is dropped on
+      // collision because the live map's claim is authoritative.
+      expect(resolveHandle(CONV_A, "t1")).toBe(200);
+    });
+
+    it("hydration's merge restores persisted handles when there's no live conflict", async () => {
+      await seedConv(CONV_A, [100]);
+      await chatDb.updateConversation(CONV_A, {
+        handleState: { handles: { t1: 100 }, counter: 2 },
+      });
+      vi.stubGlobal("chrome", {
+        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+      });
+      // Realistic flow: hydration completes BEFORE any handles are minted.
+      await loadHandlesForConversation(CONV_A);
+      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+      // Counter advanced; new tab gets t2.
+      expect(getOrCreateHandle(CONV_A, 200)).toBe("t2");
+    });
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
@@ -4,6 +4,7 @@ import { chatDb } from "../../chat-db";
 import {
   clearHandles,
   dropTab,
+  flushPersistsForTests,
   getOrCreateHandle,
   listHandles,
   loadHandlesForConversation,
@@ -25,14 +26,11 @@ async function seedConv(id: string, ownedTabIds: number[] = []) {
 }
 
 /**
- * Wait one microtask + one macrotask. The persistence write inside
- * `getOrCreateHandle` is fire-and-forget; tests need a flush point so the
- * chatDb write settles before they re-read.
+ * Deterministic flush of pending persistence writes for a conversation.
+ * Replaces a previous timing-based helper that was flaky under load.
  */
-async function flushPersist() {
-  await Promise.resolve();
-  await new Promise((r) => setTimeout(r, 0));
-  await Promise.resolve();
+async function flushPersist(convId: string = CONV_A) {
+  await flushPersistsForTests(convId);
 }
 
 describe("tab-handles", () => {

--- a/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
@@ -128,7 +128,10 @@ describe("tab-handles", () => {
       clearHandles(CONV_A);
       expect(resolveHandle(CONV_A, "t1")).toBeUndefined();
 
-      // Persisted state survives → hydration restores it.
+      // Hydration restores it. Stub chrome so the tab is reported live.
+      vi.stubGlobal("chrome", {
+        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+      });
       await loadHandlesForConversation(CONV_A);
       expect(resolveHandle(CONV_A, "t1")).toBe(100);
     });

--- a/apps/extension/src/lib/agent/__tests__/tab-legend.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-legend.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTabLegendEntries,
+  isInternalChromeUrl,
+  renderTabLegend,
+} from "../tab-legend";
+
+const CONV = "conv-x";
+
+function fakeGetOrCreateHandle(_convId: string, tabId: number): string {
+  return `t${tabId}`;
+}
+
+describe("isInternalChromeUrl", () => {
+  it("classifies extension and chrome URLs as internal", () => {
+    expect(isInternalChromeUrl("chrome://settings")).toBe(true);
+    expect(isInternalChromeUrl("chrome-extension://abc/popup.html")).toBe(true);
+    expect(isInternalChromeUrl("devtools://devtools/x")).toBe(true);
+  });
+
+  it("classifies http/https URLs as not internal", () => {
+    expect(isInternalChromeUrl("https://example.com")).toBe(false);
+    expect(isInternalChromeUrl("http://localhost:3000")).toBe(false);
+  });
+
+  it("treats undefined/empty as not internal (so a fetch failure doesn't auto-drop)", () => {
+    expect(isInternalChromeUrl(undefined)).toBe(false);
+    expect(isInternalChromeUrl("")).toBe(false);
+  });
+});
+
+describe("buildTabLegendEntries", () => {
+  it("returns one entry per live, non-internal tab", async () => {
+    const getTab = vi.fn(async (tabId: number) => ({
+      url: `https://example.com/${tabId}`,
+      title: `Tab ${tabId}`,
+    }));
+    const entries = await buildTabLegendEntries({
+      conversationId: CONV,
+      ownedTabIds: [1, 2, 3],
+      getTab,
+      getOrCreateHandle: fakeGetOrCreateHandle,
+      activeTabId: null,
+    });
+    expect(entries).toEqual([
+      { handle: "t1", url: "https://example.com/1", title: "Tab 1", active: false },
+      { handle: "t2", url: "https://example.com/2", title: "Tab 2", active: false },
+      { handle: "t3", url: "https://example.com/3", title: "Tab 3", active: false },
+    ]);
+  });
+
+  it("marks the active tab", async () => {
+    const getTab = async (tabId: number) => ({
+      url: `https://example.com/${tabId}`,
+      title: `Tab ${tabId}`,
+    });
+    const entries = await buildTabLegendEntries({
+      conversationId: CONV,
+      ownedTabIds: [10, 20],
+      getTab,
+      getOrCreateHandle: fakeGetOrCreateHandle,
+      activeTabId: 20,
+    });
+    expect(entries[0].active).toBe(false);
+    expect(entries[1].active).toBe(true);
+  });
+
+  it("drops tabs whose getTab() rejects (closed tab)", async () => {
+    const getTab = async (tabId: number) => {
+      if (tabId === 99) throw new Error("No tab with id 99");
+      return { url: `https://example.com/${tabId}`, title: `Tab ${tabId}` };
+    };
+    const entries = await buildTabLegendEntries({
+      conversationId: CONV,
+      ownedTabIds: [1, 99, 2],
+      getTab,
+      getOrCreateHandle: fakeGetOrCreateHandle,
+      activeTabId: null,
+    });
+    expect(entries.map((e) => e.handle)).toEqual(["t1", "t2"]);
+  });
+
+  it("drops tabs that landed on a chrome-extension:// URL", async () => {
+    const getTab = async (tabId: number) => {
+      if (tabId === 5) {
+        return {
+          url: "chrome-extension://abc/something.html",
+          title: "Extension page",
+        };
+      }
+      return { url: `https://example.com/${tabId}`, title: `Tab ${tabId}` };
+    };
+    const entries = await buildTabLegendEntries({
+      conversationId: CONV,
+      ownedTabIds: [1, 5, 2],
+      getTab,
+      getOrCreateHandle: fakeGetOrCreateHandle,
+      activeTabId: null,
+    });
+    expect(entries.map((e) => e.handle)).toEqual(["t1", "t2"]);
+  });
+
+  it("falls back to '(untitled)' when title is empty", async () => {
+    const getTab = async (_tabId: number) => ({
+      url: "https://example.com/foo",
+      title: "  ",
+    });
+    const entries = await buildTabLegendEntries({
+      conversationId: CONV,
+      ownedTabIds: [1],
+      getTab,
+      getOrCreateHandle: fakeGetOrCreateHandle,
+      activeTabId: null,
+    });
+    expect(entries[0].title).toBe("(untitled)");
+  });
+
+  it("returns [] when ownedTabIds is empty", async () => {
+    const entries = await buildTabLegendEntries({
+      conversationId: CONV,
+      ownedTabIds: [],
+      getTab: async () => ({ url: "x", title: "x" }),
+      getOrCreateHandle: fakeGetOrCreateHandle,
+      activeTabId: null,
+    });
+    expect(entries).toEqual([]);
+  });
+});
+
+describe("renderTabLegend", () => {
+  it("emits a clear bootstrap hint when there are no entries", () => {
+    const out = renderTabLegend([]);
+    expect(out).toContain("## Tabs in this conversation");
+    expect(out).toContain("No tabs bound to this conversation yet");
+    expect(out).toContain("navigate({ url })");
+  });
+
+  it("formats each entry on its own line with handle, title, and url", () => {
+    const out = renderTabLegend([
+      {
+        handle: "t1",
+        url: "https://amazon.com/dp/X",
+        title: "Amazon — X",
+        active: false,
+      },
+      {
+        handle: "t2",
+        url: "https://github.com/o/r",
+        title: "GitHub - o/r",
+        active: true,
+      },
+    ]);
+    expect(out).toContain("- t1: Amazon — X — https://amazon.com/dp/X");
+    expect(out).toContain("- t2: GitHub - o/r — https://github.com/o/r  [active]");
+    // Should mention how to use it
+    expect(out).toContain("Pass one of these handles");
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tab-legend.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-legend.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { TabId } from "../driver";
 import {
   buildTabLegendEntries,
   isInternalChromeUrl,
@@ -7,7 +8,7 @@ import {
 
 const CONV = "conv-x";
 
-function fakeGetOrCreateHandle(_convId: string, tabId: number): string {
+function fakeGetOrCreateHandle(_convId: string, tabId: TabId): string {
   return `t${tabId}`;
 }
 
@@ -31,7 +32,7 @@ describe("isInternalChromeUrl", () => {
 
 describe("buildTabLegendEntries", () => {
   it("returns one entry per live, non-internal tab", async () => {
-    const getTab = vi.fn(async (tabId: number) => ({
+    const getTab = vi.fn(async (tabId: TabId) => ({
       url: `https://example.com/${tabId}`,
       title: `Tab ${tabId}`,
     }));
@@ -50,7 +51,7 @@ describe("buildTabLegendEntries", () => {
   });
 
   it("marks the active tab", async () => {
-    const getTab = async (tabId: number) => ({
+    const getTab = async (tabId: TabId) => ({
       url: `https://example.com/${tabId}`,
       title: `Tab ${tabId}`,
     });
@@ -66,7 +67,7 @@ describe("buildTabLegendEntries", () => {
   });
 
   it("drops tabs whose getTab() rejects (closed tab)", async () => {
-    const getTab = async (tabId: number) => {
+    const getTab = async (tabId: TabId) => {
       if (tabId === 99) throw new Error("No tab with id 99");
       return { url: `https://example.com/${tabId}`, title: `Tab ${tabId}` };
     };
@@ -81,7 +82,7 @@ describe("buildTabLegendEntries", () => {
   });
 
   it("drops tabs that landed on a chrome-extension:// URL", async () => {
-    const getTab = async (tabId: number) => {
+    const getTab = async (tabId: TabId) => {
       if (tabId === 5) {
         return {
           url: "chrome-extension://abc/something.html",
@@ -101,7 +102,7 @@ describe("buildTabLegendEntries", () => {
   });
 
   it("falls back to '(untitled)' when title is empty", async () => {
-    const getTab = async (_tabId: number) => ({
+    const getTab = async (_tabId: TabId) => ({
       url: "https://example.com/foo",
       title: "  ",
     });

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -23,6 +23,7 @@ import {
   loadHandlesForConversation,
   resolveHandle as resolveTabHandle,
 } from "./tab-handles";
+import { buildTabLegendEntries, renderTabLegend } from "./tab-legend";
 import {
   clickElementTool,
   createSkillTool,
@@ -767,6 +768,24 @@ export async function createAgentTransport(
     instructions += conv.todos
       .map((t, i) => `${i + 1}. [${t.status.toUpperCase()}] ${t.content}`)
       .join("\n");
+  }
+
+  // Inject the live tab legend. Tools that take a `tab` arg expect handles
+  // from this list; the agent reads it each turn to know what's available.
+  // Owned-tabs only: tabs the user has open elsewhere don't appear here
+  // until the agent calls selectTab to bind them.
+  if (agentConversationId) {
+    const entries = await buildTabLegendEntries({
+      conversationId: agentConversationId,
+      ownedTabIds: conv?.ownedTabIds ?? [],
+      getTab: async (tabId) => {
+        const tab = await chrome.tabs.get(tabId);
+        return { url: tab.url, title: tab.title };
+      },
+      getOrCreateHandle: getOrCreateTabHandle,
+      activeTabId: getTargetTabId(),
+    });
+    instructions += `\n\n${renderTabLegend(entries)}`;
   }
 
   const memories = await memoryDb.list(spaceId);

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -511,14 +511,21 @@ function toSDKTool<TInput, TOutput>(
    * origin, used by both the approval allowlist check and the per-tool-call
    * origin capture for the "Always allow on <site>" UI.
    *
-   * Returns `null` if no handle is present (e.g. tools that don't take a
-   * `tab` arg) or it can't be resolved (stale handle, conversation switch
-   * mid-flight). Callers fall back to safe defaults in that case.
+   * Takes an explicit `cid` rather than reading the module-level
+   * `agentConversationId` so that a single tool call (which may invoke
+   * this from `needsApproval`, `onInputAvailable`, and `execute` separately)
+   * always resolves against the same conversation map even if the user
+   * switches conversations mid-call.
+   *
+   * Returns `null` if no cid is provided, no handle is present, the handle
+   * doesn't resolve (stale handle, conversation switch mid-flight), or
+   * `chrome.tabs.get` rejects (closed tab). Callers fall back to safe
+   * defaults in that case.
    */
   const resolveTabFromInput = async (
+    cid: string | null,
     input: unknown,
   ): Promise<{ tabId: number; tab: chrome.tabs.Tab } | null> => {
-    const cid = agentConversationId;
     if (!cid) return null;
     const handle = (input as { tab?: unknown })?.tab;
     if (typeof handle !== "string" || handle.length === 0) return null;
@@ -535,7 +542,9 @@ function toSDKTool<TInput, TOutput>(
   const needsApproval =
     approvalRequired && isTabTool
       ? async ({ input }: { input: unknown }) => {
-          const resolved = await resolveTabFromInput(input);
+          // Capture cid once at entry — see resolveTabFromInput's contract.
+          const cid = agentConversationId;
+          const resolved = await resolveTabFromInput(cid, input);
           if (resolved?.tab.url) {
             try {
               const origin = new URL(resolved.tab.url).origin;
@@ -552,6 +561,10 @@ function toSDKTool<TInput, TOutput>(
     input: TInput,
     options: { toolCallId: string; experimental_context?: unknown },
   ) => {
+    // Capture cid once at entry so all resolveTabFromInput calls below
+    // (pre- and post-execute) hit the same conversation map even if the
+    // user switches conversations mid-tool.
+    const cid = agentConversationId;
     if (isTabTool) {
       agentActive = true;
       notifyAgentStatus(true, currentSpaceColor);
@@ -562,7 +575,7 @@ function toSDKTool<TInput, TOutput>(
       // Capture the resolved tab info for the indicator UI / "tab badge"
       // shown alongside the tool call. Pulled from the explicit `tab` arg
       // when available — same source the tool's own execute() will use.
-      const resolved = await resolveTabFromInput(input);
+      const resolved = await resolveTabFromInput(cid, input);
       if (resolved) {
         toolTabInfoStore.set(options.toolCallId, {
           tabId: resolved.tabId,
@@ -583,7 +596,7 @@ function toSDKTool<TInput, TOutput>(
       if (isTabTool) {
         // Refresh the tab info post-execute so the UI shows the landed
         // URL/title (navigate / clickElement may have changed it).
-        const resolved = await resolveTabFromInput(input);
+        const resolved = await resolveTabFromInput(cid, input);
         if (resolved) {
           toolTabInfoStore.set(options.toolCallId, {
             tabId: resolved.tabId,
@@ -608,8 +621,10 @@ function toSDKTool<TInput, TOutput>(
           // Resolve the agent-supplied `tab` arg to a concrete tab so the
           // approval UI can show "Always allow on <site>". This runs before
           // the SDK transitions to `approval-requested`, so the UI sees the
-          // origin on first render.
-          const resolved = await resolveTabFromInput(opts.input);
+          // origin on first render. Capture cid once at entry — see
+          // resolveTabFromInput's contract.
+          const cid = agentConversationId;
+          const resolved = await resolveTabFromInput(cid, opts.input);
           if (!resolved) return;
           if (resolved.tab.id != null) {
             capturedTabIds.set(opts.toolCallId, resolved.tab.id);
@@ -777,23 +792,11 @@ export async function createAgentTransport(
       .join("\n");
   }
 
-  // Inject the live tab legend. Tools that take a `tab` arg expect handles
-  // from this list; the agent reads it each turn to know what's available.
-  // Owned-tabs only: tabs the user has open elsewhere don't appear here
-  // until the agent calls selectTab to bind them.
-  if (agentConversationId) {
-    const entries = await buildTabLegendEntries({
-      conversationId: agentConversationId,
-      ownedTabIds: conv?.ownedTabIds ?? [],
-      getTab: async (tabId) => {
-        const tab = await chrome.tabs.get(tabId);
-        return { url: tab.url, title: tab.title };
-      },
-      getOrCreateHandle: getOrCreateTabHandle,
-      activeTabId: getTargetTabId(),
-    });
-    instructions += `\n\n${renderTabLegend(entries)}`;
-  }
+  // The tab legend is intentionally NOT appended to `instructions` here.
+  // ownedTabIds and tab URLs change mid-conversation (navigate adds a tab,
+  // user closes a tab, etc.); a static legend baked at transport-construction
+  // time would go stale. Instead we build it just-in-time inside `prepareCall`
+  // below so every model call sees the live state.
 
   const memories = await memoryDb.list(spaceId);
   if (memories.length > 0) {
@@ -931,6 +934,29 @@ export async function createAgentTransport(
   // by the wrapper transport so a previous turn's signal doesn't leak.
   let needsMidStreamCompaction = false;
 
+  /**
+   * Build the dynamic "## Tabs in this conversation" block from live state.
+   * Re-reads ownedTabIds from chatDb and queries chrome.tabs each call so
+   * the agent sees the current tab set on every turn (not the snapshot
+   * baked at transport-construction time).
+   */
+  async function buildLegendBlock(): Promise<string> {
+    const cid = agentConversationId;
+    if (!cid) return "";
+    const liveConv = await chatDb.getConversation(cid);
+    const entries = await buildTabLegendEntries({
+      conversationId: cid,
+      ownedTabIds: liveConv?.ownedTabIds ?? [],
+      getTab: async (tabId) => {
+        const tab = await chrome.tabs.get(Number(tabId));
+        return { url: tab.url, title: tab.title };
+      },
+      getOrCreateHandle: (c, tabId) => getOrCreateTabHandle(c, Number(tabId)),
+      activeTabId: getTargetTabId(),
+    });
+    return renderTabLegend(entries);
+  }
+
   const agent = new ToolLoopAgent({
     model,
     tools,
@@ -941,6 +967,20 @@ export async function createAgentTransport(
     // Session helpers read live agent state via getters so the same context
     // object stays valid across conversation switches.
     experimental_context: buildExtensionToolContext(),
+    // Append a fresh tab legend on every model call. The SDK invokes
+    // prepareCall right before each generate/stream, so this picks up
+    // tabs added by `navigate`, removed by closure, etc. — even
+    // mid-conversation.
+    prepareCall: async (callArgs) => {
+      const legend = await buildLegendBlock();
+      const baseInstructions = callArgs.instructions ?? "";
+      return {
+        ...callArgs,
+        instructions: legend
+          ? `${baseInstructions}\n\n${legend}`
+          : baseInstructions,
+      };
+    },
     onStepFinish: (stepResult) => {
       const usage = stepResult.usage;
       if (usage.inputTokens != null || usage.outputTokens != null) {

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -20,6 +20,7 @@ import type { ToolContext } from "./driver";
 import {
   clearHandles,
   getOrCreateHandle as getOrCreateTabHandle,
+  loadHandlesForConversation,
   resolveHandle as resolveTabHandle,
 } from "./tab-handles";
 import {
@@ -337,6 +338,13 @@ export function setAgentContext(
   }
   agentConversationId = conversationId;
   agentHostTabId = hostTabId;
+  // Hydrate the persisted handle map for the new conversation. Fire-and-
+  // forget: tools that hit a not-yet-hydrated map will see "Unknown tab
+  // handle" and recover via listTabs. In practice the user-message →
+  // first-tool-call window is large enough for this to settle.
+  if (conversationId) {
+    loadHandlesForConversation(conversationId).catch(() => {});
+  }
 }
 
 export function getAgentContext(): {

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -104,7 +104,7 @@ Rule of thumb: if it only matters when working in this particular space, scope i
 - A memory is clearly outdated based on conversation context
 `;
 
-import { getActiveUserTab, getTargetTabId, setTargetTabId } from "./active-tab";
+import { getTargetTabId } from "./active-tab";
 
 const INDICATOR_CSS = `
   #openbrowse-agent-border {
@@ -247,8 +247,24 @@ async function removeIndicator(tabId: number) {
 export function notifyAgentStatus(working: boolean, color?: string | null) {
   indicatorQueue = indicatorQueue.then(async () => {
     try {
-      const tab = await getActiveUserTab();
-      if (!tab.id) return;
+      // Use chrome.tabs.query directly rather than getActiveUserTab(): the
+      // indicator only needs the user's currently-focused tab, and
+      // getActiveUserTab has a side effect of pinning targetTabId on
+      // bootstrap that would leak into the tab legend's [active] marker.
+      const [tab] = await chrome.tabs.query({
+        active: true,
+        currentWindow: true,
+      });
+      if (!tab?.id) return;
+      // Skip injection on internal pages (extension/chrome/devtools UI).
+      const url = tab.url ?? "";
+      if (
+        url.startsWith("chrome://") ||
+        url.startsWith("chrome-extension://") ||
+        url.startsWith("devtools://")
+      ) {
+        return;
+      }
       if (working) {
         await injectIndicator(tab.id, color);
       } else {
@@ -285,11 +301,6 @@ let currentSpaceColor: string | null = null;
 let indicatorQueue: Promise<void> = Promise.resolve();
 
 let agentConversationId: string | null = null;
-// Tab id of the panel/popover that initiated this agent run. Used as the
-// implicit host tab to bind to a fresh conversation on the first tab tool
-// call (so the agent has a target without the user manually clicking
-// "Work on this tab").
-let agentHostTabId: number | null = null;
 
 let lastTotalTokens = 0;
 let currentModelDef: ModelDefinition | undefined;
@@ -330,15 +341,11 @@ export function resetTokenTracking() {
   lastTotalTokens = 0;
 }
 
-export function setAgentContext(
-  conversationId: string | null,
-  hostTabId: number | null = null,
-) {
+export function setAgentContext(conversationId: string | null) {
   if (agentConversationId && agentConversationId !== conversationId) {
     clearHandles(agentConversationId);
   }
   agentConversationId = conversationId;
-  agentHostTabId = hostTabId;
   // Hydrate the persisted handle map for the new conversation. Fire-and-
   // forget: tools that hit a not-yet-hydrated map will see "Unknown tab
   // handle" and recover via listTabs. In practice the user-message →
@@ -350,11 +357,9 @@ export function setAgentContext(
 
 export function getAgentContext(): {
   conversationId: string | null;
-  hostTabId: number | null;
 } {
   return {
     conversationId: agentConversationId,
-    hostTabId: agentHostTabId,
   };
 }
 
@@ -501,18 +506,44 @@ function toSDKTool<TInput, TOutput>(
 
   const approvalRequired = t.approval?.required ?? false;
 
+  /**
+   * Resolve the `tab` arg from a tool's input to a real chrome tab id +
+   * origin, used by both the approval allowlist check and the per-tool-call
+   * origin capture for the "Always allow on <site>" UI.
+   *
+   * Returns `null` if no handle is present (e.g. tools that don't take a
+   * `tab` arg) or it can't be resolved (stale handle, conversation switch
+   * mid-flight). Callers fall back to safe defaults in that case.
+   */
+  const resolveTabFromInput = async (
+    input: unknown,
+  ): Promise<{ tabId: number; tab: chrome.tabs.Tab } | null> => {
+    const cid = agentConversationId;
+    if (!cid) return null;
+    const handle = (input as { tab?: unknown })?.tab;
+    if (typeof handle !== "string" || handle.length === 0) return null;
+    const tabId = resolveTabHandle(cid, handle);
+    if (tabId == null) return null;
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      return { tabId, tab };
+    } catch {
+      return null;
+    }
+  };
+
   const needsApproval =
     approvalRequired && isTabTool
-      ? async () => {
-          try {
-            const tab = await getActiveUserTab();
-            if (tab.url) {
-              const origin = new URL(tab.url).origin;
+      ? async ({ input }: { input: unknown }) => {
+          const resolved = await resolveTabFromInput(input);
+          if (resolved?.tab.url) {
+            try {
+              const origin = new URL(resolved.tab.url).origin;
               const allowlist = await getToolSiteAllowlist();
               const allowed = allowlist[toolKey] ?? [];
               if (allowed.includes(origin)) return false;
-            }
-          } catch {}
+            } catch {}
+          }
           return true;
         }
       : approvalRequired;
@@ -525,60 +556,20 @@ function toSDKTool<TInput, TOutput>(
       agentActive = true;
       notifyAgentStatus(true, currentSpaceColor);
     }
-    const pinnedTabId = capturedTabIds.get(options.toolCallId);
-    const previousTargetTabId = getTargetTabId();
     capturedToolOrigins.delete(options.toolCallId);
-    if (pinnedTabId != null) {
-      capturedTabIds.delete(options.toolCallId);
-      setTargetTabId(pinnedTabId);
-    }
+
     if (isTabTool) {
-      // Implicit host-tab binding: on the first tab-interacting tool call
-      // for a conversation that hasn't owned any tabs yet, bind the panel's
-      // host tab so the agent has a working target. Skipped when the host
-      // tab is unknown, an extension/chrome page, or already in the group.
-      if (
-        agentConversationId &&
-        agentHostTabId != null &&
-        getTargetTabId() == null
-      ) {
-        try {
-          const conv = await chatDb.getConversation(agentConversationId);
-          if (conv && conv.ownedTabIds.length === 0) {
-            const hostTab = await chrome.tabs
-              .get(agentHostTabId)
-              .catch(() => null);
-            const hostUrl = hostTab?.url ?? "";
-            const isInternal =
-              hostUrl.startsWith("chrome://") ||
-              hostUrl.startsWith("chrome-extension://") ||
-              hostUrl.startsWith("devtools://");
-            if (hostTab && !isInternal && !hostTab.pinned) {
-              await chrome.runtime
-                .sendMessage({
-                  type: "BIND_ACTIVE_TAB_TO_CONVERSATION",
-                  conversationId: agentConversationId,
-                  tabId: agentHostTabId,
-                })
-                .catch(() => {});
-              setTargetTabId(agentHostTabId);
-            }
-          }
-        } catch {
-          // Best-effort; the agent's own bootstrap fallback (getActiveUserTab)
-          // will pick up where this leaves off.
-        }
+      // Capture the resolved tab info for the indicator UI / "tab badge"
+      // shown alongside the tool call. Pulled from the explicit `tab` arg
+      // when available — same source the tool's own execute() will use.
+      const resolved = await resolveTabFromInput(input);
+      if (resolved) {
+        toolTabInfoStore.set(options.toolCallId, {
+          tabId: resolved.tabId,
+          title: resolved.tab.title ?? "",
+          favIconUrl: resolved.tab.favIconUrl,
+        });
       }
-      try {
-        const tab = await getActiveUserTab();
-        if (tab.id && tab.title) {
-          toolTabInfoStore.set(options.toolCallId, {
-            tabId: tab.id,
-            title: tab.title,
-            favIconUrl: tab.favIconUrl,
-          });
-        }
-      } catch {}
     }
     try {
       // Threaded ToolContext from the SDK's experimental_context channel.
@@ -590,16 +581,16 @@ function toSDKTool<TInput, TOutput>(
       const result = await t.execute(input, ctx);
       toolResultStore.set(options.toolCallId, result);
       if (isTabTool) {
-        try {
-          const tab = await getActiveUserTab();
-          if (tab.id && tab.title) {
-            toolTabInfoStore.set(options.toolCallId, {
-              tabId: tab.id,
-              title: tab.title,
-              favIconUrl: tab.favIconUrl,
-            });
-          }
-        } catch {}
+        // Refresh the tab info post-execute so the UI shows the landed
+        // URL/title (navigate / clickElement may have changed it).
+        const resolved = await resolveTabFromInput(input);
+        if (resolved) {
+          toolTabInfoStore.set(options.toolCallId, {
+            tabId: resolved.tabId,
+            title: resolved.tab.title ?? "",
+            favIconUrl: resolved.tab.favIconUrl,
+          });
+        }
       }
       return result;
     } catch (err) {
@@ -608,36 +599,50 @@ function toSDKTool<TInput, TOutput>(
       };
       toolResultStore.set(options.toolCallId, errResult);
       return errResult as TOutput;
-    } finally {
-      if (pinnedTabId != null) {
-        setTargetTabId(previousTargetTabId);
-      }
     }
   };
 
   const onInputAvailable =
     approvalRequired && isTabTool
-      ? async (opts: { toolCallId: string }) => {
-          try {
-            const tab = await getActiveUserTab();
-            if (tab.id) capturedTabIds.set(opts.toolCallId, tab.id);
-            if (tab.url) {
-              capturedToolOrigins.set(opts.toolCallId, new URL(tab.url).origin);
+      ? async (opts: { input: unknown; toolCallId: string }) => {
+          // Resolve the agent-supplied `tab` arg to a concrete tab so the
+          // approval UI can show "Always allow on <site>". This runs before
+          // the SDK transitions to `approval-requested`, so the UI sees the
+          // origin on first render.
+          const resolved = await resolveTabFromInput(opts.input);
+          if (!resolved) return;
+          if (resolved.tab.id != null) {
+            capturedTabIds.set(opts.toolCallId, resolved.tab.id);
+          }
+          if (resolved.tab.url) {
+            try {
+              capturedToolOrigins.set(
+                opts.toolCallId,
+                new URL(resolved.tab.url).origin,
+              );
+            } catch {
+              // Non-URL-shaped value (e.g. about:blank); skip allowlist.
             }
-            if (tab.id && tab.title) {
-              toolTabInfoStore.set(opts.toolCallId, {
-                tabId: tab.id,
-                title: tab.title,
-                favIconUrl: tab.favIconUrl,
-              });
-            }
-          } catch {}
+          }
+          if (resolved.tab.id != null) {
+            toolTabInfoStore.set(opts.toolCallId, {
+              tabId: resolved.tab.id,
+              title: resolved.tab.title ?? "",
+              favIconUrl: resolved.tab.favIconUrl,
+            });
+          }
         }
       : undefined;
 
   const toModelOutput = isImageTool
     ? ({ output }: { output: TOutput }) => {
-        const { imageDataUrl } = output as { imageDataUrl: string };
+        const imageDataUrl = (output as { imageDataUrl?: string })
+          .imageDataUrl;
+        if (!imageDataUrl) {
+          // Tool errored or otherwise produced no image; let the SDK fall
+          // back to the default JSON output by returning undefined.
+          return undefined;
+        }
         const base64 = imageDataUrl.replace(/^data:image\/png;base64,/, "");
         return {
           type: "content" as const,
@@ -661,6 +666,8 @@ function toSDKTool<TInput, TOutput>(
     strict: true,
     execute,
     needsApproval,
+    ...(onInputAvailable && { onInputAvailable }),
+    ...(toModelOutput && { toModelOutput }),
   } as ToolSet[string];
 }
 

--- a/apps/extension/src/lib/agent/driver/browser-driver.ts
+++ b/apps/extension/src/lib/agent/driver/browser-driver.ts
@@ -56,6 +56,13 @@ export interface BrowserDriver {
    */
   getActiveTab(): Promise<BrowserTabInfo>;
 
+  /**
+   * Get info about a specific tab by id. Throws if the tab no longer
+   * exists. Used by tools that resolve a `tab` arg (a stable handle) to a
+   * concrete tab — they do not want the driver's "active" notion.
+   */
+  getTab(tabId: TabId): Promise<BrowserTabInfo>;
+
   /** Pin a specific tab as the agent's working target. */
   setActiveTab(tabId: TabId | null): Promise<void>;
 

--- a/apps/extension/src/lib/agent/driver/extension-driver.ts
+++ b/apps/extension/src/lib/agent/driver/extension-driver.ts
@@ -62,6 +62,11 @@ export class ExtensionDriver implements BrowserDriver {
     return toBrowserTabInfo(tab);
   }
 
+  async getTab(tabId: TabId): Promise<BrowserTabInfo> {
+    const tab = await chrome.tabs.get(tabId as number);
+    return toBrowserTabInfo(tab);
+  }
+
   async setActiveTab(tabId: TabId | null): Promise<void> {
     setTargetTabId(tabId == null ? null : (tabId as number));
   }

--- a/apps/extension/src/lib/agent/driver/index.ts
+++ b/apps/extension/src/lib/agent/driver/index.ts
@@ -15,4 +15,9 @@ export type {
   TabId,
 } from "./browser-driver";
 export type { ToolContext, ToolSession } from "./tool-context";
-export { handleForTab } from "./tool-context";
+export {
+  handleForTab,
+  resolveTabIdOrThrow,
+  resolveTabOrThrow,
+  ToolTabResolutionError,
+} from "./tool-context";

--- a/apps/extension/src/lib/agent/driver/tool-context.ts
+++ b/apps/extension/src/lib/agent/driver/tool-context.ts
@@ -15,7 +15,7 @@
  * (`agent-transport.ts`), not in the portable tool surface.
  */
 
-import type { BrowserDriver, TabId } from "./browser-driver";
+import type { BrowserDriver, BrowserTabInfo, TabId } from "./browser-driver";
 import type { TodoItem } from "../../types";
 
 export interface ToolSession {
@@ -69,4 +69,50 @@ export interface ToolContext {
  */
 export function handleForTab(ctx: ToolContext, tabId: TabId): string {
   return ctx.session?.getOrCreateHandle?.(tabId) ?? `t${tabId}`;
+}
+
+/**
+ * Resolve a `tab` arg (a stable handle like `t1`) to a concrete tab id.
+ *
+ * This is the canonical entry point for every tab-interacting tool's
+ * execute(): tools never pick a tab via the driver's "active" notion any
+ * more — they always operate on the explicit handle the agent passed.
+ *
+ * Throws a structured `ToolTabResolutionError` so the SDK wrapper can
+ * surface a clean message to the agent without a stack trace.
+ */
+export class ToolTabResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ToolTabResolutionError";
+  }
+}
+
+export function resolveTabIdOrThrow(
+  ctx: ToolContext,
+  handle: string,
+): TabId {
+  const tabId = ctx.session?.resolveHandle?.(handle);
+  if (tabId == null) {
+    throw new ToolTabResolutionError(
+      `Unknown tab handle "${handle}". Call listTabs to see available handles, or navigate to open a new tab.`,
+    );
+  }
+  return tabId;
+}
+
+export async function resolveTabOrThrow(
+  ctx: ToolContext,
+  handle: string,
+): Promise<BrowserTabInfo> {
+  const tabId = resolveTabIdOrThrow(ctx, handle);
+  try {
+    return await ctx.driver.getTab(tabId);
+  } catch (err) {
+    throw new ToolTabResolutionError(
+      `Tab ${handle} (id=${String(tabId)}) is no longer available: ${
+        err instanceof Error ? err.message : String(err)
+      }. Call listTabs to refresh handles.`,
+    );
+  }
 }

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -1,6 +1,16 @@
 export const SYSTEM_PROMPT = `You are OpenBrowse, an AI browser agent. You help users understand and interact with web pages.
 
-You have tools to interact with the user's browser tabs. Tools automatically target the user's active browsing tab — you do NOT need to select or switch tabs unless the user asks to work with a different one.
+You have tools to interact with browser tabs. Every tab-interacting tool requires an explicit \`tab\` argument — a stable handle like \`t1\`, \`t2\` that identifies which tab to act on. Available handles for the current conversation are listed in the \`## Tabs in this conversation\` section below (auto-injected each turn).
+
+## Tab handles
+
+- A handle is a short string (\`t1\`, \`t2\`, ...) that identifies one tab. Handles are stable per conversation: if you got \`t1\` for a tab earlier, that same string keeps referring to that same tab on later turns and across service-worker restarts.
+- The \`## Tabs in this conversation\` section below lists every handle currently available, plus the tab's title and URL. Read it before issuing any tab tool call.
+- To start a fresh conversation that has no handles yet, call \`navigate({ url })\` with no \`tab\` arg. \`navigate\` will open a new background tab and return its handle in the response. Use that handle for follow-up tools.
+- To act on an existing tab, pass its handle: \`snapshot({ tab: "t1" })\`, \`clickElement({ tab: "t1", target: "@e3" })\`, etc.
+- To navigate an existing tab to a different URL, use \`navigate({ url, tab: "t1" })\`.
+- To act on a tab the user already had open (one you didn't navigate to), call \`listTabs\` to get the full list of handles, then \`selectTab({ tab: "..." })\` to bind it into the conversation. After selectTab the handle appears in the legend.
+- A tool call with an unknown handle returns a clear error. If you see one, call \`listTabs\` and try again with a fresh handle.
 
 ## Working autonomously
 
@@ -25,17 +35,18 @@ Your current plan will be appended to your instructions at every turn. Keep it i
 
 ## Page Interaction Workflow
 
-1. Use \`snapshot\` to see interactive elements with @refs (e.g. @e1, @e2). On heavy pages (Amazon, Gmail, Notion, any e-commerce site, any social feed) — **always start with \`mode: "viewport"\` or scope with \`selector\` to keep the tree small.** A full \`interactive\` snapshot of Amazon's homepage returns 300+ refs; viewport mode typically returns 30-60. The response includes \`belowFoldCount\` when more content exists off-screen; \`scrollPage\` + re-snapshot to reach it. Use element selectors (e.g. \`"main"\`, \`"#search"\`, \`".s-main-slot"\`) — NOT attribute selectors like \`[role="main"]\` (those don't match implicit ARIA roles).
-2. Use @refs in clickElement/typeInElement: \`clickElement({ target: "@e3" })\`
+1. Use \`snapshot({ tab })\` to see interactive elements with @refs (e.g. @e1, @e2). On heavy pages (Amazon, Gmail, Notion, any e-commerce site, any social feed) — **always start with \`mode: "viewport"\` or scope with \`selector\` to keep the tree small.** A full \`interactive\` snapshot of Amazon's homepage returns 300+ refs; viewport mode typically returns 30-60. The response includes \`belowFoldCount\` when more content exists off-screen; \`scrollPage\` + re-snapshot to reach it. Use element selectors (e.g. \`"main"\`, \`"#search"\`, \`".s-main-slot"\`) — NOT attribute selectors like \`[role="main"]\` (those don't match implicit ARIA roles).
+2. Use @refs in clickElement/typeInElement: \`clickElement({ tab: "t1", target: "@e3" })\`. The \`@ref\` is tied to the tab whose snapshot produced it — do NOT pass refs from one tab to another.
 3. \`clickElement\`, \`typeInElement\`, and \`navigate\` automatically return a \`diff\` (or a fresh snapshot on navigate) — inspect it to verify your action worked before issuing the next one. A \`diff: null\` response means the action produced no visible change, which usually signals a silent failure.
-4. **To submit a form, ALWAYS use \`typeInElement({ target: "@e5", text: "...", submit: true })\`** — never append \\n to the text. The \`submit: true\` flag presses Enter AND waits for navigation to settle, which the legacy newline trick does not.
-5. Use \`extract\` to pull structured data (product lists, search results, table rows) from a page. Provide an instruction and optionally a JSON Schema. Mark URL fields as \`{"type": "string", "format": "uri"}\` for reliable link extraction — the tool substitutes URLs with numeric IDs to prevent hallucination and rehydrates them before returning. Use element selectors like \`"main"\` or \`".s-main-slot"\` (NOT \`[role="main"]\`).
-6. Use \`readPage\` when you need full text content (articles, long-form text).
-7. Use \`screenshot\` when visual context would help; add \`annotate: true\` to overlay color-coded @ref labels on interactive elements (buttons blue, links green, inputs orange, other gray).
+4. **To submit a form, ALWAYS use \`typeInElement({ tab, target: "@e5", text: "...", submit: true })\`** — never append \\n to the text. The \`submit: true\` flag presses Enter AND waits for navigation to settle, which the legacy newline trick does not.
+5. Use \`extract({ tab, instruction, schema? })\` to pull structured data (product lists, search results, table rows) from a page. Provide an instruction and optionally a JSON Schema. Mark URL fields as \`{"type": "string", "format": "uri"}\` for reliable link extraction — the tool substitutes URLs with numeric IDs to prevent hallucination and rehydrates them before returning. Use element selectors like \`"main"\` or \`".s-main-slot"\` (NOT \`[role="main"]\`).
+6. Use \`readPage({ tab })\` when you need full text content (articles, long-form text).
+7. Use \`screenshot({ tab })\` when visual context would help; add \`annotate: true\` to overlay color-coded @ref labels on interactive elements (buttons blue, links green, inputs orange, other gray).
 
 ### Example: extracting a product list
 \`\`\`
 extract({
+  tab: "t1",
   instruction: "Extract the top 3 non-sponsored results with title, price, and url",
   selector: "main",
   schema: {
@@ -59,11 +70,12 @@ extract({
 
 ## Guidelines
 
+- ALWAYS pass an explicit \`tab\` handle to tab-interacting tools.
 - ALWAYS use snapshot before clicking or typing — never guess CSS selectors
-- Use @refs from the most recent snapshot (e.g. "@e5") as the target for clickElement and typeInElement
-- CSS selectors are a fallback only when refs are unavailable
-- Tabs are identified by handles (t1, t2, ...) from listTabs — use these with selectTab
-- Use scrollPage to see more content, then snapshot again to get updated refs
+- Use @refs from the most recent snapshot of the SAME tab (e.g. "@e5") as the target for clickElement and typeInElement.
+- CSS selectors are a fallback only when refs are unavailable.
+- Read the \`## Tabs in this conversation\` section to see what handles you have. If empty, your only first-action option is \`navigate({ url })\` (without a \`tab\` arg) to bootstrap a new tab.
+- Use \`scrollPage({ tab })\` to see more content, then snapshot again to get updated refs.
 - Navigate when the task requires it. Don't switch tabs gratuitously, but don't refuse to navigate just because the user didn't say "navigate".
 - Don't navigate to URLs you have invented or guessed. Find the URL by searching on the page, following links, or running a Google query. Asking the user is a fallback, not the first step.
 - If snapshot returns an empty result or refCount: 0, try another approach: switch \`mode\` (viewport ↔ interactive), scope to a different selector, scrollPage and re-snapshot, or take a screenshot. Don't give up after a single retry.
@@ -82,7 +94,7 @@ You are operating in a sandboxed, browser-based virtual file system (VFS). You h
 You have two tools for running JavaScript (Note: these do NOT run in your Virtual Workspace):
 
 - \`executeCode\`: Runs in an isolated sandbox. Use for computation, data transforms, API calls (fetch). No DOM access. Pass data via \`input\` parameter, access it as \`__input\` in your code. Use \`return\` to produce output.
-- \`executeOnPage\`: Runs in the active tab with full DOM/page access. Requires user approval. Use when you need to read or modify the page beyond what snapshot/clickElement/typeInElement provide — for example, scraping structured data from a product grid, or reading \`data-*\` attributes that don't appear in the accessibility tree.
+- \`executeOnPage({ tab, code, args? })\`: Runs in a specific tab's page context with full DOM access. Requires user approval before each execution. Use when you need to read or modify a page beyond what snapshot/clickElement/typeInElement provide — for example, scraping structured data from a product grid, or reading \`data-*\` attributes that don't appear in the accessibility tree.
 
 Prefer the existing browser tools (snapshot, clickElement, etc.) for simple interactions. Use executeOnPage only when you need complex multi-step DOM manipulation or need to access page JavaScript variables/state.
 
@@ -93,4 +105,5 @@ The biggest failure mode is giving up too early. Default to trying one more thin
 - A click or type returned \`diff: null\` (no visible change): re-snapshot for fresh refs, then try a different element or selector.
 - The page is still loading: scroll or screenshot to wait, don't bail.
 - A tool errored: if the error looks transient, retry; if structural, change approach.
+- An "Unknown tab handle" error means the legend has changed — call \`listTabs\` to refresh and pick a valid handle.
 - Don't retry the same exact tool call with the same input more than 2-3 times.`;

--- a/apps/extension/src/lib/agent/tab-handles.ts
+++ b/apps/extension/src/lib/agent/tab-handles.ts
@@ -1,3 +1,26 @@
+/**
+ * Per-conversation handle map. Handles (`t1`, `t2`, ...) are stable agent-
+ * facing identifiers that map to chrome tab ids. Tools take a handle in
+ * their `tab` arg; the session resolves it back to a real tab id.
+ *
+ * State is split:
+ *   - In-memory (`maps`): fast sync access used by the tools' execute path
+ *     and the session-helper getters threaded through ToolContext.
+ *   - chatDb-backed (`conversation.handleState`): survives service-worker
+ *     restarts and the conversation list re-mount cycle. Only handles for
+ *     the conversation's owned tabs are persisted; ephemeral handles
+ *     minted for non-owned tabs (e.g. from `listTabs`) live only in memory.
+ *
+ * The sync API (`getOrCreateHandle`, `resolveHandle`) reads from the
+ * in-memory map only. Hydration (`loadHandlesForConversation`) is
+ * fire-and-forget from `setAgentContext`; it merges restored state into
+ * whatever in-memory state the running agent has already accumulated, so
+ * a handle minted before hydration completes is never lost. Persistence
+ * is fire-and-forget on every mutation, debounced+chained per conversation.
+ */
+
+import { chatDb, type PersistedHandleState } from "@/lib/chat-db";
+
 export interface TabHandle {
   handle: string;
   chromeTabId: number;
@@ -11,16 +34,249 @@ interface HandleMap {
 
 const maps = new Map<string, HandleMap>();
 
+/** In-flight hydration promises, keyed by conversation id. */
+const hydrationPromises = new Map<string, Promise<void>>();
+
+/**
+ * In-flight persist chains, keyed by conversation id. We chain writes so
+ * concurrent mutations serialize and tests can deterministically await the
+ * latest one. Entries auto-clean themselves once the chain settles AND no
+ * newer write has been queued — see the `.finally` in `persist()`.
+ */
+const persistChains = new Map<string, Promise<void>>();
+
+/**
+ * Set of conversation ids that have a queued-but-not-yet-started persist
+ * write. Used to coalesce: when many mutations happen in quick succession
+ * (e.g. `listTabs` minting handles for 20 tabs), only one chatDb round-trip
+ * needs to run — it'll read the latest in-memory state when it executes.
+ */
+const persistDirty = new Set<string>();
+
+function emptyMap(): HandleMap {
+  return { handleToTab: new Map(), tabToHandle: new Map(), counter: 1 };
+}
+
 function getMap(conversationId: string): HandleMap {
   let map = maps.get(conversationId);
   if (!map) {
-    map = { handleToTab: new Map(), tabToHandle: new Map(), counter: 1 };
+    map = emptyMap();
     maps.set(conversationId, map);
   }
   return map;
 }
 
-export function getOrCreateHandle(conversationId: string, tabId: number): string {
+function snapshot(map: HandleMap): PersistedHandleState {
+  const handles: Record<string, number> = {};
+  for (const [h, id] of map.handleToTab) handles[h] = id;
+  return { handles, counter: map.counter };
+}
+
+/**
+ * Project a snapshot to only the handles whose tabId is in `ownedSet`.
+ * Used by `persist()` so non-owned handles (e.g. minted while enumerating
+ * `listTabs`) don't bloat chatDb across SW lifetimes.
+ */
+function snapshotOwned(
+  map: HandleMap,
+  ownedSet: Set<number>,
+): PersistedHandleState {
+  const handles: Record<string, number> = {};
+  for (const [h, id] of map.handleToTab) {
+    if (ownedSet.has(id)) handles[h] = id;
+  }
+  return { handles, counter: map.counter };
+}
+
+function restore(state: PersistedHandleState | undefined): HandleMap {
+  if (!state) return emptyMap();
+  const map = emptyMap();
+  for (const [h, id] of Object.entries(state.handles)) {
+    map.handleToTab.set(h, id);
+    map.tabToHandle.set(id, h);
+  }
+  // Defensive: clamp the stored counter to a finite positive integer (in
+  // case chatDb was tampered with or partially written). If somehow lower
+  // than the highest seen handle suffix, advance it so newly-minted
+  // handles can't collide.
+  let maxSeen = 0;
+  for (const h of map.handleToTab.keys()) {
+    const m = h.match(/^t(\d+)$/);
+    if (m) maxSeen = Math.max(maxSeen, Number(m[1]));
+  }
+  const cleanCounter =
+    Number.isFinite(state.counter) && state.counter > 0 ? state.counter : 1;
+  map.counter = Math.max(cleanCounter, maxSeen + 1);
+  return map;
+}
+
+/**
+ * Persist the in-memory handle map for a conversation back to chatDb.
+ * Fire-and-forget; failures are swallowed. Writes are chained per
+ * conversation so concurrent calls serialize (and so tests can
+ * deterministically await `flushPersistsForTests`). Only handles whose
+ * tabId is in the conversation's `ownedTabIds` are written; ephemeral
+ * handles minted by `listTabs` for non-owned tabs stay in memory only.
+ *
+ * Calls are coalesced: if a write is already queued (pending), additional
+ * persist() calls before it starts return early. The pending write reads
+ * latest in-memory state when it executes, so no mutation is lost.
+ *
+ * The chain re-checks `maps.get(conversationId)` after every async hop.
+ * If the conversation was cleared (`clearHandles`) mid-flight — including
+ * across a chatDb reset in tests — the chain aborts before writing
+ * anything stale.
+ */
+function persist(conversationId: string): void {
+  const map = maps.get(conversationId);
+  if (!map) return;
+  if (persistDirty.has(conversationId)) return; // coalesce: a write is already queued
+  persistDirty.add(conversationId);
+  const prev = persistChains.get(conversationId) ?? Promise.resolve();
+  const next = prev
+    .catch(() => {}) // never let a previous failure cancel later writes
+    .then(async () => {
+      // Claim the dirty flag *before* the await so subsequent mutations
+      // queue a fresh write rather than getting silently dropped by the
+      // coalesce check above.
+      persistDirty.delete(conversationId);
+      if (!maps.has(conversationId)) return; // cleared before we ran
+      const conv = await chatDb.getConversation(conversationId);
+      // Re-check after the chatDb read: clearHandles may have been called
+      // while we were suspended.
+      const liveMap = maps.get(conversationId);
+      if (!liveMap) return;
+      const ownedSet = new Set(conv?.ownedTabIds ?? []);
+      const state = snapshotOwned(liveMap, ownedSet);
+      // Last guard before the write — chatDb may have been reset between
+      // the read and the write (only happens in tests, but trivially safe
+      // to check).
+      if (!maps.has(conversationId)) return;
+      await chatDb.updateConversation(conversationId, { handleState: state });
+    })
+    .catch((err) => {
+      console.warn("[tab-handles] persist failed", err);
+    })
+    .finally(() => {
+      // Drop the chain entry only if no newer write piggy-backed on us.
+      // Otherwise the newer write is still pending and persistChains points
+      // at IT, not us — leave it alone.
+      if (persistChains.get(conversationId) === next) {
+        persistChains.delete(conversationId);
+      }
+    });
+  persistChains.set(conversationId, next);
+}
+
+/**
+ * Test helper: await the in-flight persist chain for a conversation. Allows
+ * tests to assert on chatDb state without timing-based flushes. Production
+ * code never waits on persistence.
+ */
+export function flushPersistsForTests(
+  conversationId: string,
+): Promise<void> {
+  return persistChains.get(conversationId) ?? Promise.resolve();
+}
+
+/**
+ * Hydrate the in-memory handle map for a conversation from chatDb. Drops
+ * any persisted handle whose tab no longer exists. Idempotent: subsequent
+ * calls return the same in-flight promise until it settles.
+ *
+ * Merges restored state into any existing in-memory map for the
+ * conversation rather than replacing it, so handles minted between
+ * `setAgentContext` and the chatDb read landing aren't lost.
+ *
+ * Called fire-and-forget from `setAgentContext`. Tests can `await` the
+ * returned promise for deterministic ordering.
+ *
+ * If `clearHandles(conversationId)` is called while hydration is in
+ * flight, the hydration cancels its merge step on completion (the
+ * cleared state takes precedence over the now-stale persisted snapshot).
+ */
+export function loadHandlesForConversation(
+  conversationId: string,
+): Promise<void> {
+  const existing = hydrationPromises.get(conversationId);
+  if (existing) return existing;
+
+  // Forward-declare so the closure can verify it wasn't cleared.
+  let token!: Promise<void>;
+  token = (async () => {
+    try {
+      const conv = await chatDb.getConversation(conversationId);
+      const restored = restore(conv?.handleState);
+
+      // Prune dead tabs so a stale handle can't resolve to a closed tab.
+      const tabIds = Array.from(restored.tabToHandle.keys());
+      const liveness = await Promise.all(
+        tabIds.map((id) => {
+          // `chrome` is a free identifier on extension globals; in tests
+          // / non-extension contexts it may be undefined entirely. Use a
+          // typeof guard before any property access.
+          const chromeRef =
+            typeof chrome !== "undefined" ? chrome : undefined;
+          if (!chromeRef?.tabs?.get) {
+            // No chrome.tabs available (tests / non-extension context).
+            // Treat all persisted handles as live; tests can override
+            // per case via vi.stubGlobal.
+            return Promise.resolve(true);
+          }
+          return chromeRef.tabs
+            .get(id)
+            .then(() => true)
+            .catch(() => false);
+        }),
+      );
+
+      // If we were cleared mid-flight, abort: the new state owns the
+      // conversation now and we shouldn't repopulate maps with stale
+      // persisted entries.
+      if (hydrationPromises.get(conversationId) !== token) return;
+
+      // Merge into the existing in-memory map (creating one if needed).
+      // Crucially we do NOT overwrite freshly-minted handles that the
+      // running agent already added between setAgentContext and this
+      // promise settling.
+      const live = getMap(conversationId);
+      let pruned = false;
+      tabIds.forEach((id, i) => {
+        if (!liveness[i]) {
+          pruned = true;
+          return;
+        }
+        const handle = restored.tabToHandle.get(id)!;
+        // Only adopt the restored binding if neither side is already
+        // claimed in-memory (the live map wins).
+        if (live.handleToTab.has(handle)) return;
+        if (live.tabToHandle.has(id)) return;
+        live.handleToTab.set(handle, id);
+        live.tabToHandle.set(id, handle);
+      });
+      live.counter = Math.max(live.counter, restored.counter);
+
+      // If we pruned anything, write the pruned snapshot back so the
+      // next cold-start doesn't re-pay the liveness round-trip on dead ids.
+      if (pruned) persist(conversationId);
+    } catch (err) {
+      console.warn("[tab-handles] hydrate failed", err);
+      // Leave the in-memory map as whatever was already there (or empty).
+    } finally {
+      if (hydrationPromises.get(conversationId) === token) {
+        hydrationPromises.delete(conversationId);
+      }
+    }
+  })();
+
+  hydrationPromises.set(conversationId, token);
+  return token;
+}
+
+export function getOrCreateHandle(
+  conversationId: string,
+  tabId: number,
+): string {
   const map = getMap(conversationId);
   const existing = map.tabToHandle.get(tabId);
   if (existing) return existing;
@@ -28,23 +284,60 @@ export function getOrCreateHandle(conversationId: string, tabId: number): string
   const handle = `t${map.counter++}`;
   map.handleToTab.set(handle, tabId);
   map.tabToHandle.set(tabId, handle);
+  persist(conversationId);
   return handle;
 }
 
-export function resolveHandle(conversationId: string, handle: string): number | undefined {
+export function resolveHandle(
+  conversationId: string,
+  handle: string,
+): number | undefined {
   return maps.get(conversationId)?.handleToTab.get(handle);
 }
 
+/**
+ * Clear all handle state for a conversation. Called when the agent context
+ * switches conversations (`setAgentContext`) so a stale in-memory map from
+ * a different conversation can't leak into the new one. Persisted state in
+ * chatDb is left intact for the next time the conversation is activated.
+ */
 export function clearHandles(conversationId: string): void {
   maps.delete(conversationId);
+  hydrationPromises.delete(conversationId);
+  persistDirty.delete(conversationId);
 }
 
-chrome.tabs.onRemoved.addListener((tabId) => {
-  for (const map of maps.values()) {
+/**
+ * List the live `{handle, tabId}` pairs for a conversation. Used by the
+ * system-prompt tab-legend renderer. Reads only from the in-memory map —
+ * call `loadHandlesForConversation` first if you need post-restart state.
+ */
+export function listHandles(
+  conversationId: string,
+): { handle: string; tabId: number }[] {
+  const map = maps.get(conversationId);
+  if (!map) return [];
+  return Array.from(map.handleToTab, ([handle, tabId]) => ({ handle, tabId }));
+}
+
+/**
+ * Drop a single handle (e.g. when its tab is closed). Idempotent.
+ */
+export function dropTab(tabId: number): void {
+  for (const [conversationId, map] of maps) {
     const handle = map.tabToHandle.get(tabId);
     if (handle) {
       map.handleToTab.delete(handle);
       map.tabToHandle.delete(tabId);
+      persist(conversationId);
     }
   }
-});
+}
+
+// Auto-cleanup when chrome closes a tab. Best-effort; in non-extension
+// contexts (tests) `chrome.tabs` is undefined and we no-op.
+if (typeof chrome !== "undefined" && chrome.tabs?.onRemoved?.addListener) {
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    dropTab(tabId);
+  });
+}

--- a/apps/extension/src/lib/agent/tab-handles.ts
+++ b/apps/extension/src/lib/agent/tab-handles.ts
@@ -66,16 +66,11 @@ function getMap(conversationId: string): HandleMap {
   return map;
 }
 
-function snapshot(map: HandleMap): PersistedHandleState {
-  const handles: Record<string, number> = {};
-  for (const [h, id] of map.handleToTab) handles[h] = id;
-  return { handles, counter: map.counter };
-}
-
 /**
- * Project a snapshot to only the handles whose tabId is in `ownedSet`.
- * Used by `persist()` so non-owned handles (e.g. minted while enumerating
- * `listTabs`) don't bloat chatDb across SW lifetimes.
+ * Project the in-memory map to a chatDb-shaped record, including only
+ * handles whose tabId is in `ownedSet`. Non-owned handles (e.g. minted
+ * while enumerating `listTabs` for the user's other tabs) stay in memory
+ * but don't bloat chatDb across SW lifetimes.
  */
 function snapshotOwned(
   map: HandleMap,

--- a/apps/extension/src/lib/agent/tab-handles.ts
+++ b/apps/extension/src/lib/agent/tab-handles.ts
@@ -274,7 +274,18 @@ export function getOrCreateHandle(
 ): string {
   const map = getMap(conversationId);
   const existing = map.tabToHandle.get(tabId);
-  if (existing) return existing;
+  if (existing) {
+    // Re-persist on every access. Cheap (the coalesce in `persist()`
+    // collapses N calls in a tick to 1 chatDb write) and necessary: a
+    // handle minted ephemerally — e.g. by `listTabs` for a tab that was
+    // not yet in `ownedTabIds` — gets filtered out by `snapshotOwned()`
+    // at mint time. If `selectTab` later binds that tab into the
+    // conversation, we need a chance to re-snapshot so the handle lands
+    // in chatDb. Without this re-persist, that ephemeral handle would
+    // be lost on the next service-worker restart.
+    persist(conversationId);
+    return existing;
+  }
 
   const handle = `t${map.counter++}`;
   map.handleToTab.set(handle, tabId);

--- a/apps/extension/src/lib/agent/tab-legend.ts
+++ b/apps/extension/src/lib/agent/tab-legend.ts
@@ -1,0 +1,89 @@
+/**
+ * Builds the dynamic "## Tabs in this conversation" block for the system
+ * prompt. Pulled out of agent-transport so it can be tested without a live
+ * chatDb / chrome.tabs.
+ *
+ * Owned-tabs only: the legend is the authoritative list of handles the
+ * agent should pass as `tab` args. Tabs the user has open elsewhere do
+ * NOT appear here unless the agent calls `selectTab` to bind them.
+ */
+
+import type { TabId } from "./driver";
+
+export interface TabLegendInput {
+  conversationId: string;
+  ownedTabIds: number[];
+  /**
+   * Per-tab info fetcher. Should resolve with the live tab info, or reject
+   * if the tab no longer exists (the legend renderer treats rejection as
+   * "drop this entry").
+   */
+  getTab: (tabId: number) => Promise<{ url: string | undefined; title: string | undefined }>;
+  /** Mint or retrieve a stable handle for the given (conversation, tabId). */
+  getOrCreateHandle: (conversationId: string, tabId: number) => string;
+  /** The currently-tracked active tab (used to mark `[active]`). May be null. */
+  activeTabId: TabId | null;
+}
+
+export interface TabLegendEntry {
+  handle: string;
+  url: string;
+  title: string;
+  active: boolean;
+}
+
+export function isInternalChromeUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  return (
+    url.startsWith("chrome://") ||
+    url.startsWith("chrome-extension://") ||
+    url.startsWith("devtools://")
+  );
+}
+
+export async function buildTabLegendEntries(
+  input: TabLegendInput,
+): Promise<TabLegendEntry[]> {
+  const entries: TabLegendEntry[] = [];
+  for (const tabId of input.ownedTabIds) {
+    let url: string | undefined;
+    let title: string | undefined;
+    try {
+      const info = await input.getTab(tabId);
+      url = info.url;
+      title = info.title;
+    } catch {
+      // Tab no longer exists; skip.
+      continue;
+    }
+    if (!url) continue;
+    if (isInternalChromeUrl(url)) continue;
+    const handle = input.getOrCreateHandle(input.conversationId, tabId);
+    const cleanTitle = (title ?? "").trim() || "(untitled)";
+    entries.push({
+      handle,
+      url,
+      title: cleanTitle,
+      active: input.activeTabId === tabId,
+    });
+  }
+  return entries;
+}
+
+export function renderTabLegend(entries: TabLegendEntry[]): string {
+  if (entries.length === 0) {
+    return [
+      "## Tabs in this conversation",
+      "No tabs bound to this conversation yet. To bootstrap, call `navigate({ url })` (without a `tab` arg) to open a new background tab and receive its handle.",
+    ].join("\n");
+  }
+  const lines = entries.map(
+    (e) =>
+      `- ${e.handle}: ${e.title} — ${e.url}${e.active ? "  [active]" : ""}`,
+  );
+  return [
+    "## Tabs in this conversation",
+    "Pass one of these handles as the `tab` argument to tab-tools.",
+    ...lines,
+  ].join("\n");
+}

--- a/apps/extension/src/lib/agent/tab-legend.ts
+++ b/apps/extension/src/lib/agent/tab-legend.ts
@@ -12,15 +12,15 @@ import type { TabId } from "./driver";
 
 export interface TabLegendInput {
   conversationId: string;
-  ownedTabIds: number[];
+  ownedTabIds: TabId[];
   /**
    * Per-tab info fetcher. Should resolve with the live tab info, or reject
    * if the tab no longer exists (the legend renderer treats rejection as
    * "drop this entry").
    */
-  getTab: (tabId: number) => Promise<{ url: string | undefined; title: string | undefined }>;
+  getTab: (tabId: TabId) => Promise<{ url: string | undefined; title: string | undefined }>;
   /** Mint or retrieve a stable handle for the given (conversation, tabId). */
-  getOrCreateHandle: (conversationId: string, tabId: number) => string;
+  getOrCreateHandle: (conversationId: string, tabId: TabId) => string;
   /** The currently-tracked active tab (used to mark `[active]`). May be null. */
   activeTabId: TabId | null;
 }

--- a/apps/extension/src/lib/agent/tools/click-element.ts
+++ b/apps/extension/src/lib/agent/tools/click-element.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
 import type { BrowserDriver, TabId } from "../driver";
+import { resolveTabOrThrow } from "../driver";
 import { getRef, getPreviousSnapshot, invalidateRefs } from "../ref-store";
 import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to click in (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   target: z
     .string()
     .describe(
@@ -16,6 +22,7 @@ const parameters = z.object({
 type Input = z.infer<typeof parameters>;
 
 const outputSchema = z.object({
+  tab: z.string(),
   clicked: z.literal(true),
   target: z.string(),
   diff: z.string().nullable().optional(),
@@ -26,11 +33,11 @@ type Output = z.infer<typeof outputSchema>;
 export const clickElementTool: BrowserTool<Input, Output> = {
   name: "clickElement",
   description:
-    "Click an element on the page. Use @ref from snapshot (preferred) or a CSS selector. The response automatically includes a diff of what changed on the page — use it to verify the action worked before acting again. If diff is null the click produced no visible change.",
+    "Click an element on a page. Pass `tab` (handle from the tab legend or listTabs) and `target` — either an @ref from a recent snapshot of THAT tab (preferred) or a CSS selector as fallback. The response automatically includes a diff of what changed on the page — use it to verify the action worked before acting again. If diff is null the click produced no visible change.",
   parameters,
   outputSchema,
-  execute: async ({ target }, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle, target }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
 
     const previousSnapshot = getPreviousSnapshot(tabId);
@@ -64,7 +71,7 @@ export const clickElementTool: BrowserTool<Input, Output> = {
       } catch {
         // page may have navigated away / tab closed; ignore
       }
-      return { clicked: true, target };
+      return { tab: handle, clicked: true, target };
     }
 
     try {
@@ -72,15 +79,17 @@ export const clickElementTool: BrowserTool<Input, Output> = {
       const diff = diffSnapshots(previousSnapshot, snapshotText);
       if (diff === null) {
         return {
+          tab: handle,
           clicked: true,
           target,
           diff: null,
           note: "No visible page change detected. The click may not have had the expected effect.",
         };
       }
-      return { clicked: true, target, diff };
+      return { tab: handle, clicked: true, target, diff };
     } catch (err) {
       return {
+        tab: handle,
         clicked: true,
         target,
         note: `Click succeeded but post-action snapshot failed: ${

--- a/apps/extension/src/lib/agent/tools/execute-on-page.ts
+++ b/apps/extension/src/lib/agent/tools/execute-on-page.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 import type { BrowserTool } from "../types";
+import { resolveTabOrThrow } from "../driver";
 import { invalidateRefs } from "../ref-store";
 
 const TIMEOUT_MS = 30_000;
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to execute against (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   code: z
     .string()
     .describe(
@@ -18,6 +24,7 @@ const parameters = z.object({
 
 type Input = z.infer<typeof parameters>;
 const outputSchema = z.object({
+  tab: z.string(),
   result: z.unknown().optional(),
   error: z.string().optional(),
 });
@@ -26,14 +33,14 @@ type Output = z.infer<typeof outputSchema>;
 export const executeOnPageTool: BrowserTool<Input, Output> = {
   name: "executeOnPage",
   description:
-    "Execute JavaScript in the active tab's page context with full DOM access. Requires user approval before each execution. Use when you need complex DOM manipulation or access to page JavaScript variables/state beyond what readPage/clickElement/typeInElement provide.",
+    "Execute JavaScript in a tab's page context with full DOM access. Pass `tab` (handle from the tab legend or listTabs). Requires user approval before each execution. Use when you need complex DOM manipulation or access to page JavaScript variables/state beyond what readPage/clickElement/typeInElement provide.",
   parameters,
   outputSchema,
   approval: { required: true },
-  execute: async ({ code, args }, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle, code, args }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     if (tab.id == null) {
-      return { error: "No active tab available" };
+      return { tab: handle, error: "Tab id missing" };
     }
 
     let parsedArgs: unknown = null;
@@ -58,17 +65,17 @@ export const executeOnPageTool: BrowserTool<Input, Output> = {
     ]);
 
     if (evalResult === "timeout") {
-      return { error: "Execution timed out after 30s" };
+      return { tab: handle, error: "Execution timed out after 30s" };
     }
 
     if (evalResult.exceptionDetails) {
       const ex = evalResult.exceptionDetails;
       const msg = ex.exception?.description ?? ex.text ?? "Unknown error";
-      return { error: msg };
+      return { tab: handle, error: msg };
     }
 
     // Assume successful execution may have modified the DOM
     invalidateRefs(tab.id);
-    return { result: evalResult.result?.value ?? null };
+    return { tab: handle, result: evalResult.result?.value ?? null };
   },
 };

--- a/apps/extension/src/lib/agent/tools/extract.ts
+++ b/apps/extension/src/lib/agent/tools/extract.ts
@@ -1,6 +1,7 @@
 import { generateObject, jsonSchema } from "ai";
 import { z } from "zod";
 import { getCurrentAgentModel } from "../agent-transport";
+import { resolveTabOrThrow } from "../driver";
 import { captureSnapshot, captureSnapshotWithUrlIds } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
 
@@ -35,6 +36,11 @@ type JSONSchemaObject = {
 type UrlPath = (string | "*")[];
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to extract from (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   instruction: z
     .string()
     .describe(
@@ -56,6 +62,7 @@ const parameters = z.object({
 
 type Input = z.infer<typeof parameters>;
 type Output = {
+  tab: string;
   data: unknown;
   warnings?: string[];
 };
@@ -73,9 +80,9 @@ Rules:
 export const extractTool: BrowserTool<Input, Output> = {
   name: "extract",
   description:
-    "Extract structured data from the current page using its accessibility tree. Provide an instruction (what to extract) and optionally a JSON Schema (output shape) and a CSS selector (subtree scope). Preferred over raw DOM-scraping via executeOnPage for text-based data like search results, product lists, table rows, or article content. For URL fields in the schema, use {type: 'string', format: 'uri'} — the tool substitutes URLs with numeric IDs to prevent hallucination and rehydrates them automatically.",
+    "Extract structured data from a tab using its accessibility tree. Pass `tab` (handle from the tab legend or listTabs), an `instruction` (what to extract), optionally a JSON Schema (output shape) and a CSS selector (subtree scope). Preferred over raw DOM-scraping via executeOnPage for text-based data like search results, product lists, table rows, or article content. For URL fields in the schema, use {type: 'string', format: 'uri'} — the tool substitutes URLs with numeric IDs to prevent hallucination and rehydrates them automatically.",
   parameters,
-  execute: async ({ instruction, selector, schema }, ctx) => {
+  execute: async ({ tab: handle, instruction, selector, schema }, ctx) => {
     const model = getCurrentAgentModel();
     if (!model) {
       // Invariant: if the tool is running, the agent is running, so the model
@@ -85,7 +92,7 @@ export const extractTool: BrowserTool<Input, Output> = {
       );
     }
 
-    const tab = await ctx.driver.getActiveTab();
+    const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
 
     // Normalize the user-supplied schema. Some LLMs (notably Claude) hedge on
@@ -197,8 +204,8 @@ export const extractTool: BrowserTool<Input, Output> = {
     rehydrateUrls(object, urlPaths, urlMap, warnings);
 
     return warnings.length > 0
-      ? { data: object, warnings }
-      : { data: object };
+      ? { tab: handle, data: object, warnings }
+      : { tab: handle, data: object };
   },
 };
 

--- a/apps/extension/src/lib/agent/tools/navigate.ts
+++ b/apps/extension/src/lib/agent/tools/navigate.ts
@@ -1,18 +1,20 @@
 import { z } from "zod";
-import { handleForTab } from "../driver";
+import { handleForTab, resolveTabOrThrow } from "../driver";
 import { invalidateRefs } from "../ref-store";
 import { captureSnapshot } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
 
-const parameters = z.object({
-  url: z.string().describe("The URL to navigate to"),
-  newTab: z
-    .boolean()
-    .optional()
-    .describe(
-      "Force opening a new tab instead of reusing the current one. Useful when you want to keep the current page open for comparison.",
-    ),
-});
+const parameters = z
+  .object({
+    url: z.string().describe("The URL to navigate to"),
+    tab: z
+      .string()
+      .optional()
+      .describe(
+        "Tab handle (e.g. 't1') to navigate. Omit to open a new background tab — that's the only way to acquire a fresh handle, e.g. on the first action of a conversation. See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+      ),
+  })
+  .strict();
 
 type Input = z.infer<typeof parameters>;
 
@@ -29,30 +31,34 @@ type Output = z.infer<typeof outputSchema>;
 export const navigateTool: BrowserTool<Input, Output> = {
   name: "navigate",
   description:
-    "Navigate to a URL. Reuses the current agent-owned tab if one exists, otherwise opens a new background tab. Pass newTab: true to force a new tab. The response automatically includes a snapshot of the landed page so you can interact immediately.",
+    "Navigate to a URL. Pass `tab` to navigate an existing tab (the response includes that handle); omit `tab` to open a new background tab and receive a fresh handle in the response. The response automatically includes a snapshot of the landed page so you can interact immediately. Use this as the first action of a conversation when you have no handles yet.",
   parameters,
   outputSchema,
-  execute: async ({ url, newTab }, ctx) => {
-    let tabId = null as null | ReturnType<typeof ctx.driver.getActiveTabId>;
+  execute: async ({ url, tab: handle }, ctx) => {
+    let tabId: ReturnType<typeof ctx.driver.getActiveTabId> = null;
     let createdNew = false;
 
-    if (!newTab) {
-      const currentTarget = ctx.driver.getActiveTabId();
-      if (currentTarget != null) {
-        const owned =
-          (await ctx.session?.isAgentOwnedTab?.(currentTarget)) ?? false;
-        if (owned) {
-          try {
-            await ctx.driver.updateTabUrl(currentTarget, url);
-            tabId = currentTarget;
-          } catch {
-            // Tab may have been closed; fall through to create new
-          }
-        }
+    if (handle) {
+      // Navigate the named tab. We deliberately allow the agent to navigate
+      // a tab it didn't open ("user-shared tab"); the only restriction is
+      // that the handle must resolve.
+      const target = await resolveTabOrThrow(ctx, handle);
+      try {
+        await ctx.driver.updateTabUrl(target.id, url);
+        tabId = target.id;
+      } catch (err) {
+        return {
+          navigated: true,
+          url,
+          tab: handle,
+          note: `Failed to navigate ${handle}: ${
+            err instanceof Error ? err.message : String(err)
+          }. The tab may have been closed.`,
+        } as Output;
       }
-    }
-
-    if (tabId == null) {
+    } else {
+      // No handle → create a new background tab. This is the bootstrap
+      // path used on the first action of a conversation.
       tabId = await ctx.driver.createTab(url, { active: false });
       createdNew = true;
     }
@@ -65,7 +71,7 @@ export const navigateTool: BrowserTool<Input, Output> = {
     invalidateRefs(tabId);
     await ctx.driver.waitForLoad(tabId);
 
-    const handle = handleForTab(ctx, tabId);
+    const resolvedHandle = handleForTab(ctx, tabId);
 
     // Auto-attach initial snapshot so the agent can act on the new page
     // without a follow-up snapshot call.
@@ -74,7 +80,7 @@ export const navigateTool: BrowserTool<Input, Output> = {
       return {
         navigated: true,
         url,
-        tab: handle,
+        tab: resolvedHandle,
         snapshot: snapshotText,
         refCount: refs.size,
       };
@@ -82,7 +88,7 @@ export const navigateTool: BrowserTool<Input, Output> = {
       return {
         navigated: true,
         url,
-        tab: handle,
+        tab: resolvedHandle,
         note: `Navigation succeeded but initial snapshot failed: ${
           err instanceof Error ? err.message : String(err)
         }. Call snapshot to retry.`,

--- a/apps/extension/src/lib/agent/tools/navigate.ts
+++ b/apps/extension/src/lib/agent/tools/navigate.ts
@@ -19,12 +19,13 @@ const parameters = z
 type Input = z.infer<typeof parameters>;
 
 const outputSchema = z.object({
-  navigated: z.literal(true),
+  navigated: z.boolean(),
   url: z.string(),
-  tab: z.string(),
+  tab: z.string().optional(),
   snapshot: z.string().optional(),
   refCount: z.number().optional(),
   note: z.string().optional(),
+  error: z.string().optional(),
 });
 type Output = z.infer<typeof outputSchema>;
 
@@ -47,14 +48,14 @@ export const navigateTool: BrowserTool<Input, Output> = {
         await ctx.driver.updateTabUrl(target.id, url);
         tabId = target.id;
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         return {
-          navigated: true,
+          navigated: false,
           url,
           tab: handle,
-          note: `Failed to navigate ${handle}: ${
-            err instanceof Error ? err.message : String(err)
-          }. The tab may have been closed.`,
-        } as Output;
+          error: message,
+          note: `Failed to navigate ${handle}: ${message}. The tab may have been closed.`,
+        };
       }
     } else {
       // No handle → create a new background tab. This is the bootstrap

--- a/apps/extension/src/lib/agent/tools/read-page.ts
+++ b/apps/extension/src/lib/agent/tools/read-page.ts
@@ -1,11 +1,19 @@
 import { z } from "zod";
 import type { BrowserTool } from "../types";
+import { resolveTabOrThrow } from "../driver";
 
-const parameters = z.object({});
+const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to read (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
+});
 
 type Input = z.infer<typeof parameters>;
 
 const outputSchema = z.object({
+  tab: z.string(),
   url: z.string(),
   title: z.string(),
   h1: z.string(),
@@ -18,15 +26,16 @@ type Output = z.infer<typeof outputSchema>;
 export const readPageTool: BrowserTool<Input, Output> = {
   name: "readPage",
   description:
-    "Read the content of the user's active browsing tab. Returns the page URL, title, headings, description, body text (first 10k chars), and up to 50 links.",
+    "Read the content of a tab. Pass `tab` (handle from the tab legend or listTabs). Returns the URL, title, headings, description, body text (first 10k chars), and up to 50 links.",
   parameters,
   outputSchema,
-  execute: async (_input, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     const url = tab.url ?? "";
 
     if (url.startsWith("chrome-extension://") || url.startsWith("chrome://")) {
       return {
+        tab: handle,
         url,
         title: tab.title ?? "",
         h1: "",
@@ -36,8 +45,10 @@ export const readPageTool: BrowserTool<Input, Output> = {
       };
     }
 
-    return await ctx.driver.sendToContentScript<Output>(tab.id, {
-      type: "CHAT_EXTRACT_CONTENT",
-    });
+    const result = await ctx.driver.sendToContentScript<Omit<Output, "tab">>(
+      tab.id,
+      { type: "CHAT_EXTRACT_CONTENT" },
+    );
+    return { tab: handle, ...result };
   },
 };

--- a/apps/extension/src/lib/agent/tools/screenshot.ts
+++ b/apps/extension/src/lib/agent/tools/screenshot.ts
@@ -1,9 +1,15 @@
 import { z } from "zod";
 import type { BrowserDriver, TabId } from "../driver";
+import { resolveTabOrThrow } from "../driver";
 import { getRefsForTab, type RefEntry } from "../ref-store";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to capture (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   annotate: z
     .boolean()
     .optional()
@@ -19,6 +25,7 @@ const parameters = z.object({
 type Input = z.infer<typeof parameters>;
 
 const outputSchema = z.object({
+  tab: z.string(),
   imageDataUrl: z.string().optional(),
   annotatedCount: z.number().optional(),
   annotationError: z.string().optional(),
@@ -29,11 +36,11 @@ type Output = z.infer<typeof outputSchema>;
 export const screenshotTool: BrowserTool<Input, Output> = {
   name: "screenshot",
   description:
-    "Capture a screenshot of the target tab (set via selectTab, or the active browsing tab). Works even if the tab is not focused. Use annotate: true to overlay @ref labels from the most recent snapshot — useful when the page has visual complexity the accessibility tree doesn't capture well. The response includes annotatedCount when annotation succeeded; if annotation was requested but failed, an annotationError field explains why.",
+    "Capture a screenshot of a tab. Pass `tab` (handle from the tab legend or listTabs). Works even if the tab is not focused. Use annotate: true to overlay @ref labels from the most recent snapshot — useful when the page has visual complexity the accessibility tree doesn't capture well. The response includes annotatedCount when annotation succeeded; if annotation was requested but failed, an annotationError field explains why.",
   parameters,
   outputSchema,
-  execute: async ({ annotate, fullPage }, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle, annotate, fullPage }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
 
     const captureParams: Record<string, unknown> = { format: "png" };
@@ -105,6 +112,7 @@ export const screenshotTool: BrowserTool<Input, Output> = {
     }
 
     const out: Output = {
+      tab: handle,
       imageDataUrl: `data:image/png;base64,${imageData}`,
     };
     if (annotatedCount != null) out.annotatedCount = annotatedCount;

--- a/apps/extension/src/lib/agent/tools/scroll-page.ts
+++ b/apps/extension/src/lib/agent/tools/scroll-page.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
+import { resolveTabOrThrow } from "../driver";
 import { invalidateRefs } from "../ref-store";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to scroll (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   direction: z
     .enum(["up", "down"])
     .describe("Direction to scroll"),
@@ -15,6 +21,7 @@ const parameters = z.object({
 type Input = z.infer<typeof parameters>;
 
 const outputSchema = z.object({
+  tab: z.string(),
   scrolled: z.literal(true),
   direction: z.string(),
   amount: z.number(),
@@ -24,11 +31,11 @@ type Output = z.infer<typeof outputSchema>;
 export const scrollPageTool: BrowserTool<Input, Output> = {
   name: "scrollPage",
   description:
-    "Scroll the user's active page up or down. Useful for revealing content below the fold or navigating back to the top.",
+    "Scroll a page up or down. Pass `tab` (handle from the tab legend or listTabs). Useful for revealing content below the fold or navigating back to the top.",
   parameters,
   outputSchema,
-  execute: async ({ direction, amount }, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle, direction, amount }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     const pixels = amount ?? 600;
 
     const result = await ctx.driver.sendToContentScript<{
@@ -43,6 +50,6 @@ export const scrollPageTool: BrowserTool<Input, Output> = {
     if (!result.success)
       throw new Error(result.error ?? "Failed to scroll");
     invalidateRefs(tab.id);
-    return { scrolled: true, direction, amount: pixels };
+    return { tab: handle, scrolled: true, direction, amount: pixels };
   },
 };

--- a/apps/extension/src/lib/agent/tools/select-tab.ts
+++ b/apps/extension/src/lib/agent/tools/select-tab.ts
@@ -4,7 +4,9 @@ import type { BrowserTool } from "../types";
 const parameters = z.object({
   tab: z
     .string()
-    .describe("Tab handle from listTabs (e.g. 't1', 't2')"),
+    .describe(
+      "Tab handle from listTabs (e.g. 't1'). Use this to bind a tab the agent didn't open (e.g. one the user already had) into the conversation so subsequent tool calls can address it.",
+    ),
 });
 
 type Input = z.infer<typeof parameters>;
@@ -14,7 +16,7 @@ type Output = { selected: true; tab: string };
 export const selectTabTool: BrowserTool<Input, Output> = {
   name: "selectTab",
   description:
-    "Set which tab tools like readPage/clickElement/typeInElement/snapshot should target. Does NOT switch the user's visible tab. Use handles from listTabs.",
+    "Bind an external (user-opened) tab into this conversation so it appears in the tab legend and can be passed as the `tab` arg to other tools. Does NOT switch the user's visible tab. Use handles from listTabs.",
   parameters,
   execute: async ({ tab }, ctx) => {
     let tabId = ctx.session?.resolveHandle?.(tab);
@@ -34,13 +36,10 @@ export const selectTabTool: BrowserTool<Input, Output> = {
     const target = tabs.find((t) => t.id === tabId);
     if (!target) throw new Error(`Tab ${tabId} not found`);
 
-    // Only fold into the agent's tab group if one already exists. Creating
-    // a group from selectTab alone would be too aggressive — the agent may
-    // just be peeking at an existing tab.
-    const hasGroup = (await ctx.session?.hasOwnedTabGroup?.()) ?? false;
-    if (hasGroup) {
-      await ctx.session?.bindActiveTabToConversation?.(tabId);
-    }
+    // Always fold into the conversation's owned tabs so the tab appears in
+    // the agent's tab legend on subsequent turns. Binding into the group (if
+    // one exists) is a side effect of the same call.
+    await ctx.session?.bindActiveTabToConversation?.(tabId);
 
     await ctx.driver.setActiveTab(tabId);
     return { selected: true, tab };

--- a/apps/extension/src/lib/agent/tools/snapshot.ts
+++ b/apps/extension/src/lib/agent/tools/snapshot.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 import type { BrowserTool } from "../types";
+import { resolveTabOrThrow } from "../driver";
 import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to snapshot (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   mode: z
     .enum(["interactive", "full", "viewport"])
     .optional()
@@ -23,6 +29,7 @@ const parameters = z.object({
 
 type Input = z.infer<typeof parameters>;
 const outputSchema = z.object({
+  tab: z.string(),
   snapshot: z.string(),
   refCount: z.number(),
   url: z.string(),
@@ -34,11 +41,11 @@ type Output = z.infer<typeof outputSchema>;
 export const snapshotTool: BrowserTool<Input, Output> = {
   name: "snapshot",
   description:
-    "Get the page's accessibility tree with @refs for interactive elements. Use refs with clickElement/typeInElement. On heavy pages, scope with `selector` or use `mode: 'viewport'` to see only above-the-fold elements. Action tools (click/type/navigate) already auto-attach diffs — call this explicitly only when you need the full tree, a scoped view, or after executeOnPage.",
+    "Get a tab's accessibility tree with @refs for interactive elements. Pass `tab` (handle from the tab legend or listTabs). Use refs with clickElement/typeInElement. On heavy pages, scope with `selector` or use `mode: 'viewport'` to see only above-the-fold elements. Action tools (click/type/navigate) already auto-attach diffs — call this explicitly only when you need the full tree, a scoped view, or after executeOnPage.",
   parameters,
   outputSchema,
-  execute: async ({ mode, selector, diff }, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle, mode, selector, diff }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
     const url = tab.url ?? "";
 
@@ -53,6 +60,7 @@ export const snapshotTool: BrowserTool<Input, Output> = {
       });
 
     const baseResult: Output = {
+      tab: handle,
       snapshot:
         diff && previous
           ? (diffSnapshots(previous, snapshotText) ?? "(no changes)")

--- a/apps/extension/src/lib/agent/tools/type-in-element.ts
+++ b/apps/extension/src/lib/agent/tools/type-in-element.ts
@@ -90,21 +90,9 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     }
 
     if (shouldPressEnter) {
-      await ctx.driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
-        type: "keyDown",
-        key: "Enter",
-        code: "Enter",
-        windowsVirtualKeyCode: 13,
-        nativeVirtualKeyCode: 13,
-      });
-      await ctx.driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
-        type: "keyUp",
-        key: "Enter",
-        code: "Enter",
-        windowsVirtualKeyCode: 13,
-        nativeVirtualKeyCode: 13,
-      });
-
+      // Wait for any navigation the Enter key may have triggered to settle.
+      // The Enter dispatch itself happened inside the try block above; this
+      // post-action block is purely settle/wait, no second dispatch.
       await new Promise((r) => setTimeout(r, 200));
       await ctx.driver.waitForLoad(tabId, 8000).catch(() => {});
     }

--- a/apps/extension/src/lib/agent/tools/type-in-element.ts
+++ b/apps/extension/src/lib/agent/tools/type-in-element.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
 import type { BrowserDriver, TabId } from "../driver";
+import { resolveTabOrThrow } from "../driver";
 import { getRef, getPreviousSnapshot, invalidateRefs } from "../ref-store";
 import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to type in (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
   target: z
     .string()
     .describe(
@@ -27,6 +33,7 @@ const parameters = z.object({
 type Input = z.infer<typeof parameters>;
 
 const outputSchema = z.object({
+  tab: z.string(),
   typed: z.literal(true),
   target: z.string(),
   text: z.string(),
@@ -39,11 +46,11 @@ type Output = z.infer<typeof outputSchema>;
 export const typeInElementTool: BrowserTool<Input, Output> = {
   name: "typeInElement",
   description:
-    "Type text into an input or textarea. Use @ref from snapshot (preferred) or a CSS selector. Pass submit: true to press Enter and wait for the page to settle. The response automatically includes a diff of what changed on the page.",
+    "Type text into an input or textarea. Pass `tab` (handle from the tab legend or listTabs) and `target` — either an @ref from a recent snapshot of THAT tab (preferred) or a CSS selector as fallback. Pass submit: true to press Enter and wait for the page to settle. The response automatically includes a diff of what changed on the page.",
   parameters,
   outputSchema,
-  execute: async ({ target, text, clearFirst, submit }, ctx) => {
-    const tab = await ctx.driver.getActiveTab();
+  execute: async ({ tab: handle, target, text, clearFirst, submit }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
 
     const previousSnapshot = getPreviousSnapshot(tabId);
@@ -105,6 +112,7 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     invalidateRefs(tabId);
 
     const baseResult = {
+      tab: handle,
       typed: true as const,
       target,
       text,

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -3,6 +3,19 @@ import { queueDb } from "./queue-db";
 import type { SerializedUIPart, TodoItem } from "./types";
 import { OPFS } from "./vfs/opfs";
 
+/**
+ * Persisted handle map for a conversation. Handles (`t1`, `t2`, ...) are
+ * stable identifiers the agent uses to address tabs in tool args. Backed
+ * by a sync in-memory cache in `tab-handles.ts`; this field lets the cache
+ * survive service-worker restarts and conversation switches.
+ */
+export interface PersistedHandleState {
+  /** handle → chrome tab id */
+  handles: Record<string, number>;
+  /** Next handle counter (1-based, monotonic per conversation). */
+  counter: number;
+}
+
 interface ChatDB extends DBSchema {
   conversations: {
     key: string;
@@ -13,6 +26,7 @@ interface ChatDB extends DBSchema {
       ownedGroupId: number | null;
       ownedTabIds: number[];
       todos?: TodoItem[];
+      handleState?: PersistedHandleState;
       createdAt: number;
       updatedAt: number;
     };
@@ -50,7 +64,10 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
     // v7: migrates legacy `{ type: "compaction", auto, ... }` parts
     // to the AI SDK's DataUIPart contract:
     // `{ type: "data-compaction", data: { auto, ... } }`.
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 7, {
+    // v8: introduces `handleState` (tab-handle persistence) on conversations.
+    // No data migration: the field is optional and tab-handles.ts treats
+    // missing/empty state as a fresh map starting at counter 1.
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 8, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -156,6 +173,11 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
           };
           migrateCompactionParts();
         }
+        if (oldVersion < 8) {
+          // `handleState` is optional on the conversation record; tab-handles.ts
+          // treats `undefined` as "fresh map, counter starts at 1". No data
+          // backfill required — the schema bump only signals the field exists.
+        }
       },
     });
   }
@@ -184,8 +206,16 @@ export const chatDb = {
   },
 
   async createConversation(
-    conv: Omit<ChatDB["conversations"]["value"], "ownedGroupId" | "ownedTabIds" | "todos"> &
-      Partial<Pick<ChatDB["conversations"]["value"], "ownedGroupId" | "ownedTabIds" | "todos">>,
+    conv: Omit<
+      ChatDB["conversations"]["value"],
+      "ownedGroupId" | "ownedTabIds" | "todos" | "handleState"
+    > &
+      Partial<
+        Pick<
+          ChatDB["conversations"]["value"],
+          "ownedGroupId" | "ownedTabIds" | "todos" | "handleState"
+        >
+      >,
   ): Promise<void> {
     const db = await getDb();
     await db.put("conversations", {
@@ -214,10 +244,17 @@ export const chatDb = {
     updates: Partial<ChatDB["conversations"]["value"]>,
   ): Promise<void> {
     const db = await getDb();
-    const existing = await db.get("conversations", id);
+    // Read-modify-write inside a single transaction. idb serializes
+    // readwrite transactions on the same store within a connection, so
+    // concurrent updateConversation calls can't drop each other's writes
+    // (which would happen with a separate db.get / db.put pair if a
+    // second writer's `get` raced with the first writer's `put`).
+    const tx = db.transaction("conversations", "readwrite");
+    const existing = await tx.store.get(id);
     if (existing) {
-      await db.put("conversations", { ...existing, ...updates });
+      await tx.store.put({ ...existing, ...updates });
     }
+    await tx.done;
     // Only broadcast for fields that materially affect conversation-list UIs.
     // Excludes high-frequency churn like `updatedAt` (per message turn),
     // `ownedTabIds`/`ownedGroupId` (tab-scoping reconciliation), and `todos`
@@ -328,5 +365,13 @@ export const chatDb = {
       await tx.store.delete(msg.id);
     }
     await tx.done;
+  },
+
+  /**
+   * Test/debug helper. Reset the in-memory db handle so a fresh
+   * `indexedDB` (e.g. fake-indexeddb in tests) is opened on next call.
+   */
+  _resetForTests(): void {
+    dbPromise = null;
   },
 };

--- a/apps/extension/test-setup.ts
+++ b/apps/extension/test-setup.ts
@@ -1,0 +1,59 @@
+/**
+ * Vitest setup file. Provides a minimal `globalThis.chrome` stub so modules
+ * that touch `chrome.runtime`, `chrome.tabs`, `chrome.storage`, etc. at
+ * module-construction time can load in the Node test environment.
+ *
+ * Tests that need specific chrome behavior should `vi.stubGlobal("chrome", ...)`
+ * at the start of the relevant test or beforeEach — the stub here is a
+ * minimum-viable shim, not a full mock.
+ */
+
+if (typeof (globalThis as { chrome?: unknown }).chrome === "undefined") {
+  const noop = () => {};
+  const noopReturning = <T>(fallback: T) => () => fallback;
+  (globalThis as { chrome?: unknown }).chrome = {
+    runtime: {
+      id: "test-extension",
+      onMessage: {
+        addListener: noop,
+        removeListener: noop,
+        hasListener: noopReturning(false),
+      },
+      sendMessage: () => Promise.resolve({ ok: true }),
+      onStartup: { addListener: noop },
+      onInstalled: { addListener: noop },
+      getURL: (path: string) => `chrome-extension://test/${path}`,
+      lastError: undefined as unknown,
+    },
+    tabs: {
+      onRemoved: { addListener: noop, removeListener: noop },
+      onUpdated: { addListener: noop, removeListener: noop },
+      onActivated: { addListener: noop, removeListener: noop },
+      get: () => Promise.reject(new Error("chrome.tabs.get not stubbed")),
+      query: () => Promise.resolve([] as never[]),
+      sendMessage: () => Promise.resolve(undefined),
+    },
+    storage: {
+      local: {
+        get: () => Promise.resolve({}),
+        set: () => Promise.resolve(),
+        remove: () => Promise.resolve(),
+      },
+      onChanged: { addListener: noop, removeListener: noop },
+    },
+    windows: {
+      getCurrent: () => Promise.resolve({ id: 1 }),
+    },
+    debugger: {
+      onDetach: { addListener: noop, removeListener: noop },
+      onEvent: { addListener: noop, removeListener: noop },
+      attach: () => Promise.resolve(),
+      detach: () => Promise.resolve(),
+      sendCommand: () => Promise.resolve({}),
+    },
+    scripting: {
+      executeScript: () => Promise.resolve([]),
+      insertCSS: () => Promise.resolve(),
+    },
+  };
+}

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    setupFiles: ["./test-setup.ts"],
   },
   resolve: {
     alias: {

--- a/packages/bench/src/drivers/playwright-driver.ts
+++ b/packages/bench/src/drivers/playwright-driver.ts
@@ -227,6 +227,12 @@ export class PlaywrightDriver implements BrowserDriver {
     return await this.toTabInfo(tracked);
   }
 
+  async getTab(tabId: TabId): Promise<BrowserTabInfo> {
+    this.checkCrashed();
+    const tracked = await this.requirePage(tabId);
+    return await this.toTabInfo(tracked);
+  }
+
   async setActiveTab(tabId: TabId | null): Promise<void> {
     this.checkCrashed();
     if (tabId != null && !this.pages.has(tabId)) {

--- a/packages/bench/src/drivers/visualizing-driver.ts
+++ b/packages/bench/src/drivers/visualizing-driver.ts
@@ -193,6 +193,10 @@ export class VisualizingDriver implements BrowserDriver {
     return this.inner.getActiveTab();
   }
 
+  getTab(tabId: TabId): Promise<BrowserTabInfo> {
+    return this.inner.getTab(tabId);
+  }
+
   setActiveTab(tabId: TabId | null): Promise<void> {
     return this.inner.setActiveTab(tabId);
   }

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -16,7 +16,7 @@
 
 import type { LanguageModel } from "ai";
 import { resolve } from "node:path";
-import type { BrowserDriver, ToolContext, TabId } from "@agent/driver";
+import type { BrowserDriver, ToolContext } from "@agent/driver";
 import {
   buildTabLegendEntries,
   renderTabLegend,
@@ -281,14 +281,9 @@ async function runTrialInner(
     const driverForLegend = driver;
     const legendEntries = await buildTabLegendEntries({
       conversationId: "bench",
-      ownedTabIds: [initialTabId as number],
+      ownedTabIds: [initialTabId],
       getTab: async (tabId) => {
-        // The bench's BENCH_TOOL_CATALOG passes string ids through. Coerce
-        // to whatever shape the driver expects; PlaywrightDriver uses
-        // strings, ExtensionDriver uses numbers.
-        const info = await driverForLegend
-          .getTab(tabId as unknown as TabId)
-          .catch(() => null);
+        const info = await driverForLegend.getTab(tabId).catch(() => null);
         return { url: info?.url, title: info?.title };
       },
       getOrCreateHandle: (_cid, tabId) => String(tabId),

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -16,10 +16,15 @@
 
 import type { LanguageModel } from "ai";
 import { resolve } from "node:path";
-import type { BrowserDriver, ToolContext } from "@agent/driver";
+import type { BrowserDriver, ToolContext, TabId } from "@agent/driver";
+import {
+  buildTabLegendEntries,
+  renderTabLegend,
+} from "@agent/tab-legend";
 import {
   BENCH_TOOL_CATALOG,
   buildBenchAgent,
+  buildBenchSystemPrompt,
   DEFAULT_TOOL_SET,
   type BenchToolName,
 } from "./agent/build-agent";
@@ -234,15 +239,66 @@ async function runTrialInner(
       driver: driverFacade,
       session: {
         conversationId: null,
+        // Bench TabIds are already stable strings (`t0`, `t1`, ...) emitted
+        // by PlaywrightDriver, so we identity-map them as agent-facing
+        // handles. No persistence needed — bench trials are single-run.
+        getOrCreateHandle: (tabId) => String(tabId),
+        resolveHandle: (handle) => handle,
         isAgentOwnedTab: async () => true,
         getTodos: async () => trialTodos,
         setTodos: async (todos) => { trialTodos = todos; },
       },
     };
 
+    // Pre-navigate to the task's startUrl BEFORE building the agent so the
+    // initial tab can be included in the system-prompt tab legend. This
+    // mirrors how a user would start a session: "I'm on amazon.com, find
+    // me a keyboard." `createTab` returns the new tab id but doesn't pin
+    // it (mirrors the ExtensionDriver — pinning is the navigate tool's job
+    // in production). The runner pins explicitly here so the agent's
+    // first tool call has a valid working tab.
+    //
+    // We use the inner driver here (not the visualizing wrapper) because
+    // the initial setup navigation isn't a click/type action — no overlay
+    // needed.
+    const initialTabId = await driver.createTab(task.startUrl).catch((e) => {
+      throw {
+        kind: "infrastructure-error",
+        message: `Failed to navigate to start URL: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      };
+    });
+    await driver.setActiveTab(initialTabId);
+    await driver.waitForLoad(initialTabId);
+
+    // Build the system prompt with a one-tab legend for the pre-navigated
+    // page. Reuses the same builder/renderer as the production extension
+    // so bench trials see byte-for-byte the same prompt structure as
+    // chrome-side, and any future legend-format change propagates here
+    // automatically.
+    const baseSystemPrompt = config.systemPrompt ?? buildBenchSystemPrompt();
+    const driverForLegend = driver;
+    const legendEntries = await buildTabLegendEntries({
+      conversationId: "bench",
+      ownedTabIds: [initialTabId as number],
+      getTab: async (tabId) => {
+        // The bench's BENCH_TOOL_CATALOG passes string ids through. Coerce
+        // to whatever shape the driver expects; PlaywrightDriver uses
+        // strings, ExtensionDriver uses numbers.
+        const info = await driverForLegend
+          .getTab(tabId as unknown as TabId)
+          .catch(() => null);
+        return { url: info?.url, title: info?.title };
+      },
+      getOrCreateHandle: (_cid, tabId) => String(tabId),
+      activeTabId: initialTabId,
+    });
+    const promptWithLegend = `${baseSystemPrompt}\n\n${renderTabLegend(legendEntries)}`;
+
     const { agent, transport, getNeedsMidStreamCompaction } = buildBenchAgent(ctx, {
       model: config.model,
-      systemPrompt: config.systemPrompt,
+      systemPrompt: promptWithLegend,
       toolNames: config.toolNames,
       onStepFinish: (step) => {
         steps += 1;
@@ -261,24 +317,6 @@ async function runTrialInner(
         }
       },
     });
-
-    // Pre-navigate to the task's startUrl so the agent doesn't have to spend
-    // its first turn just opening the page. This mirrors how a user would
-    // start a session: "I'm on amazon.com, find me a keyboard."
-    //
-    // `createTab` returns the new tab id but doesn't pin it (mirrors the
-    // ExtensionDriver — pinning is the navigate tool's job in production).
-    // The runner pins explicitly here so the agent's first tool call has a
-    // valid working tab.
-    //
-    // We use the inner driver here (not the visualizing wrapper) because
-    // the initial setup navigation isn't a click/type action — no overlay
-    // needed.
-    const initialTabId = await driver.createTab(task.startUrl).catch(e => {
-      throw { kind: "infrastructure-error", message: `Failed to navigate to start URL: ${e instanceof Error ? e.message : String(e)}` };
-    });
-    await driver.setActiveTab(initialTabId);
-    await driver.waitForLoad(initialTabId);
 
     // Set up an abort controller for timeout
     const abortController = new AbortController();


### PR DESCRIPTION
## Why

Two real bugs in the agent's tab handling:

1. **"Always allow on `<domain>`" approval button never appeared.** The capture path (`onInputAvailable`) was defined in `agent-transport.ts:toSDKTool` but never wired into the returned `ToolSet` entry — silently broken since this code was written.
2. **`executeOnPage` (and friends) couldn't find a target tab when a conversation was started from `home.html`.** Tab resolution went via `getActiveUserTab()` which returned the user's currently-focused window. From `home.html` that's a `chrome-extension://` page, correctly rejected by the internal-page filter, so resolution threw with "No agent target tab" and the approval UI rendered with no `siteOrigin`.

Root cause for both: implicit "active tab" semantics. Fix: replace with explicit `tab` handle args on every tab-interacting tool, plus a per-turn tab legend injected into the system prompt so the agent knows what handles are available.

## What

- **Required `tab: string` arg** on `snapshot`, `readPage`, `screenshot`, `scrollPage`, `clickElement`, `typeInElement`, `executeOnPage`, `extract`. Schemas reject inputs missing `tab`. Tools resolve via `resolveTabOrThrow(ctx, handle)` instead of `ctx.driver.getActiveTab()`.
- **`navigate` is the bootstrap path:** omit `tab` to create a new background tab and receive a fresh handle in the response. `newTab` flag removed; `tab + newTab:true` would be ambiguous and is now rejected by `.strict()`.
- **`selectTab` always binds** the chosen tab into the conversation's owned-tabs (was conditional on having a tab group).
- **Stable handles per conversation** (`tab-handles.ts`): minted as `t1`, `t2`…, persisted to chatDb (`handleState` field, schema v8 with no-op data migration). Survives service-worker restarts. Hydration merges restored state into the live in-memory map (live wins on collision); aborts entirely if `clearHandles` ran mid-flight; prunes dead tabs.
- **Tab legend injection** in the system prompt, mirroring the existing `todoWrite` plan injection pattern. Owned-tabs only (the agent doesn't get nudged toward acting on the user's personal browsing).
- **Origin capture wired correctly:** `onInputAvailable` now reads `input.tab`, resolves it via the conversation's handle map, and populates `capturedToolOrigins` from the resolved tab's URL. Approval UI sees the origin on first render. Implicit host-tab binding removed (`agentHostTabId`, `hostTabIdOverride`, `resolveHostTabId` all gone — they only existed to feed the now-deleted binding code).
- **Bench alignment:** `runner.ts` pre-navigates to `task.startUrl` before building the agent, then injects a single-tab legend via the same `renderTabLegend(buildTabLegendEntries(...))` helpers production uses — bench prompt structure stays in lockstep with chrome-side. `BrowserDriver.getTab(tabId)` added; both `ExtensionDriver` and `PlaywrightDriver` implement it.

## Architecture notes

- `tab-handles.ts` persistence is fire-and-forget with per-conversation chains and write coalescing (so a `listTabs` enumerating 20 tabs produces 1 chatDb write, not 20). Only handles whose `tabId ∈ ownedTabIds` are written; ephemeral handles minted for non-owned tabs (preview/listTabs) stay in memory.
- `chatDb.updateConversation` now wraps its read-modify-write in a single `readwrite` transaction so concurrent writers (e.g. `bindTabsToConversation` in the background racing handle persistence during `navigate`) can't drop each other's fields.
- `notifyAgentStatus` uses `chrome.tabs.query` directly instead of `getActiveUserTab()` — the latter has a side effect of pinning `targetTabId` on bootstrap which used to leak into the legend's `[active]` marker.

## Test infrastructure

- New `apps/extension/test-setup.ts` registered as vitest `setupFile`. Provides a minimal `chrome.*` shim so modules that touch `chrome.runtime` / `chrome.debugger` / etc. at module-construction time can load in the Node test environment without `ReferenceError`.

## Verification

- `pnpm compile` clean across all workspaces.
- `pnpm -F openbrowse test` → **143/143 pass** (was 93 on `main`; +50 new tests covering tab-handles persistence/hydration/race fixes, schema requirements on each tool, and tab-legend rendering).
- `pnpm -F openbrowse build` clean.
- Manually validated end-to-end: home.html cold-start → `navigate({ url })` → executeOnPage → "Always allow on google.com" button appears and persists site to allowlist (`chrome.storage.local["tool-site-allowlist"]`). Reload extension, button stays gone for that origin.

## Breaking changes

- **Agent contract:** every tab-interacting tool now requires `tab`. In-flight tool calls from old conversation state will fail schema validation on resume; the agent recovers by calling `listTabs` and retrying.
- **chatDb v8:** new `handleState` field on conversations. Optional, no data backfill, existing v7 conversations open as if no handles exist (next `getOrCreateHandle` mints `t1`).
- **Bench baseline numbers:** prompt is longer (~300 tokens for the tab-handles documentation block) and tools changed shape — old bench numbers are not apples-to-apples. Plan to re-baseline after merge.

## Out of scope (intentional follow-ups)

- `executePython` is exported from `tools/index.ts` but not registered in `agent-transport.ts:browserTools`. Separate, smaller fix; called out earlier in the originating conversation.
- Multi-tab parallel dispatch in a single tool call. Now expressible with `tab` args, but no UI/prompt work to actually surface it; separate initiative.

## Commits

```
da6658d feat(agent): persist tab handles per conversation
7354b86 feat(agent): require tab arg on tab-interacting tools
871ccb5 feat(agent): inject tab legend into system prompt
8de9912 feat(agent): origin capture from explicit tab handle, drop implicit host-binding
f7d47c9 chore(bench): align bench harness with explicit tab args
28a3ef6 docs: explicit tab args + tab legend
```

33 files changed, +1564 / −293.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools and page actions now require explicit tab handles; navigate() without a tab opens a background tab and returns its handle.
  * Tool results now include the originating tab handle and tab-aware approvals/indicators.
  * Per-conversation tab-handle persistence and hydration across restarts.

* **Documentation**
  * Guides, system prompt, and tool reference updated for explicit tab-handle workflows.

* **Tests**
  * New tests covering tab-handle lifecycle, legend rendering, and tool contract changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->