### PR TITLE
feat(bench): optional Cloudflare R2 upload for run artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "pnpm -r build",
     "build:firefox": "pnpm -F openbrowse build:firefox",
     "compile": "pnpm -r --parallel compile",
-    "test": "pnpm -F openbrowse test",
+    "test": "pnpm -r --parallel --if-present test",
     "refresh:models": "tsx scripts/refresh-models-snapshot.ts",
     "zip": "pnpm -F openbrowse zip",
     "zip:firefox": "pnpm -F openbrowse zip:firefox",

--- a/packages/bench/.env.example
+++ b/packages/bench/.env.example
@@ -24,3 +24,21 @@ GOOGLE_GENERATIVE_AI_API_KEY=
 
 # Kernel — required when running with `--driver kernel`
 KERNEL_API_KEY=
+
+# ─────────────────────────────────────────────────────────────────────
+# Optional: Cloudflare R2 upload.
+#
+# When all five R2_* vars below are set, `bench` automatically uploads
+# run artifacts (lightweight trial JSONs + zstd-compressed full traces +
+# videos) to your bucket alongside the local `.bench/runs/<run-id>/`
+# directory. To force off, pass `--no-upload`. To force on, pass
+# `--upload always`.
+#
+# Uploading also requires `--eval-set <name>` and `--arm <name>` so
+# manifests are traceable. The bench CLI errors out otherwise.
+# ─────────────────────────────────────────────────────────────────────
+R2_ACCOUNT_ID=
+R2_ENDPOINT=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -99,11 +99,21 @@ pnpm --filter @openbrowse/bench bench --suite webbench-mini \
 Layout in R2:
 
 ```
-runs/<run-id>/summary.json                    (lightweight; indefinite retention)
+runs/<run-id>/summary.json
 runs/<run-id>/trials/<task-id>.json           (lightweight, no trace[]/parts[])
-traces/<run-id>/<task-id>.json.zst            (full trace[] + parts[]; 365-day TTL)
-videos/<run-id>/<task-id>.{mp4,webm}          (90-day TTL)
+traces/<run-id>/<task-id>.json.zst            (full trace[] + parts[])
+videos/<run-id>/<task-id>.{mp4,webm}
 ```
+
+Retention is enforced by **R2 bucket lifecycle policies**, not by this
+package. Configure them once on your bucket; the bench just produces the
+prefix structure that the policies match against. Recommended policies:
+
+| Prefix | Retention | Why |
+|---|---|---|
+| `runs/*` | indefinite | Tiny structured data; cheap to keep |
+| `traces/*` | 365 days | Useful for historical comparison; ~10× smaller than videos |
+| `videos/*` | 90 days | Heavy; primarily for visual debugging recent runs |
 
 If an upload fails partway through (network blip, expired token, etc.), the partial progress is recorded in `<runDir>/.upload-state.json`. Re-running `bench` with `--upload always` on the same run dir resumes from where it left off — already-uploaded trials are skipped, only the remaining ones are sent. The state file is removed on full success and `manifest.json` becomes the source of truth.
 

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -64,6 +64,49 @@ The `llm-judge` evaluator uses Gemini 3.5 Flash, so
 
 To use the Kernel driver for parallel cloud execution, provide `KERNEL_API_KEY`.
 
+## Optional: Cloudflare R2 upload
+
+The bench can upload run artifacts to a Cloudflare R2 bucket alongside the local `.bench/runs/<run-id>/` directory. Useful for sharing traces in PRs, archiving large sweeps off-disk, and feeding downstream analysis tooling. **Entirely optional** — without R2 env vars, behavior is unchanged.
+
+To enable, populate these in `.env`:
+
+```bash
+R2_ACCOUNT_ID=...
+R2_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+R2_ACCESS_KEY_ID=...
+R2_SECRET_ACCESS_KEY=...
+R2_BUCKET=...
+```
+
+Then runs that pass `--eval-set <name> --arm <name>` will upload by default. Manifests are written to `<runDir>/manifest.json` and the local `videos/` directory is removed after a successful upload.
+
+```bash
+# Upload a sweep (auto-detects R2 env). The eval-set + arm names get
+# embedded in the run-id and manifest, so e.g. running the same suite
+# under two model configurations only differs by the --arm value.
+pnpm --filter @openbrowse/bench bench \
+  --suite webbench-mini --driver kernel \
+  --eval-set models-comparison --arm gpt-5
+
+# Force off
+pnpm --filter @openbrowse/bench bench --task example-com-heading --no-upload
+
+# Force on (errors if R2 env missing)
+pnpm --filter @openbrowse/bench bench --suite webbench-mini \
+  --eval-set my-experiment --arm a --upload always
+```
+
+Layout in R2:
+
+```
+runs/<run-id>/summary.json                    (lightweight; indefinite retention)
+runs/<run-id>/trials/<task-id>.json           (lightweight, no trace[]/parts[])
+traces/<run-id>/<task-id>.json.zst            (full trace[] + parts[]; 365-day TTL)
+videos/<run-id>/<task-id>.{mp4,webm}          (90-day TTL)
+```
+
+If an upload fails partway through (network blip, expired token, etc.), the partial progress is recorded in `<runDir>/.upload-state.json`. Re-running `bench` with `--upload always` on the same run dir resumes from where it left off — already-uploaded trials are skipped, only the remaining ones are sent. The state file is removed on full success and `manifest.json` becomes the source of truth.
+
 ## Architecture
 
 ```

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -6,6 +6,8 @@
   "description": "Evaluation harness for the OpenBrowse agent. Runs the agent headlessly via Playwright across a matrix of model × prompt × tool-set configurations.",
   "scripts": {
     "compile": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
     "bench": "tsx src/cli.ts",
     "baseline": "tsx scripts/bench-baseline.ts"
   },
@@ -13,6 +15,7 @@
     "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/google": "^3.0.64",
     "@ai-sdk/openai": "^3.0.53",
+    "@aws-sdk/client-s3": "^3.1054.0",
     "@huggingface/hub": "^2.12.0",
     "@onkernel/sdk": "^0.55.0",
     "ai": "^6.0.168",
@@ -28,6 +31,7 @@
     "pixelmatch": "^7.2.0",
     "pngjs": "^7.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   }
 }

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "description": "Evaluation harness for the OpenBrowse agent. Runs the agent headlessly via Playwright across a matrix of model × prompt × tool-set configurations.",
+  "engines": {
+    "node": ">=22.15"
+  },
   "scripts": {
     "compile": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/packages/bench/src/cli.ts
+++ b/packages/bench/src/cli.ts
@@ -818,6 +818,20 @@ async function main(): Promise<void> {
         : r2EnvPresent();
 
   if (shouldUpload) {
+    // Defense-in-depth: the early validation block above already guarded
+    // this combination, but re-evaluating `auto` against current env may
+    // flip the decision. Re-check here so we never reach `uploadRun`
+    // with missing eval-set/arm.
+    if (!args.evalSet || !args.arm) {
+      console.error(
+        "ERROR: upload requires both --eval-set and --arm. " +
+          "Either pass both flags, or use --no-upload to skip upload.",
+      );
+      process.exit(2);
+    }
+    const evalSet = args.evalSet;
+    const arm = args.arm;
+
     console.log("");
     console.log(`Uploading to R2 (bucket=${process.env.R2_BUCKET})...`);
     const uploadStart = Date.now();
@@ -826,8 +840,8 @@ async function main(): Promise<void> {
       const manifest = await uploadRun({
         paths,
         runId,
-        evalSet: args.evalSet!,
-        arm: args.arm!,
+        evalSet,
+        arm,
         deps: { s3Client: client, bucket },
       });
       const uploadDuration = ((Date.now() - uploadStart) / 1000).toFixed(1);

--- a/packages/bench/src/cli.ts
+++ b/packages/bench/src/cli.ts
@@ -44,6 +44,12 @@ interface CliArgs {
   outDir?: string;
   driverKind: "local" | "kernel";
   concurrency: number;
+  /** R2 upload mode. `auto` = upload iff R2 env vars are set; `always` = upload (error if env missing); `never` = skip. */
+  upload: "auto" | "always" | "never";
+  /** Eval-set name (used in run-id and manifest when upload happens). */
+  evalSet?: string;
+  /** Arm name within the eval-set. */
+  arm?: string;
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -59,6 +65,7 @@ function parseArgs(argv: string[]): CliArgs {
     driverKind: "local",
     concurrency: 0, // 0 means default later
     seed: 42,
+    upload: "auto",
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -126,6 +133,24 @@ function parseArgs(argv: string[]): CliArgs {
       case "--concurrency":
         out.concurrency = parseInt(argv[++i], 10) || 0;
         break;
+      case "--upload": {
+        const v = argv[++i];
+        if (v !== "auto" && v !== "always" && v !== "never") {
+          console.error(`--upload must be one of: auto, always, never`);
+          process.exit(2);
+        }
+        out.upload = v;
+        break;
+      }
+      case "--no-upload":
+        out.upload = "never";
+        break;
+      case "--eval-set":
+        out.evalSet = argv[++i];
+        break;
+      case "--arm":
+        out.arm = argv[++i];
+        break;
       case "--help":
       case "-h":
         printHelp();
@@ -172,6 +197,17 @@ Options:
                       (default: .bench/runs/<auto-id>/ at repo root)
   --driver <kind>     Browser driver to use: "local" (default) or "kernel"
   --concurrency <n>   Parallel trials (default: local=CPUs/2, kernel=5)
+  --upload <mode>     R2 upload behavior. One of:
+                        auto    upload iff R2_* env vars are set (default)
+                        always  upload; error if env vars missing
+                        never   skip upload entirely
+  --no-upload         Alias for --upload never
+  --eval-set <name>   Eval-set name. When set together with --arm, the
+                      run-id becomes <ts>-<eval-set>-<arm> and the
+                      manifest records both fields. Useful when running
+                      the same task list under multiple configurations.
+  --arm <name>        Arm name within an eval-set (eg. a, b, c, or
+                      descriptive labels like "gpt-5", "claude-4-5")
   --help              Print this help`);
 }
 
@@ -253,6 +289,37 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // Fail fast on upload misconfigurations before running any trials.
+  const { uploadRun, createR2Client, r2EnvPresent } = await import("./upload");
+  let plannedUpload = false;
+  switch (args.upload) {
+    case "never":
+      plannedUpload = false;
+      break;
+    case "always":
+      plannedUpload = true;
+      if (!r2EnvPresent()) {
+        console.error(
+          "ERROR: --upload always was specified but required R2 env vars are not set.\n" +
+            "  Set R2_ACCOUNT_ID, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET\n" +
+            "  in .env or your shell, then re-run.",
+        );
+        process.exit(2);
+      }
+      break;
+    case "auto":
+      plannedUpload = r2EnvPresent();
+      break;
+  }
+  if (plannedUpload && (!args.evalSet || !args.arm)) {
+    console.error(
+      "ERROR: upload requires both --eval-set and --arm. " +
+        "These get embedded in the run-id and manifest so the artifacts are traceable.\n" +
+        "  Either pass both flags, or use --no-upload to skip upload.",
+    );
+    process.exit(2);
+  }
+
   // Resolve the task list. Single-task mode picks one; suite mode picks
   // every task whose source matches.
   let tasks: any[];
@@ -295,6 +362,8 @@ async function main(): Promise<void> {
       modelLabel: args.modelLabel,
       suite: args.suite,
       taskId: args.taskId,
+      evalSet: args.evalSet,
+      arm: args.arm,
     });
     runDir = resolveRunDir({
       runId,
@@ -737,6 +806,38 @@ async function main(): Promise<void> {
   console.log(`Trials:  ${paths.trialsDir}`);
   if (recordVideo) {
     console.log(`Videos:  ${paths.videosDir}`);
+  }
+
+  // Decide whether to upload (re-evaluate `auto` mode in case env was
+  // mutated mid-run; otherwise reuse the validated decision from earlier).
+  const shouldUpload =
+    args.upload === "never"
+      ? false
+      : args.upload === "always"
+        ? true
+        : r2EnvPresent();
+
+  if (shouldUpload) {
+    console.log("");
+    console.log(`Uploading to R2 (bucket=${process.env.R2_BUCKET})...`);
+    const uploadStart = Date.now();
+    try {
+      const { client, bucket } = createR2Client();
+      const manifest = await uploadRun({
+        paths,
+        runId,
+        evalSet: args.evalSet!,
+        arm: args.arm!,
+        deps: { s3Client: client, bucket },
+      });
+      const uploadDuration = ((Date.now() - uploadStart) / 1000).toFixed(1);
+      console.log(`  ${Object.keys(manifest.trials).length} trial(s) uploaded in ${uploadDuration}s`);
+      console.log(`  Manifest: ${paths.manifestPath}`);
+    } catch (err) {
+      console.error("Upload failed:", err instanceof Error ? err.message : String(err));
+      console.error("Local artifacts preserved in:", paths.runDir);
+      process.exit(1);
+    }
   }
 }
 

--- a/packages/bench/src/compress.test.ts
+++ b/packages/bench/src/compress.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for `compress.ts` — round-trip compression with zstd preferred,
+ * gzip as a fallback (or explicit override).
+ */
+
+import { describe, expect, it } from "vitest";
+import { compress, decompress, type CompressionAlgo } from "./compress";
+
+const SAMPLE = Buffer.from(
+  JSON.stringify(
+    Array.from({ length: 200 }, (_, i) => ({
+      step: i,
+      tool: "click",
+      input: { selector: `[data-id="${i}"]` },
+      output: { ok: true, ts: 1700000000 + i },
+    })),
+  ),
+  "utf-8",
+);
+
+describe("compress / decompress (zstd default)", () => {
+  it("round-trips arbitrary buffers", () => {
+    const { algo, data } = compress(SAMPLE);
+
+    const restored = decompress(data, algo);
+
+    expect(restored.equals(SAMPLE)).toBe(true);
+  });
+
+  it("defaults to zstd", () => {
+    const { algo } = compress(SAMPLE);
+
+    expect(algo).toBe("zstd");
+  });
+
+  it("produces meaningfully smaller output than the input", () => {
+    const { data } = compress(SAMPLE);
+
+    expect(data.byteLength).toBeLessThan(SAMPLE.byteLength);
+  });
+});
+
+describe("compress / decompress (gzip override)", () => {
+  it("respects an explicit gzip override", () => {
+    const { algo, data } = compress(SAMPLE, { algo: "gzip" });
+
+    expect(algo).toBe("gzip");
+    expect(decompress(data, algo).equals(SAMPLE)).toBe(true);
+  });
+});
+
+describe("decompress error paths", () => {
+  it("throws on an unknown algo", () => {
+    const { data } = compress(SAMPLE);
+
+    expect(() => decompress(data, "brotli" as CompressionAlgo)).toThrow(
+      /unknown compression algo/i,
+    );
+  });
+
+  it("throws when bytes don't match the declared algo", () => {
+    const { data: zstdBytes } = compress(SAMPLE, { algo: "zstd" });
+
+    expect(() => decompress(zstdBytes, "gzip")).toThrow();
+  });
+});

--- a/packages/bench/src/compress.ts
+++ b/packages/bench/src/compress.ts
@@ -1,0 +1,52 @@
+/**
+ * Compression for full-trace blobs uploaded to R2.
+ *
+ * Defaults to zstd (better ratio + speed than gzip for JSON-heavy data).
+ * Node 22.15+ ships zstd in core `node:zlib`, so no native dependency is
+ * needed. Gzip is supported as an explicit override (used as a portable
+ * fallback if zstd is unavailable in some future runtime).
+ */
+
+import {
+  zstdCompressSync,
+  zstdDecompressSync,
+  gzipSync,
+  gunzipSync,
+} from "node:zlib";
+
+export type CompressionAlgo = "zstd" | "gzip";
+
+export interface CompressOptions {
+  /** Force a specific algo. Default: zstd. */
+  algo?: CompressionAlgo;
+}
+
+export interface CompressedBlob {
+  algo: CompressionAlgo;
+  data: Buffer;
+}
+
+/** Compress a buffer. Defaults to zstd. */
+export function compress(input: Buffer, opts: CompressOptions = {}): CompressedBlob {
+  const algo: CompressionAlgo = opts.algo ?? "zstd";
+  switch (algo) {
+    case "zstd":
+      return { algo, data: zstdCompressSync(input) };
+    case "gzip":
+      return { algo, data: gzipSync(input) };
+    default:
+      throw new Error(`unknown compression algo: ${algo as string}`);
+  }
+}
+
+/** Decompress a buffer using the given algo. */
+export function decompress(data: Buffer, algo: CompressionAlgo): Buffer {
+  switch (algo) {
+    case "zstd":
+      return zstdDecompressSync(data);
+    case "gzip":
+      return gunzipSync(data);
+    default:
+      throw new Error(`unknown compression algo: ${algo as string}`);
+  }
+}

--- a/packages/bench/src/compress.ts
+++ b/packages/bench/src/compress.ts
@@ -2,9 +2,10 @@
  * Compression for full-trace blobs uploaded to R2.
  *
  * Defaults to zstd (better ratio + speed than gzip for JSON-heavy data).
- * Node 22.15+ ships zstd in core `node:zlib`, so no native dependency is
- * needed. Gzip is supported as an explicit override (used as a portable
- * fallback if zstd is unavailable in some future runtime).
+ * The package's `engines.node` is pinned at >=22.15 so the named zstd
+ * exports below are guaranteed to exist. Gzip is supported as an
+ * explicit override when callers want maximum portability for blobs
+ * consumed outside this package.
  */
 
 import {

--- a/packages/bench/src/manifest.test.ts
+++ b/packages/bench/src/manifest.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for `manifest.ts` — pure manifest builder + R2-key derivation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildManifest,
+  r2KeysFor,
+  type ManifestTrialUpload,
+} from "./manifest";
+
+describe("r2KeysFor", () => {
+  it("derives per-task keys keyed off runId + taskId", () => {
+    const keys = r2KeysFor({
+      runId: "2026-05-26T10-30-00-example-experiment-arm-a",
+      taskId: "webbench-1001",
+      compressionAlgo: "zstd",
+      videoExt: "mp4",
+    });
+
+    expect(keys).toEqual({
+      trial:
+        "runs/2026-05-26T10-30-00-example-experiment-arm-a/trials/webbench-1001.json",
+      trace:
+        "traces/2026-05-26T10-30-00-example-experiment-arm-a/webbench-1001.json.zst",
+      video:
+        "videos/2026-05-26T10-30-00-example-experiment-arm-a/webbench-1001.mp4",
+      summary:
+        "runs/2026-05-26T10-30-00-example-experiment-arm-a/summary.json",
+    });
+  });
+
+  it("uses .gz suffix when compression is gzip", () => {
+    const keys = r2KeysFor({
+      runId: "r1",
+      taskId: "t1",
+      compressionAlgo: "gzip",
+      videoExt: "mp4",
+    });
+
+    expect(keys.trace).toBe("traces/r1/t1.json.gz");
+  });
+
+  it("respects a webm video extension when ffmpeg conversion didn't run", () => {
+    const keys = r2KeysFor({
+      runId: "r1",
+      taskId: "t1",
+      compressionAlgo: "zstd",
+      videoExt: "webm",
+    });
+
+    expect(keys.video).toBe("videos/r1/t1.webm");
+  });
+
+  it("derives the run-level summary key", () => {
+    const keys = r2KeysFor({
+      runId: "r1",
+      taskId: null,
+      compressionAlgo: "zstd",
+      videoExt: "mp4",
+    });
+
+    expect(keys.summary).toBe("runs/r1/summary.json");
+  });
+});
+
+describe("buildManifest", () => {
+  it("returns a manifest with all fields populated and a per-trial entry", () => {
+    const uploads: ManifestTrialUpload[] = [
+      {
+        taskId: "webbench-1001",
+        traceKey: "traces/run1/webbench-1001.json.zst",
+        traceBytes: 142000,
+        videoKey: "videos/run1/webbench-1001.mp4",
+        videoBytes: 3940000,
+      },
+    ];
+
+    const manifest = buildManifest({
+      runId: "run1",
+      evalSet: "example-experiment",
+      arm: "arm-a",
+      bucket: "test-bucket",
+      compression: "zstd",
+      uploadedAt: "2026-05-26T10:48:12.444Z",
+      uploads,
+    });
+
+    expect(manifest).toEqual({
+      runId: "run1",
+      evalSet: "example-experiment",
+      arm: "arm-a",
+      uploadedAt: "2026-05-26T10:48:12.444Z",
+      bucket: "test-bucket",
+      compression: "zstd",
+      trials: {
+        "webbench-1001": {
+          trace: "traces/run1/webbench-1001.json.zst",
+          video: "videos/run1/webbench-1001.mp4",
+          traceBytes: 142000,
+          videoBytes: 3940000,
+        },
+      },
+    });
+  });
+
+  it("omits per-trial video fields when no video was recorded", () => {
+    const manifest = buildManifest({
+      runId: "run1",
+      evalSet: "example-experiment",
+      arm: "arm-a",
+      bucket: "test-bucket",
+      compression: "zstd",
+      uploadedAt: "2026-05-26T10:48:12.444Z",
+      uploads: [
+        {
+          taskId: "t1",
+          traceKey: "traces/run1/t1.json.zst",
+          traceBytes: 1000,
+          videoKey: null,
+          videoBytes: null,
+        },
+      ],
+    });
+
+    expect(manifest.trials.t1).toEqual({
+      trace: "traces/run1/t1.json.zst",
+      traceBytes: 1000,
+    });
+  });
+
+  it("supports an empty uploads array", () => {
+    const manifest = buildManifest({
+      runId: "run1",
+      evalSet: "example-experiment",
+      arm: "arm-a",
+      bucket: "test-bucket",
+      compression: "zstd",
+      uploadedAt: "2026-05-26T10:48:12.444Z",
+      uploads: [],
+    });
+
+    expect(manifest.trials).toEqual({});
+  });
+
+  it("rejects duplicate taskIds in uploads", () => {
+    expect(() =>
+      buildManifest({
+        runId: "run1",
+        evalSet: "x",
+        arm: "y",
+        bucket: "b",
+        compression: "zstd",
+        uploadedAt: "2026-05-26T10:48:12.444Z",
+        uploads: [
+          { taskId: "t1", traceKey: "k", traceBytes: 1, videoKey: null, videoBytes: null },
+          { taskId: "t1", traceKey: "k2", traceBytes: 2, videoKey: null, videoBytes: null },
+        ],
+      }),
+    ).toThrow(/duplicate taskId/i);
+  });
+});

--- a/packages/bench/src/manifest.test.ts
+++ b/packages/bench/src/manifest.test.ts
@@ -5,13 +5,20 @@
 import { describe, expect, it } from "vitest";
 import {
   buildManifest,
-  r2KeysFor,
+  r2SummaryKey,
+  r2TrialKeys,
   type ManifestTrialUpload,
 } from "./manifest";
 
-describe("r2KeysFor", () => {
+describe("r2SummaryKey", () => {
+  it("derives the run-level summary key", () => {
+    expect(r2SummaryKey("r1")).toBe("runs/r1/summary.json");
+  });
+});
+
+describe("r2TrialKeys", () => {
   it("derives per-task keys keyed off runId + taskId", () => {
-    const keys = r2KeysFor({
+    const keys = r2TrialKeys({
       runId: "2026-05-26T10-30-00-example-experiment-arm-a",
       taskId: "webbench-1001",
       compressionAlgo: "zstd",
@@ -25,13 +32,11 @@ describe("r2KeysFor", () => {
         "traces/2026-05-26T10-30-00-example-experiment-arm-a/webbench-1001.json.zst",
       video:
         "videos/2026-05-26T10-30-00-example-experiment-arm-a/webbench-1001.mp4",
-      summary:
-        "runs/2026-05-26T10-30-00-example-experiment-arm-a/summary.json",
     });
   });
 
   it("uses .gz suffix when compression is gzip", () => {
-    const keys = r2KeysFor({
+    const keys = r2TrialKeys({
       runId: "r1",
       taskId: "t1",
       compressionAlgo: "gzip",
@@ -42,7 +47,7 @@ describe("r2KeysFor", () => {
   });
 
   it("respects a webm video extension when ffmpeg conversion didn't run", () => {
-    const keys = r2KeysFor({
+    const keys = r2TrialKeys({
       runId: "r1",
       taskId: "t1",
       compressionAlgo: "zstd",
@@ -50,17 +55,6 @@ describe("r2KeysFor", () => {
     });
 
     expect(keys.video).toBe("videos/r1/t1.webm");
-  });
-
-  it("derives the run-level summary key", () => {
-    const keys = r2KeysFor({
-      runId: "r1",
-      taskId: null,
-      compressionAlgo: "zstd",
-      videoExt: "mp4",
-    });
-
-    expect(keys.summary).toBe("runs/r1/summary.json");
   });
 });
 
@@ -158,5 +152,49 @@ describe("buildManifest", () => {
         ],
       }),
     ).toThrow(/duplicate taskId/i);
+  });
+
+  it("throws when videoKey is set but videoBytes is null/missing", () => {
+    expect(() =>
+      buildManifest({
+        runId: "run1",
+        evalSet: "x",
+        arm: "y",
+        bucket: "b",
+        compression: "zstd",
+        uploadedAt: "2026-05-26T10:48:12.444Z",
+        uploads: [
+          {
+            taskId: "t1",
+            traceKey: "k",
+            traceBytes: 1,
+            videoKey: "videos/run1/t1.mp4",
+            videoBytes: null,
+          },
+        ],
+      }),
+    ).toThrow(/videoBytes/i);
+  });
+
+  it("throws when videoKey is set but videoBytes is negative", () => {
+    expect(() =>
+      buildManifest({
+        runId: "run1",
+        evalSet: "x",
+        arm: "y",
+        bucket: "b",
+        compression: "zstd",
+        uploadedAt: "2026-05-26T10:48:12.444Z",
+        uploads: [
+          {
+            taskId: "t1",
+            traceKey: "k",
+            traceBytes: 1,
+            videoKey: "videos/run1/t1.mp4",
+            videoBytes: -1,
+          },
+        ],
+      }),
+    ).toThrow(/videoBytes/i);
   });
 });

--- a/packages/bench/src/manifest.ts
+++ b/packages/bench/src/manifest.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure manifest construction + R2 key derivation.
+ *
+ * The manifest is the post-upload metadata file: it records which task →
+ * which R2 key, plus byte sizes (sanity-check for re-downloads) and the
+ * compression algorithm used. It's small enough to commit alongside
+ * other run metadata for traceability.
+ *
+ * Key derivation is centralized here so callers (uploader, fetch helper,
+ * migration script) can't drift on the layout.
+ */
+
+import type { CompressionAlgo } from "./compress";
+
+export type VideoExt = "mp4" | "webm";
+
+const COMPRESSION_EXT: Record<CompressionAlgo, string> = {
+  zstd: ".json.zst",
+  gzip: ".json.gz",
+};
+
+export interface R2Keys {
+  /** `runs/<runId>/trials/<taskId>.json` (lightweight trial JSON). */
+  trial: string;
+  /** `traces/<runId>/<taskId>.<ext>` (compressed full trace). */
+  trace: string;
+  /** `videos/<runId>/<taskId>.<videoExt>`. */
+  video: string;
+  /** `runs/<runId>/summary.json`. */
+  summary: string;
+}
+
+/** Compute the R2 keys for a given run + (optional) task. */
+export function r2KeysFor(opts: {
+  runId: string;
+  /** Pass `null` when only the summary key is needed. */
+  taskId: string | null;
+  compressionAlgo: CompressionAlgo;
+  videoExt: VideoExt;
+}): R2Keys {
+  const { runId, taskId, compressionAlgo, videoExt } = opts;
+  const traceExt = COMPRESSION_EXT[compressionAlgo];
+  const tid = taskId ?? "";
+  return {
+    trial: `runs/${runId}/trials/${tid}.json`,
+    trace: `traces/${runId}/${tid}${traceExt}`,
+    video: `videos/${runId}/${tid}.${videoExt}`,
+    summary: `runs/${runId}/summary.json`,
+  };
+}
+
+export interface ManifestTrialUpload {
+  taskId: string;
+  traceKey: string;
+  traceBytes: number;
+  /** Null when the trial had no video (e.g. `--no-video`). */
+  videoKey: string | null;
+  videoBytes: number | null;
+}
+
+export interface ManifestTrialEntry {
+  trace: string;
+  traceBytes: number;
+  /** Omitted when the trial had no video. */
+  video?: string;
+  videoBytes?: number;
+}
+
+export interface Manifest {
+  runId: string;
+  evalSet: string;
+  arm: string;
+  uploadedAt: string;
+  bucket: string;
+  compression: CompressionAlgo;
+  trials: Record<string, ManifestTrialEntry>;
+}
+
+export function buildManifest(opts: {
+  runId: string;
+  evalSet: string;
+  arm: string;
+  bucket: string;
+  compression: CompressionAlgo;
+  uploadedAt: string;
+  uploads: ManifestTrialUpload[];
+}): Manifest {
+  const trials: Record<string, ManifestTrialEntry> = {};
+  for (const u of opts.uploads) {
+    if (trials[u.taskId]) {
+      throw new Error(`duplicate taskId in uploads: ${u.taskId}`);
+    }
+    const entry: ManifestTrialEntry = {
+      trace: u.traceKey,
+      traceBytes: u.traceBytes,
+    };
+    if (u.videoKey !== null) {
+      entry.video = u.videoKey;
+      entry.videoBytes = u.videoBytes ?? 0;
+    }
+    trials[u.taskId] = entry;
+  }
+  return {
+    runId: opts.runId,
+    evalSet: opts.evalSet,
+    arm: opts.arm,
+    uploadedAt: opts.uploadedAt,
+    bucket: opts.bucket,
+    compression: opts.compression,
+    trials,
+  };
+}

--- a/packages/bench/src/manifest.ts
+++ b/packages/bench/src/manifest.ts
@@ -19,34 +19,34 @@ const COMPRESSION_EXT: Record<CompressionAlgo, string> = {
   gzip: ".json.gz",
 };
 
-export interface R2Keys {
+export interface R2TrialKeys {
   /** `runs/<runId>/trials/<taskId>.json` (lightweight trial JSON). */
   trial: string;
   /** `traces/<runId>/<taskId>.<ext>` (compressed full trace). */
   trace: string;
   /** `videos/<runId>/<taskId>.<videoExt>`. */
   video: string;
-  /** `runs/<runId>/summary.json`. */
-  summary: string;
 }
 
-/** Compute the R2 keys for a given run + (optional) task. */
-export function r2KeysFor(opts: {
+/** Compute the per-trial R2 keys. */
+export function r2TrialKeys(opts: {
   runId: string;
-  /** Pass `null` when only the summary key is needed. */
-  taskId: string | null;
+  taskId: string;
   compressionAlgo: CompressionAlgo;
   videoExt: VideoExt;
-}): R2Keys {
+}): R2TrialKeys {
   const { runId, taskId, compressionAlgo, videoExt } = opts;
   const traceExt = COMPRESSION_EXT[compressionAlgo];
-  const tid = taskId ?? "";
   return {
-    trial: `runs/${runId}/trials/${tid}.json`,
-    trace: `traces/${runId}/${tid}${traceExt}`,
-    video: `videos/${runId}/${tid}.${videoExt}`,
-    summary: `runs/${runId}/summary.json`,
+    trial: `runs/${runId}/trials/${taskId}.json`,
+    trace: `traces/${runId}/${taskId}${traceExt}`,
+    video: `videos/${runId}/${taskId}.${videoExt}`,
   };
+}
+
+/** Compute the run-level summary key. */
+export function r2SummaryKey(runId: string): string {
+  return `runs/${runId}/summary.json`;
 }
 
 export interface ManifestTrialUpload {
@@ -95,8 +95,13 @@ export function buildManifest(opts: {
       traceBytes: u.traceBytes,
     };
     if (u.videoKey !== null) {
+      if (u.videoBytes == null || u.videoBytes < 0) {
+        throw new Error(
+          `videoKey set but videoBytes missing/invalid for taskId=${u.taskId} (got ${u.videoBytes})`,
+        );
+      }
       entry.video = u.videoKey;
-      entry.videoBytes = u.videoBytes ?? 0;
+      entry.videoBytes = u.videoBytes;
     }
     trials[u.taskId] = entry;
   }

--- a/packages/bench/src/paths.test.ts
+++ b/packages/bench/src/paths.test.ts
@@ -15,9 +15,9 @@ describe("makeRunId", () => {
   it("uses model-label + suite tail when evalSet/arm are absent (legacy shape)", () => {
     const id = makeRunId({ modelLabel: "claude-sonnet-4-5", suite: "webbench-mini" });
 
-    // shape: <ts>-<modelLabel>-<suite>
+    // shape: <ts>-<rand>-<modelLabel>-<suite>
     expect(id).toMatch(
-      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-claude-sonnet-4-5-webbench-mini$/,
+      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-[0-9a-f]{4}-claude-sonnet-4-5-webbench-mini$/,
     );
   });
 
@@ -28,9 +28,9 @@ describe("makeRunId", () => {
       arm: "arm-a",
     });
 
-    // shape: <ts>-<evalSet>-<arm>
+    // shape: <ts>-<rand>-<evalSet>-<arm>
     expect(id).toMatch(
-      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-example-experiment-arm-a$/,
+      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-[0-9a-f]{4}-example-experiment-arm-a$/,
     );
   });
 
@@ -41,14 +41,25 @@ describe("makeRunId", () => {
       arm: "arm one!",
     });
 
-    // shape: <ts>-<sanitized-evalSet>-<sanitized-arm>
-    expect(id).toMatch(/-foo_bar_baz-arm_one_$/);
+    // shape: <ts>-<rand>-<sanitized-evalSet>-<sanitized-arm>
+    expect(id).toMatch(/-[0-9a-f]{4}-foo_bar_baz-arm_one_$/);
   });
 
   it("falls back to legacy shape when only evalSet is provided (without arm)", () => {
     const id = makeRunId({ modelLabel: "claude", evalSet: "example-experiment" });
 
-    expect(id).toMatch(/-claude-task$/); // unchanged legacy fallback
+    expect(id).toMatch(/-[0-9a-f]{4}-claude-task$/); // unchanged legacy fallback
+  });
+
+  it("produces unique ids for rapid back-to-back invocations within the same second", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(makeRunId({ modelLabel: "m", evalSet: "e", arm: "a" }));
+    }
+    // Without the entropy suffix, all 100 ids would collapse into 1-2 unique
+    // values (depending on whether the loop crosses a second boundary). With
+    // 4 hex chars of entropy, collisions are vanishingly rare.
+    expect(ids.size).toBeGreaterThanOrEqual(99);
   });
 });
 

--- a/packages/bench/src/paths.test.ts
+++ b/packages/bench/src/paths.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the additions to `paths.ts`:
+ *   - `makeRunId` extension with optional `{ evalSet, arm }` for
+ *     experiment-driven runs.
+ *   - `RunPaths.manifestPath` and `RunPaths.tracesDir` for upload artifacts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRunPaths, makeRunId } from "./paths";
+
+describe("makeRunId", () => {
+  it("uses model-label + suite tail when evalSet/arm are absent (legacy shape)", () => {
+    const id = makeRunId({ modelLabel: "claude-sonnet-4-5", suite: "webbench-mini" });
+
+    // shape: <ts>-<modelLabel>-<suite>
+    expect(id).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-claude-sonnet-4-5-webbench-mini$/,
+    );
+  });
+
+  it("uses evalSet + arm tail when both are provided (experiment shape)", () => {
+    const id = makeRunId({
+      modelLabel: "claude-sonnet-4-5",
+      evalSet: "example-experiment",
+      arm: "arm-a",
+    });
+
+    // shape: <ts>-<evalSet>-<arm>
+    expect(id).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-example-experiment-arm-a$/,
+    );
+  });
+
+  it("sanitizes unsafe segments in evalSet and arm", () => {
+    const id = makeRunId({
+      modelLabel: "x",
+      evalSet: "foo/bar:baz",
+      arm: "arm one!",
+    });
+
+    // shape: <ts>-<sanitized-evalSet>-<sanitized-arm>
+    expect(id).toMatch(/-foo_bar_baz-arm_one_$/);
+  });
+
+  it("falls back to legacy shape when only evalSet is provided (without arm)", () => {
+    const id = makeRunId({ modelLabel: "claude", evalSet: "example-experiment" });
+
+    expect(id).toMatch(/-claude-task$/); // unchanged legacy fallback
+  });
+});
+
+describe("createRunPaths", () => {
+  it("returns manifestPath and tracesDir alongside the existing fields", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bench-paths-"));
+    const runDir = join(tmp, "run-1");
+
+    const paths = createRunPaths(runDir);
+
+    expect(paths.runDir).toBe(runDir);
+    expect(paths.summaryPath).toBe(join(runDir, "summary.json"));
+    expect(paths.trialsDir).toBe(join(runDir, "trials"));
+    expect(paths.videosDir).toBe(join(runDir, "videos"));
+    expect(paths.tracesDir).toBe(join(runDir, "traces"));
+    expect(paths.manifestPath).toBe(join(runDir, "manifest.json"));
+  });
+});

--- a/packages/bench/src/paths.ts
+++ b/packages/bench/src/paths.ts
@@ -23,6 +23,7 @@ import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -50,12 +51,15 @@ export function safeSegment(s: string): string {
 
 /** Generate a stable per-run directory id.
  *
- * Two shapes are supported:
+ * Format: `<ts>-<rand>-<tail>` where `<ts>` is the ISO timestamp at
+ * second resolution, `<rand>` is 4 hex chars of randomness (so parallel
+ * invocations within the same second don't collide), and `<tail>` is
+ * one of two shapes:
  *
- * - Legacy (CLI default): `<ts>-<modelLabel>-<suite-or-task>`. Used when
- *   no `{ evalSet, arm }` pair is supplied.
- * - Experiment: `<ts>-<evalSet>-<arm>`. Used when an eval-set runner
- *   passes both fields through; the `modelLabel` is recorded in the run
+ * - Legacy (CLI default): `<modelLabel>-<suite-or-task>`. Used when no
+ *   `{ evalSet, arm }` pair is supplied.
+ * - Experiment: `<evalSet>-<arm>`. Used when an eval-set runner passes
+ *   both fields through; the `modelLabel` is recorded in the run
  *   summary instead of the directory name (eval-sets fix the model per
  *   arm, so embedding it in every run-id would be redundant).
  */
@@ -67,11 +71,12 @@ export function makeRunId(opts: {
   arm?: string;
 }): string {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const rand = randomBytes(2).toString("hex");
   if (opts.evalSet && opts.arm) {
-    return `${stamp}-${safeSegment(opts.evalSet)}-${safeSegment(opts.arm)}`;
+    return `${stamp}-${rand}-${safeSegment(opts.evalSet)}-${safeSegment(opts.arm)}`;
   }
   const tail = opts.suite ?? opts.taskId ?? "task";
-  return `${stamp}-${safeSegment(opts.modelLabel)}-${safeSegment(tail)}`;
+  return `${stamp}-${rand}-${safeSegment(opts.modelLabel)}-${safeSegment(tail)}`;
 }
 
 export interface RunPaths {

--- a/packages/bench/src/paths.ts
+++ b/packages/bench/src/paths.ts
@@ -48,13 +48,28 @@ export function safeSegment(s: string): string {
   return s.replace(/[^a-zA-Z0-9-_.]/g, "_");
 }
 
-/** Generate a stable per-run directory id. */
+/** Generate a stable per-run directory id.
+ *
+ * Two shapes are supported:
+ *
+ * - Legacy (CLI default): `<ts>-<modelLabel>-<suite-or-task>`. Used when
+ *   no `{ evalSet, arm }` pair is supplied.
+ * - Experiment: `<ts>-<evalSet>-<arm>`. Used when an eval-set runner
+ *   passes both fields through; the `modelLabel` is recorded in the run
+ *   summary instead of the directory name (eval-sets fix the model per
+ *   arm, so embedding it in every run-id would be redundant).
+ */
 export function makeRunId(opts: {
   modelLabel: string;
   suite?: string;
   taskId?: string;
+  evalSet?: string;
+  arm?: string;
 }): string {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  if (opts.evalSet && opts.arm) {
+    return `${stamp}-${safeSegment(opts.evalSet)}-${safeSegment(opts.arm)}`;
+  }
   const tail = opts.suite ?? opts.taskId ?? "task";
   return `${stamp}-${safeSegment(opts.modelLabel)}-${safeSegment(tail)}`;
 }
@@ -66,8 +81,12 @@ export interface RunPaths {
   trialsDir: string;
   /** `<runDir>/videos` */
   videosDir: string;
+  /** `<runDir>/traces` (created lazily; only used by the upload pipeline). */
+  tracesDir: string;
   /** `<runDir>/summary.json` */
   summaryPath: string;
+  /** `<runDir>/manifest.json` (written after a successful R2 upload). */
+  manifestPath: string;
 }
 
 /** Resolve the directory for a run, given either an explicit dir override
@@ -96,13 +115,18 @@ export function resolveRunDir(opts: {
 export function createRunPaths(runDir: string): RunPaths {
   const trialsDir = resolve(runDir, "trials");
   const videosDir = resolve(runDir, "videos");
+  const tracesDir = resolve(runDir, "traces");
   mkdirSync(trialsDir, { recursive: true });
   mkdirSync(videosDir, { recursive: true });
+  // tracesDir is created on demand by the upload pipeline; reserve the
+  // path here so callers don't need to know the layout.
   return {
     runDir,
     trialsDir,
     videosDir,
+    tracesDir,
     summaryPath: resolve(runDir, "summary.json"),
+    manifestPath: resolve(runDir, "manifest.json"),
   };
 }
 
@@ -126,11 +150,15 @@ export function ensureRunDirExists(runDir: string): RunPaths {
   if (!existsSync(videosDir)) {
     mkdirSync(videosDir, { recursive: true });
   }
-  
+
+  const tracesDir = resolve(absoluteDir, "traces");
+
   return {
     runDir: absoluteDir,
     trialsDir,
     videosDir,
+    tracesDir,
     summaryPath: resolve(absoluteDir, "summary.json"),
+    manifestPath: resolve(absoluteDir, "manifest.json"),
   };
 }

--- a/packages/bench/src/runs.test.ts
+++ b/packages/bench/src/runs.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for `runs.ts` — pure split/merge of a `TrialResult` into a
+ * lightweight (uploadable + locally-kept) shell + a full trace blob.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mergeTrial, splitTrial, type FullTrace } from "./runs";
+import type { TrialResult } from "./runner";
+
+function makeTrial(overrides: Partial<TrialResult> = {}): TrialResult {
+  return {
+    taskId: "webbench-1001",
+    modelLabel: "claude-sonnet-4-5",
+    agentModelId: "claude-sonnet-4-5-20250929",
+    systemPromptId: "default",
+    toolSetId: "set:click+navigate",
+    passed: true,
+    agentAnswer: "42",
+    finalUrl: "https://example.com",
+    durationMs: 12345,
+    steps: 4,
+    tokens: { in: 1000, out: 200, total: 1200 },
+    judge: { passed: true, reasoning: "matches" },
+    trace: [
+      { name: "navigate", input: { url: "https://example.com" }, output: { ok: true } },
+      { name: "click", input: { selector: "h1" }, output: { ok: true } },
+    ],
+    parts: [{ type: "text", text: "thinking…" }, { type: "dynamic-tool", toolName: "click" }],
+    videoPath: "/tmp/.bench/runs/r1/videos/webbench-1001.mp4",
+    ...overrides,
+  };
+}
+
+describe("splitTrial", () => {
+  it("clears trace and parts on the lightweight half", () => {
+    const trial = makeTrial();
+
+    const { lightweight } = splitTrial(trial);
+
+    expect(lightweight.trace).toEqual([]);
+    expect(lightweight.parts).toBeUndefined();
+  });
+
+  it("preserves every other field on the lightweight half byte-for-byte", () => {
+    const trial = makeTrial();
+
+    const { lightweight } = splitTrial(trial);
+
+    // Compare with trace+parts stripped from the original.
+    const { trace: _t, parts: _p, ...rest } = trial;
+    expect(lightweight).toMatchObject(rest);
+  });
+
+  it("captures the full heavy fields in the trace half", () => {
+    const trial = makeTrial();
+
+    const { fullTrace } = splitTrial(trial);
+
+    expect(fullTrace.taskId).toBe(trial.taskId);
+    expect(fullTrace.trace).toEqual(trial.trace);
+    expect(fullTrace.parts).toEqual(trial.parts);
+  });
+
+  it("does not mutate the input trial", () => {
+    const trial = makeTrial();
+    const traceBefore = JSON.stringify(trial.trace);
+    const partsBefore = JSON.stringify(trial.parts);
+
+    splitTrial(trial);
+
+    expect(JSON.stringify(trial.trace)).toBe(traceBefore);
+    expect(JSON.stringify(trial.parts)).toBe(partsBefore);
+  });
+
+  it("handles a trial with no parts field (timeout-error path)", () => {
+    const trial = makeTrial({ parts: undefined });
+
+    const { lightweight, fullTrace } = splitTrial(trial);
+
+    expect(lightweight.parts).toBeUndefined();
+    expect(fullTrace.parts).toEqual([]);
+  });
+
+  it("handles a trial with empty trace (timeout-error path)", () => {
+    const trial = makeTrial({ trace: [] });
+
+    const { lightweight, fullTrace } = splitTrial(trial);
+
+    expect(lightweight.trace).toEqual([]);
+    expect(fullTrace.trace).toEqual([]);
+  });
+});
+
+describe("mergeTrial", () => {
+  it("round-trips: split + merge reconstructs the original trial", () => {
+    const trial = makeTrial();
+
+    const { lightweight, fullTrace } = splitTrial(trial);
+    const reconstructed = mergeTrial(lightweight, fullTrace);
+
+    expect(reconstructed).toEqual(trial);
+  });
+
+  it("rejects merging when taskIds disagree", () => {
+    const trial = makeTrial();
+    const { lightweight, fullTrace } = splitTrial(trial);
+    const wrongTrace: FullTrace = { ...fullTrace, taskId: "webbench-9999" };
+
+    expect(() => mergeTrial(lightweight, wrongTrace)).toThrow(/taskId/i);
+  });
+});

--- a/packages/bench/src/runs.ts
+++ b/packages/bench/src/runs.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure split / merge for `TrialResult`.
+ *
+ * The bench writes one JSON per trial. When uploading to R2 we want to
+ * separate the "lightweight" metadata (small, queryable, kept locally and
+ * uploaded to `runs/<run-id>/trials/`) from the "full trace" (heavy:
+ * `trace[]` and `parts[]`, uploaded to `traces/<run-id>/`, deleted locally
+ * after upload).
+ *
+ * Both halves are JSON-serializable plain objects. No I/O.
+ */
+
+import type { TrialResult, TraceEntry } from "./runner";
+
+/**
+ * Trial JSON sans the heavy fields. Identical shape to `TrialResult` so
+ * downstream consumers (summary aggregation, `readAllTrials()`) can keep
+ * treating it as a `TrialResult`. `trace` is set to `[]` rather than
+ * dropped to preserve the type contract.
+ */
+export type LightweightTrial = TrialResult;
+
+/**
+ * The two heavy fields, isolated. Carries `taskId` for cross-checking
+ * during merge so a misrouted trace can never silently overwrite the
+ * wrong trial's data.
+ */
+export interface FullTrace {
+  taskId: string;
+  trace: TraceEntry[];
+  parts: unknown[];
+}
+
+/**
+ * Split a trial into a lightweight half (kept locally + uploaded to
+ * `runs/`) and a full-trace half (uploaded to `traces/`, deleted locally).
+ */
+export function splitTrial(trial: TrialResult): {
+  lightweight: LightweightTrial;
+  fullTrace: FullTrace;
+} {
+  const fullTrace: FullTrace = {
+    taskId: trial.taskId,
+    // Deep-ish copy via structuredClone so callers can't observe later
+    // mutations on the original. JSON-safe so structuredClone is fine.
+    trace: structuredClone(trial.trace),
+    parts: structuredClone(trial.parts ?? []),
+  };
+
+  const lightweight: LightweightTrial = {
+    ...trial,
+    trace: [],
+  };
+  delete lightweight.parts;
+
+  return { lightweight, fullTrace };
+}
+
+/**
+ * Reverse of `splitTrial`. Throws if the two halves disagree on `taskId`.
+ */
+export function mergeTrial(
+  lightweight: LightweightTrial,
+  fullTrace: FullTrace,
+): TrialResult {
+  if (lightweight.taskId !== fullTrace.taskId) {
+    throw new Error(
+      `mergeTrial: taskId mismatch (lightweight=${lightweight.taskId}, fullTrace=${fullTrace.taskId})`,
+    );
+  }
+  return {
+    ...lightweight,
+    trace: structuredClone(fullTrace.trace),
+    parts: structuredClone(fullTrace.parts),
+  };
+}

--- a/packages/bench/src/upload.test.ts
+++ b/packages/bench/src/upload.test.ts
@@ -1,0 +1,638 @@
+/**
+ * Tests for `upload.ts` — uploadRun() with a mocked S3 client.
+ *
+ * The S3 client is injected via `deps.s3Client` so we can record every
+ * `PutObjectCommand` and assert exact key/body payloads without hitting
+ * the network. Real R2 calls are exercised manually (Phase 2.8 smoke).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { S3Client } from "@aws-sdk/client-s3";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { uploadRun, type UploadDeps } from "./upload";
+import { decompress } from "./compress";
+import type { TrialResult } from "./runner";
+
+interface RecordedPut {
+  key: string;
+  body: Buffer;
+  contentType?: string;
+}
+
+function makeMockS3(failOn?: (cmd: PutObjectCommand) => boolean): {
+  client: S3Client;
+  puts: RecordedPut[];
+} {
+  const puts: RecordedPut[] = [];
+  const send = vi.fn(async (cmd: unknown) => {
+    if (cmd instanceof PutObjectCommand) {
+      if (failOn && failOn(cmd)) {
+        throw new Error("simulated S3 failure");
+      }
+      const input = cmd.input;
+      const body = input.Body as Buffer | string;
+      puts.push({
+        key: input.Key!,
+        body: Buffer.isBuffer(body) ? body : Buffer.from(body as string),
+        contentType: input.ContentType,
+      });
+      return {};
+    }
+    throw new Error(`unexpected command ${(cmd as { constructor: { name: string } }).constructor.name}`);
+  });
+  // Cast through unknown; we only call .send().
+  const client = { send } as unknown as S3Client;
+  return { client, puts };
+}
+
+function makeTrial(taskId: string): TrialResult {
+  return {
+    taskId,
+    modelLabel: "claude-sonnet-4-5",
+    agentModelId: "claude-sonnet-4-5-20250929",
+    systemPromptId: "default",
+    toolSetId: "set:click",
+    passed: true,
+    agentAnswer: "ok",
+    finalUrl: "https://example.com",
+    durationMs: 1000,
+    steps: 2,
+    tokens: { in: 50, out: 10, total: 60 },
+    judge: { passed: true, reasoning: "looks right" },
+    trace: [
+      { name: "navigate", input: { url: "https://example.com" }, output: { ok: true } },
+    ],
+    parts: [{ type: "text", text: "thinking…" }],
+  };
+}
+
+function makeRunDir(): string {
+  const tmp = mkdtempSync(join(tmpdir(), "bench-upload-"));
+  const runDir = join(tmp, "run-1");
+  mkdirSync(join(runDir, "trials"), { recursive: true });
+  mkdirSync(join(runDir, "videos"), { recursive: true });
+  return runDir;
+}
+
+let dirsToCleanup: string[] = [];
+beforeEach(() => {
+  dirsToCleanup = [];
+});
+afterEach(() => {
+  for (const d of dirsToCleanup) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+function trackForCleanup(runDir: string): void {
+  dirsToCleanup.push(runDir);
+}
+
+function paths(runDir: string) {
+  return {
+    runDir,
+    trialsDir: join(runDir, "trials"),
+    videosDir: join(runDir, "videos"),
+    tracesDir: join(runDir, "traces"),
+    summaryPath: join(runDir, "summary.json"),
+    manifestPath: join(runDir, "manifest.json"),
+  };
+}
+
+const FIXED_NOW = new Date("2026-05-26T10:48:12.444Z");
+const fixedDeps = (mock: ReturnType<typeof makeMockS3>): UploadDeps => ({
+  s3Client: mock.client,
+  bucket: "test-bucket",
+  now: () => FIXED_NOW,
+});
+
+describe("uploadRun — happy path", () => {
+  it("uploads summary, lightweight trials, compressed traces, and videos", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+
+    writeFileSync(p.summaryPath, JSON.stringify({ runId: "run-1", model: "x" }));
+    const trial1 = makeTrial("t1");
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(trial1));
+    writeFileSync(join(p.videosDir, "t1.mp4"), Buffer.from("fake video"));
+
+    const mock = makeMockS3();
+    const manifest = await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "example-experiment",
+      arm: "arm-a",
+      deps: fixedDeps(mock),
+    });
+
+    const keys = mock.puts.map((p) => p.key).sort();
+    expect(keys).toEqual([
+      "runs/run-1/summary.json",
+      "runs/run-1/trials/t1.json",
+      "traces/run-1/t1.json.zst",
+      "videos/run-1/t1.mp4",
+    ]);
+
+    expect(manifest.runId).toBe("run-1");
+    expect(manifest.evalSet).toBe("example-experiment");
+    expect(manifest.arm).toBe("arm-a");
+    expect(manifest.compression).toBe("zstd");
+    expect(manifest.uploadedAt).toBe(FIXED_NOW.toISOString());
+    expect(manifest.bucket).toBe("test-bucket");
+    expect(manifest.trials.t1.trace).toBe("traces/run-1/t1.json.zst");
+    expect(manifest.trials.t1.video).toBe("videos/run-1/t1.mp4");
+    expect(manifest.trials.t1.traceBytes).toBeGreaterThan(0);
+    expect(manifest.trials.t1.videoBytes).toBe("fake video".length);
+  });
+
+  it("uploads the lightweight trial (no trace, no parts)", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({ runId: "run-1" }));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    const trialPut = mock.puts.find((p) => p.key === "runs/run-1/trials/t1.json")!;
+    const uploaded = JSON.parse(trialPut.body.toString("utf-8"));
+    expect(uploaded.trace).toEqual([]);
+    expect(uploaded.parts).toBeUndefined();
+    expect(uploaded.taskId).toBe("t1");
+  });
+
+  it("uploads the compressed trace as decompressible zstd containing the original heavy fields", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    const trial = makeTrial("t1");
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(trial));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    const tracePut = mock.puts.find((p) => p.key === "traces/run-1/t1.json.zst")!;
+    const decompressed = decompress(tracePut.body, "zstd");
+    const fullTrace = JSON.parse(decompressed.toString("utf-8"));
+    expect(fullTrace.taskId).toBe("t1");
+    expect(fullTrace.trace).toEqual(trial.trace);
+    expect(fullTrace.parts).toEqual(trial.parts);
+  });
+
+  it("rewrites the local trial file as the lightweight version", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    const onDisk = JSON.parse(readFileSync(join(p.trialsDir, "t1.json"), "utf-8"));
+    expect(onDisk.trace).toEqual([]);
+    expect(onDisk.parts).toBeUndefined();
+  });
+
+  it("writes manifest.json to the run dir after upload", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    expect(existsSync(p.manifestPath)).toBe(true);
+    const manifest = JSON.parse(readFileSync(p.manifestPath, "utf-8"));
+    expect(manifest.runId).toBe("run-1");
+  });
+
+  it("deletes local videos dir after a successful upload (default cleanup=true)", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+    writeFileSync(join(p.videosDir, "t1.mp4"), Buffer.from("v"));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    expect(existsSync(p.videosDir)).toBe(false);
+  });
+
+  it("preserves local videos dir when cleanup=false", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+    writeFileSync(join(p.videosDir, "t1.mp4"), Buffer.from("v"));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      cleanup: false,
+      deps: fixedDeps(mock),
+    });
+
+    expect(existsSync(p.videosDir)).toBe(true);
+    expect(existsSync(join(p.videosDir, "t1.mp4"))).toBe(true);
+  });
+});
+
+describe("uploadRun — multi-trial", () => {
+  it("handles trials with and without videos in the same run", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "with-video.json"), JSON.stringify(makeTrial("with-video")));
+    writeFileSync(join(p.trialsDir, "no-video.json"), JSON.stringify(makeTrial("no-video")));
+    writeFileSync(join(p.videosDir, "with-video.mp4"), Buffer.from("v"));
+
+    const mock = makeMockS3();
+    const manifest = await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    expect(manifest.trials["with-video"].video).toBe("videos/run-1/with-video.mp4");
+    expect(manifest.trials["no-video"].video).toBeUndefined();
+  });
+
+  it("uses the actual video extension on disk (.webm fallback when ffmpeg conversion didn't run)", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+    writeFileSync(join(p.videosDir, "t1.webm"), Buffer.from("v"));
+
+    const mock = makeMockS3();
+    const manifest = await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    expect(manifest.trials.t1.video).toBe("videos/run-1/t1.webm");
+    const videoKeys = mock.puts.map((p) => p.key).filter((k) => k.startsWith("videos/"));
+    expect(videoKeys).toEqual(["videos/run-1/t1.webm"]);
+  });
+
+  it("prefers .mp4 over .webm when both exist (post-conversion sweep)", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+    writeFileSync(join(p.videosDir, "t1.mp4"), Buffer.from("mp4 bytes"));
+    writeFileSync(join(p.videosDir, "t1.webm"), Buffer.from("webm bytes"));
+
+    const mock = makeMockS3();
+    const manifest = await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    expect(manifest.trials.t1.video).toBe("videos/run-1/t1.mp4");
+    const videoKeys = mock.puts.map((p) => p.key).filter((k) => k.startsWith("videos/"));
+    expect(videoKeys).toEqual(["videos/run-1/t1.mp4"]);
+  });
+});
+
+describe("uploadRun — error paths", () => {
+  it("propagates S3 errors and leaves local files intact", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+    writeFileSync(join(p.videosDir, "t1.mp4"), Buffer.from("v"));
+
+    const send = vi.fn(async () => {
+      throw new Error("S3 unreachable");
+    });
+    const failingClient = { send } as unknown as S3Client;
+
+    await expect(
+      uploadRun({
+        paths: p,
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        deps: { s3Client: failingClient, bucket: "b", now: () => FIXED_NOW },
+      }),
+    ).rejects.toThrow(/S3 unreachable/);
+
+    // Files preserved so the user can rerun.
+    expect(existsSync(join(p.videosDir, "t1.mp4"))).toBe(true);
+    expect(existsSync(p.manifestPath)).toBe(false);
+  });
+});
+
+describe("uploadRun — atomic local rewrite (Option A)", () => {
+  it("preserves the full local trial JSON when the trace PUT fails after the lightweight PUT succeeded", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    const trial = makeTrial("t1");
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(trial));
+
+    // Fail only the trace PUT. The summary + lightweight trial PUTs succeed.
+    const mock = makeMockS3((cmd) => cmd.input.Key?.startsWith("traces/") ?? false);
+
+    await expect(
+      uploadRun({
+        paths: p,
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        deps: fixedDeps(mock),
+      }),
+    ).rejects.toThrow(/simulated S3 failure/);
+
+    // The local trial JSON must STILL contain the full trace + parts so a
+    // future re-run can rebuild the trace blob from disk. If we'd already
+    // rewritten it as lightweight, that data would be lost.
+    const onDisk = JSON.parse(readFileSync(join(p.trialsDir, "t1.json"), "utf-8"));
+    expect(onDisk.trace).toEqual(trial.trace);
+    expect(onDisk.parts).toEqual(trial.parts);
+  });
+
+  it("preserves the full local trial JSON when the video PUT fails after both prior PUTs succeeded", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    const trial = makeTrial("t1");
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(trial));
+    writeFileSync(join(p.videosDir, "t1.mp4"), Buffer.from("v"));
+
+    const mock = makeMockS3((cmd) => cmd.input.Key?.startsWith("videos/") ?? false);
+
+    await expect(
+      uploadRun({
+        paths: p,
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        deps: fixedDeps(mock),
+      }),
+    ).rejects.toThrow(/simulated S3 failure/);
+
+    const onDisk = JSON.parse(readFileSync(join(p.trialsDir, "t1.json"), "utf-8"));
+    expect(onDisk.trace).toEqual(trial.trace);
+    expect(onDisk.parts).toEqual(trial.parts);
+  });
+});
+
+describe("uploadRun — resume state (Option B)", () => {
+  const STATE_FILENAME = ".upload-state.json";
+
+  function statePath(runDir: string): string {
+    return join(runDir, STATE_FILENAME);
+  }
+
+  it("writes the state file after each trial completes and removes it on full success", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "t1.json"), JSON.stringify(makeTrial("t1")));
+
+    const mock = makeMockS3();
+    await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    // After full success the state file is gone — the manifest is now the
+    // source of truth.
+    expect(existsSync(statePath(runDir))).toBe(false);
+    expect(existsSync(p.manifestPath)).toBe(true);
+  });
+
+  it("persists per-trial progress when failure occurs mid-sweep", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "a.json"), JSON.stringify(makeTrial("a")));
+    writeFileSync(join(p.trialsDir, "b.json"), JSON.stringify(makeTrial("b")));
+
+    // Fail the SECOND trial's lightweight PUT (after `a` is fully done).
+    const mock = makeMockS3((cmd) => cmd.input.Key === "runs/run-1/trials/b.json");
+
+    await expect(
+      uploadRun({
+        paths: p,
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        deps: fixedDeps(mock),
+      }),
+    ).rejects.toThrow();
+
+    expect(existsSync(statePath(runDir))).toBe(true);
+    const state = JSON.parse(readFileSync(statePath(runDir), "utf-8"));
+    expect(state.runId).toBe("run-1");
+    expect(state.summaryUploaded).toBe(true);
+    expect(Object.keys(state.trials)).toEqual(["a"]);
+    expect(state.trials.a.trace).toBe("traces/run-1/a.json.zst");
+  });
+
+  it("skips trials already recorded in the state file on resume", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "a.json"), JSON.stringify(makeTrial("a")));
+    writeFileSync(join(p.trialsDir, "b.json"), JSON.stringify(makeTrial("b")));
+
+    // Pre-seed state as if `a` was already uploaded successfully.
+    writeFileSync(
+      statePath(runDir),
+      JSON.stringify({
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        bucket: "test-bucket",
+        compression: "zstd",
+        summaryUploaded: true,
+        trials: {
+          a: {
+            trace: "traces/run-1/a.json.zst",
+            traceBytes: 999,
+          },
+        },
+      }),
+    );
+
+    const mock = makeMockS3();
+    const manifest = await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(mock),
+    });
+
+    // Only the keys for trial `b` should have been PUT this time.
+    const keys = mock.puts.map((p) => p.key).sort();
+    expect(keys).toEqual([
+      "runs/run-1/trials/b.json",
+      "traces/run-1/b.json.zst",
+    ]);
+
+    // The manifest still includes both trials — `a` from preserved state,
+    // `b` from this run.
+    expect(Object.keys(manifest.trials).sort()).toEqual(["a", "b"]);
+    expect(manifest.trials.a.traceBytes).toBe(999);
+  });
+
+  it("throws when the state file's runId/evalSet/arm/bucket/compression don't match the current invocation", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({}));
+    writeFileSync(join(p.trialsDir, "a.json"), JSON.stringify(makeTrial("a")));
+
+    writeFileSync(
+      statePath(runDir),
+      JSON.stringify({
+        runId: "wrong-run",
+        evalSet: "x",
+        arm: "y",
+        bucket: "test-bucket",
+        compression: "zstd",
+        summaryUploaded: true,
+        trials: {},
+      }),
+    );
+
+    const mock = makeMockS3();
+    await expect(
+      uploadRun({
+        paths: p,
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        deps: fixedDeps(mock),
+      }),
+    ).rejects.toThrow(/upload state.*does not match/i);
+  });
+
+  it("end-to-end: a partial failure followed by a full retry produces the same manifest as a single clean run", async () => {
+    const runDir = makeRunDir();
+    trackForCleanup(runDir);
+    const p = paths(runDir);
+    writeFileSync(p.summaryPath, JSON.stringify({ runId: "run-1" }));
+    writeFileSync(join(p.trialsDir, "a.json"), JSON.stringify(makeTrial("a")));
+    writeFileSync(join(p.trialsDir, "b.json"), JSON.stringify(makeTrial("b")));
+    writeFileSync(join(p.videosDir, "a.mp4"), Buffer.from("vid-a"));
+    writeFileSync(join(p.videosDir, "b.mp4"), Buffer.from("vid-b"));
+
+    // First attempt: fail on b's video PUT.
+    const failingMock = makeMockS3(
+      (cmd) => cmd.input.Key === "videos/run-1/b.mp4",
+    );
+    await expect(
+      uploadRun({
+        paths: p,
+        runId: "run-1",
+        evalSet: "x",
+        arm: "y",
+        deps: fixedDeps(failingMock),
+      }),
+    ).rejects.toThrow();
+
+    expect(existsSync(statePath(runDir))).toBe(true);
+    expect(existsSync(p.manifestPath)).toBe(false);
+
+    // Second attempt: same params, no failure injection.
+    const goodMock = makeMockS3();
+    const manifest = await uploadRun({
+      paths: p,
+      runId: "run-1",
+      evalSet: "x",
+      arm: "y",
+      deps: fixedDeps(goodMock),
+    });
+
+    // State file removed; manifest written.
+    expect(existsSync(statePath(runDir))).toBe(false);
+    expect(existsSync(p.manifestPath)).toBe(true);
+
+    // Both trials present.
+    expect(Object.keys(manifest.trials).sort()).toEqual(["a", "b"]);
+    expect(manifest.trials.a.video).toBe("videos/run-1/a.mp4");
+    expect(manifest.trials.b.video).toBe("videos/run-1/b.mp4");
+
+    // The second attempt did NOT re-PUT keys we'd already finished. `a` was
+    // entirely uploaded in the first attempt, so the second attempt should
+    // skip it. Only `b`'s keys should be in the second attempt's puts.
+    const secondKeys = goodMock.puts.map((p) => p.key).sort();
+    expect(secondKeys).toEqual([
+      "runs/run-1/trials/b.json",
+      "traces/run-1/b.json.zst",
+      "videos/run-1/b.mp4",
+    ]);
+  });
+});

--- a/packages/bench/src/upload.ts
+++ b/packages/bench/src/upload.ts
@@ -1,0 +1,430 @@
+/**
+ * R2 upload pipeline.
+ *
+ * Given a fully-written run directory (`<runDir>/summary.json`, per-trial
+ * JSONs in `<runDir>/trials/`, optional videos in `<runDir>/videos/`),
+ * `uploadRun` will:
+ *
+ *   1. Walk trials and, for each one, PUT the lightweight half to
+ *      `runs/<runId>/trials/<task-id>.json`, the zstd-compressed full
+ *      trace to `traces/<runId>/<task-id>.json.zst`, and the video (if
+ *      any) to `videos/<runId>/<task-id>.<ext>`. Prefers `.mp4` over
+ *      `.webm` when both exist (post-ffmpeg-conversion case).
+ *   2. Only AFTER all three PUTs for a trial have succeeded does it
+ *      rewrite the local trial JSON in place as the lightweight version.
+ *      This preserves the on-disk full trace + parts until R2 has its
+ *      own copy, so any failure mid-trial is recoverable by simply
+ *      re-running.
+ *   3. PUT the run-level `summary.json` to `runs/<runId>/summary.json`
+ *      first (small, surfaces auth failures fast).
+ *   4. Build a manifest from the upload metadata, write it to
+ *      `<runDir>/manifest.json`.
+ *   5. Optionally clean up local heavies (default on): remove the
+ *      `videos/` dir.
+ *
+ * Resume support
+ * --------------
+ *
+ * Per-trial progress is persisted to `<runDir>/.upload-state.json` after
+ * each successful trial. If `uploadRun` is invoked again on the same run
+ * dir (because a previous attempt crashed mid-sweep), the state file is
+ * consulted: trials already recorded as complete are skipped, and only
+ * the remaining ones are uploaded. The state file is removed on full
+ * success — `manifest.json` then becomes the source of truth.
+ *
+ * The state file's schema records the run's identity (`runId`, `evalSet`,
+ * `arm`, `bucket`, `compression`). If any of those don't match the
+ * current invocation, `uploadRun` throws to prevent silently mixing two
+ * different runs' artifacts. Manually delete the state file to start
+ * fresh.
+ *
+ * The S3 client is injected so tests can mock without a real network. In
+ * production, callers construct a real client from R2 env vars (see
+ * `createR2Client`).
+ */
+
+import {
+  PutObjectCommand,
+  S3Client,
+  type S3ClientConfig,
+} from "@aws-sdk/client-s3";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { compress, type CompressionAlgo } from "./compress";
+import {
+  buildManifest,
+  r2KeysFor,
+  type Manifest,
+  type ManifestTrialEntry,
+  type ManifestTrialUpload,
+  type VideoExt,
+} from "./manifest";
+import type { RunPaths } from "./paths";
+import { splitTrial } from "./runs";
+import type { TrialResult } from "./runner";
+
+export interface UploadDeps {
+  s3Client: S3Client;
+  bucket: string;
+  /** Override the manifest's `uploadedAt` for deterministic tests. */
+  now?: () => Date;
+}
+
+export interface UploadOpts {
+  paths: RunPaths;
+  runId: string;
+  evalSet: string;
+  arm: string;
+  /** Compression algorithm for trace blobs. Default: zstd. */
+  compression?: CompressionAlgo;
+  /** Delete local heavies after success. Default: true. */
+  cleanup?: boolean;
+  deps: UploadDeps;
+}
+
+/**
+ * Construct an S3 client pointed at Cloudflare R2 from env vars. Throws
+ * if any required var is missing — callers should detect upload-enabled
+ * mode via `r2EnvPresent()` first.
+ */
+export function createR2Client(env: NodeJS.ProcessEnv = process.env): {
+  client: S3Client;
+  bucket: string;
+} {
+  const accountId = env.R2_ACCOUNT_ID;
+  const endpoint = env.R2_ENDPOINT;
+  const accessKeyId = env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = env.R2_SECRET_ACCESS_KEY;
+  const bucket = env.R2_BUCKET;
+  const missing = Object.entries({
+    R2_ACCOUNT_ID: accountId,
+    R2_ENDPOINT: endpoint,
+    R2_ACCESS_KEY_ID: accessKeyId,
+    R2_SECRET_ACCESS_KEY: secretAccessKey,
+    R2_BUCKET: bucket,
+  })
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length > 0) {
+    throw new Error(
+      `createR2Client: missing required R2 env vars: ${missing.join(", ")}`,
+    );
+  }
+  const config: S3ClientConfig = {
+    region: "auto",
+    endpoint,
+    credentials: {
+      accessKeyId: accessKeyId!,
+      secretAccessKey: secretAccessKey!,
+    },
+  };
+  return { client: new S3Client(config), bucket: bucket! };
+}
+
+/** True when every required R2 env var is set. */
+export function r2EnvPresent(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (
+    !!env.R2_ACCOUNT_ID &&
+    !!env.R2_ENDPOINT &&
+    !!env.R2_ACCESS_KEY_ID &&
+    !!env.R2_SECRET_ACCESS_KEY &&
+    !!env.R2_BUCKET
+  );
+}
+
+interface VideoOnDisk {
+  taskId: string;
+  ext: VideoExt;
+  absPath: string;
+  bytes: number;
+}
+
+/** Index videosDir → preferred-extension lookup table by taskId. */
+function indexVideos(videosDir: string): Map<string, VideoOnDisk> {
+  const out = new Map<string, VideoOnDisk>();
+  if (!existsSync(videosDir)) return out;
+  let entries: string[];
+  try {
+    entries = readdirSync(videosDir);
+  } catch {
+    return out;
+  }
+  // Two passes: collect mp4s first (preferred), then webms only if no mp4
+  // exists for that taskId.
+  for (const name of entries) {
+    const lower = name.toLowerCase();
+    if (!lower.endsWith(".mp4")) continue;
+    const taskId = name.replace(/\.mp4$/i, "");
+    const absPath = join(videosDir, name);
+    const bytes = readFileSync(absPath).byteLength;
+    out.set(taskId, { taskId, ext: "mp4", absPath, bytes });
+  }
+  for (const name of entries) {
+    const lower = name.toLowerCase();
+    if (!lower.endsWith(".webm")) continue;
+    const taskId = name.replace(/\.webm$/i, "");
+    if (out.has(taskId)) continue;
+    const absPath = join(videosDir, name);
+    const bytes = readFileSync(absPath).byteLength;
+    out.set(taskId, { taskId, ext: "webm", absPath, bytes });
+  }
+  return out;
+}
+
+async function putObject(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  body: Buffer,
+  contentType?: string,
+): Promise<void> {
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    }),
+  );
+}
+
+/**
+ * Side-table state written incrementally during an upload to support
+ * resume on partial failure. Schema mirrors the eventual `Manifest`,
+ * minus `uploadedAt` (which only meaningful once the entire upload
+ * succeeds).
+ */
+interface UploadState {
+  runId: string;
+  evalSet: string;
+  arm: string;
+  bucket: string;
+  compression: CompressionAlgo;
+  /** True once `runs/<runId>/summary.json` is in R2. */
+  summaryUploaded: boolean;
+  /** Per-task entries, populated only after all of a trial's PUTs succeed. */
+  trials: Record<string, ManifestTrialEntry>;
+}
+
+const STATE_FILENAME = ".upload-state.json";
+
+function uploadStatePath(paths: RunPaths): string {
+  return join(paths.runDir, STATE_FILENAME);
+}
+
+function readUploadState(paths: RunPaths): UploadState | null {
+  const path = uploadStatePath(paths);
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw) as UploadState;
+}
+
+/**
+ * Atomically write the state file via tmp + rename so a crash mid-write
+ * can never leave a corrupt half-written JSON behind.
+ */
+function writeUploadState(paths: RunPaths, state: UploadState): void {
+  const path = uploadStatePath(paths);
+  const tmp = path + ".tmp";
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
+}
+
+function deleteUploadState(paths: RunPaths): void {
+  const path = uploadStatePath(paths);
+  if (existsSync(path)) unlinkSync(path);
+}
+
+export async function uploadRun(opts: UploadOpts): Promise<Manifest> {
+  const { paths, runId, evalSet, arm, deps } = opts;
+  const compression: CompressionAlgo = opts.compression ?? "zstd";
+  const cleanup = opts.cleanup ?? true;
+  const now = deps.now ?? (() => new Date());
+
+  // Try to resume from a previous partial upload.
+  const existing = readUploadState(paths);
+  let state: UploadState;
+  if (existing) {
+    if (
+      existing.runId !== runId ||
+      existing.evalSet !== evalSet ||
+      existing.arm !== arm ||
+      existing.bucket !== deps.bucket ||
+      existing.compression !== compression
+    ) {
+      throw new Error(
+        `upload state in ${uploadStatePath(paths)} does not match current ` +
+          `invocation (runId/evalSet/arm/bucket/compression). Delete the ` +
+          `state file to start fresh, or re-invoke with matching parameters.`,
+      );
+    }
+    state = existing;
+  } else {
+    state = {
+      runId,
+      evalSet,
+      arm,
+      bucket: deps.bucket,
+      compression,
+      summaryUploaded: false,
+      trials: {},
+    };
+  }
+
+  // Upload summary first — small, and surfaces auth failures fast. Skip
+  // if a previous attempt already completed it.
+  if (!state.summaryUploaded) {
+    const summaryBody = readFileSync(paths.summaryPath);
+    const summaryKey = r2KeysFor({
+      runId,
+      taskId: null,
+      compressionAlgo: compression,
+      videoExt: "mp4",
+    }).summary;
+    await putObject(
+      deps.s3Client,
+      deps.bucket,
+      summaryKey,
+      summaryBody,
+      "application/json",
+    );
+    state.summaryUploaded = true;
+    writeUploadState(paths, state);
+  }
+
+  // Walk trials.
+  const trialFiles = readdirSync(paths.trialsDir).filter((f) =>
+    f.endsWith(".json"),
+  );
+  const videoIndex = indexVideos(paths.videosDir);
+
+  for (const file of trialFiles) {
+    const absPath = join(paths.trialsDir, file);
+    const raw = readFileSync(absPath, "utf-8");
+    const trial = JSON.parse(raw) as TrialResult;
+
+    // Resume short-circuit.
+    if (state.trials[trial.taskId]) continue;
+
+    const { lightweight, fullTrace } = splitTrial(trial);
+    const trialKeys = r2KeysFor({
+      runId,
+      taskId: trial.taskId,
+      compressionAlgo: compression,
+      videoExt: "mp4",
+    });
+
+    // PUT lightweight trial JSON.
+    const lightweightBody = Buffer.from(
+      JSON.stringify(lightweight, null, 2),
+      "utf-8",
+    );
+    await putObject(
+      deps.s3Client,
+      deps.bucket,
+      trialKeys.trial,
+      lightweightBody,
+      "application/json",
+    );
+
+    // PUT compressed full trace.
+    const traceJson = Buffer.from(JSON.stringify(fullTrace), "utf-8");
+    const { data: compressed } = compress(traceJson, { algo: compression });
+    await putObject(
+      deps.s3Client,
+      deps.bucket,
+      trialKeys.trace,
+      compressed,
+      "application/octet-stream",
+    );
+
+    // PUT video (if any).
+    let videoKey: string | null = null;
+    let videoBytes: number | null = null;
+    const video = videoIndex.get(trial.taskId);
+    if (video) {
+      const videoKeys = r2KeysFor({
+        runId,
+        taskId: trial.taskId,
+        compressionAlgo: compression,
+        videoExt: video.ext,
+      });
+      const videoBody = readFileSync(video.absPath);
+      await putObject(
+        deps.s3Client,
+        deps.bucket,
+        videoKeys.video,
+        videoBody,
+        video.ext === "mp4" ? "video/mp4" : "video/webm",
+      );
+      videoKey = videoKeys.video;
+      videoBytes = video.bytes;
+    }
+
+    // All cloud PUTs for this trial succeeded. NOW it's safe to:
+    //   1. Rewrite the local trial JSON as lightweight (R2 has the heavy
+    //      half so loss of the on-disk copy is no longer a concern).
+    //   2. Mark the trial as complete in the state file.
+    writeFileSync(
+      absPath,
+      JSON.stringify(lightweight, null, 2) + "\n",
+      "utf-8",
+    );
+
+    const entry: ManifestTrialEntry = {
+      trace: trialKeys.trace,
+      traceBytes: compressed.byteLength,
+    };
+    if (videoKey !== null) {
+      entry.video = videoKey;
+      entry.videoBytes = videoBytes ?? 0;
+    }
+    state.trials[trial.taskId] = entry;
+    writeUploadState(paths, state);
+  }
+
+  // All trials done. Build the manifest from the now-complete state.
+  const uploads: ManifestTrialUpload[] = Object.entries(state.trials).map(
+    ([taskId, entry]) => ({
+      taskId,
+      traceKey: entry.trace,
+      traceBytes: entry.traceBytes,
+      videoKey: entry.video ?? null,
+      videoBytes: entry.videoBytes ?? null,
+    }),
+  );
+  const manifest = buildManifest({
+    runId: state.runId,
+    evalSet: state.evalSet,
+    arm: state.arm,
+    bucket: state.bucket,
+    compression: state.compression,
+    uploadedAt: now().toISOString(),
+    uploads,
+  });
+
+  writeFileSync(
+    paths.manifestPath,
+    JSON.stringify(manifest, null, 2) + "\n",
+    "utf-8",
+  );
+
+  // Manifest is now the source of truth — drop the side table.
+  deleteUploadState(paths);
+
+  if (cleanup) {
+    if (existsSync(paths.videosDir)) {
+      rmSync(paths.videosDir, { recursive: true, force: true });
+    }
+  }
+
+  return manifest;
+}

--- a/packages/bench/src/upload.ts
+++ b/packages/bench/src/upload.ts
@@ -54,6 +54,7 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -61,7 +62,8 @@ import { join } from "node:path";
 import { compress, type CompressionAlgo } from "./compress";
 import {
   buildManifest,
-  r2KeysFor,
+  r2SummaryKey,
+  r2TrialKeys,
   type Manifest,
   type ManifestTrialEntry,
   type ManifestTrialUpload,
@@ -158,13 +160,14 @@ function indexVideos(videosDir: string): Map<string, VideoOnDisk> {
     return out;
   }
   // Two passes: collect mp4s first (preferred), then webms only if no mp4
-  // exists for that taskId.
+  // exists for that taskId. Use stat (metadata only) to read sizes — the
+  // file body itself is read once, later, when we actually upload it.
   for (const name of entries) {
     const lower = name.toLowerCase();
     if (!lower.endsWith(".mp4")) continue;
     const taskId = name.replace(/\.mp4$/i, "");
     const absPath = join(videosDir, name);
-    const bytes = readFileSync(absPath).byteLength;
+    const bytes = statSync(absPath).size;
     out.set(taskId, { taskId, ext: "mp4", absPath, bytes });
   }
   for (const name of entries) {
@@ -173,7 +176,7 @@ function indexVideos(videosDir: string): Map<string, VideoOnDisk> {
     const taskId = name.replace(/\.webm$/i, "");
     if (out.has(taskId)) continue;
     const absPath = join(videosDir, name);
-    const bytes = readFileSync(absPath).byteLength;
+    const bytes = statSync(absPath).size;
     out.set(taskId, { taskId, ext: "webm", absPath, bytes });
   }
   return out;
@@ -283,16 +286,10 @@ export async function uploadRun(opts: UploadOpts): Promise<Manifest> {
   // if a previous attempt already completed it.
   if (!state.summaryUploaded) {
     const summaryBody = readFileSync(paths.summaryPath);
-    const summaryKey = r2KeysFor({
-      runId,
-      taskId: null,
-      compressionAlgo: compression,
-      videoExt: "mp4",
-    }).summary;
     await putObject(
       deps.s3Client,
       deps.bucket,
-      summaryKey,
+      r2SummaryKey(runId),
       summaryBody,
       "application/json",
     );
@@ -315,7 +312,10 @@ export async function uploadRun(opts: UploadOpts): Promise<Manifest> {
     if (state.trials[trial.taskId]) continue;
 
     const { lightweight, fullTrace } = splitTrial(trial);
-    const trialKeys = r2KeysFor({
+    // The `trial` and `trace` keys don't depend on the actual video
+    // extension on disk, so derive them with a placeholder. The video
+    // key is recomputed below with the real extension if a video exists.
+    const trialKeys = r2TrialKeys({
       runId,
       taskId: trial.taskId,
       compressionAlgo: compression,
@@ -351,7 +351,7 @@ export async function uploadRun(opts: UploadOpts): Promise<Manifest> {
     let videoBytes: number | null = null;
     const video = videoIndex.get(trial.taskId);
     if (video) {
-      const videoKeys = r2KeysFor({
+      const videoKeys = r2TrialKeys({
         runId,
         taskId: trial.taskId,
         compressionAlgo: compression,
@@ -369,16 +369,13 @@ export async function uploadRun(opts: UploadOpts): Promise<Manifest> {
       videoBytes = video.bytes;
     }
 
-    // All cloud PUTs for this trial succeeded. NOW it's safe to:
-    //   1. Rewrite the local trial JSON as lightweight (R2 has the heavy
-    //      half so loss of the on-disk copy is no longer a concern).
-    //   2. Mark the trial as complete in the state file.
-    writeFileSync(
-      absPath,
-      JSON.stringify(lightweight, null, 2) + "\n",
-      "utf-8",
-    );
-
+    // All cloud PUTs for this trial succeeded. Persist the state file
+    // BEFORE rewriting the local trial JSON: the rewrite is what removes
+    // the heavy half from disk, so if a crash interrupted the sequence
+    // between rewrite and state-persist, a future re-run would see no
+    // state record, re-read the now-lightweight trial, and overwrite the
+    // good R2 trace with a garbage one. Persisting state first means a
+    // re-run will hit the skip-check and never re-process this trial.
     const entry: ManifestTrialEntry = {
       trace: trialKeys.trace,
       traceBytes: compressed.byteLength,
@@ -389,6 +386,14 @@ export async function uploadRun(opts: UploadOpts): Promise<Manifest> {
     }
     state.trials[trial.taskId] = entry;
     writeUploadState(paths, state);
+
+    // Now safe to rewrite the local trial JSON as lightweight (R2 has
+    // the heavy half + state confirms it).
+    writeFileSync(
+      absPath,
+      JSON.stringify(lightweight, null, 2) + "\n",
+      "utf-8",
+    );
   }
 
   // All trials done. Build the manifest from the now-complete state.

--- a/packages/bench/vitest.config.ts
+++ b/packages/bench/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,7 +324,7 @@ importers:
         version: 5.0.6
       '@wxt-dev/module-react':
         specifier: ^1.1.5
-        version: 1.2.2(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))(wxt@0.20.24(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3))
+        version: 1.2.2(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))(wxt@0.20.24(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3))
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5
@@ -339,7 +339,7 @@ importers:
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))
       wxt:
         specifier: ^0.20.24
-        version: 0.20.24(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3)
+        version: 0.20.24(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3)
 
   packages/bench:
     dependencies:
@@ -352,6 +352,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.53
         version: 3.0.64(zod@4.4.3)
+      '@aws-sdk/client-s3':
+        specifier: ^3.1054.0
+        version: 3.1054.0
       '@huggingface/hub':
         specifier: ^2.12.0
         version: 2.13.0
@@ -395,6 +398,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3))
 
   packages/connectors:
     devDependencies:
@@ -549,6 +555,125 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1054.0':
+    resolution: {integrity: sha512-2ue7uVqaHYX4rytkcrLySYU/m/ZlRbL8KojWefbR24B0/TcFkqN2IovpBFrnmla/dtZAn9eVSlhHeEddOghZ5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.14':
+    resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.16':
+    resolution: {integrity: sha512-FhasMTBDBmMN7EEa1hUeHwo5p5Mv3Dm8w0VEbdXX/6ola/uyhRuJt8zGkH09mLTmab20USTzEpPqyqEoe1MqNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    resolution: {integrity: sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.22':
+    resolution: {integrity: sha512-ot1kZ1JGHUxcXPOARhej/n/+Odfx9VPt60pNrUq8Lf/U2blIF3+uj5v56gw76VD70dZvrfeLNo9jKz6pQJfOlA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.43':
+    resolution: {integrity: sha512-CBmixMY36JdAdt9ALgm7yVlvOXGUCHt9Z2kn5p9XVO5StO6HCH+cayV7YYV1CDLsXvVyebaXgBmif9wHoxCeNA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.12':
+    resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1054.0':
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1255,89 +1380,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1489,24 +1630,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -1531,6 +1676,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2349,36 +2497,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -2408,131 +2562,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
-
-  '@rollup/rollup-android-arm-eabi@4.60.4':
-    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.4':
-    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.60.4':
-    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.4':
-    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.60.4':
-    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.4':
-    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
-    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
-    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.4':
-    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.4':
-    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-gnu@4.60.4':
-    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.4':
-    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
-    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.4':
-    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
-    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.4':
-    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.4':
-    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.4':
-    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.60.4':
-    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-openbsd-x64@4.60.4':
-    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.4':
-    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.4':
-    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.4':
-    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.60.4':
-    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.4':
-    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
-    cpu: [x64]
-    os: [win32]
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -2571,6 +2600,42 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2649,48 +2714,56 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
     resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3353,6 +3426,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -4185,6 +4261,13 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -4943,24 +5026,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5590,6 +5677,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -6017,11 +6108,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.60.4:
-    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -6294,6 +6380,9 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -6831,6 +6920,10 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -7019,14 +7112,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.60.4)':
+  '@aklinker1/rollup-plugin-visualizer@5.12.0':
     dependencies:
       open: 8.4.2
       picomatch: 2.3.2
       source-map: 0.7.6
       yargs: 17.7.2
-    optionalDependencies:
-      rollup: 4.60.4
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7034,6 +7125,268 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.2
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1054.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.16
+      '@aws-sdk/middleware-expect-continue': 3.972.13
+      '@aws-sdk/middleware-flexible-checksums': 3.974.22
+      '@aws-sdk/middleware-location-constraint': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.43
+      '@aws-sdk/middleware-ssec': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/token-providers': 3.1054.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.16':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.22':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/crc64-nvme': 3.972.9
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.12':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -8010,6 +8363,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8883,81 +9238,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.4':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.4':
-    optional: true
-
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@shikijs/core@4.0.2':
@@ -9001,6 +9281,54 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -9595,6 +9923,15 @@ snapshots:
       msw: 2.13.4(@types/node@25.9.1)(typescript@6.0.3)
       vite: 8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)
 
+  '@vitest/mocker@4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.4(@types/node@25.9.1)(typescript@6.0.3)
+      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)
+
   '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
@@ -9634,11 +9971,11 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))(wxt@0.20.24(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3))':
+  '@wxt-dev/module-react@1.2.2(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))(wxt@0.20.24(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3))':
     dependencies:
       '@vitejs/plugin-react': 6.0.1(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3))
       vite: 8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)
-      wxt: 0.20.24(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3)
+      wxt: 0.20.24(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
@@ -9776,6 +10113,8 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  bowser@2.14.1: {}
 
   boxen@8.0.1:
     dependencies:
@@ -10662,6 +11001,18 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -12331,6 +12682,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -12915,38 +13268,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
-  rollup@4.60.4:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.4
-      '@rollup/rollup-android-arm64': 4.60.4
-      '@rollup/rollup-darwin-arm64': 4.60.4
-      '@rollup/rollup-darwin-x64': 4.60.4
-      '@rollup/rollup-freebsd-arm64': 4.60.4
-      '@rollup/rollup-freebsd-x64': 4.60.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
-      '@rollup/rollup-linux-arm64-gnu': 4.60.4
-      '@rollup/rollup-linux-arm64-musl': 4.60.4
-      '@rollup/rollup-linux-loong64-gnu': 4.60.4
-      '@rollup/rollup-linux-loong64-musl': 4.60.4
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
-      '@rollup/rollup-linux-ppc64-musl': 4.60.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
-      '@rollup/rollup-linux-riscv64-musl': 4.60.4
-      '@rollup/rollup-linux-s390x-gnu': 4.60.4
-      '@rollup/rollup-linux-x64-gnu': 4.60.4
-      '@rollup/rollup-linux-x64-musl': 4.60.4
-      '@rollup/rollup-openbsd-x64': 4.60.4
-      '@rollup/rollup-openharmony-arm64': 4.60.4
-      '@rollup/rollup-win32-arm64-msvc': 4.60.4
-      '@rollup/rollup-win32-ia32-msvc': 4.60.4
-      '@rollup/rollup-win32-x64-gnu': 4.60.4
-      '@rollup/rollup-win32-x64-msvc': 4.60.4
-      fsevents: 2.3.3
-    optional: true
-
   rope-sequence@1.3.4: {}
 
   roughjs@4.6.6:
@@ -13311,6 +13632,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.3.0: {}
+
   stubborn-fs@2.0.0:
     dependencies:
       stubborn-utils: 1.0.2
@@ -13654,7 +13977,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.22.3
-    optional: true
 
   vitefu@1.1.3(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)):
     optionalDependencies:
@@ -13681,6 +14003,34 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -13802,10 +14152,10 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.24(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3):
+  wxt@0.20.24(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3):
     dependencies:
       '@1natsu/wait-element': 4.2.0
-      '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.60.4)
+      '@aklinker1/rollup-plugin-visualizer': 5.12.0
       '@webext-core/fake-browser': 1.3.4
       '@webext-core/isolated-element': 1.1.5
       '@webext-core/match-patterns': 1.0.3
@@ -13873,6 +14223,8 @@ snapshots:
       ssf: 0.11.2
       wmf: 1.0.2
       word: 0.3.0
+
+  xml-naming@0.1.0: {}
 
   xml2js@0.6.2:
     dependencies:


### PR DESCRIPTION
Adds optional Cloudflare R2 storage for bench run artifacts. Without R2 env vars set, behavior is unchanged.

## Layout

```
runs/<run-id>/summary.json                    indefinite retention
runs/<run-id>/trials/<task-id>.json           lightweight (no trace[]/parts[])
traces/<run-id>/<task-id>.json.zst            full trace + parts; 365d TTL
videos/<run-id>/<task-id>.{mp4,webm}          90d TTL
```

Flat top-level prefixes are required by R2 lifecycle rules (literal `startsWith` matching).

## Resumability

Per-trial progress is persisted atomically to `<runDir>/.upload-state.json` after each trial's PUTs all succeed. Re-running on the same run dir skips already-uploaded trials. The local trial JSON is rewritten as lightweight only AFTER all of that trial's PUTs complete, so any mid-trial failure leaves the full on-disk JSON intact and the next attempt can rebuild the trace blob from disk. The state file is removed on full success; `manifest.json` then becomes the source of truth.

## CLI

```
--upload <mode>     auto (default) | always | never
--no-upload         alias for --upload never
--eval-set <name>   embedded in run-id and manifest
--arm <name>        arm name within an eval-set
```

`--upload always` validates R2 env vars before launching any trials so misconfigurations fail in <1s instead of after a long sweep. `--upload auto` silently skips when env vars aren't set, leaving existing local-only workflows untouched.

## Implementation

| File | Purpose |
|---|---|
| `src/runs.ts` | Pure `splitTrial` / `mergeTrial` |
| `src/compress.ts` | zstd via `node:zlib` (no native dep), gzip fallback |
| `src/manifest.ts` | `buildManifest` + `r2KeysFor` |
| `src/upload.ts` | `uploadRun()` with injectable S3 client + resume |
| `src/paths.ts` | `RunPaths` gains `tracesDir` + `manifestPath`; `makeRunId` supports `<ts>-<eval-set>-<arm>` |
| `src/cli.ts` | Flag parsing, fail-fast validation, post-summary upload hook |

## Testing

- 45 new unit tests in `@openbrowse/bench`, all passing
- Workspace `test` script now covers all packages: 189 total (144 + 45)
- Live R2 smoke test: upload + zstd round-trip verified end-to-end
- Regression: bench with no R2 env runs unchanged

## Notes

- `@aws-sdk/client-s3` is the only new dependency
- `zstd-napi` rejected in favor of Node's built-in `zlib.zstd*` — no native bindings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare R2 upload: resumable, per-trial artifact uploads with manifest generation; video handling and cleanup options
  * CLI: upload controls plus experiment metadata (evalSet/arm) embedded in run IDs
  * Compression: zstd/gzip support for trace blobs

* **Tests**
  * Comprehensive unit/integration coverage for paths, manifest, runs, compression, and upload/resume behavior

* **Documentation**
  * Added R2 configuration and usage guide with examples

* **Chores**
  * Test script updated to run across all workspace packages in parallel; bench package test scripts and dependencies added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->