### PR TITLE
chore(release): make package.json the version source of truth

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["openbrowse-docs", "@openbrowse/connectors"]
+  "ignore": ["openbrowse-docs", "@openbrowse/connectors", "@openbrowse/bench"]
 }

--- a/.changeset/explicit-tab-arg.md
+++ b/.changeset/explicit-tab-arg.md
@@ -1,5 +1,5 @@
 ---
-"openbrowse": minor
+"openbrowse": patch
 ---
 
 Agent: tab arguments on browser tools are now explicit (`tab: "t1"`) instead of relying on an implicit "active tab". Fixes the "Always allow on this domain" approval button not appearing when the agent acted from the home tab. Conversation tab handles persist across service worker restarts. (#39)

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -51,8 +51,13 @@ jobs:
       - name: Open / update Version Packages PR (or tag release)
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          # Runs `pnpm version` (which calls `changeset version`).
-          version: pnpm version
+          # Inlined instead of `pnpm version` — under pnpm 11, the
+          # `version` token is intercepted as the built-in
+          # npm-compatible version command (which requires a bump
+          # arg) instead of running the root package.json script of
+          # the same name. Inlining the script body removes the
+          # dependency on script-vs-builtin resolution.
+          version: pnpm exec changeset version && pnpm install --lockfile-only
           # No npm publish — we do not publish to npm. The git tag
           # created here is the trigger for release.yml to build and
           # publish the GitHub Release zip.

--- a/apps/docs/content/docs/contributing/development.mdx
+++ b/apps/docs/content/docs/contributing/development.mdx
@@ -56,28 +56,13 @@ packages/
 
 ## Cutting a release
 
-OpenBrowse doesn't have release CI yet — releases are produced manually.
+Releases are driven by [Changesets](https://github.com/changesets/changesets).
 
-1. Bump `version` in `apps/extension/package.json` and the `version`
-   field in the `manifest` block of `apps/extension/wxt.config.ts`.
-   Keep them in sync.
-2. From the repo root:
-   ```bash
-   pnpm zip
-   ```
-   This builds the extension and packages it as
-   `apps/extension/.output/openbrowse-<version>-chrome.zip`.
-3. Tag the commit and push:
-   ```bash
-   git tag v<version>
-   git push origin v<version>
-   ```
-4. Create a GitHub Release for that tag and attach the zip. The docs'
-   [Install page](/docs/overview#manual-install-current) links to
-   `releases/latest`, so the new zip becomes the recommended download
-   automatically.
-5. Upload the same zip to the Chrome Web Store dashboard as a new
-   version of the listing.
+1. If a PR changes user-facing behavior, run `pnpm changeset` and commit the generated `.changeset/*.md` file. See [`.changeset/README.md`](https://github.com/openbrowse-ai/openbrowse/blob/main/.changeset/README.md).
+2. On every push to `main`, the **Changesets** workflow automatically opens or updates a "Version Packages" PR that bumps `apps/extension/package.json`, regenerates `apps/extension/CHANGELOG.md`, and consumes the changeset files.
+3. Merging the Version Packages PR creates a `vX.Y.Z` git tag.
+4. The tag triggers the **Release extension** workflow, which builds `apps/extension/.output/openbrowse-<version>-chrome.zip`, asserts the pinned manifest `key`, and publishes a GitHub Release with the zip attached. The docs' [Install page](/docs/overview#manual-install-current) links to `releases/latest`, so the new zip becomes the recommended manual download automatically.
+5. The Chrome Web Store upload is intentionally a manual step — log into the developer dashboard and upload the exact same zip from the GitHub release as a new version of the listing.
 
 import { Callout } from "fumadocs-ui/components/callout";
 

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -79,7 +79,6 @@ export default defineConfig({
   manifest: ({ mode }) => ({
     name: "OpenBrowse",
     description: "The open source browser agent.",
-    version: "0.2.1",
     // Pins the extension ID to the Chrome Web Store listing. Required so
     // that storage from manual / unpacked installs (loaded from a release
     // zip) carries over to the Web Store install: same `key` -> same


### PR DESCRIPTION
Fixes the release pipeline so the in-flight v0.2.2 release can ship correctly. Three latent bugs + one bump-type correction:

## What

- **`apps/extension/wxt.config.ts`**: removes the hardcoded `version: "0.2.1"` so WXT's manifest builder reads from `apps/extension/package.json`. Without this, Changesets-driven version bumps would never reach the published manifest.
- **`.github/workflows/changesets.yml`**: replaces `pnpm version` with `pnpm exec changeset version && pnpm install --lockfile-only`. Under pnpm 11, `pnpm version` is intercepted as the built-in npm-compat command (requires a bump arg) and the Changesets workflow has been silently failing.
- **`.changeset/config.json`**: adds `@openbrowse/bench` to the ignore list (was missing alongside `openbrowse-docs` and `@openbrowse/connectors`).
- **`.changeset/explicit-tab-arg.md`**: corrects bump type from `minor` to `patch` — #39 was a bug fix on the 0.2.x line, not a new feature.
- **`apps/docs/content/docs/contributing/development.mdx`**: rewrites the stale 'Cutting a release' section which claimed release CI did not exist.

## Verification

Verified locally on this branch:
- `pnpm compile` — clean
- `pnpm test` — 144/144
- `pnpm zip` — produces `openbrowse-0.2.1-chrome.zip` whose embedded manifest reports `"version": "0.2.1"` (matches package.json) with the pinned `key` intact.

## What happens after merge

The Changesets workflow runs against `main` with the pending `.changeset/explicit-tab-arg.md` and the now-fixed `version:` step. It should open a 'Version Packages' PR that bumps `apps/extension/package.json` 0.2.1 → 0.2.2 and regenerates `CHANGELOG.md`. Merging that PR creates the `v0.2.2` tag, which triggers `release.yml` to publish the GitHub Release zip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to reflect new automated workflow.

* **Bug Fixes**
  * Browser tool tab arguments are now explicitly specified for improved consistency.

* **Chores**
  * Updated build configuration and release automation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->