### PR TITLE
fix(ci): use `pnpm run version` in Changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -51,13 +51,16 @@ jobs:
       - name: Open / update Version Packages PR (or tag release)
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          # Inlined instead of `pnpm version` — under pnpm 11, the
-          # `version` token is intercepted as the built-in
-          # npm-compatible version command (which requires a bump
-          # arg) instead of running the root package.json script of
-          # the same name. Inlining the script body removes the
-          # dependency on script-vs-builtin resolution.
-          version: pnpm exec changeset version && pnpm install --lockfile-only
+          # `pnpm run version` (NOT `pnpm version`) — the latter is
+          # pnpm's built-in npm-compat command and would require a
+          # bump argument; `pnpm run` invokes the script alias from
+          # the root package.json, whose body
+          # (`changeset version && pnpm install --lockfile-only`)
+          # runs in sh so the `&&` chain is interpreted correctly.
+          # The Changesets action's `version:` input does not run
+          # commands through a shell, so chaining commands directly
+          # here would pass them as args to the first binary.
+          version: pnpm run version
           # No npm publish — we do not publish to npm. The git tag
           # created here is the trigger for release.yml to build and
           # publish the GitHub Release zip.


### PR DESCRIPTION
Two bugs surfaced when the Changesets workflow ran on main after #43:

1. **Inline command failed.** The `version:` input on `changesets/action` does not run through a shell, so `pnpm exec changeset version && pnpm install --lockfile-only` had the `&&` and trailing tokens passed as positional args to `changeset`, producing `Too many arguments passed to changesets`. Switching to `pnpm run version` invokes the existing root `package.json` script alias of the same name; its body `changeset version && pnpm install --lockfile-only` runs in sh and chains correctly, while still avoiding the original `pnpm version` builtin collision under pnpm 11.

2. **"GitHub Actions is not permitted to create or approve pull requests".** This is a separate repo setting (Settings → Actions → General → Workflow permissions), not a workflow change. It must be enabled separately for the Changesets workflow to be able to open the Version Packages PR.

Smoke-tested locally — `pnpm run version` produces:
- `apps/extension/package.json` 0.2.1 → 0.2.2
- New `## 0.2.2 / Patch Changes` entry in `apps/extension/CHANGELOG.md`
- `.changeset/explicit-tab-arg.md` consumed
- Lockfile regenerated to match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow configuration to ensure reliable version updates and release tagging processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->