### PR TITLE
chore(release): adopt Changesets workspace tag format

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -30,7 +30,7 @@ A markdown file is created in `.changeset/` — commit it with your PR.
 
 1. PRs land on `main`, each carrying a `.changeset/*.md`.
 2. The `Changesets` workflow (`.github/workflows/changesets.yml`) opens or updates a "Version Packages" PR that bumps `apps/extension/package.json`, regenerates `apps/extension/CHANGELOG.md`, and deletes the consumed changeset files.
-3. Merging the Version Packages PR creates a git tag `vX.Y.Z`.
+3. Merging the Version Packages PR creates a git tag `openbrowse@X.Y.Z` (Changesets' workspace tag format).
 4. The tag triggers `release.yml`, which builds the extension zip and publishes it as a GitHub Release.
 5. Chrome Web Store upload is still a deliberate manual step.
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["openbrowse-docs", "@openbrowse/connectors", "@openbrowse/bench"]
+  "ignore": ["openbrowse-docs", "@openbrowse/connectors", "@openbrowse/bench"],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
 }

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,8 +4,10 @@ name: Changesets
 #   - If there are pending changesets in .changeset/, open or update a
 #     "Version Packages" PR that bumps versions and updates CHANGELOG.
 #   - When that PR is merged, this workflow creates the matching git
-#     tag (e.g. v0.3.0). The existing release.yml workflow picks up the
-#     tag and publishes the GitHub Release zip.
+#     tag (e.g. openbrowse@0.2.3 — Changesets' workspace tag format
+#     for private packages, enabled via `privatePackages.tag` in
+#     .changeset/config.json). The release.yml workflow picks up
+#     the tag and publishes the GitHub Release zip (titled vX.Y.Z).
 #
 # Contributors who change user-facing behavior should run
 # `pnpm changeset` and commit the generated `.changeset/*.md` file.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release extension
 
 # Builds the Chrome extension and publishes it as a GitHub Release.
 #
-# Triggered by pushing a tag matching v* (e.g. v0.1.0), or manually via
-# the Actions UI. The workflow asserts that the tag's version matches
+# Triggered by pushing a tag matching v* or openbrowse@* (e.g.
+# openbrowse@0.2.2), or manually via the Actions UI. The workflow
+# asserts that the resolved version matches
 # apps/extension/package.json so a tag/manifest mismatch fails fast
 # rather than producing a confusing release.
 #
@@ -15,10 +16,11 @@ on:
   push:
     tags:
       - "v*"
+      - "openbrowse@*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to build (e.g. v0.1.0)"
+        description: "Existing tag to build (e.g. openbrowse@0.2.2 or v0.1.0)"
         required: true
 
 permissions:
@@ -43,8 +45,13 @@ jobs:
             TAG="${GITHUB_REF#refs/tags/}"
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          # Strip the leading 'v' for comparison against package.json.
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          # Strip whichever prefix is present. Changesets tags
+          # private workspace packages as 'openbrowse@X.Y.Z'; legacy
+          # tags use 'vX.Y.Z'. We accept both so workflow_dispatch
+          # against old tags still works.
+          VERSION="${TAG#v}"
+          VERSION="${VERSION#openbrowse@}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -105,6 +112,11 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
+          # Display the release on the Releases page as 'vX.Y.Z' even
+          # though the underlying tag is 'openbrowse@X.Y.Z' (Changesets
+          # workspace format). Keeps the GH release UI clean and
+          # backwards-compatible with the v0.1.x / v0.2.x history.
+          name: v${{ steps.tag.outputs.version }}
           files: apps/extension/.output/openbrowse-*-chrome.zip
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/openbrowse-ai/openbrowse/actions/workflows/ci.yml"><img src="https://github.com/openbrowse-ai/openbrowse/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/openbrowse-ai/openbrowse/releases/latest"><img src="https://img.shields.io/github/v/release/openbrowse-ai/openbrowse?display_name=tag&sort=semver" alt="Latest release"></a>
+  <a href="https://github.com/openbrowse-ai/openbrowse/releases/latest"><img src="https://img.shields.io/github/v/release/openbrowse-ai/openbrowse?display_name=release&sort=semver" alt="Latest release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/openbrowse-ai/openbrowse" alt="License: MIT"></a>
   <a href="https://discord.gg/v47UJ27TTa"><img src="https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://github.com/openbrowse-ai/openbrowse/stargazers"><img src="https://img.shields.io/github/stars/openbrowse-ai/openbrowse?style=flat" alt="GitHub stars"></a>

--- a/apps/docs/content/docs/contributing/development.mdx
+++ b/apps/docs/content/docs/contributing/development.mdx
@@ -60,8 +60,8 @@ Releases are driven by [Changesets](https://github.com/changesets/changesets).
 
 1. If a PR changes user-facing behavior, run `pnpm changeset` and commit the generated `.changeset/*.md` file. See [`.changeset/README.md`](https://github.com/openbrowse-ai/openbrowse/blob/main/.changeset/README.md).
 2. On every push to `main`, the **Changesets** workflow automatically opens or updates a "Version Packages" PR that bumps `apps/extension/package.json`, regenerates `apps/extension/CHANGELOG.md`, and consumes the changeset files.
-3. Merging the Version Packages PR creates a `vX.Y.Z` git tag.
-4. The tag triggers the **Release extension** workflow, which builds `apps/extension/.output/openbrowse-<version>-chrome.zip`, asserts the pinned manifest `key`, and publishes a GitHub Release with the zip attached. The docs' [Install page](/docs/overview#manual-install-current) links to `releases/latest`, so the new zip becomes the recommended manual download automatically.
+3. Merging the Version Packages PR creates an `openbrowse@X.Y.Z` git tag (Changesets' workspace tag format for private packages, enabled via `privatePackages.tag` in `.changeset/config.json`).
+4. The tag triggers the **Release extension** workflow, which builds `apps/extension/.output/openbrowse-<version>-chrome.zip`, asserts the pinned manifest `key`, and publishes a GitHub Release titled `vX.Y.Z` with the zip attached. The docs' [Install page](/docs/overview#manual-install-current) links to `releases/latest`, so the new zip becomes the recommended manual download automatically.
 5. The Chrome Web Store upload is intentionally a manual step — log into the developer dashboard and upload the exact same zip from the GitHub release as a new version of the listing.
 
 import { Callout } from "fumadocs-ui/components/callout";


### PR DESCRIPTION
Fixes the silent 'auto-tag' step in the Changesets release pipeline so v0.2.3+ ship fully automated.

## Root causes (both verified locally)

1. `changeset tag` skips private packages by default (`@changesets/cli/dist/changesets-cli.cjs.js:1304`: `allowPrivatePackages = config.privatePackages.tag`, default `false`). Our `openbrowse` package is `private: true`, so the Version Packages PR merge created no tag and `release.yml` never fired.
2. With `privatePackages.tag = true`, Changesets emits the workspace tag format `openbrowse@X.Y.Z` (`changesets-cli.cjs.js:1122`), not `vX.Y.Z`. Format isn't configurable.

## Changes

- **`.changeset/config.json`**: enable `privatePackages.{version, tag}`.
- **`.github/workflows/release.yml`**: trigger on both `openbrowse@*` (new) and `v*` (legacy / manual fallback). Strip whichever prefix is present before comparing against `apps/extension/package.json` version. Set GH Release `name` to `vX.Y.Z` so the Releases page stays clean despite the longer underlying tag.
- **`.github/workflows/changesets.yml`**: refresh header comment.
- **`apps/docs/content/docs/contributing/development.mdx` + `.changeset/README.md`**: document the new tag format.
- **`README.md`**: switch shields.io 'latest release' badge from `display_name=tag` to `display_name=release` so it follows the cleaner GH Release name.

## Local verification

- `pnpm install --lockfile-only` clean (no lockfile drift)
- `pnpm exec changeset tag` creates `openbrowse@0.2.2` against `main` (was silently no-op before)
- Strip logic round-trips both formats correctly:
  ```
  v0.1.0                 -> 0.1.0
  v0.2.1                 -> 0.2.1
  openbrowse@0.2.2       -> 0.2.2
  openbrowse@0.3.0       -> 0.3.0
  ```
- Local test tag deleted before commit.

## What happens after merge

This PR alone does **not** ship v0.2.2 (no pending changesets in `.changeset/` to trigger another Changesets run). To unblock v0.2.2 manually, after merging:

```bash
git checkout main && git pull --ff-only origin main
git tag openbrowse@0.2.2 298a9ec     # the existing version-bump commit
git push origin openbrowse@0.2.2
```

That tag triggers `release.yml`, which builds + publishes the GH Release `v0.2.2` with `openbrowse-0.2.2-chrome.zip` attached.

For v0.2.3+: fully automated — Changesets' tag step now succeeds end-to-end, no manual tagging needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to reflect current release practices.

* **Chores**
  * Enhanced GitHub Actions release workflow for improved tag format handling.
  * Updated README release badge to display latest release information.
  * Refined Changesets configuration for package versioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->