### PR TITLE
chore: add changeset for v0.3.0

### DIFF
--- a/.changeset/explicit-tab-arg.md
+++ b/.changeset/explicit-tab-arg.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": minor
+---
+
+Agent: tab arguments on browser tools are now explicit (`tab: "t1"`) instead of relying on an implicit "active tab". Fixes the "Always allow on this domain" approval button not appearing when the agent acted from the home tab. Conversation tab handles persist across service worker restarts. (#39)


### PR DESCRIPTION
Drafts the release note for PR #39.

Merging this will trigger the `changesets` workflow to open a 'Version Packages' PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "Always allow on this domain" permission button failed to appear when performing actions from the home tab.
  * Improved conversation tab state persistence across service worker restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->