### PR TITLE
feat: completion check — review and refine drafted responses before they ship

### DIFF
--- a/.changeset/nimble-seeds-tigers.md
+++ b/.changeset/nimble-seeds-tigers.md
@@ -1,0 +1,10 @@
+---
+"openbrowse": patch
+---
+
+Agent reliability fixes:
+
+- Tab handles now persist across mid-stream conversation switches, so in-flight tool calls in the previous chat don't lose the tab they were targeting.
+- Stranded tool calls left over from interrupted streams heal cleanly on edit/retry/regenerate instead of breaking the conversation on resume.
+- Approving a tool call while other tools are still running in the same step no longer drops the auto-resume — the agent now picks up the approved call once the rest of the step completes.
+- Editing a user message in chat-db now logs a warning when the target id can't be found, surfacing the historical "stale tail after edit" failure mode at first repro instead of silently months later.

--- a/.changeset/nimble-seeds-tigers.md
+++ b/.changeset/nimble-seeds-tigers.md
@@ -8,3 +8,5 @@ Agent reliability fixes:
 - Stranded tool calls left over from interrupted streams heal cleanly on edit/retry/regenerate instead of breaking the conversation on resume.
 - Approving a tool call while other tools are still running in the same step no longer drops the auto-resume — the agent now picks up the approved call once the rest of the step completes.
 - Editing a user message in chat-db now logs a warning when the target id can't be found, surfacing the historical "stale tail after edit" failure mode at first repro instead of silently months later.
+- The completion-check evaluator now pins to its transport instance, so multiple concurrent agent windows can't drift across each other's models mid-stream.
+- Evaluator-error fallback messages no longer expose internal error details to the chat or markdown export; detailed errors stay in the developer console.

--- a/.changeset/silver-vines-foxes.md
+++ b/.changeset/silver-vines-foxes.md
@@ -2,4 +2,4 @@
 "openbrowse": minor
 ---
 
-Agent: a separate skeptical evaluator now reviews each drafted final response before it reaches you, and asks the agent to revise if the response is incomplete or unsupported by what was actually observed. Mid-loop refinements show as a compact "Refining answer" pill; unresolved concerns surface as a soft warning. Choose a cheaper or faster evaluator model in Settings → Completion check, or leave it on the default. Chat exports and the per-message Copy button now include the rejection block as part of the audit trail.
+Agent: a separate skeptical evaluator now reviews each drafted final response before it reaches you, and asks the agent to revise if the response is incomplete or unsupported by what was actually observed. Mid-loop refinements show as a compact "Refining answer" pill; unresolved concerns surface as a soft warning. Choose a cheaper or faster evaluator model in Settings → General, or leave it on the default. Chat exports and the per-message Copy button now include the rejection block as part of the audit trail.

--- a/.changeset/silver-vines-foxes.md
+++ b/.changeset/silver-vines-foxes.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": minor
+---
+
+Agent: a separate skeptical evaluator now reviews each drafted final response before it reaches you, and asks the agent to revise if the response is incomplete or unsupported by what was actually observed. Mid-loop refinements show as a compact "Refining answer" pill; unresolved concerns surface as a soft warning. Choose a cheaper or faster evaluator model in Settings → Completion check, or leave it on the default. Chat exports and the per-message Copy button now include the rejection block as part of the audit trail.

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -1,12 +1,86 @@
-import type { AgentUIMessage } from "@/lib/types";
+import type {
+  AgentUIMessage,
+  CompletionCheckRejectionData,
+  CompletionCheckRunningData,
+} from "@/lib/types";
 import { Reasoning } from "@/components/ai-elements/reasoning";
 import { Markdown } from "./Markdown";
 import { MessageActions } from "./MessageActions";
+import { CompletionCheckBlock } from "./CompletionCheckBlock";
+import { CompletionCheckRunningBlock } from "./CompletionCheckRunningBlock";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { ToolApprovalBlock } from "./ToolApprovalBlock";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 import { capturedToolOrigins, allowToolOnSite } from "@/lib/agent/agent-transport";
 import "@/components/chat/tool-previews";
+
+/**
+ * Map a tool UIPart's terminal/non-terminal `state` to the visual state
+ * the chat row should render in, plus the `result` payload to hand to
+ * the row's body.
+ *
+ * The AI SDK's tool UIPart can land in one of: `input-streaming`,
+ * `input-available`, `approval-requested`, `approval-responded`,
+ * `output-available`, `output-error`, `output-denied`. Earlier this
+ * helper only recognized `output-available` and `output-denied`, so an
+ * `output-error` part (e.g. from a tool that threw and the wrapper
+ * serialized as `{ error: "..." }` but the SDK normalized into the
+ * dedicated `output-error` state with an `errorText`) silently fell
+ * through to `state="call"` — the "Running code..." pending row,
+ * forever.
+ *
+ * Treat `output-error` as terminal:
+ *  - Surface a synthetic `{ error: errorText }` object so existing
+ *    custom renderers (e.g. `<CodeResult>`) light up their red error
+ *    path automatically.
+ *  - Tell `ToolCallBlock` to use the new `"errored"` row variant so
+ *    the collapsed row label shows a red AlertCircle + "Failed" suffix
+ *    instead of pretending the tool succeeded.
+ *
+ * `isStreaming` guards against false positives: while the assistant
+ * message is still streaming, a non-terminal tool part is genuinely
+ * in flight and should render as pending (`"call"`). Once the message
+ * finishes streaming, any remaining non-terminal part is an orphan —
+ * the SDK will never advance it — and should render as `"errored"`.
+ * This catches cases like `approval-responded` where the user approved
+ * but the agent loop never picked the call back up to invoke
+ * `execute()`.
+ */
+export function resolveToolPartState(
+  p: { state?: unknown; output?: unknown; errorText?: unknown },
+  opts: { isStreaming?: boolean } = {},
+): { state: "call" | "result" | "denied" | "errored"; result?: unknown } {
+  const state = p.state;
+
+  if (state === "output-available") {
+    return { state: "result", result: p.output };
+  }
+  if (state === "output-error") {
+    const errText =
+      typeof p.errorText === "string" && p.errorText.length > 0
+        ? p.errorText
+        : "Tool execution failed";
+    return { state: "errored", result: { error: errText } };
+  }
+  if (state === "output-denied") {
+    return { state: "denied" };
+  }
+
+  // Non-terminal state. If the message is still streaming this part is
+  // genuinely in flight — render as pending. If streaming has finished,
+  // the part is an orphan that will never advance.
+  if (opts.isStreaming) {
+    return { state: "call" };
+  }
+
+  // Orphan: produce a human-readable error distinguishing the two main
+  // cases so the user understands what happened.
+  const orphanMessage =
+    state === "approval-responded"
+      ? "Tool execution was skipped after approval."
+      : "Tool did not return a result before the turn ended.";
+  return { state: "errored", result: { error: orphanMessage } };
+}
 
 interface AssistantMessageProps {
   message: AgentUIMessage;
@@ -59,16 +133,15 @@ export function AssistantMessage({ message, isStreaming = false, onRegenerate, o
                 />
               );
             }
-            const hasOutput = part.state === "output-available";
-            const isDenied = (part.state as string) === "output-denied";
+            const toolState = resolveToolPartState(part, { isStreaming });
             return (
               <ToolCallBlock
                 key={part.toolCallId}
                 toolName={part.toolName}
                 toolCallId={part.toolCallId}
                 args={(part.input as Record<string, unknown>) ?? {}}
-                result={hasOutput ? part.output : undefined}
-                state={isDenied ? "denied" : hasOutput ? "result" : "call"}
+                result={toolState.result}
+                state={toolState.state}
               />
             );
           }
@@ -79,6 +152,34 @@ export function AssistantMessage({ message, isStreaming = false, onRegenerate, o
                 src={part.url}
                 alt="Generated image"
                 className="max-w-full max-h-[300px] rounded-md my-1"
+              />
+            );
+          }
+          if (part.type === "data-completion-check-rejection") {
+            // The SDK narrows `part.data` to
+            // `CompletionCheckRejectionData` because the part type is
+            // registered in `AgentDataParts`. Cast for safety against
+            // future schema drift.
+            const data = part.data as CompletionCheckRejectionData;
+            return <CompletionCheckBlock key={i} data={data} />;
+          }
+          if (part.type === "data-completion-check-running") {
+            // Live status indicator for an in-flight evaluator call.
+            // Renders a "Running quality check…" spinner during the
+            // "evaluating" phase; renders nothing once the gate
+            // resolves (any outcome). For rejected/force-emitted
+            // outcomes the sibling `data-completion-check-rejection`
+            // block carries the user-facing message; for
+            // approved/skipped outcomes the gate is silent (the
+            // user already sees the response — no badge).
+            // `isStreaming` is a defensive guard against stale
+            // "evaluating" parts from aborted streams.
+            const data = part.data as CompletionCheckRunningData;
+            return (
+              <CompletionCheckRunningBlock
+                key={i}
+                data={data}
+                isStreaming={isStreaming}
               />
             );
           }
@@ -102,18 +203,15 @@ export function AssistantMessage({ message, isStreaming = false, onRegenerate, o
                   />
                 );
               }
-              const hasOutput = p.state === "output-available";
-              const isDenied = p.state === "output-denied";
+              const toolState = resolveToolPartState(p, { isStreaming });
               return (
                 <ToolCallBlock
                   key={part.toolCallId}
                   toolName={toolName}
                   toolCallId={part.toolCallId}
                   args={(p.input as Record<string, unknown>) ?? {}}
-                  result={
-                    hasOutput && "output" in p ? p.output : undefined
-                  }
-                  state={isDenied ? "denied" : hasOutput ? "result" : "call"}
+                  result={toolState.result}
+                  state={toolState.state}
                 />
               );
             }

--- a/apps/extension/src/components/chat/CompletionCheckBlock.tsx
+++ b/apps/extension/src/components/chat/CompletionCheckBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -90,6 +90,7 @@ export function CompletionCheckBlock({
   data: CompletionCheckRejectionData;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const bodyId = useId();
   const variant = selectVariant(data);
 
   // Evaluator-error variant: minimal, non-interactive note. No
@@ -122,6 +123,8 @@ export function CompletionCheckBlock({
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls={bodyId}
         className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left"
       >
         {expanded ? (
@@ -135,7 +138,10 @@ export function CompletionCheckBlock({
         </span>
       </button>
       {expanded && (
-        <div className="border-t border-current/15 px-2.5 py-2">
+        <div
+          id={bodyId}
+          className="border-t border-current/15 px-2.5 py-2"
+        >
           <ul className="space-y-1 leading-relaxed">
             {data.concerns.map((c, i) => (
               <li key={i} className="flex gap-1.5">

--- a/apps/extension/src/components/chat/CompletionCheckBlock.tsx
+++ b/apps/extension/src/components/chat/CompletionCheckBlock.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Info,
+  Sparkles,
+  TriangleAlert,
+} from "lucide-react";
+import type { CompletionCheckRejectionData } from "@/lib/types";
+
+/**
+ * Three visual variants for the rejection block. The choice depends
+ * on `data.reason` and `data.forceEmittedNext`; see {@link selectVariant}.
+ *
+ *  - `"evaluator-error"`: subtle gray informational note. The
+ *    evaluator itself failed; the agent's response is unaffected, so
+ *    we shouldn't alarm the user. No expand affordance, no concerns.
+ *  - `"force-emit"`: soft warning. The gate caught real issues that
+ *    were NOT resolved (loop hit budget). Worth surfacing prominently.
+ *  - `"refining"`: neutral. The gate caught issues mid-loop and the
+ *    agent revised. By the time the user sees this rendered, the
+ *    revised response is also visible — this block is the audit
+ *    trail showing the agent self-corrected. Compact by default.
+ */
+type Variant = "evaluator-error" | "force-emit" | "refining";
+
+/**
+ * Pure decision: which variant to render.
+ *
+ * Exported for unit tests; rendering logic stays manual.
+ */
+export function selectVariant(data: CompletionCheckRejectionData): Variant {
+  if (data.reason === "evaluator-error") return "evaluator-error";
+  if (data.forceEmittedNext) return "force-emit";
+  return "refining";
+}
+
+/**
+ * Pure formatting: the heading text shown in the collapsed pill.
+ *
+ * "issue" / "issues" pluralize for `refining`. `force-emit` uses
+ * "flagged" because "issues" with a warning icon doubles the warning
+ * voice. `evaluator-error` uses a fixed string.
+ *
+ * Exported for unit tests.
+ */
+export function selectHeading(
+  variant: Variant,
+  concernCount: number,
+): string {
+  switch (variant) {
+    case "evaluator-error":
+      return "Quality check skipped — evaluator could not complete.";
+    case "force-emit":
+      return `This response may have issues (${concernCount} flagged)`;
+    case "refining": {
+      const noun = concernCount === 1 ? "issue" : "issues";
+      return `Refining answer (${concernCount} ${noun})`;
+    }
+  }
+}
+
+/**
+ * Renders a `data-completion-check-rejection` part as an inline
+ * audit-trail block within an assistant message.
+ *
+ * UX principles for this block:
+ *
+ *  - **No internal jargon inline.** Dimension labels (`completeness`,
+ *    `surfaceAccuracy`, etc.), evidence quotes, and the reasoning
+ *    paragraph are all internal scaffolding the user doesn't need.
+ *    Each concern surfaces only its `userSummary` — a one-sentence
+ *    plain-language observation produced by the evaluator.
+ *  - **Default collapsed.** The block lives in the message scrollback;
+ *    expanded-by-default would mean every refined turn dumps a wall
+ *    of text on every render.
+ *  - **Tiered intensity.** Mid-loop refinements (most common case)
+ *    are neutral — the agent self-corrected. Force-emits are warning-
+ *    colored because the user actually needs to know the answer might
+ *    be wrong. Evaluator errors are gray because nothing the user
+ *    sees is affected.
+ *
+ * The full technical detail (dimensions, evidence, reasoning, follow-up
+ * sent to the agent) is preserved in the markdown export — see
+ * `lib/format-markdown.ts`.
+ */
+export function CompletionCheckBlock({
+  data,
+}: {
+  data: CompletionCheckRejectionData;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const variant = selectVariant(data);
+
+  // Evaluator-error variant: minimal, non-interactive note. No
+  // concerns to surface, no expansion affordance.
+  if (variant === "evaluator-error") {
+    return (
+      <div
+        className="my-2 flex items-center gap-1.5 rounded-md border border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[0.6875rem] text-muted-foreground"
+        data-testid="completion-check-block"
+        data-variant="evaluator-error"
+      >
+        <Info className="size-3 shrink-0" />
+        <span>{selectHeading(variant, data.concerns.length)}</span>
+      </div>
+    );
+  }
+
+  const isForceEmit = variant === "force-emit";
+  const palette = isForceEmit
+    ? "border-red-500/40 bg-red-500/5 text-red-700 dark:text-red-300"
+    : "border-muted-foreground/20 bg-muted/30 text-muted-foreground";
+  const Icon = isForceEmit ? TriangleAlert : Sparkles;
+
+  return (
+    <div
+      className={`my-2 rounded-md border ${palette} text-xs`}
+      data-testid="completion-check-block"
+      data-variant={variant}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left"
+      >
+        {expanded ? (
+          <ChevronDown className="size-3 shrink-0" />
+        ) : (
+          <ChevronRight className="size-3 shrink-0" />
+        )}
+        <Icon className="size-3.5 shrink-0" />
+        <span className="flex-1 font-medium">
+          {selectHeading(variant, data.concerns.length)}
+        </span>
+      </button>
+      {expanded && (
+        <div className="border-t border-current/15 px-2.5 py-2">
+          <ul className="space-y-1 leading-relaxed">
+            {data.concerns.map((c, i) => (
+              <li key={i} className="flex gap-1.5">
+                <span className="opacity-50 shrink-0">•</span>
+                <span>{c.userSummary}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/extension/src/components/chat/CompletionCheckRunningBlock.tsx
+++ b/apps/extension/src/components/chat/CompletionCheckRunningBlock.tsx
@@ -1,0 +1,52 @@
+import { Loader2Icon } from "lucide-react";
+import type { CompletionCheckRunningData } from "@/lib/types";
+
+/**
+ * Renders a `data-completion-check-running` part as an inline status
+ * indicator within an assistant message.
+ *
+ * Single visual state by design:
+ *  - **`"evaluating"`**: small pill with spinner and "Running quality
+ *    check…" text. Surfaces the silent window between assistant
+ *    streaming finishing and the gate producing a verdict — without
+ *    this, evaluator calls that take 5–30 seconds make the UI look
+ *    stuck.
+ *  - **`"done"`**: renders nothing, regardless of outcome.
+ *
+ *    Approve / skip: the gate is plumbing; the user already sees the
+ *    response. We don't surface a "Verified" badge — that adds noise
+ *    on every clean turn without enabling action.
+ *
+ *    Reject / force-emit: the sibling `data-completion-check-rejection`
+ *    block carries the message ("Refining answer" or "This response
+ *    may have issues"). Rendering both would double up.
+ *
+ * `isStreaming` is plumbed from the chat status. We use it to defend
+ * against stale `"evaluating"` state — if a stream is aborted mid-
+ * gate, the part can persist with `phase: "evaluating"`. (Note: with
+ * the strip-on-serialize policy in `useAgentChat.ts`, this case is
+ * also handled at persistence time so the part never reaches reload.
+ * The runtime guard remains as belt-and-suspenders for in-memory
+ * abort scenarios.)
+ */
+export function CompletionCheckRunningBlock({
+  data,
+  isStreaming,
+}: {
+  data: CompletionCheckRunningData;
+  isStreaming: boolean;
+}) {
+  if (data.phase !== "evaluating") return null;
+  if (!isStreaming) return null;
+
+  return (
+    <div
+      className="my-2 inline-flex items-center gap-1.5 text-[0.6875rem] text-muted-foreground"
+      data-testid="completion-check-running"
+      data-phase="evaluating"
+    >
+      <Loader2Icon className="size-3 shrink-0 animate-spin" />
+      <span>Running quality check…</span>
+    </div>
+  );
+}

--- a/apps/extension/src/components/chat/ToolCallBlock.tsx
+++ b/apps/extension/src/components/chat/ToolCallBlock.tsx
@@ -8,7 +8,7 @@ import { toolResultStore, toolTabInfoStore } from "@/lib/agent/agent-transport";
 import { getMcpRegistry } from "@/lib/mcp";
 import { cn } from "@/lib/utils";
 import { getConnectorForMcpTool } from "@openbrowse/connectors";
-import { ChevronRight, Globe, X } from "lucide-react";
+import { AlertCircle, ChevronRight, Globe, X } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { CodeResult } from "./tool-results/execute-code";
@@ -52,7 +52,7 @@ interface ToolCallBlockProps {
   toolCallId: string;
   args: Record<string, unknown>;
   result?: unknown;
-  state: "call" | "result" | "denied";
+  state: "call" | "result" | "denied" | "errored";
 }
 
 const TOOL_LABELS: Record<string, { pending: string; done: string }> = {
@@ -173,6 +173,7 @@ export function ToolCallBlock({
   const [expanded, setExpanded] = useState(false);
   const pending = state === "call";
   const denied = state === "denied";
+  const errored = state === "errored";
   const resolvedResult = result ?? toolResultStore.get(toolCallId);
   const serverIdMatch = toolName.match(/^mcp_([^_]+)_/);
   const serverUrl = serverIdMatch
@@ -246,12 +247,24 @@ export function ToolCallBlock({
                   id={mcpInfo.connector.id}
                   className="size-3.5 shrink-0"
                 />
+              ) : errored ? (
+                <AlertCircle className="size-3 shrink-0 text-red-500/80" />
               ) : (
                 <span className="size-1.5 rounded-full shrink-0 bg-muted-foreground/40" />
               )}
-              <span className="text-sm text-muted-foreground">
+              <span
+                className={cn(
+                  "text-sm",
+                  errored ? "text-red-600/90 dark:text-red-400/90" : "text-muted-foreground",
+                )}
+              >
                 {dynamicLabels.done}
               </span>
+              {errored && (
+                <span className="text-[11px] text-red-600/70 dark:text-red-400/70 ml-1">
+                  Failed
+                </span>
+              )}
               {showTabBadge && <TabBadge toolCallId={toolCallId} />}
               <ChevronRight
                 className={cn(
@@ -291,6 +304,8 @@ export function ToolCallBlock({
               id={mcpInfo.connector.id}
               className="size-3.5 shrink-0"
             />
+          ) : errored ? (
+            <AlertCircle className="size-3 shrink-0 text-red-500/80" />
           ) : (
             <span
               className={cn(
@@ -311,7 +326,21 @@ export function ToolCallBlock({
               {dynamicLabels.pending}
             </span>
           ) : (
-            <span className="text-sm text-muted-foreground">{dynamicLabels.done}</span>
+            <span
+              className={cn(
+                "text-sm",
+                errored
+                  ? "text-red-600/90 dark:text-red-400/90"
+                  : "text-muted-foreground",
+              )}
+            >
+              {dynamicLabels.done}
+            </span>
+          )}
+          {errored && (
+            <span className="text-[11px] text-red-600/70 dark:text-red-400/70 ml-1">
+              Failed
+            </span>
           )}
           {showTabBadge && <TabBadge toolCallId={toolCallId} />}
           {!pending && (

--- a/apps/extension/src/components/chat/__tests__/completion-check-block.test.ts
+++ b/apps/extension/src/components/chat/__tests__/completion-check-block.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectHeading,
+  selectVariant,
+} from "../CompletionCheckBlock";
+import type { CompletionCheckRejectionData } from "@/lib/types";
+
+/**
+ * Pure-function tests for the rejection-block render decisions. The
+ * JSX rendering itself is verified manually; the variant + heading
+ * helpers are extracted so the branching logic is exercised in unit
+ * tests without React Testing Library setup.
+ */
+
+function makeData(
+  overrides: Partial<CompletionCheckRejectionData>,
+): CompletionCheckRejectionData {
+  return {
+    rejectionRound: 1,
+    reasoning: "x",
+    concerns: [],
+    forceEmittedNext: false,
+    ...overrides,
+  };
+}
+
+describe("selectVariant", () => {
+  it("evaluator-error reason short-circuits regardless of forceEmittedNext", () => {
+    expect(
+      selectVariant(
+        makeData({ reason: "evaluator-error", forceEmittedNext: true }),
+      ),
+    ).toBe("evaluator-error");
+    expect(
+      selectVariant(
+        makeData({ reason: "evaluator-error", forceEmittedNext: false }),
+      ),
+    ).toBe("evaluator-error");
+  });
+
+  it("forceEmittedNext === true → 'force-emit' (when not evaluator-error)", () => {
+    expect(selectVariant(makeData({ forceEmittedNext: true }))).toBe(
+      "force-emit",
+    );
+  });
+
+  it("default → 'refining'", () => {
+    expect(selectVariant(makeData({ forceEmittedNext: false }))).toBe(
+      "refining",
+    );
+  });
+});
+
+describe("selectHeading", () => {
+  it("evaluator-error renders the fixed plain-language string", () => {
+    expect(selectHeading("evaluator-error", 0)).toBe(
+      "Quality check skipped — evaluator could not complete.",
+    );
+    // Concern count is irrelevant for evaluator-error.
+    expect(selectHeading("evaluator-error", 5)).toBe(
+      "Quality check skipped — evaluator could not complete.",
+    );
+  });
+
+  it("force-emit uses 'flagged' and the response-may-have-issues phrasing", () => {
+    expect(selectHeading("force-emit", 1)).toBe(
+      "This response may have issues (1 flagged)",
+    );
+    expect(selectHeading("force-emit", 3)).toBe(
+      "This response may have issues (3 flagged)",
+    );
+  });
+
+  it("refining pluralizes 'issue' for count 1, 'issues' otherwise", () => {
+    expect(selectHeading("refining", 1)).toBe("Refining answer (1 issue)");
+    expect(selectHeading("refining", 2)).toBe("Refining answer (2 issues)");
+    // Edge: 0 concerns shouldn't normally happen for a rejection
+    // block, but the helper is total — make sure it still pluralizes.
+    expect(selectHeading("refining", 0)).toBe("Refining answer (0 issues)");
+  });
+
+  it("never includes the round number (UX preference: hide internal state)", () => {
+    expect(selectHeading("refining", 1)).not.toMatch(/round/i);
+    expect(selectHeading("force-emit", 1)).not.toMatch(/round/i);
+  });
+
+  it("never includes evaluator-internal jargon (dimension names)", () => {
+    const tokens = [
+      "completeness",
+      "evidenceGrounding",
+      "surfaceAccuracy",
+      "planClosure",
+      "noPrematureHandoff",
+    ];
+    for (const t of tokens) {
+      expect(selectHeading("refining", 1)).not.toContain(t);
+      expect(selectHeading("force-emit", 1)).not.toContain(t);
+      expect(selectHeading("evaluator-error", 0)).not.toContain(t);
+    }
+  });
+});

--- a/apps/extension/src/components/chat/__tests__/resolve-tool-part-state.test.ts
+++ b/apps/extension/src/components/chat/__tests__/resolve-tool-part-state.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { resolveToolPartState } from "../AssistantMessage";
+
+describe("resolveToolPartState", () => {
+  // ── Terminal states (unaffected by isStreaming) ─────────────────────
+
+  it("maps output-available → 'result' with the original output payload", () => {
+    const r = resolveToolPartState({
+      state: "output-available",
+      output: { ok: true, value: 42 },
+    });
+    expect(r.state).toBe("result");
+    expect(r.result).toEqual({ ok: true, value: 42 });
+  });
+
+  it("output-available is unaffected by isStreaming flag", () => {
+    const streaming = resolveToolPartState(
+      { state: "output-available", output: { x: 1 } },
+      { isStreaming: true },
+    );
+    const done = resolveToolPartState(
+      { state: "output-available", output: { x: 1 } },
+      { isStreaming: false },
+    );
+    expect(streaming.state).toBe("result");
+    expect(done.state).toBe("result");
+  });
+
+  it("maps output-denied → 'denied' with no result", () => {
+    const r = resolveToolPartState({ state: "output-denied" });
+    expect(r.state).toBe("denied");
+    expect(r.result).toBeUndefined();
+  });
+
+  it("maps output-error → 'errored' and synthesizes { error: errorText }", () => {
+    const r = resolveToolPartState({
+      state: "output-error",
+      errorText: "Unknown tab handle \"t1\"",
+    });
+    expect(r.state).toBe("errored");
+    expect(r.result).toEqual({ error: 'Unknown tab handle "t1"' });
+  });
+
+  it("output-error with missing errorText → 'errored' with a generic fallback message", () => {
+    const r = resolveToolPartState({ state: "output-error" });
+    expect(r.state).toBe("errored");
+    expect((r.result as { error: string }).error).toMatch(/failed/i);
+  });
+
+  it("output-error with empty errorText → 'errored' with the generic fallback", () => {
+    const r = resolveToolPartState({ state: "output-error", errorText: "" });
+    expect(r.state).toBe("errored");
+    expect((r.result as { error: string }).error).toMatch(/failed/i);
+  });
+
+  it("output-error with non-string errorText defensively → 'errored' fallback", () => {
+    const r = resolveToolPartState({
+      state: "output-error",
+      errorText: 42 as unknown,
+    });
+    expect(r.state).toBe("errored");
+    expect((r.result as { error: string }).error).toMatch(/failed/i);
+  });
+
+  it("output-error is unaffected by isStreaming flag", () => {
+    const r = resolveToolPartState(
+      { state: "output-error", errorText: "boom" },
+      { isStreaming: true },
+    );
+    expect(r.state).toBe("errored");
+  });
+
+  // ── Non-terminal states while streaming (genuine in-flight) ─────────
+
+  it.each([
+    ["input-streaming"],
+    ["input-available"],
+    ["approval-requested"],
+    ["approval-responded"],
+  ])("non-terminal state '%s' + isStreaming:true → 'call' (genuinely in flight)", (state) => {
+    const r = resolveToolPartState({ state }, { isStreaming: true });
+    expect(r.state).toBe("call");
+    expect(r.result).toBeUndefined();
+  });
+
+  it("unknown state + isStreaming:true → 'call'", () => {
+    const r = resolveToolPartState({ state: "future-sdk-state" }, { isStreaming: true });
+    expect(r.state).toBe("call");
+  });
+
+  // ── Non-terminal states once streaming has finished (orphans) ───────
+
+  it("approval-responded + isStreaming:false → 'errored' with skipped-after-approval message", () => {
+    // This is the exact bug from the user's session: type="dynamic-tool",
+    // state="approval-responded", user had approved but the agent loop
+    // never picked the call back up to run execute().
+    const r = resolveToolPartState(
+      { state: "approval-responded" },
+      { isStreaming: false },
+    );
+    expect(r.state).toBe("errored");
+    const err = (r.result as { error: string }).error;
+    expect(err).toMatch(/skipped after approval/i);
+  });
+
+  it.each([
+    ["input-streaming"],
+    ["input-available"],
+  ])("non-terminal state '%s' + isStreaming:false → 'errored' with turn-ended message", (state) => {
+    const r = resolveToolPartState({ state }, { isStreaming: false });
+    expect(r.state).toBe("errored");
+    const err = (r.result as { error: string }).error;
+    expect(err).toMatch(/did not return a result/i);
+  });
+
+  it("unknown future state + isStreaming:false → 'errored' (defensive default)", () => {
+    const r = resolveToolPartState({ state: "totally-new-state" }, { isStreaming: false });
+    expect(r.state).toBe("errored");
+  });
+
+  it("missing state + isStreaming:false → 'errored' (defensive default)", () => {
+    const r = resolveToolPartState({}, { isStreaming: false });
+    expect(r.state).toBe("errored");
+  });
+
+  // ── Default opts (no isStreaming provided = undefined = falsy) ───────
+  // Matches historical message renders where isStreaming is not passed.
+
+  it("non-terminal state with no opts provided → 'errored' (treats undefined isStreaming as false)", () => {
+    const r = resolveToolPartState({ state: "input-available" });
+    expect(r.state).toBe("errored");
+  });
+});

--- a/apps/extension/src/entrypoints/settings/GeneralTab.tsx
+++ b/apps/extension/src/entrypoints/settings/GeneralTab.tsx
@@ -162,6 +162,43 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
         </Select>
       </div>
 
+      <div className="space-y-2">
+        <Label>Completion check model</Label>
+        <p className="text-xs text-muted-foreground">
+          Before each final response reaches you, a separate skeptical
+          evaluator reviews it for completeness and evidence grounding.
+          Defaults to the agent model with a fresh context. Choose a
+          cheaper/faster model here to reduce per-turn cost — typically
+          a smaller model from the same provider works well.
+        </p>
+        <Select
+          value={settings.completionCheck?.evaluatorModel || "__default__"}
+          onValueChange={(v) =>
+            onChange({
+              completionCheck: {
+                ...settings.completionCheck,
+                evaluatorModel: v === "__default__" ? undefined : v,
+              },
+            })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Same as agent model" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__default__">Same as agent model</SelectItem>
+            {enabledModelOptions.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                <span className="flex items-center gap-2">
+                  {opt.providerId && <RegistryIcon id={opt.providerId} className="size-4" />}
+                  {opt.label}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
       <div className="space-y-4 pt-4 border-t">
         <h3 className="text-sm font-medium">Keyboard Shortcuts</h3>
         <p className="text-xs text-muted-foreground">

--- a/apps/extension/src/hooks/__tests__/useAgentChat-persistence.test.ts
+++ b/apps/extension/src/hooks/__tests__/useAgentChat-persistence.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { serializeParts, deserializePart } from "../useAgentChat";
+import type {
+  AgentUIMessage,
+  CompletionCheckRejectionData,
+  CompletionCheckRunningData,
+} from "@/lib/types";
+
+/**
+ * Round-trip persistence contract for assistant message parts.
+ *
+ * `serializeParts` is a whitelist: only known part types survive the
+ * trip to chat-db. New `AgentDataParts` variants must be added to BOTH
+ * the serializer and the deserializer — these tests exist to catch
+ * regressions where a UI part is rendered live but silently dropped
+ * after a page reload.
+ */
+
+describe("serializeParts / deserializePart round-trip", () => {
+  it("preserves data-completion-check-rejection across the round trip", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "Two specific gaps.",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "Asked for top 3 but listed 2.",
+          userSummary: "Only 2 items listed but 3 were requested.",
+          evidence: "draft mentions only 2 items",
+        },
+        {
+          dimension: "evidenceGrounding",
+          detail: "Price $149 not present in any tool call this turn.",
+          userSummary: "The price ($149) wasn't verified on any page.",
+        },
+      ],
+      forceEmittedNext: false,
+    };
+    const live = [
+      { type: "data-completion-check-rejection", data } as never,
+    ] as AgentUIMessage["parts"];
+
+    const serialized = serializeParts(live);
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0]).toEqual({
+      type: "data-completion-check-rejection",
+      data,
+    });
+
+    const rehydrated = serialized
+      .map(deserializePart)
+      .filter((p): p is NonNullable<typeof p> => p !== null);
+    expect(rehydrated).toHaveLength(1);
+    expect(rehydrated[0]).toEqual({
+      type: "data-completion-check-rejection",
+      data,
+    });
+  });
+
+  it("preserves data-completion-check-rejection with reason=evaluator-error", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "Evaluator error: ...",
+      concerns: [],
+      forceEmittedNext: true,
+      reason: "evaluator-error",
+    };
+    const live = [
+      { type: "data-completion-check-rejection", data } as never,
+    ] as AgentUIMessage["parts"];
+    const round = serializeParts(live).map(deserializePart);
+    expect(round[0]).toEqual({
+      type: "data-completion-check-rejection",
+      data,
+    });
+  });
+
+  it("strips data-completion-check-running (done + approved) at serialize time", () => {
+    // The running indicator is a live-stream concern only. Approve/
+    // skip outcomes render nothing in the new minimal UX (no
+    // "Verified" badge), and persisting them would be dead weight.
+    // Verify the strip happens at serialize time so chatDb stays
+    // clean.
+    const data: CompletionCheckRunningData = {
+      id: "run-1",
+      phase: "done",
+      outcome: "approved",
+    };
+    const live = [
+      { type: "data-completion-check-running", data } as never,
+    ] as AgentUIMessage["parts"];
+
+    const serialized = serializeParts(live);
+    expect(serialized).toHaveLength(0);
+  });
+
+  it("strips data-completion-check-running (done + rejected) at serialize time", () => {
+    // Reject/force-emit running entries are also stripped — the
+    // sibling rejection block carries the user-facing message; the
+    // running entry has no remaining job after the stream closes.
+    const data: CompletionCheckRunningData = {
+      id: "run-1",
+      phase: "done",
+      outcome: "rejected",
+    };
+    const live = [
+      { type: "data-completion-check-running", data } as never,
+    ] as AgentUIMessage["parts"];
+    expect(serializeParts(live)).toHaveLength(0);
+  });
+
+  it("strips data-completion-check-running (evaluating) at serialize time", () => {
+    // An aborted stream may leave an "evaluating" entry in memory.
+    // We don't persist those either — saved-means-stream-is-over;
+    // a saved "evaluating" part would semantically lie. The
+    // in-memory `isStreaming` guard handles the live abort case.
+    const data: CompletionCheckRunningData = {
+      id: "run-2",
+      phase: "evaluating",
+    };
+    const live = [
+      { type: "data-completion-check-running", data } as never,
+    ] as AgentUIMessage["parts"];
+    expect(serializeParts(live)).toHaveLength(0);
+  });
+
+  it("strips running entries from a mixed parts array, preserves order of survivors", () => {
+    // Realistic case: text + running indicator interleaved. The
+    // running indicator drops out; remaining parts keep their order.
+    const live = [
+      { type: "text", text: "I found three options." },
+      {
+        type: "data-completion-check-running",
+        data: {
+          id: "run-3",
+          phase: "done",
+          outcome: "approved",
+        } as CompletionCheckRunningData,
+      },
+      { type: "text", text: "Final summary." },
+    ] as never[] as AgentUIMessage["parts"];
+
+    const serialized = serializeParts(live);
+    expect(serialized).toHaveLength(2);
+    expect(serialized[0]).toMatchObject({
+      type: "text",
+      text: "I found three options.",
+    });
+    expect(serialized[1]).toMatchObject({
+      type: "text",
+      text: "Final summary.",
+    });
+  });
+});

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -293,8 +293,11 @@ function healPendingTools(
       const ap = pp.approval as
         | { id?: unknown; approved?: unknown }
         | undefined;
+      // Strict denial shape: must have a string id AND `approved`
+      // explicitly false. `approved: true` paired with state
+      // `output-denied` is contradictory and gets healed.
       return !(
-        ap && typeof ap.id === "string" && typeof ap.approved === "boolean"
+        ap && typeof ap.id === "string" && ap.approved === false
       );
     }
     return false;
@@ -318,16 +321,20 @@ function healPendingTools(
 
       // approval-requested keeps its dedicated path so the UI's
       // "denied" affordance renders consistently with explicit
-      // user-deny actions.
+      // user-deny actions. Validate the approval id is a real string
+      // before trusting it; malformed approvals fall through to the
+      // default output-error heal below.
       if (state === "approval-requested" && p.approval) {
-        const approval = p.approval as { id: string };
-        changed = true;
-        return {
-          ...part,
-          input,
-          state: "output-denied",
-          approval: { id: approval.id, approved: false, reason: denyReason },
-        } as typeof part;
+        const approval = p.approval as { id?: unknown };
+        if (typeof approval.id === "string") {
+          changed = true;
+          return {
+            ...part,
+            input,
+            state: "output-denied",
+            approval: { id: approval.id, approved: false, reason: denyReason },
+          } as typeof part;
+        }
       }
 
       // Default heal: every other malformed/non-terminal case becomes

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -9,7 +9,6 @@ import {
   needsCompaction,
   resetTokenTracking,
   getCurrentModelDef,
-  setCurrentModelDef,
 } from "@/lib/agent/agent-transport";
 import { setAgentActive, setAgentInactive } from "@/lib/active-agents";
 import {
@@ -44,7 +43,7 @@ import type {
 } from "@/lib/types";
 import { Chat, useChat } from "@ai-sdk/react";
 import {
-  lastAssistantMessageIsCompleteWithApprovalResponses,
+  isToolUIPart,
 } from "ai";
 import type {
   ChatTransport,
@@ -76,7 +75,17 @@ function generateId() {
   return crypto.randomUUID();
 }
 
-function serializeParts(parts: AgentMessage["parts"]): SerializedUIPart[] {
+/**
+ * Serialize a UIMessage's parts into the chat-db's persistable shape.
+ *
+ * Exported (rather than module-private) so the round-trip persistence
+ * contract can be tested directly without spinning up the full chat
+ * lifecycle. The whitelist nature of this function is the most
+ * common source of "data part rendered live but disappeared after
+ * reload" bugs — having a dedicated test suite catches new variants
+ * being added to the UI but not to the serializer.
+ */
+export function serializeParts(parts: AgentMessage["parts"]): SerializedUIPart[] {
   return parts.flatMap((part): SerializedUIPart[] => {
     switch (part.type) {
       case "text":
@@ -99,6 +108,28 @@ function serializeParts(parts: AgentMessage["parts"]): SerializedUIPart[] {
       case "data-compaction":
         // `part.data` is `CompactionData` thanks to AgentDataParts.
         return [{ type: "data-compaction", data: part.data }];
+      case "data-completion-check-rejection":
+        // Persist completion-check rejection blocks so users see the
+        // concerns again after a reload. Without this case, the chunk
+        // is silently dropped at serialize time and the conversation
+        // looks like the gate never ran.
+        return [{ type: "data-completion-check-rejection", data: part.data }];
+      case "data-completion-check-running":
+        // Strip running indicators at serialize time. They're a live-
+        // stream concern only:
+        //  - "evaluating" entries shouldn't survive reload — saved
+        //    means the stream is over forever, but a persisted
+        //    "evaluating" part would semantically lie about that
+        //    state.
+        //  - "done" entries render nothing in the UI (the spinner is
+        //    gone; rejected/force-emitted are surfaced by the
+        //    sibling rejection block; approved/skipped are silent).
+        //    Persisting them would be dead weight in chatDb.
+        //
+        // The runtime UI guard (`isStreaming` check in
+        // CompletionCheckRunningBlock) handles in-memory mid-stream
+        // aborts; we never need this part on disk.
+        return [];
       case "dynamic-tool":
         return [
           {
@@ -175,20 +206,32 @@ function hasMeaningfulContent(parts: SerializedUIPart[]): boolean {
  * Heals "stranded" tool calls in `messages` so a subsequent prompt
  * does not trip the AI SDK's `MissingToolResultsError`.
  *
- * Two states get healed:
+ * The healer recognizes "terminal" states by inclusion (states that
+ * already carry an `output` or `errorText` and survive the round-trip
+ * through `convertToModelMessages`). Anything else is non-terminal and
+ * gets healed:
  *
  * - `approval-requested` → `output-denied` with `approval.approved = false`.
  *   Mirrors the pre-existing inline cleanup; see the long comment in
  *   {@link handleSubmit} below for why we mutate state directly here
  *   rather than calling `addToolApprovalResponse` / `addToolOutput`.
  *
- * - `input-available` → `output-error`. Happens when a tool call started
- *   but its result was never recorded (page refreshed mid-stream, the
- *   stream errored after emitting `tool-input-available` but before
- *   `tool-output-available`, etc.). Synthesizing an `output-error` with
- *   a clear errorText keeps the model in the loop — it sees the failed
- *   attempt instead of an unexplained text gap, and can decide whether
- *   to retry or proceed.
+ * - `input-streaming`, `input-available`, `output-streaming`, or any
+ *   other unrecognized non-terminal state → `output-error` with a
+ *   synthetic `errorText`. Happens when a tool call started but its
+ *   result was never recorded (page refreshed mid-stream, the stream
+ *   errored after emitting `tool-input-available` / `tool-input-start`
+ *   / `tool-output-start` but before `tool-output-available`, the user
+ *   edited a prior message while a tool was streaming, etc.).
+ *   Synthesizing an `output-error` keeps the model in the loop — it
+ *   sees the failed attempt instead of an unexplained text gap, and
+ *   convertToModelMessages can produce a well-formed tool-result
+ *   content with `output: { type: "error-text", value: errorText }`.
+ *
+ * Defining terminal states by inclusion (rather than non-terminal by
+ * exclusion) means the healer is forward-compatible with new states
+ * the AI SDK adds: anything we don't explicitly recognize as terminal
+ * gets healed defensively, which is the safe default.
  *
  * Returns both the new full `messages` list and the subset that
  * actually changed. Callers persist the changed subset to chatDb so
@@ -197,56 +240,117 @@ function hasMeaningfulContent(parts: SerializedUIPart[]): boolean {
 const TOOL_HEAL_INTERRUPT_TEXT =
   "Tool execution was interrupted before it returned a result";
 
+/**
+ * Tool-part states that already carry the data `convertToModelMessages`
+ * needs to emit a valid model message. Anything outside this set is
+ * non-terminal and must be healed before the messages are sent to the
+ * model.
+ */
+const TERMINAL_TOOL_STATES = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+]);
+
 function healPendingTools(
   messages: AgentMessage[],
   denyReason: string,
 ): { healed: AgentMessage[]; healedMessages: AgentMessage[] } {
-  const isPendingTool = (p: unknown): boolean => {
+  const isToolPart = (p: unknown): boolean => {
     const pp = p as Record<string, unknown>;
-    const isTool =
+    return (
       pp.type === "dynamic-tool" ||
       (typeof pp.type === "string" &&
-        (pp.type as string).startsWith("tool-"));
-    if (!isTool) return false;
-    return (
-      pp.state === "approval-requested" || pp.state === "input-available"
+        (pp.type as string).startsWith("tool-"))
     );
   };
 
-  const anyPending = messages.some((m) => m.parts.some(isPendingTool));
+  /**
+   * A tool part is "valid for conversion" iff:
+   *  - state is terminal (in {output-available, output-error, output-denied})
+   *  - the per-state required field is present and well-formed:
+   *      output-available → output is defined
+   *      output-error     → errorText is a non-empty string
+   *      output-denied    → approval is { id, approved: false }
+   *  - input is defined (object or any non-undefined value).
+   *
+   * Anything else is non-terminal/malformed and must be healed.
+   */
+  const needsHeal = (p: unknown): boolean => {
+    if (!isToolPart(p)) return false;
+    const pp = p as Record<string, unknown>;
+    const state = pp.state;
+    if (typeof state !== "string") return true;
+    if (!TERMINAL_TOOL_STATES.has(state)) return true;
+    if (pp.input === undefined || pp.input === null) return true;
+    if (state === "output-available") {
+      return pp.output === undefined || pp.output === null;
+    }
+    if (state === "output-error") {
+      return typeof pp.errorText !== "string" || pp.errorText.length === 0;
+    }
+    if (state === "output-denied") {
+      const ap = pp.approval as
+        | { id?: unknown; approved?: unknown }
+        | undefined;
+      return !(
+        ap && typeof ap.id === "string" && typeof ap.approved === "boolean"
+      );
+    }
+    return false;
+  };
+
+  const anyPending = messages.some((m) => m.parts.some(needsHeal));
   if (!anyPending) return { healed: messages, healedMessages: [] };
 
   const healedMessages: AgentMessage[] = [];
   const healed = messages.map((msg) => {
     let changed = false;
     const newParts = msg.parts.map((part) => {
+      if (!needsHeal(part)) return part;
       const p = part as Record<string, unknown>;
-      const isTool =
-        p.type === "dynamic-tool" ||
-        (typeof p.type === "string" &&
-          (p.type as string).startsWith("tool-"));
-      if (!isTool) return part;
+      const state = typeof p.state === "string" ? p.state : undefined;
 
-      if (p.state === "approval-requested" && p.approval) {
+      // Always carry an `input` object forward — convertToModelMessages's
+      // `tool-call` content requires it.
+      const input =
+        p.input === undefined || p.input === null ? {} : p.input;
+
+      // approval-requested keeps its dedicated path so the UI's
+      // "denied" affordance renders consistently with explicit
+      // user-deny actions.
+      if (state === "approval-requested" && p.approval) {
         const approval = p.approval as { id: string };
         changed = true;
         return {
           ...part,
+          input,
           state: "output-denied",
           approval: { id: approval.id, approved: false, reason: denyReason },
         } as typeof part;
       }
 
-      if (p.state === "input-available") {
-        changed = true;
-        return {
-          ...part,
-          state: "output-error",
-          errorText: TOOL_HEAL_INTERRUPT_TEXT,
-        } as typeof part;
-      }
-
-      return part;
+      // Default heal: every other malformed/non-terminal case becomes
+      // output-error. Strip any partial `output` so errorText is the
+      // sole signal.
+      const { output: _output, ...rest } = part as { output?: unknown } & Record<
+        string,
+        unknown
+      >;
+      void _output;
+      changed = true;
+      const errorText =
+        state === "output-error" &&
+        typeof p.errorText === "string" &&
+        p.errorText.length > 0
+          ? p.errorText
+          : TOOL_HEAL_INTERRUPT_TEXT;
+      return {
+        ...rest,
+        input,
+        state: "output-error",
+        errorText,
+      } as typeof part;
     });
     if (!changed) return msg;
     const newMsg = { ...msg, parts: newParts };
@@ -289,7 +393,11 @@ async function persistHealedMessages(
   }
 }
 
-function deserializePart(
+/**
+ * Inverse of {@link serializeParts}. Exported alongside the serializer
+ * so the round-trip contract can be tested.
+ */
+export function deserializePart(
   p: SerializedUIPart,
 ): AgentMessage["parts"][number] | null {
   switch (p.type) {
@@ -316,6 +424,15 @@ function deserializePart(
       // Reuse the shared `CompactionPart` shape — by construction it
       // matches the data-compaction variant of `AgentMessage["parts"][number]`.
       return { type: "data-compaction", data: p.data } satisfies CompactionPart;
+    case "data-completion-check-rejection":
+      // Round-trip the rejection block so concerns are visible after a
+      // reload. The data shape matches the AgentDataParts registration,
+      // so the `as never` cast is a TS artifact (the SDK widens
+      // `data-${string}` types to `unknown`-data variants).
+      return {
+        type: "data-completion-check-rejection",
+        data: p.data,
+      } as never;
     case "dynamic-tool":
       return deserializeToolPart(p);
     default:
@@ -374,7 +491,54 @@ function getOrCreateChat(
   const chat = new Chat<AgentMessage>({
     transport: transport ?? undefined,
     generateId,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+    // Resume the agent loop after the user approves a tool call. We
+    // provide our own implementation instead of the SDK's
+    // `lastAssistantMessageIsCompleteWithApprovalResponses` because
+    // that function treats `approval-responded` as a terminal state
+    // equivalent to `output-available`. It therefore fires the
+    // auto-resume immediately after the user clicks "Allow" — but
+    // `addToolApprovalResponse` guards the auto-resume with
+    // `this.status !== 'streaming'`. When other tools in the same step
+    // are still streaming (e.g. navigate calls running in parallel),
+    // the resume is silently dropped and the approved tool is permanently
+    // orphaned in `approval-responded` state with no output.
+    //
+    // Our version only fires once every tool in the last step has
+    // produced an actual output (`output-available`, `output-error`,
+    // `output-denied`), treating `approval-responded` correctly as
+    // "user said yes, but tool hasn't run yet" (non-terminal). This
+    // prevents premature auto-resume and ensures the agent loop picks
+    // up the approved call after the rest of the step finishes.
+    sendAutomaticallyWhen: ({ messages }: { messages: import("ai").UIMessage[] }) => {
+      const message = messages[messages.length - 1];
+      if (!message || message.role !== "assistant") return false;
+
+      const lastStepStartIndex = message.parts.reduce(
+        (lastIndex: number, part: import("ai").UIMessage["parts"][number], index: number) =>
+          part.type === "step-start" ? index : lastIndex,
+        -1,
+      );
+
+      const lastStepTools = message.parts
+        .slice(lastStepStartIndex + 1)
+        .filter(isToolUIPart);
+
+      // Must have at least one approval response to trigger resume.
+      const hasApprovalResponse = lastStepTools.some(
+        (p) => p.state === "approval-responded",
+      );
+      if (!hasApprovalResponse) return false;
+
+      // All tools must be in a truly terminal state — approval-responded
+      // is intentionally NOT included here, unlike the SDK's version.
+      return lastStepTools.every(
+        (p) =>
+          p.state === "output-available" ||
+          p.state === "output-error" ||
+          p.state === "output-denied" ||
+          p.state === "approval-responded",
+      );
+    },
     onFinish: async ({ message }) => {
       // Clear the cross-context "agent is running" indicator. onFinish
       // fires for every terminal state (success, abort, disconnect,
@@ -903,7 +1067,19 @@ export function useAgentChat({
           const continueText = overflow
             ? "The previous request exceeded the context window. The conversation was compacted. Continue where you left off, or ask for clarification if unsure how to proceed."
             : "Continue where you left off, or ask for clarification if unsure how to proceed.";
-          sendMessage({ text: continueText });
+          // Synthetic continue message — intentionally not persisted to
+          // chatDb (the compaction marker + summary above stand in for
+          // it, so on refresh the conversation resumes from the summary
+          // without resurrecting this prompt). We still pass an explicit
+          // id rather than letting the SDK auto-generate one, purely
+          // for consistency with the other `sendMessage` call sites
+          // (`handleSubmit`, queue-flush, `confirmEdit`); behavior is
+          // unchanged because nothing reads this id from chatDb.
+          sendMessage({
+            id: generateId(),
+            role: "user",
+            parts: [{ type: "text", text: continueText }],
+          });
         }
       } catch (err) {
         if (
@@ -1055,8 +1231,14 @@ export function useAgentChat({
           mediaType: vf.mediaType,
           url: vf.url,
         }));
+        // Same id-alignment requirement as `handleSubmit`/`confirmEdit`:
+        // generate the id once and use it for both the chatDb row and
+        // the SDK's in-memory message so a later `confirmEdit` can find
+        // the row by id. See the comment in `handleSubmit` for the full
+        // failure mode.
+        const userMessageId = generateId();
         await chatDb.saveMessage({
-          id: generateId(),
+          id: userMessageId,
           conversationId,
           role: "user",
           content: persistedText,
@@ -1080,11 +1262,15 @@ export function useAgentChat({
           mediaType: vf.mediaType,
           url: vf.url,
         }));
-        if (text) {
-          sendMessage({ text, files: files.length > 0 ? files : undefined });
-        } else {
-          sendMessage({ files });
-        }
+        const sendParts: AgentMessage["parts"] = [
+          ...(text ? [{ type: "text" as const, text }] : []),
+          ...files,
+        ];
+        sendMessage({
+          id: userMessageId,
+          role: "user",
+          parts: sendParts,
+        });
 
         await queueDb.releaseHead(conversationId, claimed.id, true);
       } catch (err) {
@@ -1322,8 +1508,19 @@ export function useAgentChat({
         url: vf.url,
       }));
 
+      // Generate the message id once and use it for both the chatDb
+      // row and the AI SDK's in-memory chat state. Without this, the
+      // SDK auto-generates its own id on `sendMessage`, the two ids
+      // diverge, and a later `confirmEdit` calling
+      // `chatDb.deleteMessagesFrom(messageId)` (where `messageId` is
+      // the SDK id) silently no-ops because no chatDb row matches —
+      // leaving the entire post-edit tail in chat-db. After a refresh
+      // the stale tail reappears alongside the new turn.
+      // See `confirmEdit` below for the matching pattern.
+      const userMessageId = generateId();
+
       await chatDb.saveMessage({
-        id: generateId(),
+        id: userMessageId,
         conversationId: convId,
         role: "user",
         content: persistedText,
@@ -1352,11 +1549,21 @@ export function useAgentChat({
         // from DB and call sendMessage on the correct chat instance.
         onNewConversation(convId);
       } else {
-        if (text) {
-          sendMessage({ text, files: files.length > 0 ? files : undefined });
-        } else {
-          sendMessage({ files });
-        }
+        // Construct a full `UIMessage` (id + role + parts) instead of
+        // the `{ text, files }` shorthand so the SDK adopts our
+        // `userMessageId` instead of generating its own. Note: `text`
+        // (with mention context) goes to the model; chatDb stores
+        // `persistedText` (without mention context) — same split as
+        // `confirmEdit`.
+        const sendParts: AgentMessage["parts"] = [
+          ...(text ? [{ type: "text" as const, text }] : []),
+          ...files,
+        ];
+        sendMessage({
+          id: userMessageId,
+          role: "user",
+          parts: sendParts,
+        });
       }
     },
     [input, isConfigured, spaceId, onNewConversation, sendMessage, agentSettings.agentModel, settings.providerConfigs, messages, setMessages],

--- a/apps/extension/src/lib/__tests__/chat-db-delete.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-delete.test.ts
@@ -1,0 +1,132 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "../chat-db";
+
+const CONV = "conv-edit-truncation";
+
+async function seedConv(id: string = CONV) {
+  await chatDb.createConversation({
+    id,
+    title: id,
+    spaceId: null,
+    ownedTabIds: [],
+    createdAt: 0,
+    updatedAt: 0,
+  });
+}
+
+async function seedMessage(
+  id: string,
+  role: "user" | "assistant",
+  createdAt: number,
+  text = "",
+) {
+  await chatDb.saveMessage({
+    id,
+    conversationId: CONV,
+    role,
+    content: text,
+    parts: text ? [{ type: "text", text }] : [],
+    createdAt,
+  });
+}
+
+describe("chatDb.deleteMessagesFrom", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("deletes the target and every later message by createdAt", async () => {
+    await seedConv();
+    await seedMessage("u1", "user", 100, "hello");
+    await seedMessage("a1", "assistant", 200, "world");
+    await seedMessage("u2", "user", 300, "edit me");
+    await seedMessage("a2", "assistant", 400, "old answer");
+    await seedMessage("u3", "user", 500, "follow up");
+    await seedMessage("a3", "assistant", 600, "follow answer");
+
+    await chatDb.deleteMessagesFrom(CONV, "u2");
+
+    const remaining = await chatDb.getMessages(CONV);
+    expect(remaining.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("treats createdAt as a >= cutoff (target itself is removed)", async () => {
+    await seedConv();
+    await seedMessage("u1", "user", 100);
+    await seedMessage("a1", "assistant", 200);
+
+    await chatDb.deleteMessagesFrom(CONV, "u1");
+
+    const remaining = await chatDb.getMessages(CONV);
+    expect(remaining).toEqual([]);
+  });
+
+  /**
+   * Regression guard for the user-message ID-mismatch bug. Previously
+   * `handleSubmit` and the queue auto-flush persisted the user message
+   * with `chatDb.saveMessage({ id: generateId(), ... })` and then called
+   * the SDK's `sendMessage({ text, files })` (no id), letting the SDK
+   * auto-generate a *different* UUID for the in-memory message. When
+   * the user later tried to edit, `confirmEdit` called
+   * `deleteMessagesFrom` with the SDK-generated id, which never matched
+   * any chatDb row — so the silent no-op left every "deleted" message in
+   * place. After refresh the stale tail reappeared above the new turn.
+   *
+   * The fix aligns the ids at the call sites; this test pins the
+   * underlying chatDb contract so the warning fires loudly if a similar
+   * caller-bug is ever reintroduced.
+   */
+  it("logs a warning and is a no-op when the messageId is not in the conversation", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await seedConv();
+    await seedMessage("u1", "user", 100);
+    await seedMessage("a1", "assistant", 200);
+
+    await chatDb.deleteMessagesFrom(CONV, "id-that-does-not-exist");
+
+    const remaining = await chatDb.getMessages(CONV);
+    expect(remaining.map((m) => m.id)).toEqual(["u1", "a1"]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [warnMessage] = warn.mock.calls[0];
+    expect(warnMessage).toContain("id-that-does-not-exist");
+    expect(warnMessage).toContain(CONV);
+  });
+
+  it("scopes deletion to the requested conversation", async () => {
+    await seedConv();
+    await chatDb.createConversation({
+      id: "other",
+      title: "other",
+      spaceId: null,
+      ownedTabIds: [],
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await seedMessage("u1", "user", 100);
+    await seedMessage("a1", "assistant", 200);
+    // Other conversation has a message at the same createdAt as the
+    // target — it must NOT be deleted.
+    await chatDb.saveMessage({
+      id: "other-u1",
+      conversationId: "other",
+      role: "user",
+      content: "",
+      parts: [],
+      createdAt: 100,
+    });
+
+    await chatDb.deleteMessagesFrom(CONV, "u1");
+
+    expect(await chatDb.getMessages(CONV)).toEqual([]);
+    const otherMsgs = await chatDb.getMessages("other");
+    expect(otherMsgs.map((m) => m.id)).toEqual(["other-u1"]);
+  });
+});

--- a/apps/extension/src/lib/__tests__/format-markdown.test.ts
+++ b/apps/extension/src/lib/__tests__/format-markdown.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatMessageAsMarkdown,
+  formatPartAsMarkdown,
+} from "../format-markdown";
+import { COMPLETION_CHECK_PREFIX } from "../agent/compacting-transport";
+import type {
+  CompletionCheckRejectionData,
+  CompletionCheckRunningData,
+} from "../types";
+
+/**
+ * Markdown rendering for chat exports + per-message Copy.
+ *
+ * The export pipeline (`handleExportChat` in sidepanel/home App.tsx)
+ * routes every part through `formatPartAsMarkdown`. Anything that
+ * returns null is silently dropped from the export. The completion-
+ * check parts (`data-completion-check-rejection`,
+ * `data-completion-check-running`) used to fall through to null,
+ * meaning exports were missing audit-trail info the user saw on
+ * screen. These tests pin the rendering contract so future part
+ * types don't get accidentally dropped.
+ */
+
+describe("formatPartAsMarkdown — completion-check parts", () => {
+  it("renders a mid-loop rejection block as a blockquote with reasoning + concerns", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "Two specific gaps.",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "Asked for top 3 but listed 2.",
+          userSummary: "Only 2 items listed but 3 were requested.",
+          evidence: "draft mentions only 2 items",
+        },
+        {
+          dimension: "evidenceGrounding",
+          detail: "Price $149 not present in any tool call this turn.",
+          userSummary: "The price ($149) wasn't verified on any page.",
+        },
+      ],
+      forceEmittedNext: false,
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-rejection",
+      data,
+    });
+    // Heading uses the in-loop label, not the failed label.
+    expect(out).toContain("> **Completion check**");
+    expect(out).not.toContain("Completion check failed");
+    // Reasoning + concerns rendered as blockquote.
+    expect(out).toContain("> Two specific gaps.");
+    expect(out).toContain("> - **completeness**: Asked for top 3 but listed 2.");
+    expect(out).toContain(">   _Evidence:_ draft mentions only 2 items");
+    expect(out).toContain(
+      "> - **evidenceGrounding**: Price $149 not present in any tool call this turn.",
+    );
+  });
+
+  it("does NOT include the redundant 'follow-up sent to agent' code block", () => {
+    // Anti-regression: the follow-up payload duplicates the reasoning
+    // and concerns already rendered in the blockquote above. Earlier
+    // versions of this function appended a fenced code block with the
+    // synthetic message that was sent to the agent. Removed because
+    // the only unique content (round number + boilerplate directive)
+    // doesn't earn its keep.
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "Issue.",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "Asked for top 3 but listed 2.",
+          userSummary: "Only 2 items listed but 3 were requested.",
+        },
+      ],
+      forceEmittedNext: false,
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-rejection",
+      data,
+    });
+    expect(out).not.toContain("_Follow-up sent to agent:_");
+    expect(out).not.toContain(COMPLETION_CHECK_PREFIX);
+    expect(out).not.toContain("Continue working until each concern is resolved");
+    // No round number leak either.
+    expect(out).not.toContain("(round 1)");
+    // The reasoning and concern themselves should appear EXACTLY ONCE
+    // in the output (not duplicated by the removed follow-up section).
+    expect(out?.split("Asked for top 3 but listed 2.").length).toBe(2);
+    expect(out?.split("Issue.").length).toBe(2);
+  });
+
+  it("renders a force-emit rejection block with 'failed' heading", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 3,
+      reasoning: "Still not addressed.",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "still incomplete",
+          userSummary: "The response is still incomplete.",
+        },
+      ],
+      forceEmittedNext: true,
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-rejection",
+      data,
+    });
+    expect(out).toContain("> **Completion check failed**");
+    expect(out).toContain("> - **completeness**: still incomplete");
+    // Force-emit also doesn't include the (now-removed) follow-up
+    // section. Anti-regression to keep parity with mid-loop rejections.
+    expect(out).not.toContain("_Follow-up sent to agent:_");
+    expect(out).not.toContain(COMPLETION_CHECK_PREFIX);
+  });
+
+  it("renders evaluator-error rejection as a single italic note, no concerns enumerated", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "Evaluator error: No output generated.",
+      // The evaluator-error path may carry zero or many synthetic
+      // concerns; either way, exports collapse to the single italic line.
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "synthetic concern",
+          userSummary: "synthetic user summary",
+        },
+      ],
+      forceEmittedNext: true,
+      reason: "evaluator-error",
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-rejection",
+      data,
+    });
+    expect(out).toBe(
+      "> _Quality check skipped — evaluator could not complete._",
+    );
+    // The synthetic concern is intentionally NOT rendered for
+    // evaluator-error: the user shouldn't see fake concerns from a
+    // failed verifier.
+    expect(out).not.toContain("synthetic concern");
+    expect(out).not.toContain("Completion check");
+  });
+
+  it("renders a rejection block with no evidence (no Evidence: line)", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "x",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "missing item",
+          userSummary: "Something's missing.",
+        },
+      ],
+      forceEmittedNext: false,
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-rejection",
+      data,
+    });
+    expect(out).not.toContain("_Evidence:_");
+  });
+
+  it("running indicator (evaluating phase) is dropped from exports", () => {
+    const data: CompletionCheckRunningData = {
+      id: "run-1",
+      phase: "evaluating",
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-running",
+      data,
+    });
+    expect(out).toBeNull();
+  });
+
+  it("running indicator (done + approved → would be Verified badge) is dropped from exports", () => {
+    const data: CompletionCheckRunningData = {
+      id: "run-1",
+      phase: "done",
+      outcome: "approved",
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-running",
+      data,
+    });
+    expect(out).toBeNull();
+  });
+
+  it("running indicator (done + rejected) is dropped from exports", () => {
+    const data: CompletionCheckRunningData = {
+      id: "run-1",
+      phase: "done",
+      outcome: "rejected",
+    };
+    const out = formatPartAsMarkdown({
+      type: "data-completion-check-running",
+      data,
+    });
+    expect(out).toBeNull();
+  });
+});
+
+describe("formatMessageAsMarkdown — mixed parts integration", () => {
+  it("preserves order: text → rejection block → text", () => {
+    const data: CompletionCheckRejectionData = {
+      rejectionRound: 1,
+      reasoning: "Issue.",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "missing 3rd",
+          userSummary: "Third item is missing.",
+        },
+      ],
+      forceEmittedNext: false,
+    };
+    const message = {
+      parts: [
+        { type: "text", text: "Here is what I found." },
+        { type: "data-completion-check-rejection", data },
+        { type: "text", text: "Final answer after fix." },
+      ],
+    };
+    const out = formatMessageAsMarkdown(message);
+    const firstTextIdx = out.indexOf("Here is what I found.");
+    const blockIdx = out.indexOf("> **Completion check**");
+    const secondTextIdx = out.indexOf("Final answer after fix.");
+    expect(firstTextIdx).toBeGreaterThanOrEqual(0);
+    expect(blockIdx).toBeGreaterThan(firstTextIdx);
+    expect(secondTextIdx).toBeGreaterThan(blockIdx);
+  });
+
+  it("running indicators are completely absent from a mixed message export", () => {
+    const runningData: CompletionCheckRunningData = {
+      id: "run-1",
+      phase: "done",
+      outcome: "approved",
+    };
+    const message = {
+      parts: [
+        { type: "text", text: "An answer." },
+        { type: "data-completion-check-running", data: runningData },
+      ],
+    };
+    const out = formatMessageAsMarkdown(message);
+    expect(out).toBe("An answer.");
+    // Just to be explicit: no Verified marker leaked.
+    expect(out).not.toMatch(/verified/i);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/completion-check-pinning.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/completion-check-pinning.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Verifies that the completion-check gate's view of conversationId is
+ * pinned at `CompactingChatTransport.sendMessages` entry, not read
+ * lazily mid-stream. The bug being prevented:
+ *
+ *   1. User sends a message in conversation A; agent loop starts.
+ *   2. Mid-stream, user navigates to conversation B and the UI calls
+ *      `setAgentContext('B')`.
+ *   3. The post-iteration gate (`buildCompletionCheckInput`) used to
+ *      read `agentConversationId` directly, so its chatDb todos lookup
+ *      and telemetry routed to B instead of A.
+ *
+ * After the fix, the transport snapshots `getActiveConversationId()`
+ * synchronously at the top of `sendMessages` and threads the snapshot
+ * through to the gate as `pinnedConversationId`. The gate's closure
+ * uses that value exclusively.
+ */
+
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "vitest";
+import type { ToolSet, UIMessageChunk } from "ai";
+import {
+  CompactingChatTransport,
+  runWithRejectionLoop,
+  type RejectionLoopAgent,
+} from "../compacting-transport";
+import type { AgentUIMessage } from "../../types";
+
+function userMessage(text: string): AgentUIMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+  } as AgentUIMessage;
+}
+
+function makeStubAgent(text: string): RejectionLoopAgent {
+  return {
+    tools: {},
+    stream: async () => {
+      const id = "m-1";
+      return {
+        toUIMessageStream: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue({ type: "text-start", id } as never);
+              controller.enqueue({
+                type: "text-delta",
+                id,
+                delta: text,
+              } as never);
+              controller.enqueue({ type: "text-end", id } as never);
+              controller.close();
+            },
+          }),
+      };
+    },
+  };
+}
+
+async function drainStream(
+  stream: ReadableStream<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const reader = stream.getReader();
+  const chunks: UIMessageChunk[] = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  return chunks;
+}
+
+describe("runWithRejectionLoop — pinnedConversationId", () => {
+  it("forwards pinnedConversationId verbatim to buildCompletionCheckInput", async () => {
+    const observed: { pinnedConversationId: string | null }[] = [];
+    const stream = runWithRejectionLoop({
+      agent: makeStubAgent("done."),
+      validatedMessages: [userMessage("hi")],
+      sendMessagesAtCall: [userMessage("hi")],
+      abortSignal: undefined,
+      pinnedConversationId: "conv-A",
+      buildCompletionCheckInput: ({ pinnedConversationId }) => {
+        observed.push({ pinnedConversationId });
+        // Returning undefined makes the loop exit after the first
+        // iteration without invoking the gate model — sufficient for
+        // proving the cid was threaded through.
+        return undefined;
+      },
+    });
+    await drainStream(stream);
+
+    expect(observed).toEqual([{ pinnedConversationId: "conv-A" }]);
+  });
+
+  it("forwards null pinnedConversationId unchanged", async () => {
+    const observed: { pinnedConversationId: string | null }[] = [];
+    const stream = runWithRejectionLoop({
+      agent: makeStubAgent("done."),
+      validatedMessages: [userMessage("hi")],
+      sendMessagesAtCall: [userMessage("hi")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: ({ pinnedConversationId }) => {
+        observed.push({ pinnedConversationId });
+        return undefined;
+      },
+    });
+    await drainStream(stream);
+
+    expect(observed).toEqual([{ pinnedConversationId: null }]);
+  });
+});
+
+describe("CompactingChatTransport — pinning at sendMessages entry", () => {
+  /**
+   * Build a minimal `Agent<never, ToolSet, never>` stub. Type assertion
+   * is necessary because the SDK's full Agent class has many private
+   * fields the test doesn't need.
+   */
+  function makeAgent(text: string): unknown {
+    return {
+      tools: {} satisfies ToolSet,
+      stream: async () => ({
+        toUIMessageStream: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue({ type: "text-start", id: "m1" } as never);
+              controller.enqueue({
+                type: "text-delta",
+                id: "m1",
+                delta: text,
+              } as never);
+              controller.enqueue({ type: "text-end", id: "m1" } as never);
+              controller.close();
+            },
+          }),
+      }),
+    };
+  }
+
+  it("captures cid synchronously at sendMessages entry, even if the getter changes after", async () => {
+    let activeCid: string | null = "conv-A";
+    const observed: (string | null)[] = [];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const transport = new CompactingChatTransport({
+      agent: makeAgent("answer.") as any,
+      getActiveConversationId: () => activeCid,
+      buildCompletionCheckInput: ({ pinnedConversationId }) => {
+        observed.push(pinnedConversationId);
+        return undefined;
+      },
+    });
+
+    // Begin sending. The transport reads the getter once at entry; the
+    // returned ReadableStream is consumed below.
+    const streamPromise = transport.sendMessages({
+      messages: [userMessage("Q")],
+      abortSignal: undefined,
+      // Cast: SDK has additional optional params we don't need here.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // Flip the source-of-truth between sendMessages entry and the gate.
+    // The gate fires after the agent's iteration emits its final-text
+    // chunks; the rejection-loop body isn't synchronous with sendMessages
+    // entry, so the transport must have already pinned by now.
+    activeCid = "conv-B";
+
+    const stream = await streamPromise;
+    await drainStream(stream);
+
+    // Even though the getter is now returning B, the gate should have
+    // received A — the value at sendMessages entry.
+    expect(observed).toEqual(["conv-A"]);
+  });
+
+  it("captures null when getActiveConversationId is not provided", async () => {
+    const observed: (string | null)[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const transport = new CompactingChatTransport({
+      agent: makeAgent("answer.") as any,
+      // getActiveConversationId omitted on purpose.
+      buildCompletionCheckInput: ({ pinnedConversationId }) => {
+        observed.push(pinnedConversationId);
+        return undefined;
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = await transport.sendMessages({
+      messages: [userMessage("Q")],
+      abortSignal: undefined,
+    } as any);
+    await drainStream(stream);
+
+    expect(observed).toEqual([null]);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
@@ -1,0 +1,1842 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockLanguageModelV3 } from "ai/test";
+import type { LanguageModel, UIMessageChunk } from "ai";
+import type { TodoItem } from "../../types";
+import { runEvaluator } from "../completion-check/evaluator";
+import {
+  runCompletionCheck,
+  shouldGate,
+  type SkipReason,
+} from "../completion-check";
+import {
+  buildEvaluatorSystemPrompt,
+  buildEvaluatorUserPrompt,
+} from "../completion-check/prompt";
+import { completionCheckTelemetry } from "../completion-check/telemetry";
+import {
+  MAX_REJECTION_ROUNDS,
+  type EvaluatorVerdict,
+  type ToolCallTraceEntry,
+} from "../completion-check/types";
+import {
+  buildCompletionCheckFeedbackMessage,
+  emitCompletionCheckRunningChunk,
+  observeChunkForCompletionCheck,
+  COMPLETION_CHECK_PREFIX,
+  runWithRejectionLoop,
+  type RejectionLoopAgent,
+} from "../compacting-transport";
+import { setCurrentAgentModel } from "../current-agent-model";
+import type { AgentUIMessage } from "../../types";
+
+function makeTodo(content: string, status: TodoItem["status"]): TodoItem {
+  const now = Date.now();
+  return {
+    id: crypto.randomUUID(),
+    content,
+    status,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Build a `ToolCallTraceEntry` for tests with minimal boilerplate. Most
+ * tests only care about `name` and `state`; this helper supplies sane
+ * defaults for everything else.
+ */
+function makeTrace(
+  name: string,
+  opts: {
+    inputSummary?: string;
+    outputSummary?: string | null;
+    state?: ToolCallTraceEntry["state"];
+  } = {},
+): ToolCallTraceEntry {
+  return {
+    name,
+    inputSummary: opts.inputSummary ?? "{}",
+    outputSummary:
+      opts.outputSummary === undefined ? null : opts.outputSummary,
+    state: opts.state ?? "completed",
+  };
+}
+
+/**
+ * Build a `MockLanguageModelV3` that returns a fixed verdict shape.
+ *
+ * Cast through `unknown` to `LanguageModel`: the SDK exports its own
+ * `LanguageModel` union that's structurally compatible with V3 mocks
+ * but not assignable without a TS hint.
+ */
+function mockEvaluatorModel(verdictJson: object): LanguageModel {
+  // Cast through `any` for the doGenerate return — the AI SDK's V3 type
+  // surface is in flux across @ai-sdk/provider versions and the strict
+  // shape (especially `LanguageModelV3FinishReason`'s enum) often
+  // mismatches between the version `ai/test` was built against and the
+  // one resolved here. Test-only escape hatch.
+  const m = new MockLanguageModelV3({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    doGenerate: (async () => ({
+      content: [{ type: "text", text: JSON.stringify(verdictJson) }],
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+      warnings: [],
+    })) as never,
+  });
+  return m as unknown as LanguageModel;
+}
+
+describe("shouldGate", () => {
+  it("skips when final text is empty (tool-only turn)", () => {
+    const r = shouldGate({
+      finalText: "   ",
+      todos: [makeTodo("x", "in_progress")],
+      toolCallTrace: [],
+    });
+    expect(r).toEqual({
+      gate: false,
+      reason: "no-final-text" satisfies SkipReason,
+    });
+  });
+
+  it("skips trivial Q&A turns: no todos and no tool calls", () => {
+    const r = shouldGate({
+      finalText: "Hello!",
+      todos: [],
+      toolCallTrace: [],
+    });
+    expect(r).toEqual({
+      gate: false,
+      reason: "trigger-not-met" satisfies SkipReason,
+    });
+  });
+
+  it("gates when todos exist (planned task)", () => {
+    const r = shouldGate({
+      finalText: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [],
+    });
+    expect(r).toEqual({ gate: true });
+  });
+
+  it("gates when tool calls were made (acted on the world) even without todos", () => {
+    const r = shouldGate({
+      finalText: "Found the price.",
+      todos: [],
+      toolCallTrace: [makeTrace("extract")],
+    });
+    expect(r).toEqual({ gate: true });
+  });
+
+  it("gates when both todos and tool calls present", () => {
+    const r = shouldGate({
+      finalText: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [makeTrace("snapshot")],
+    });
+    expect(r).toEqual({ gate: true });
+  });
+});
+
+describe("runEvaluator (real, mocked LLM)", () => {
+  afterEach(() => {
+    setCurrentAgentModel(null);
+  });
+
+  it("returns optimistic approve when no model is available", async () => {
+    setCurrentAgentModel(null);
+    const v = await runEvaluator({
+      originalRequest: "find me a keyboard",
+      draftedResponse: "I found 2 of the 3 you asked for.",
+      todos: [],
+      toolCallTrace: [],
+    });
+    expect(v.decision).toBe("approve");
+    expect(v.concerns).toEqual([]);
+    expect(v.confidence).toBe(0);
+    expect(v.reasoning).toMatch(/no language model/i);
+  });
+
+  it("approves when the model emits an approve verdict", async () => {
+    const model = mockEvaluatorModel({
+      decision: "approve",
+      concerns: [],
+      reasoning: "Looks complete.",
+      confidence: 0.92,
+    });
+    const v = await runEvaluator({
+      originalRequest: "do X",
+      draftedResponse: "did X",
+      todos: [],
+      toolCallTrace: [],
+      model,
+    });
+    expect(v.decision).toBe("approve");
+    expect(v.concerns).toEqual([]);
+    expect(v.confidence).toBeCloseTo(0.92);
+  });
+
+  it("rejects with structured concerns when the model emits a reject verdict", async () => {
+    const model = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "Asked for top 3 but listed 2.",
+          userSummary: "Only 2 items listed but 3 were requested.",
+          evidence: "draft mentions Logitech MX, Keychron K2",
+        },
+        {
+          dimension: "evidenceGrounding",
+          detail: "Price $149 not present in any tool call this turn.",
+          userSummary: "The price ($149) wasn't verified on any page.",
+        },
+      ],
+      reasoning: "Two specific gaps.",
+      confidence: 0.78,
+    });
+    const v = await runEvaluator({
+      originalRequest: "find top 3 keyboards",
+      draftedResponse: "I found 2: Logitech MX ($149), Keychron K2.",
+      todos: [],
+      toolCallTrace: [],
+      model,
+    });
+    expect(v.decision).toBe("reject");
+    expect(v.concerns).toHaveLength(2);
+    expect(v.concerns[0].dimension).toBe("completeness");
+    expect(v.concerns[0].evidence).toContain("Logitech");
+    expect(v.concerns[1].dimension).toBe("evidenceGrounding");
+    expect(v.concerns[1].evidence).toBeUndefined();
+  });
+
+  it("repairs reject-with-empty-concerns into a synthetic completeness concern", async () => {
+    const model = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [],
+      reasoning: "Just feels off.",
+      confidence: 0.5,
+    });
+    const v = await runEvaluator({
+      originalRequest: "do X",
+      draftedResponse: "did Y",
+      todos: [],
+      toolCallTrace: [],
+      model,
+    });
+    expect(v.decision).toBe("reject");
+    expect(v.concerns).toHaveLength(1);
+    expect(v.concerns[0].dimension).toBe("completeness");
+  });
+
+  it("schema requires userSummary on every concern", async () => {
+    // Verdict missing userSummary on a concern: should fail schema
+    // validation. The evaluator throws (caller in runCompletionCheck
+    // catches and force-emits; here we just observe the throw).
+    const model = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "Missing required item.",
+          // userSummary intentionally absent — should reject.
+        },
+      ],
+      reasoning: "Missing field.",
+      confidence: 0.8,
+    });
+    await expect(
+      runEvaluator({
+        originalRequest: "do X",
+        draftedResponse: "did X",
+        todos: [],
+        toolCallTrace: [],
+        model,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("synthetic-concern repair path includes userSummary", async () => {
+    // The repair path fires when the model emits decision=reject but
+    // concerns:[]. The synthesized concern must satisfy the new
+    // required `userSummary` field — otherwise the type contract
+    // breaks downstream.
+    const model = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [],
+      reasoning: "Just feels off.",
+      confidence: 0.5,
+    });
+    const v = await runEvaluator({
+      originalRequest: "do X",
+      draftedResponse: "did Y",
+      todos: [],
+      toolCallTrace: [],
+      model,
+    });
+    expect(v.concerns).toHaveLength(1);
+    expect(v.concerns[0].userSummary).toBeTruthy();
+    expect(typeof v.concerns[0].userSummary).toBe("string");
+    expect(v.concerns[0].userSummary.length).toBeGreaterThan(0);
+  });
+
+  it("threads userSummary through from the parsed verdict", async () => {
+    const summary = "Hours might be off — site shows different hours.";
+    const model = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "surfaceAccuracy",
+          detail: "Drafted hours conflict with site hours.",
+          userSummary: summary,
+          evidence: "site shows 8pm",
+        },
+      ],
+      reasoning: "Hours mismatch.",
+      confidence: 0.85,
+    });
+    const v = await runEvaluator({
+      originalRequest: "find a cafe",
+      draftedResponse: "Open until 7pm.",
+      todos: [],
+      toolCallTrace: [],
+      model,
+    });
+    expect(v.concerns[0].userSummary).toBe(summary);
+  });
+
+  it("falls back to setCurrentAgentModel when model parameter is omitted", async () => {
+    const model = mockEvaluatorModel({
+      decision: "approve",
+      concerns: [],
+      reasoning: "From global model.",
+      confidence: 0.8,
+    });
+    setCurrentAgentModel(model);
+    const v = await runEvaluator({
+      originalRequest: "do X",
+      draftedResponse: "did X",
+      todos: [],
+      toolCallTrace: [],
+    });
+    expect(v.decision).toBe("approve");
+    expect(v.reasoning).toContain("From global model");
+  });
+
+  it("with-tools mode: routes through generateText + Output.object and parses verdict", async () => {
+    const verdict = {
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "evidenceGrounding",
+          detail: "Price $149 not in any tool output.",
+          userSummary: "The price ($149) wasn't verified on any page.",
+        },
+      ],
+      reasoning: "Could not ground the price claim.",
+      confidence: 0.85,
+    };
+    const verdictText = JSON.stringify(verdict);
+
+    // generateText uses doGenerate. Note V3 finishReason shape:
+    // `{ unified, raw }` rather than a plain string. The earlier
+    // generateObject tests work with the plain string because the
+    // generateObject path tolerates both forms; generateText is
+    // strict about the V3 shape.
+    const model = new MockLanguageModelV3({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doGenerate: (async () => ({
+        content: [{ type: "text", text: verdictText }],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: { total: 10 },
+          outputTokens: { total: 10 },
+          totalTokens: { total: 20 },
+        },
+        warnings: [],
+      })) as never,
+    }) as unknown as LanguageModel;
+
+    const v = await runEvaluator({
+      originalRequest: "find cheapest keyboard",
+      draftedResponse: "Cheapest is Logitech MX at $149.",
+      todos: [],
+      toolCallTrace: [],
+      model,
+      allowTools: true,
+      tools: {
+        // Cast to any: the structural Tool shape has many required
+        // fields; the mock model never actually invokes the tool, so
+        // this stub suffices for routing the with-tools branch.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        snapshot: { description: "stub", parameters: {} } as any,
+      },
+      maxSteps: 3,
+    });
+    expect(v.decision).toBe("reject");
+    expect(v.concerns).toHaveLength(1);
+    expect(v.concerns[0].dimension).toBe("evidenceGrounding");
+  });
+
+  it("with-tools mode is skipped when tools map is empty (no-tools fast path)", async () => {
+    const model = mockEvaluatorModel({
+      decision: "approve",
+      concerns: [],
+      reasoning: "ok",
+      confidence: 0.9,
+    });
+    // allowTools: true but tools is empty → no-tools generateObject
+    // path. The mock above is configured for generateObject (doGenerate),
+    // not generateText (doStream). If routing fell through to with-tools
+    // we'd hit a runtime error.
+    const v = await runEvaluator({
+      originalRequest: "do X",
+      draftedResponse: "did X",
+      todos: [],
+      toolCallTrace: [],
+      model,
+      allowTools: true,
+      tools: {},
+    });
+    expect(v.decision).toBe("approve");
+  });
+
+  it("with-tools mode: two-stage fallback when first stage hits step cap without committing", async () => {
+    // Simulate the production failure mode: generateText finishes its
+    // last step with finishReason='tool-calls' (model wanted more
+    // tools but stopWhen capped it), so result.output throws
+    // NoOutputGeneratedError. The evaluator should catch that and run
+    // a second-stage generateObject call to commit a verdict from the
+    // accumulated work.
+    const finalVerdict = {
+      decision: "approve",
+      concerns: [],
+      reasoning: "Committed via second-stage fallback.",
+      confidence: 0.7,
+    };
+
+    let callCount = 0;
+    const model = new MockLanguageModelV3({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doGenerate: (async () => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: generateText. Return a non-'stop' finishReason
+          // so the SDK never invokes parseCompleteOutput, leaving
+          // result.output undefined → throws NoOutputGeneratedError.
+          return {
+            content: [{ type: "text", text: "thinking..." }],
+            finishReason: { unified: "length", raw: "length" },
+            usage: {
+              inputTokens: { total: 10 },
+              outputTokens: { total: 5 },
+              totalTokens: { total: 15 },
+            },
+            warnings: [],
+          };
+        }
+        // Second call: generateObject second-stage commit. Return a
+        // valid verdict so the fallback succeeds.
+        return {
+          content: [{ type: "text", text: JSON.stringify(finalVerdict) }],
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: {
+            inputTokens: { total: 10 },
+            outputTokens: { total: 10 },
+            totalTokens: { total: 20 },
+          },
+          warnings: [],
+        };
+      }) as never,
+    }) as unknown as LanguageModel;
+
+    const v = await runEvaluator({
+      originalRequest: "do X",
+      draftedResponse: "did X",
+      todos: [],
+      toolCallTrace: [],
+      model,
+      allowTools: true,
+      tools: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        snapshot: { description: "stub", parameters: {} } as any,
+      },
+      maxSteps: 1,
+    });
+
+    // Assert both calls happened: first stage (generateText) + second
+    // stage (generateObject commit).
+    expect(callCount).toBe(2);
+    expect(v.decision).toBe("approve");
+    expect(v.reasoning).toContain("second-stage");
+    expect(v.confidence).toBeCloseTo(0.7);
+  });
+
+  it("with-tools mode: schema-validation errors are NOT caught by the fallback", async () => {
+    // Distinct from NoOutputGeneratedError: if the model commits valid
+    // text that doesn't match the schema, we want that to surface
+    // (real bug) rather than silently fall through to second-stage.
+    const badJson = JSON.stringify({
+      decision: "approve",
+      concerns: "not-an-array", // schema violation
+      reasoning: "x",
+      confidence: 0.5,
+    });
+    let callCount = 0;
+    const model = new MockLanguageModelV3({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doGenerate: (async () => {
+        callCount++;
+        return {
+          content: [{ type: "text", text: badJson }],
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: {
+            inputTokens: { total: 10 },
+            outputTokens: { total: 10 },
+            totalTokens: { total: 20 },
+          },
+          warnings: [],
+        };
+      }) as never,
+    }) as unknown as LanguageModel;
+
+    await expect(
+      runEvaluator({
+        originalRequest: "do X",
+        draftedResponse: "did X",
+        todos: [],
+        toolCallTrace: [],
+        model,
+        allowTools: true,
+        tools: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          snapshot: { description: "stub", parameters: {} } as any,
+        },
+        maxSteps: 1,
+      }),
+    ).rejects.toThrow();
+    // Only one call should have happened — the fallback didn't trigger.
+    expect(callCount).toBe(1);
+  });
+});
+
+describe("buildEvaluatorSystemPrompt", () => {
+  it("includes every concern dimension by name", () => {
+    const p = buildEvaluatorSystemPrompt({ hasTools: false });
+    for (const dim of [
+      "completeness",
+      "planClosure",
+      "evidenceGrounding",
+      "noPrematureHandoff",
+      "surfaceAccuracy",
+    ]) {
+      expect(p).toContain(`**${dim}**`);
+    }
+  });
+
+  it("differs by hasTools", () => {
+    const a = buildEvaluatorSystemPrompt({ hasTools: false });
+    const b = buildEvaluatorSystemPrompt({ hasTools: true });
+    expect(a).not.toBe(b);
+    expect(b).toMatch(/read-only|snapshot|extract/i);
+    expect(a).toContain("no tools available");
+  });
+
+  it("instructs to default to skepticism", () => {
+    const p = buildEvaluatorSystemPrompt({ hasTools: false });
+    expect(p.toLowerCase()).toContain("skeptic");
+  });
+
+  it("documents the userSummary field with observation-voice rules", () => {
+    const p = buildEvaluatorSystemPrompt({ hasTools: false });
+    // Mentions both fields the evaluator must produce.
+    expect(p).toContain("`detail`");
+    expect(p).toContain("`userSummary`");
+    // Establishes the user-facing voice constraints.
+    expect(p.toLowerCase()).toContain("observation voice");
+    expect(p).toContain("Never mention \"the agent\"");
+    // Provides at least one good and one bad example, so the model
+    // can't generalize "agent voice is fine in some cases".
+    expect(p.toLowerCase()).toContain("good `usersummary` example");
+    expect(p.toLowerCase()).toContain("bad `usersummary` example");
+    // Forbids prescriptive verbs explicitly.
+    expect(p).toMatch(/should/);
+    expect(p).toMatch(/needs to/);
+  });
+});
+
+describe("buildEvaluatorUserPrompt", () => {
+  it("renders empty todos and trace as readable placeholders", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "do X",
+      draftedResponse: "did X",
+      todos: [],
+      toolCallTrace: [],
+    });
+    expect(out).toContain("(no todos in this conversation)");
+    expect(out).toContain("(no tool calls in this turn)");
+  });
+
+  it("renders todo statuses uppercase", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "do X",
+      draftedResponse: "did X",
+      todos: [{ content: "first", status: "in_progress" }],
+      toolCallTrace: [],
+    });
+    expect(out).toContain("[IN_PROGRESS] first");
+  });
+
+  it("includes original request and drafted response verbatim", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "find cheapest keyboard under $150",
+      draftedResponse: "I found 2 candidates: Logitech MX, Keychron K2",
+      todos: [],
+      toolCallTrace: [],
+    });
+    expect(out).toContain("find cheapest keyboard under $150");
+    expect(out).toContain("I found 2 candidates: Logitech MX, Keychron K2");
+  });
+
+  it("renders completed tool calls with both input and output", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "x",
+      draftedResponse: "y",
+      todos: [],
+      toolCallTrace: [
+        makeTrace("snapshot", {
+          inputSummary: "{}",
+          outputSummary: "<page text>...",
+          state: "completed",
+        }),
+      ],
+    });
+    expect(out).toContain("1. snapshot");
+    expect(out).toContain("input: {}");
+    expect(out).toContain("output: <page text>...");
+    // Completed entries should NOT be tagged with state.
+    expect(out).not.toContain("snapshot [completed]");
+  });
+
+  it("renders errored tool calls with [errored] tag and error: prefix", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "x",
+      draftedResponse: "y",
+      todos: [],
+      toolCallTrace: [
+        makeTrace("extract", {
+          inputSummary: '{"selector":".missing"}',
+          outputSummary: "Element not found",
+          state: "errored",
+        }),
+      ],
+    });
+    expect(out).toContain("extract [errored]");
+    expect(out).toContain("error: Element not found");
+  });
+
+  it("renders denied tool calls with [denied] tag and explanatory line", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "x",
+      draftedResponse: "y",
+      todos: [],
+      toolCallTrace: [
+        makeTrace("navigate", {
+          inputSummary: '{"url":"https://x.com"}',
+          outputSummary: null,
+          state: "denied",
+        }),
+      ],
+    });
+    expect(out).toContain("navigate [denied]");
+    expect(out).toContain("user denied");
+  });
+
+  it("renders pending tool calls with [pending] tag and explanatory line", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "x",
+      draftedResponse: "y",
+      todos: [],
+      toolCallTrace: [
+        makeTrace("snapshot", {
+          inputSummary: "{}",
+          outputSummary: null,
+          state: "pending",
+        }),
+      ],
+    });
+    expect(out).toContain("snapshot [pending]");
+    expect(out).toContain("did not complete");
+  });
+
+  it("preface tells the evaluator the trace includes outputs", () => {
+    const out = buildEvaluatorUserPrompt({
+      originalRequest: "x",
+      draftedResponse: "y",
+      todos: [],
+      toolCallTrace: [],
+    });
+    // The preface is what nudges the evaluator NOT to re-call tools.
+    expect(out.toLowerCase()).toContain("captured outputs");
+  });
+});
+
+describe("completionCheckTelemetry", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    completionCheckTelemetry._resetForTests();
+  });
+
+  it("records and lists rows for a conversation, sorted by timestamp", async () => {
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 0,
+      rejectionRound: 0,
+      outcomeKind: "approved",
+      verdict: {
+        decision: "approve",
+        concerns: [],
+        reasoning: "ok",
+        confidence: 0.9,
+      },
+      timestamp: 1000,
+    });
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 1,
+      rejectionRound: 0,
+      outcomeKind: "rejected",
+      verdict: {
+        decision: "reject",
+        concerns: [
+          {
+            dimension: "completeness",
+            detail: "missing item",
+            userSummary: "An item is missing.",
+          },
+        ],
+        reasoning: "incomplete",
+        confidence: 0.8,
+      },
+      timestamp: 2000,
+    });
+    const rows = await completionCheckTelemetry.listForConversation("c1");
+    expect(rows.map((r) => r.outcomeKind)).toEqual(["approved", "rejected"]);
+    expect(rows[1].concernDimensions).toEqual(["completeness"]);
+  });
+
+  it("aggregate counts outcomes and dimensions", async () => {
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 0,
+      rejectionRound: 0,
+      outcomeKind: "approved",
+      verdict: {
+        decision: "approve",
+        concerns: [],
+        reasoning: "ok",
+        confidence: 0.9,
+      },
+    });
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 1,
+      rejectionRound: 0,
+      outcomeKind: "rejected",
+      verdict: {
+        decision: "reject",
+        concerns: [
+          { dimension: "completeness", detail: "x", userSummary: "x." },
+          {
+            dimension: "evidenceGrounding",
+            detail: "y",
+            userSummary: "y.",
+          },
+        ],
+        reasoning: "z",
+        confidence: 0.8,
+      },
+    });
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 2,
+      rejectionRound: 0,
+      outcomeKind: "skipped",
+      verdict: null,
+      skipReason: "trigger-not-met",
+    });
+    const agg = await completionCheckTelemetry.aggregate();
+    expect(agg.totalVerdicts).toBe(3);
+    expect(agg.byOutcome.approved).toBe(1);
+    expect(agg.byOutcome.rejected).toBe(1);
+    expect(agg.byOutcome.skipped).toBe(1);
+    expect(agg.byDimension.completeness).toBe(1);
+    expect(agg.byDimension.evidenceGrounding).toBe(1);
+    expect(agg.byDimension.planClosure).toBe(0);
+  });
+
+  it("aggregate respects sinceMs filter", async () => {
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 0,
+      rejectionRound: 0,
+      outcomeKind: "approved",
+      verdict: {
+        decision: "approve",
+        concerns: [],
+        reasoning: "old",
+        confidence: 1,
+      },
+      timestamp: 1000,
+    });
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 1,
+      rejectionRound: 0,
+      outcomeKind: "approved",
+      verdict: {
+        decision: "approve",
+        concerns: [],
+        reasoning: "new",
+        confidence: 1,
+      },
+      timestamp: 5000,
+    });
+    const agg = await completionCheckTelemetry.aggregate({ sinceMs: 3000 });
+    expect(agg.totalVerdicts).toBe(1);
+  });
+
+  it("clear empties the store", async () => {
+    await completionCheckTelemetry.record({
+      conversationId: "c1",
+      turnIndex: 0,
+      rejectionRound: 0,
+      outcomeKind: "approved",
+      verdict: {
+        decision: "approve",
+        concerns: [],
+        reasoning: "ok",
+        confidence: 1,
+      },
+    });
+    await completionCheckTelemetry.clear();
+    const rows = await completionCheckTelemetry.listAll();
+    expect(rows).toEqual([]);
+  });
+});
+
+describe("runCompletionCheck (real evaluator with mocked LLM)", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    completionCheckTelemetry._resetForTests();
+    setCurrentAgentModel(null);
+  });
+
+  afterEach(() => {
+    setCurrentAgentModel(null);
+  });
+
+  it("skips with trigger-not-met when no todos and no tool calls", async () => {
+    const out = await runCompletionCheck({
+      conversationId: "c1",
+      turnIndex: 0,
+      rejectionRound: 0,
+      originalRequest: "what is 2+2",
+      draftedResponse: "4",
+      todos: [],
+      toolCallTrace: [],
+    });
+    expect(out.kind).toBe("skipped");
+    if (out.kind === "skipped") expect(out.reason).toBe("trigger-not-met");
+    const rows = await completionCheckTelemetry.listForConversation("c1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcomeKind).toBe("skipped");
+    expect(rows[0].skipReason).toBe("trigger-not-met");
+  });
+
+  it("approves when the trigger fires and the evaluator approves", async () => {
+    const evalModel = mockEvaluatorModel({
+      decision: "approve",
+      concerns: [],
+      reasoning: "ok",
+      confidence: 0.9,
+    });
+    const out = await runCompletionCheck({
+      conversationId: "c2",
+      turnIndex: 0,
+      rejectionRound: 0,
+      originalRequest: "do X",
+      draftedResponse: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [],
+      evaluatorModel: evalModel,
+    });
+    expect(out.kind).toBe("approved");
+    const rows = await completionCheckTelemetry.listForConversation("c2");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcomeKind).toBe("approved");
+  });
+
+  it("rejects when evaluator emits reject + concerns and budget remains", async () => {
+    const evalModel = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "missing item",
+          userSummary: "An item is missing.",
+        },
+      ],
+      reasoning: "x",
+      confidence: 0.8,
+    });
+    const out = await runCompletionCheck({
+      conversationId: "c3",
+      turnIndex: 0,
+      rejectionRound: 0,
+      originalRequest: "do X",
+      draftedResponse: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [],
+      evaluatorModel: evalModel,
+    });
+    expect(out.kind).toBe("rejected");
+    if (out.kind === "rejected") {
+      expect(out.verdict.concerns).toHaveLength(1);
+      expect(out.rejectionRound).toBe(0);
+    }
+    const rows = await completionCheckTelemetry.listForConversation("c3");
+    expect(rows[0].concernDimensions).toEqual(["completeness"]);
+  });
+
+  it("force-emits when rejection budget is exceeded", async () => {
+    const evalModel = mockEvaluatorModel({
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "still incomplete",
+          userSummary: "Still incomplete.",
+        },
+      ],
+      reasoning: "x",
+      confidence: 0.8,
+    });
+    // The cap is `MAX_REJECTION_ROUNDS` (3). Calling with the last
+    // round under the cap (round = MAX-1) means `round + 1 >= MAX` and
+    // the gate force-emits.
+    const out = await runCompletionCheck({
+      conversationId: "c4",
+      turnIndex: 0,
+      rejectionRound: MAX_REJECTION_ROUNDS - 1,
+      originalRequest: "do X",
+      draftedResponse: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [],
+      evaluatorModel: evalModel,
+    });
+    expect(out.kind).toBe("force-emitted");
+    if (out.kind === "force-emitted") {
+      expect(out.reason).toBe("max-rounds-exceeded");
+    }
+  });
+
+  it("force-emits with reason=evaluator-error when evaluator throws", async () => {
+    const m = new MockLanguageModelV3({
+      doGenerate: (async () => {
+        throw new Error("provider down");
+      }) as never,
+    }) as unknown as LanguageModel;
+    const out = await runCompletionCheck({
+      conversationId: "c5",
+      turnIndex: 0,
+      rejectionRound: 0,
+      originalRequest: "do X",
+      draftedResponse: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [],
+      evaluatorModel: m,
+    });
+    expect(out.kind).toBe("force-emitted");
+    if (out.kind === "force-emitted") {
+      expect(out.reason).toBe("evaluator-error");
+      expect(out.verdict.confidence).toBe(0);
+    }
+  });
+
+  it("verdict scores field stays unpopulated", async () => {
+    const evalModel = mockEvaluatorModel({
+      decision: "approve",
+      concerns: [],
+      reasoning: "ok",
+      confidence: 1,
+    });
+    const out = await runCompletionCheck({
+      conversationId: "c6",
+      turnIndex: 0,
+      rejectionRound: 0,
+      originalRequest: "do X",
+      draftedResponse: "done",
+      todos: [makeTodo("step", "completed")],
+      toolCallTrace: [],
+      evaluatorModel: evalModel,
+    });
+    if (out.kind !== "approved") throw new Error("expected approve");
+    const v: EvaluatorVerdict = out.verdict;
+    expect(v.scores).toBeUndefined();
+    expect(v.trend).toBeUndefined();
+  });
+});
+
+describe("observeChunkForCompletionCheck", () => {
+  function freshState() {
+    return {
+      textBuffers: new Map<string, string>(),
+      lastTextMessageId: undefined as string | undefined,
+      toolCalls: new Map<string, ToolCallTraceEntry>(),
+      toolCallOrder: [] as string[],
+    };
+  }
+
+  function adapter(s: ReturnType<typeof freshState>) {
+    return {
+      textBuffers: s.textBuffers,
+      setLastTextMessageId: (id: string) => {
+        s.lastTextMessageId = id;
+      },
+      toolCalls: s.toolCalls,
+      toolCallOrder: s.toolCallOrder,
+    };
+  }
+
+  /** Convenience accessor for assertions: materialize entries in order. */
+  function materialize(
+    s: ReturnType<typeof freshState>,
+  ): ToolCallTraceEntry[] {
+    return s.toolCallOrder
+      .map((id) => s.toolCalls.get(id))
+      .filter((e): e is ToolCallTraceEntry => e !== undefined);
+  }
+
+  it("accumulates text deltas keyed by message id", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      // The transport observer treats unknown chunk fields as opaque; the
+      // shape here matches the AI SDK's text-streaming chunks well enough.
+      { type: "text-start", id: "m1" } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "text-delta", id: "m1", delta: "hello " } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "text-delta", id: "m1", delta: "world" } as never,
+      adapter(s),
+    );
+    expect(s.textBuffers.get("m1")).toBe("hello world");
+    expect(s.lastTextMessageId).toBe("m1");
+  });
+
+  it("captures tool calls with truncated input summaries", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "snapshot",
+        input: { mode: "viewport" },
+      } as never,
+      adapter(s),
+    );
+    const trace = materialize(s);
+    expect(trace).toHaveLength(1);
+    expect(trace[0].name).toBe("snapshot");
+    expect(trace[0].inputSummary).toContain("viewport");
+    expect(trace[0].state).toBe("pending");
+    expect(trace[0].outputSummary).toBeNull();
+  });
+
+  it("pairs tool input with output by toolCallId; flips state to completed", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "extract",
+        input: { selector: ".price" },
+      } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-output-available",
+        toolCallId: "tc1",
+        output: { price: "$29.99" },
+      } as never,
+      adapter(s),
+    );
+    const trace = materialize(s);
+    expect(trace).toHaveLength(1);
+    expect(trace[0].state).toBe("completed");
+    expect(trace[0].outputSummary).toContain("$29.99");
+  });
+
+  it("captures tool errors as state=errored with error text", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "extract",
+        input: { selector: ".missing" },
+      } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-output-error",
+        toolCallId: "tc1",
+        errorText: "Element not found",
+      } as never,
+      adapter(s),
+    );
+    const trace = materialize(s);
+    expect(trace[0].state).toBe("errored");
+    expect(trace[0].outputSummary).toBe("Element not found");
+  });
+
+  it("captures tool denial as state=denied with null output", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "navigate",
+        input: { url: "https://example.com" },
+      } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-output-denied",
+        toolCallId: "tc1",
+      } as never,
+      adapter(s),
+    );
+    const trace = materialize(s);
+    expect(trace[0].state).toBe("denied");
+    expect(trace[0].outputSummary).toBeNull();
+  });
+
+  it("orphaned input (no matching output before stream end) stays pending", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "snapshot",
+        input: {},
+      } as never,
+      adapter(s),
+    );
+    // Stream ends without an output chunk for tc1.
+    const trace = materialize(s);
+    expect(trace[0].state).toBe("pending");
+    expect(trace[0].outputSummary).toBeNull();
+  });
+
+  it("hard-truncates oversized outputs with truncation marker", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "readPage",
+        input: {},
+      } as never,
+      adapter(s),
+    );
+    const huge = "x".repeat(2000);
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-output-available",
+        toolCallId: "tc1",
+        output: huge,
+      } as never,
+      adapter(s),
+    );
+    const trace = materialize(s);
+    // Should be capped (800 chars + truncation marker).
+    expect(trace[0].outputSummary?.length ?? 0).toBeLessThan(huge.length);
+    expect(trace[0].outputSummary).toMatch(/truncated/);
+  });
+
+  it("preserves chunk-arrival order across multiple interleaved tools", () => {
+    const s = freshState();
+    // Three tools start, then their outputs arrive out of order.
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "a",
+        toolName: "snapshot",
+        input: {},
+      } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "b",
+        toolName: "extract",
+        input: {},
+      } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-input-available",
+        toolCallId: "c",
+        toolName: "readPage",
+        input: {},
+      } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "tool-output-available", toolCallId: "b", output: "B" } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "tool-output-available", toolCallId: "a", output: "A" } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "tool-output-available", toolCallId: "c", output: "C" } as never,
+      adapter(s),
+    );
+    const trace = materialize(s);
+    expect(trace.map((t) => t.name)).toEqual([
+      "snapshot",
+      "extract",
+      "readPage",
+    ]);
+    expect(trace.map((t) => t.outputSummary)).toEqual(["A", "B", "C"]);
+  });
+
+  it("ignores unrecognized chunk types without throwing", () => {
+    const s = freshState();
+    expect(() =>
+      observeChunkForCompletionCheck(
+        { type: "some-future-chunk-type" } as never,
+        adapter(s),
+      ),
+    ).not.toThrow();
+    expect(materialize(s)).toHaveLength(0);
+    expect(s.textBuffers.size).toBe(0);
+  });
+
+  it("output chunk without a matching input is dropped", () => {
+    const s = freshState();
+    // Output arrives without any prior input chunk.
+    observeChunkForCompletionCheck(
+      {
+        type: "tool-output-available",
+        toolCallId: "ghost",
+        output: "data",
+      } as never,
+      adapter(s),
+    );
+    expect(materialize(s)).toHaveLength(0);
+  });
+
+  it("multiple text messages: lastTextMessageId tracks the most recent", () => {
+    const s = freshState();
+    observeChunkForCompletionCheck(
+      { type: "text-start", id: "m1" } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "text-delta", id: "m1", delta: "first" } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "text-start", id: "m2" } as never,
+      adapter(s),
+    );
+    observeChunkForCompletionCheck(
+      { type: "text-delta", id: "m2", delta: "second" } as never,
+      adapter(s),
+    );
+    expect(s.lastTextMessageId).toBe("m2");
+    expect(s.textBuffers.get("m1")).toBe("first");
+    expect(s.textBuffers.get("m2")).toBe("second");
+  });
+});
+
+afterEach(() => {
+  // Tighten test isolation for the IndexedDB-using suites.
+  completionCheckTelemetry._resetForTests();
+});
+
+describe("buildCompletionCheckFeedbackMessage", () => {
+  it("emits the canonical prefix the system prompt promises", () => {
+    const m = buildCompletionCheckFeedbackMessage(
+      {
+        decision: "reject",
+        concerns: [
+          {
+            dimension: "completeness",
+            detail: "x",
+            userSummary: "x.",
+          },
+        ],
+        reasoning: "incomplete",
+        confidence: 0.8,
+      },
+      1,
+    );
+    const text = m.parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(text).toContain(COMPLETION_CHECK_PREFIX);
+    expect(text).toContain("(round 1)");
+    expect(text).toContain("completeness: x");
+    expect(text).toContain("Continue working");
+  });
+
+  it("includes evidence when present and skips the line when absent", () => {
+    const m = buildCompletionCheckFeedbackMessage(
+      {
+        decision: "reject",
+        concerns: [
+          {
+            dimension: "evidenceGrounding",
+            detail: "price unverified",
+            userSummary: "Price isn't verified.",
+            evidence: "draft says $149",
+          },
+          {
+            dimension: "completeness",
+            detail: "missing 3rd item",
+            userSummary: "Third item missing.",
+          },
+        ],
+        reasoning: "issues",
+        confidence: 0.7,
+      },
+      2,
+    );
+    const text = (m.parts[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Evidence: draft says $149");
+    // No "Evidence:" line for concerns without one
+    const completenessLineIdx = text.indexOf("completeness: missing 3rd item");
+    const tail = text.slice(completenessLineIdx);
+    // Next "- " (or end) marks the next concern; nothing in between is "Evidence:"
+    const between = tail.split("\n- ")[0];
+    expect(between).not.toContain("Evidence:");
+  });
+
+  it("produces a stable user-role message with a fresh id", () => {
+    const v: EvaluatorVerdict = {
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "x",
+          userSummary: "x.",
+        },
+      ],
+      reasoning: "x",
+      confidence: 0.5,
+    };
+    const a = buildCompletionCheckFeedbackMessage(v, 1);
+    const b = buildCompletionCheckFeedbackMessage(v, 1);
+    expect(a.role).toBe("user");
+    expect(b.role).toBe("user");
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("runWithRejectionLoop (transport integration)", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    completionCheckTelemetry._resetForTests();
+    setCurrentAgentModel(null);
+  });
+
+  /**
+   * Build a `RejectionLoopAgent` stub whose `stream()` returns one
+   * scripted iteration per call. Each iteration emits a fixed list of
+   * `UIMessageChunk`s, ending with a final-text `text-delta`/`text-end`
+   * pair so the loop's observer extracts a non-empty `finalText`.
+   *
+   * Captures every `prompt` it received so tests can assert messages
+   * grew with each rejection round.
+   */
+  function makeStubAgent(textPerIteration: string[]): RejectionLoopAgent & {
+    promptHistory: unknown[];
+    callCount: number;
+  } {
+    let i = 0;
+    const promptHistory: unknown[] = [];
+    return {
+      tools: {},
+      promptHistory,
+      get callCount() {
+        return i;
+      },
+      stream: async ({ prompt }) => {
+        promptHistory.push(prompt);
+        const text = textPerIteration[i] ?? textPerIteration.at(-1) ?? "";
+        i++;
+        const id = `m-${i}`;
+        const chunks: UIMessageChunk[] = [
+          { type: "text-start", id } as never,
+          { type: "text-delta", id, delta: text } as never,
+          { type: "text-end", id } as never,
+        ];
+        return {
+          toUIMessageStream: () =>
+            new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                for (const c of chunks) controller.enqueue(c);
+                controller.close();
+              },
+            }),
+        };
+      },
+    };
+  }
+
+  function userMessage(text: string): AgentUIMessage {
+    return {
+      id: crypto.randomUUID(),
+      role: "user",
+      parts: [{ type: "text", text }],
+    } as AgentUIMessage;
+  }
+
+  function approveModel(): LanguageModel {
+    return mockEvaluatorModel({
+      decision: "approve",
+      concerns: [],
+      reasoning: "ok",
+      confidence: 0.9,
+    });
+  }
+
+  function rejectThenApproveModel(): LanguageModel {
+    let call = 0;
+    return new MockLanguageModelV3({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doGenerate: (async () => {
+        const verdict =
+          call === 0
+            ? {
+                decision: "reject",
+                concerns: [
+                  {
+                    dimension: "completeness",
+                    detail: "missing 3rd item",
+                    userSummary: "Third item missing.",
+                  },
+                ],
+                reasoning: "incomplete",
+                confidence: 0.8,
+              }
+            : {
+                decision: "approve",
+                concerns: [],
+                reasoning: "fixed",
+                confidence: 0.9,
+              };
+        call++;
+        return {
+          content: [{ type: "text", text: JSON.stringify(verdict) }],
+          finishReason: "stop",
+          usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+          warnings: [],
+        };
+      }) as never,
+    }) as unknown as LanguageModel;
+  }
+
+  function alwaysRejectModel(): LanguageModel {
+    return mockEvaluatorModel({
+      decision: "reject",
+      concerns: [
+        {
+          dimension: "completeness",
+          detail: "still incomplete",
+          userSummary: "Still incomplete.",
+        },
+      ],
+      reasoning: "x",
+      confidence: 0.8,
+    });
+  }
+
+  async function drainStream(
+    s: ReadableStream<UIMessageChunk>,
+  ): Promise<UIMessageChunk[]> {
+    const reader = s.getReader();
+    const out: UIMessageChunk[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(value);
+    }
+    return out;
+  }
+
+  it("approve verdict ⇒ exactly one agent iteration, stream forwards chunks", async () => {
+    const agent = makeStubAgent(["The first answer."]);
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c1",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "do X",
+        draftedResponse: "(filled by loop)",
+        // Ensure trigger fires: include a tool call.
+        todos: [],
+        toolCallTrace: [makeTrace("snapshot")],
+        evaluatorModel: approveModel(),
+      }),
+    });
+    const chunks = await drainStream(stream);
+    expect(agent.callCount).toBe(1);
+    const deltas = chunks.filter(
+      (c) => (c as { type: string }).type === "text-delta",
+    );
+    expect(deltas).toHaveLength(1);
+  });
+
+  it("reject → approve ⇒ two agent iterations; second prompt has completion-check feedback; rejection chunk emitted", async () => {
+    const agent = makeStubAgent(["First answer.", "Second answer."]);
+    // Create the evaluator model once outside the builder so its
+    // reject→approve sequencing persists across rounds.
+    const evalModel = rejectThenApproveModel();
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c2",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "do X",
+        draftedResponse: "(filled by loop)",
+        todos: [],
+        toolCallTrace: [makeTrace("snapshot")],
+        evaluatorModel: evalModel,
+      }),
+    });
+    const chunks = await drainStream(stream);
+    expect(agent.callCount).toBe(2);
+
+    // Second iteration's prompt must include completion-check feedback.
+    const secondPrompt = JSON.stringify(agent.promptHistory[1]);
+    expect(secondPrompt).toContain(COMPLETION_CHECK_PREFIX);
+    expect(secondPrompt).toContain("missing 3rd item");
+
+    const deltas = chunks.filter(
+      (c) => (c as { type: string }).type === "text-delta",
+    );
+    expect(deltas).toHaveLength(2);
+
+    const rejectionChunks = chunks.filter(
+      (c) => (c as { type: string }).type === "data-completion-check-rejection",
+    );
+    expect(rejectionChunks).toHaveLength(1);
+    const rejectionData = (rejectionChunks[0] as {
+      data: {
+        concerns: { dimension: string }[];
+        rejectionRound: number;
+        forceEmittedNext?: boolean;
+      };
+    }).data;
+    expect(rejectionData.rejectionRound).toBe(1);
+    expect(rejectionData.forceEmittedNext).toBe(false);
+    expect(rejectionData.concerns[0].dimension).toBe("completeness");
+  });
+
+  it("reject loop respects MAX_REJECTION_ROUNDS and force-emits", async () => {
+    // With cap=3 and always-reject, expect 3 agent iterations
+    // (rounds 0, 1, 2 — round 2 being the cap-exceeded force-emit).
+    const agent = makeStubAgent(
+      Array.from({ length: 5 }, (_, k) => `Bad ${k}.`),
+    );
+    const evalModel = alwaysRejectModel();
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c3",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "do X",
+        draftedResponse: "(filled by loop)",
+        todos: [],
+        toolCallTrace: [makeTrace("snapshot")],
+        evaluatorModel: evalModel,
+      }),
+    });
+    const chunks = await drainStream(stream);
+    expect(agent.callCount).toBe(MAX_REJECTION_ROUNDS);
+
+    const rows = await completionCheckTelemetry.listForConversation("c3");
+    const lastOutcome = rows.at(-1)?.outcomeKind;
+    expect(lastOutcome).toBe("force-emitted");
+
+    const rejectionChunks = chunks.filter(
+      (c) => (c as { type: string }).type === "data-completion-check-rejection",
+    ) as Array<{
+      data: { rejectionRound: number; forceEmittedNext?: boolean };
+    }>;
+    // For cap=3: rounds 1, 2 (continuing) and round 3 (force-emit final).
+    expect(rejectionChunks).toHaveLength(MAX_REJECTION_ROUNDS);
+    expect(rejectionChunks.at(-1)?.data.forceEmittedNext).toBe(true);
+    expect(rejectionChunks.at(-1)?.data.rejectionRound).toBe(
+      MAX_REJECTION_ROUNDS,
+    );
+  });
+
+  it("aborted signal closes the stream without further iterations", async () => {
+    const agent = makeStubAgent(["First.", "Second."]);
+    const ctrl = new AbortController();
+    const evalModel = alwaysRejectModel();
+    let evalCallCount = 0;
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: ctrl.signal,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => {
+        evalCallCount++;
+        // Reject the first iteration but abort before the loop checks.
+        ctrl.abort();
+        return {
+          conversationId: "c4",
+          turnIndex: 0,
+          rejectionRound: 0,
+          originalRequest: "do X",
+          draftedResponse: "(filled by loop)",
+          todos: [],
+          toolCallTrace: [makeTrace("snapshot")],
+          evaluatorModel: evalModel,
+        };
+      },
+    });
+    await drainStream(stream);
+    expect(agent.callCount).toBe(1);
+    expect(evalCallCount).toBe(1);
+  });
+
+  it("buildCompletionCheckInput returning undefined ⇒ single iteration, no loop", async () => {
+    const agent = makeStubAgent(["Done."]);
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => undefined,
+    });
+    await drainStream(stream);
+    expect(agent.callCount).toBe(1);
+  });
+
+  it("emits running enter then done (outcome=approved) for a real evaluator call", async () => {
+    const agent = makeStubAgent(["The answer."]);
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c-running-1",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "do X",
+        draftedResponse: "(filled by loop)",
+        todos: [],
+        // Tool call ensures shouldGate returns gate:true.
+        toolCallTrace: [makeTrace("snapshot")],
+        evaluatorModel: approveModel(),
+      }),
+    });
+    const chunks = await drainStream(stream);
+    const running = chunks.filter(
+      (c) => (c as { type: string }).type === "data-completion-check-running",
+    ) as Array<{
+      id: string;
+      data: {
+        id: string;
+        phase: "evaluating" | "done";
+        outcome?: string;
+      };
+    }>;
+    expect(running).toHaveLength(2);
+    // Both chunks share the same chunk-level id and data.id (the SDK
+    // overwrite-by-id semantics rely on this).
+    expect(running[0].id).toBe(running[1].id);
+    expect(running[0].data.id).toBe(running[1].data.id);
+    expect(running[0].data.phase).toBe("evaluating");
+    expect(running[0].data.outcome).toBeUndefined();
+    expect(running[1].data.phase).toBe("done");
+    expect(running[1].data.outcome).toBe("approved");
+  });
+
+  it("does NOT emit running chunks when the gate would skip (no tool calls + no todos)", async () => {
+    const agent = makeStubAgent(["Hello!"]);
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("hi")],
+      sendMessagesAtCall: [userMessage("hi")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c-skip",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "hi",
+        draftedResponse: "(filled by loop)",
+        // Trigger heuristic skips this: no todos AND no tool calls.
+        todos: [],
+        toolCallTrace: [],
+        evaluatorModel: approveModel(),
+      }),
+    });
+    const chunks = await drainStream(stream);
+    const running = chunks.filter(
+      (c) => (c as { type: string }).type === "data-completion-check-running",
+    );
+    expect(running).toHaveLength(0);
+  });
+
+  it("multi-round rejection loop emits a paired enter/done per evaluator call", async () => {
+    // reject → approve sequence runs the evaluator twice → 2 paired
+    // running chunks, each with its own id.
+    const agent = makeStubAgent(["First.", "Second."]);
+    const evalModel = rejectThenApproveModel();
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c-multi",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "do X",
+        draftedResponse: "(filled by loop)",
+        todos: [],
+        toolCallTrace: [makeTrace("snapshot")],
+        evaluatorModel: evalModel,
+      }),
+    });
+    const chunks = await drainStream(stream);
+    const running = chunks.filter(
+      (c) => (c as { type: string }).type === "data-completion-check-running",
+    ) as Array<{
+      id: string;
+      data: { id: string; phase: string; outcome?: string };
+    }>;
+    expect(running).toHaveLength(4);
+    // Round 1: enter + done(rejected)
+    expect(running[0].data.phase).toBe("evaluating");
+    expect(running[1].data.phase).toBe("done");
+    expect(running[1].data.outcome).toBe("rejected");
+    // Round 2: enter + done(approved). Distinct id from round 1.
+    expect(running[2].data.phase).toBe("evaluating");
+    expect(running[3].data.phase).toBe("done");
+    expect(running[3].data.outcome).toBe("approved");
+    expect(running[0].id).not.toBe(running[2].id);
+    // Pairs share their id.
+    expect(running[0].id).toBe(running[1].id);
+    expect(running[2].id).toBe(running[3].id);
+  });
+
+  it("force-emit (max rounds exceeded) reports outcome=force-emitted on done", async () => {
+    const agent = makeStubAgent(
+      Array.from({ length: MAX_REJECTION_ROUNDS + 1 }, (_, k) => `Bad ${k}.`),
+    );
+    const evalModel = alwaysRejectModel();
+    const stream = runWithRejectionLoop({
+      agent,
+      validatedMessages: [userMessage("do X")],
+      sendMessagesAtCall: [userMessage("do X")],
+      abortSignal: undefined,
+      pinnedConversationId: null,
+      buildCompletionCheckInput: () => ({
+        conversationId: "c-fe",
+        turnIndex: 0,
+        rejectionRound: 0,
+        originalRequest: "do X",
+        draftedResponse: "(filled by loop)",
+        todos: [],
+        toolCallTrace: [makeTrace("snapshot")],
+        evaluatorModel: evalModel,
+      }),
+    });
+    const chunks = await drainStream(stream);
+    const running = chunks.filter(
+      (c) => (c as { type: string }).type === "data-completion-check-running",
+    ) as Array<{ data: { phase: string; outcome?: string } }>;
+    // The final round's done chunk should report force-emitted.
+    const lastDone = [...running]
+      .reverse()
+      .find((c) => c.data.phase === "done");
+    expect(lastDone?.data.outcome).toBe("force-emitted");
+  });
+});
+
+describe("emitCompletionCheckRunningChunk", () => {
+  it("uses data.id as the chunk id so the SDK overwrites in place", () => {
+    const enqueued: unknown[] = [];
+    const fakeController = {
+      enqueue: (c: unknown) => enqueued.push(c),
+    } as unknown as ReadableStreamDefaultController<UIMessageChunk>;
+    emitCompletionCheckRunningChunk(fakeController, {
+      id: "abc-123",
+      phase: "evaluating",
+    });
+    expect(enqueued).toHaveLength(1);
+    const chunk = enqueued[0] as { type: string; id: string; data: unknown };
+    expect(chunk.type).toBe("data-completion-check-running");
+    expect(chunk.id).toBe("abc-123");
+    expect(chunk.data).toEqual({ id: "abc-123", phase: "evaluating" });
+  });
+
+  it("threads outcome through on done chunks", () => {
+    const enqueued: unknown[] = [];
+    const fakeController = {
+      enqueue: (c: unknown) => enqueued.push(c),
+    } as unknown as ReadableStreamDefaultController<UIMessageChunk>;
+    emitCompletionCheckRunningChunk(fakeController, {
+      id: "abc-123",
+      phase: "done",
+      outcome: "approved",
+    });
+    const chunk = enqueued[0] as { data: { outcome?: string } };
+    expect(chunk.data.outcome).toBe("approved");
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
@@ -1,5 +1,5 @@
 import "fake-indexeddb/auto";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { MockLanguageModelV3 } from "ai/test";
 import type { LanguageModel, UIMessageChunk } from "ai";
 import type { TodoItem } from "../../types";

--- a/apps/extension/src/lib/agent/__tests__/set-agent-context-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/set-agent-context-handles.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Verifies that `setAgentContext(newCid)` no longer wipes the in-memory
+ * tab-handle map of the previously-active conversation. The bug being
+ * prevented:
+ *
+ *   1. Conversation A's agent loop is mid-flight; tools have minted
+ *      handles `t1`, `t2`, ... in A's handle map.
+ *   2. The user navigates to conversation B; the UI calls
+ *      `setAgentContext('B')`.
+ *   3. A's still-running tool calls go to resolve `t1` — but the previous
+ *      implementation had cleared A's handle map at step 2, so they fail
+ *      with "Unknown tab handle".
+ *
+ * After the fix, `setAgentContext` retains all in-memory handle maps;
+ * `tab-handles.ts`'s data structures are already keyed per conversation,
+ * so coexistence is safe.
+ */
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "../../chat-db";
+import { setAgentContext } from "../agent-transport";
+import {
+  clearHandles,
+  getOrCreateHandle,
+  resolveHandle,
+} from "../tab-handles";
+
+const CONV_A = "conv-a";
+const CONV_B = "conv-b";
+
+async function seedConv(id: string) {
+  await chatDb.createConversation({
+    id,
+    title: id,
+    spaceId: null,
+    ownedTabIds: [],
+    createdAt: 0,
+    updatedAt: 0,
+  });
+}
+
+describe("setAgentContext — handle-map preservation", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    clearHandles(CONV_A);
+    clearHandles(CONV_B);
+    setAgentContext(null);
+    vi.unstubAllGlobals();
+    // `loadHandlesForConversation` reads chrome.tabs.get during hydration;
+    // stub it so the (fire-and-forget) hydration doesn't reject in tests.
+    vi.stubGlobal("chrome", {
+      tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+    });
+  });
+
+  afterEach(() => {
+    clearHandles(CONV_A);
+    clearHandles(CONV_B);
+    setAgentContext(null);
+    vi.unstubAllGlobals();
+  });
+
+  it("retains the previous conversation's in-memory handle map after a switch", async () => {
+    await seedConv(CONV_A);
+    await seedConv(CONV_B);
+
+    setAgentContext(CONV_A);
+    expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+
+    // Switch to B mid-flight (as if user navigated). A's map must
+    // survive — any tool call still in-flight for A needs to keep
+    // resolving its handles.
+    setAgentContext(CONV_B);
+    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+  });
+
+  it("does not leak handles between conversations after a switch", async () => {
+    await seedConv(CONV_A);
+    await seedConv(CONV_B);
+
+    setAgentContext(CONV_A);
+    getOrCreateHandle(CONV_A, 100); // A:t1 → 100
+
+    setAgentContext(CONV_B);
+    // B's map starts empty regardless of A's contents.
+    expect(resolveHandle(CONV_B, "t1")).toBeUndefined();
+
+    // Mint a handle in B; it must not collide with A's mapping.
+    const bHandle = getOrCreateHandle(CONV_B, 200);
+    expect(resolveHandle(CONV_B, bHandle)).toBe(200);
+    expect(resolveHandle(CONV_A, "t1")).toBe(100); // A still intact.
+  });
+
+  it("repeated switches are idempotent w.r.t. handle preservation", async () => {
+    await seedConv(CONV_A);
+    await seedConv(CONV_B);
+
+    setAgentContext(CONV_A);
+    getOrCreateHandle(CONV_A, 100);
+    getOrCreateHandle(CONV_A, 200);
+
+    setAgentContext(CONV_B);
+    setAgentContext(CONV_A);
+    setAgentContext(CONV_B);
+    setAgentContext(CONV_A);
+
+    // After all the flipping, A's handles must still be there.
+    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+    expect(resolveHandle(CONV_A, "t2")).toBe(200);
+  });
+
+  it("setting context to null also preserves prior maps", async () => {
+    await seedConv(CONV_A);
+
+    setAgentContext(CONV_A);
+    getOrCreateHandle(CONV_A, 100);
+
+    setAgentContext(null);
+    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tool-context-pinning.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-context-pinning.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Verifies the per-tool-call conversationId pinning contract that
+ * `buildExtensionToolContext(pinnedConversationId)` is supposed to
+ * provide. The bug being prevented:
+ *
+ *   1. Tool call begins for conversation A.
+ *   2. Inside the tool's `execute` (between awaits), the user navigates
+ *      to conversation B and the UI calls `setAgentContext('B')`.
+ *   3. The tool's `ctx.session.setTodos(...)` is supposed to write to A,
+ *      not B.
+ *
+ * Pre-fix, session helpers read `getAgentContext().conversationId`
+ * lazily on every call — so step 3 silently misrouted to B. After the
+ * fix, the cid is captured at context construction (i.e. at
+ * tool-call entry inside `toSDKTool.execute`) and never re-read.
+ */
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "../../chat-db";
+import {
+  buildExtensionToolContext,
+  setAgentContext,
+} from "../agent-transport";
+import {
+  clearHandles,
+  getOrCreateHandle,
+} from "../tab-handles";
+import { todoWriteTool } from "../tools/todowrite";
+
+const CONV_A = "conv-a";
+const CONV_B = "conv-b";
+
+async function seedConv(
+  id: string,
+  opts: {
+    ownedTabIds?: number[];
+    ownedGroupId?: number | null;
+    todos?: import("../../types").TodoItem[];
+  } = {},
+) {
+  await chatDb.createConversation({
+    id,
+    title: id,
+    spaceId: null,
+    ownedTabIds: opts.ownedTabIds ?? [],
+    ownedGroupId: opts.ownedGroupId ?? null,
+    todos: opts.todos ?? [],
+    createdAt: 0,
+    updatedAt: 0,
+  });
+}
+
+describe("buildExtensionToolContext (per-call cid pinning)", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    clearHandles(CONV_A);
+    clearHandles(CONV_B);
+    setAgentContext(null);
+    vi.unstubAllGlobals();
+    // Tests that touch tab-binding helpers need a chrome stub so the
+    // helper's `chrome.runtime.sendMessage` doesn't blow up.
+    vi.stubGlobal("chrome", {
+      runtime: { sendMessage: vi.fn(async () => undefined) },
+    });
+  });
+
+  afterEach(() => {
+    clearHandles(CONV_A);
+    clearHandles(CONV_B);
+    setAgentContext(null);
+    vi.unstubAllGlobals();
+  });
+
+  describe("session.conversationId", () => {
+    it("is the literal pinned cid (not a getter that reads global)", () => {
+      const ctx = buildExtensionToolContext(CONV_A);
+      expect(ctx.session?.conversationId).toBe(CONV_A);
+
+      // Flipping the global must not change the pinned value.
+      setAgentContext(CONV_B);
+      expect(ctx.session?.conversationId).toBe(CONV_A);
+    });
+
+    it("is null when constructed with null", () => {
+      const ctx = buildExtensionToolContext(null);
+      expect(ctx.session?.conversationId).toBeNull();
+    });
+  });
+
+  describe("getTodos / setTodos", () => {
+    it("getTodos reads from pinned cid even after a mid-flight switch", async () => {
+      await seedConv(CONV_A, {
+        todos: [
+          {
+            id: "t-A1",
+            content: "A's task",
+            status: "pending",
+            createdAt: 0,
+            updatedAt: 0,
+          },
+        ],
+      });
+      await seedConv(CONV_B, {
+        todos: [
+          {
+            id: "t-B1",
+            content: "B's task",
+            status: "pending",
+            createdAt: 0,
+            updatedAt: 0,
+          },
+        ],
+      });
+
+      const ctx = buildExtensionToolContext(CONV_A);
+      // Switch globally between context construction and the read; must
+      // not affect the pinned read.
+      setAgentContext(CONV_B);
+
+      const todos = await ctx.session!.getTodos!();
+      expect(todos).toHaveLength(1);
+      expect(todos[0].id).toBe("t-A1");
+    });
+
+    it("setTodos writes to pinned cid even after a mid-flight switch", async () => {
+      await seedConv(CONV_A);
+      await seedConv(CONV_B);
+
+      const ctx = buildExtensionToolContext(CONV_A);
+      setAgentContext(CONV_B);
+
+      const newTodos: import("../../types").TodoItem[] = [
+        {
+          id: "new-1",
+          content: "Pinned write",
+          status: "in_progress",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ];
+      await ctx.session!.setTodos!(newTodos);
+
+      const convA = await chatDb.getConversation(CONV_A);
+      const convB = await chatDb.getConversation(CONV_B);
+      expect(convA?.todos?.[0]?.id).toBe("new-1");
+      // B must remain untouched.
+      expect(convB?.todos ?? []).toEqual([]);
+    });
+
+    it("end-to-end via todoWriteTool.execute survives a mid-await switch", async () => {
+      await seedConv(CONV_A, {
+        todos: [
+          {
+            id: "existing-A",
+            content: "Existing",
+            status: "pending",
+            createdAt: 0,
+            updatedAt: 0,
+          },
+        ],
+      });
+      await seedConv(CONV_B);
+
+      const ctx = buildExtensionToolContext(CONV_A);
+
+      // Wrap session.getTodos so we can flip the global mid-execute,
+      // simulating the user navigating to a different conversation
+      // between the tool's read and write.
+      const originalGetTodos = ctx.session!.getTodos!.bind(ctx.session);
+      ctx.session!.getTodos = async () => {
+        const result = await originalGetTodos();
+        setAgentContext(CONV_B);
+        return result;
+      };
+
+      const result = await todoWriteTool.execute(
+        {
+          todos: [
+            {
+              content: "New pinned task",
+              status: "in_progress",
+              priority: "high",
+            },
+          ],
+        },
+        ctx,
+      );
+
+      expect(result).toEqual({ saved: true });
+      const convA = await chatDb.getConversation(CONV_A);
+      const convB = await chatDb.getConversation(CONV_B);
+      expect(convA?.todos).toHaveLength(1);
+      expect(convA?.todos?.[0]?.content).toBe("New pinned task");
+      expect(convB?.todos ?? []).toEqual([]);
+    });
+
+    it("getTodos returns [] when pinned cid is null", async () => {
+      const ctx = buildExtensionToolContext(null);
+      expect(await ctx.session!.getTodos!()).toEqual([]);
+    });
+
+    it("setTodos is a no-op when pinned cid is null", async () => {
+      await seedConv(CONV_A);
+      const ctx = buildExtensionToolContext(null);
+      await ctx.session!.setTodos!([
+        {
+          id: "x",
+          content: "x",
+          status: "pending",
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ]);
+      const convA = await chatDb.getConversation(CONV_A);
+      expect(convA?.todos ?? []).toEqual([]);
+    });
+  });
+
+  describe("isAgentOwnedTab / hasOwnedTabGroup", () => {
+    it("isAgentOwnedTab targets pinned cid", async () => {
+      await seedConv(CONV_A, { ownedTabIds: [42] });
+      await seedConv(CONV_B, { ownedTabIds: [99] });
+
+      const ctxA = buildExtensionToolContext(CONV_A);
+      setAgentContext(CONV_B);
+
+      expect(await ctxA.session!.isAgentOwnedTab!(42)).toBe(true);
+      expect(await ctxA.session!.isAgentOwnedTab!(99)).toBe(false);
+    });
+
+    it("hasOwnedTabGroup targets pinned cid", async () => {
+      await seedConv(CONV_A, { ownedGroupId: 7 });
+      await seedConv(CONV_B, { ownedGroupId: null });
+
+      const ctxA = buildExtensionToolContext(CONV_A);
+      const ctxB = buildExtensionToolContext(CONV_B);
+
+      // Flip global to be sure neither reads from it.
+      setAgentContext(CONV_A);
+      expect(await ctxB.session!.hasOwnedTabGroup!()).toBe(false);
+      setAgentContext(CONV_B);
+      expect(await ctxA.session!.hasOwnedTabGroup!()).toBe(true);
+    });
+
+    it("returns false when pinned cid is null", async () => {
+      const ctx = buildExtensionToolContext(null);
+      expect(await ctx.session!.isAgentOwnedTab!(1)).toBe(false);
+      expect(await ctx.session!.hasOwnedTabGroup!()).toBe(false);
+    });
+  });
+
+  describe("getOrCreateHandle / resolveHandle", () => {
+    it("getOrCreateHandle uses pinned cid's handle map", async () => {
+      await seedConv(CONV_A);
+      await seedConv(CONV_B);
+
+      // Pre-populate B's handle map; A's is empty.
+      getOrCreateHandle(CONV_B, 500);
+
+      const ctxA = buildExtensionToolContext(CONV_A);
+      // Even with global flipped to B, ctxA's helper must mint into A.
+      setAgentContext(CONV_B);
+      const aHandle = ctxA.session!.getOrCreateHandle!(123);
+      expect(aHandle).toBe("t1");
+      // B's map is unchanged for tabId 123.
+      const ctxB = buildExtensionToolContext(CONV_B);
+      const bHandle = ctxB.session!.getOrCreateHandle!(123);
+      // tab 123 is new for B → first available counter slot.
+      expect(bHandle).toBe("t2");
+    });
+
+    it("resolveHandle uses pinned cid's handle map", async () => {
+      await seedConv(CONV_A);
+      await seedConv(CONV_B);
+      getOrCreateHandle(CONV_A, 100); // A:t1 → 100
+      getOrCreateHandle(CONV_B, 200); // B:t1 → 200
+
+      const ctxA = buildExtensionToolContext(CONV_A);
+      setAgentContext(CONV_B);
+
+      expect(ctxA.session!.resolveHandle!("t1")).toBe(100);
+    });
+
+    it("falls back to t<id> when pinned cid is null", () => {
+      const ctx = buildExtensionToolContext(null);
+      expect(ctx.session!.getOrCreateHandle!(7)).toBe("t7");
+      expect(ctx.session!.resolveHandle!("t1")).toBeUndefined();
+    });
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
@@ -299,6 +299,44 @@ describe("rewriteForLLM tool-state heal", () => {
     expect(part.errorText).toMatch(/interrupted/i);
   });
 
+  it("downgrades output-denied with approved=true (contradictory) to output-error", () => {
+    // Strict-shape contract: state=output-denied REQUIRES approved=false.
+    // `approved: true` paired with that state is semantically nonsense
+    // and gets healed to a clean output-error.
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "denied-but-approved",
+        state: "output-denied",
+        input: { url: "https://example.com" },
+        approval: { id: "ap1", approved: true },
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; errorText: string };
+    expect(part.state).toBe("output-error");
+  });
+
+  it("approval-requested with non-string id falls through to output-error heal", () => {
+    // Defensive: malformed approval id (e.g. undefined or number)
+    // shouldn't be carried forward into a synthesized output-denied —
+    // we don't trust it. Heal to output-error instead.
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "approval-bad-id",
+        state: "approval-requested",
+        input: { url: "https://example.com" },
+        approval: { id: undefined },
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; errorText: string };
+    expect(part.state).toBe("output-error");
+  });
+
   it("preserves a fully well-formed output-available part as the same instance", () => {
     const msgs: AgentUIMessage[] = [
       userMsg("hi"),

--- a/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import { rewriteForLLM } from "../compacting-transport";
+import type { AgentUIMessage } from "../../types";
+
+// Helpers ────────────────────────────────────────────────────────────
+
+function userMsg(text: string, id = `u-${Math.random()}`): AgentUIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+  } as AgentUIMessage;
+}
+
+function assistantToolPart(
+  state: string,
+  extra: Record<string, unknown> = {},
+  toolName = "navigate",
+) {
+  return {
+    type: `tool-${toolName}` as const,
+    toolCallId: `call-${state}`,
+    state,
+    input: { url: "https://example.com" },
+    ...extra,
+  } as unknown as AgentUIMessage["parts"][number];
+}
+
+function assistantWithPart(
+  part: AgentUIMessage["parts"][number],
+  id = `a-${Math.random()}`,
+): AgentUIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [part],
+  } as AgentUIMessage;
+}
+
+// Tests ──────────────────────────────────────────────────────────────
+
+describe("rewriteForLLM tool-state heal", () => {
+  it("leaves terminal output-available parts untouched", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-available", {
+          output: { navigated: true, url: "https://example.com" },
+        }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const part = out[1].parts[0] as { state: string; output: unknown };
+    expect(part.state).toBe("output-available");
+    expect(part.output).toBeDefined();
+  });
+
+  it("leaves terminal output-error parts untouched", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-error", { errorText: "boom" }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; errorText: string };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toBe("boom");
+  });
+
+  it("leaves terminal output-denied parts untouched", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-denied", {
+          approval: { id: "ap1", approved: false, reason: "user denied" },
+        }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string };
+    expect(part.state).toBe("output-denied");
+  });
+
+  it("heals input-available parts to output-error", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(assistantToolPart("input-available")),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as {
+      state: string;
+      errorText?: string;
+      output?: unknown;
+    };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toMatch(/interrupted/i);
+    expect(part.output).toBeUndefined();
+  });
+
+  it("heals input-streaming parts to output-error (the case that triggered the bug)", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(assistantToolPart("input-streaming")),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; errorText?: string };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toMatch(/interrupted/i);
+  });
+
+  it("heals output-streaming parts to output-error", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-streaming", { output: { partial: 1 } }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as {
+      state: string;
+      errorText?: string;
+      output?: unknown;
+    };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toMatch(/interrupted/i);
+    // Partial output is dropped so the part shape is unambiguous —
+    // errorText is the sole carrier of meaning for output-error.
+    expect(part.output).toBeUndefined();
+  });
+
+  it("heals approval-requested parts to output-error", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("approval-requested", {
+          approval: { id: "ap1" },
+        }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string };
+    // The transport-level heal collapses every non-terminal state to
+    // output-error. The chat-hook-level heal preserves approval
+    // semantics (output-denied), but at the transport boundary we only
+    // care about producing a valid model message; downgrading to
+    // output-error is safer than a dedicated approval path here.
+    expect(part.state).toBe("output-error");
+  });
+
+  it("heals an unrecognized future state defensively", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(assistantToolPart("totally-new-state")),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string };
+    expect(part.state).toBe("output-error");
+  });
+
+  it("preserves non-tool parts (text, data-*) regardless of healing", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "thinking..." },
+          assistantToolPart("input-streaming"),
+          { type: "text", text: "more thinking" },
+        ],
+      } as AgentUIMessage,
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out[1].parts).toHaveLength(3);
+    expect((out[1].parts[0] as { type: string }).type).toBe("text");
+    expect((out[1].parts[1] as { state: string }).state).toBe("output-error");
+    expect((out[1].parts[2] as { type: string }).type).toBe("text");
+  });
+
+  it("returns the same message instance when no heal is needed (no extra renders)", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-available", { output: { ok: true } }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out[1]).toBe(msgs[1]);
+  });
+
+  it("heals dynamic-tool parts the same as tool-* parts", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "dynamic-tool",
+        toolCallId: "dt1",
+        toolName: "mcpTool",
+        state: "input-available",
+        input: { foo: "bar" },
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; errorText?: string };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toMatch(/interrupted/i);
+  });
+
+  // ── Strict-shape repair: input/output/errorText must be present ──
+
+  it("fills in missing input on a non-terminal part with {}", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "no-input",
+        state: "input-streaming",
+        // input deliberately missing
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; input: unknown };
+    expect(part.state).toBe("output-error");
+    expect(part.input).toEqual({});
+  });
+
+  it("fills in missing input on a terminal output-error part", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "err-no-input",
+        state: "output-error",
+        errorText: "boom",
+        // input missing — convertToModelMessages still emits a
+        // tool-call assistant entry that requires it.
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { input: unknown; errorText: string };
+    expect(part.input).toEqual({});
+    expect(part.errorText).toBe("boom");
+  });
+
+  it("downgrades output-available with missing output to output-error", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "av-no-output",
+        state: "output-available",
+        input: { url: "https://example.com" },
+        // output missing
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as {
+      state: string;
+      errorText: string;
+      output?: unknown;
+    };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toMatch(/interrupted/i);
+    expect(part.output).toBeUndefined();
+  });
+
+  it("fills in missing errorText on output-error", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "err-no-text",
+        state: "output-error",
+        input: { url: "https://example.com" },
+        // errorText missing
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { errorText: string };
+    expect(typeof part.errorText).toBe("string");
+    expect(part.errorText.length).toBeGreaterThan(0);
+  });
+
+  it("downgrades output-denied with malformed approval to output-error", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "denied-no-approval",
+        state: "output-denied",
+        input: { url: "https://example.com" },
+        // approval missing/malformed
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    const part = out[1].parts[0] as { state: string; errorText: string };
+    expect(part.state).toBe("output-error");
+    expect(part.errorText).toMatch(/interrupted/i);
+  });
+
+  it("preserves a fully well-formed output-available part as the same instance", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-available", {
+          output: { type: "json", value: { ok: true } },
+          input: { url: "https://example.com" },
+        }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out[1]).toBe(msgs[1]);
+  });
+
+  it("preserves a fully well-formed output-denied part as the same instance", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(
+        assistantToolPart("output-denied", {
+          input: { url: "https://example.com" },
+          approval: { id: "ap1", approved: false, reason: "user denied" },
+        }),
+      ),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out[1]).toBe(msgs[1]);
+  });
+});

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -2,6 +2,7 @@ import { getSkillsRegistry } from "@/lib/skills/registry";
 import type { ModelDefinition } from "@/registry/providers/types";
 import type {
   ChatTransport,
+  JSONValue,
   LanguageModel,
   ToolLoopAgentSettings,
   ToolSet,
@@ -18,7 +19,6 @@ import { CompactingChatTransport } from "./compacting-transport";
 import { ExtensionDriver } from "./driver/extension-driver";
 import type { ToolContext } from "./driver";
 import {
-  clearHandles,
   getOrCreateHandle as getOrCreateTabHandle,
   loadHandlesForConversation,
   resolveHandle as resolveTabHandle,
@@ -306,19 +306,18 @@ let lastTotalTokens = 0;
 let currentModelDef: ModelDefinition | undefined;
 
 /**
- * The LanguageModel instance for the currently-active agent session. Tools
- * that need to make their own LLM calls (e.g. `extract`) read this instead of
- * wiring the model through tool context. Set in `createAgentTransport`.
+ * The LanguageModel instance for the currently-active agent session is
+ * held in {@link ./current-agent-model.ts} so tools and the completion-check
+ * evaluator can read it without dragging the full agent-transport
+ * import graph into their unit tests. We re-export the accessors here
+ * so existing call sites that imported them from this module keep
+ * working.
  */
-let currentAgentModel: LanguageModel | null = null;
-
-export function getCurrentAgentModel(): LanguageModel | null {
-  return currentAgentModel;
-}
-
-export function setCurrentAgentModel(model: LanguageModel | null): void {
-  currentAgentModel = model;
-}
+export {
+  getCurrentAgentModel,
+  setCurrentAgentModel,
+} from "./current-agent-model";
+import { setCurrentAgentModel } from "./current-agent-model";
 
 export function getLastTotalTokens(): number {
   return lastTotalTokens;
@@ -341,15 +340,32 @@ export function resetTokenTracking() {
   lastTotalTokens = 0;
 }
 
+/**
+ * Set the conversation that subsequent agent loops should bind to. This is
+ * the source of truth read by `CompactingChatTransport.sendMessages` (and
+ * by the wrapper around each tool call) at the moment a loop starts; from
+ * that point on the cid is captured and pinned for the duration of the
+ * loop / tool call.
+ *
+ * In-memory tab-handle maps for previously-active conversations are
+ * intentionally retained. The maps in `tab-handles.ts` are keyed by
+ * conversation id, so multiple conversations' handle maps coexist without
+ * interference. Wiping a previous conversation's map here used to corrupt
+ * any in-flight tool call still resolving handles for that conversation
+ * after a mid-stream switch; keeping them in memory is correct and the
+ * memory cost (a few ints per tab) is negligible. The persisted record in
+ * chatDb (`handleState`) remains the durable source of truth and is
+ * re-merged on next activation by `loadHandlesForConversation`.
+ */
 export function setAgentContext(conversationId: string | null) {
-  if (agentConversationId && agentConversationId !== conversationId) {
-    clearHandles(agentConversationId);
-  }
   agentConversationId = conversationId;
   // Hydrate the persisted handle map for the new conversation. Fire-and-
   // forget: tools that hit a not-yet-hydrated map will see "Unknown tab
   // handle" and recover via listTabs. In practice the user-message →
   // first-tool-call window is large enough for this to settle.
+  // `loadHandlesForConversation` merges restored state into whatever
+  // in-memory state already exists for this cid, so re-firing on every
+  // call is idempotent.
   if (conversationId) {
     loadHandlesForConversation(conversationId).catch(() => {});
   }
@@ -410,34 +426,38 @@ export async function allowToolOnSite(
 
 /**
  * Singleton driver instance for the production extension. Tools receive this
- * via the `ToolContext` threaded through `experimental_context`. Stateless;
- * the driver itself is just a thin facade over `cdp-session`/`active-tab`.
+ * via the `ToolContext` built per-tool-call inside `toSDKTool.execute`.
+ * Stateless; the driver itself is just a thin facade over
+ * `cdp-session`/`active-tab`.
  */
 const extensionDriver = new ExtensionDriver();
 
 /**
- * Build the `ToolContext` for an agent session. The context exposes the
- * driver plus session-level orchestration callbacks (tab handle map,
- * conversation-tab binding) that only make sense in the extension. The bench
- * harness builds its own minimal context with `session` left undefined.
+ * Build the `ToolContext` for a single tool call.
  *
- * Session helpers read `getAgentContext().conversationId` lazily at call
- * time so the same context object stays valid across conversation switches.
+ * The `pinnedConversationId` argument is captured synchronously at the
+ * tool-call boundary (see `toSDKTool.execute`) and threaded through every
+ * session helper. This guarantees that even if `setAgentContext(...)` is
+ * called mid-execute (e.g. the user switches conversations while a tool
+ * await is pending), all chatDb reads/writes and tab-handle lookups for
+ * this tool call still target the conversation that originated the call.
+ *
+ * The bench harness builds its own minimal context with `session` left
+ * undefined.
  */
-function buildExtensionToolContext(): ToolContext {
+export function buildExtensionToolContext(
+  pinnedConversationId: string | null,
+): ToolContext {
   return {
     driver: extensionDriver,
     session: {
-      get conversationId() {
-        return getAgentContext().conversationId;
-      },
+      conversationId: pinnedConversationId,
       bindTabsToConversation: async (tabIds) => {
-        const cid = getAgentContext().conversationId;
-        if (!cid) return;
+        if (!pinnedConversationId) return;
         try {
           await chrome.runtime.sendMessage({
             type: "BIND_TABS_TO_CONVERSATION",
-            conversationId: cid,
+            conversationId: pinnedConversationId,
             tabIds: tabIds.map((t) => Number(t)),
           });
         } catch {
@@ -445,12 +465,11 @@ function buildExtensionToolContext(): ToolContext {
         }
       },
       bindActiveTabToConversation: async (tabId) => {
-        const cid = getAgentContext().conversationId;
-        if (!cid) return;
+        if (!pinnedConversationId) return;
         try {
           await chrome.runtime.sendMessage({
             type: "BIND_ACTIVE_TAB_TO_CONVERSATION",
-            conversationId: cid,
+            conversationId: pinnedConversationId,
             tabId: Number(tabId),
           });
         } catch {
@@ -458,37 +477,33 @@ function buildExtensionToolContext(): ToolContext {
         }
       },
       getOrCreateHandle: (tabId) => {
-        const cid = getAgentContext().conversationId;
-        return cid
-          ? getOrCreateTabHandle(cid, Number(tabId))
+        return pinnedConversationId
+          ? getOrCreateTabHandle(pinnedConversationId, Number(tabId))
           : `t${Number(tabId)}`;
       },
       resolveHandle: (handle) => {
-        const cid = getAgentContext().conversationId;
-        return cid ? resolveTabHandle(cid, handle) : undefined;
+        return pinnedConversationId
+          ? resolveTabHandle(pinnedConversationId, handle)
+          : undefined;
       },
       isAgentOwnedTab: async (tabId) => {
-        const cid = getAgentContext().conversationId;
-        if (!cid) return false;
-        const conv = await chatDb.getConversation(cid);
+        if (!pinnedConversationId) return false;
+        const conv = await chatDb.getConversation(pinnedConversationId);
         return !!conv?.ownedTabIds.includes(Number(tabId));
       },
       hasOwnedTabGroup: async () => {
-        const cid = getAgentContext().conversationId;
-        if (!cid) return false;
-        const conv = await chatDb.getConversation(cid);
+        if (!pinnedConversationId) return false;
+        const conv = await chatDb.getConversation(pinnedConversationId);
         return conv?.ownedGroupId != null;
       },
       getTodos: async () => {
-        const cid = getAgentContext().conversationId;
-        if (!cid) return [];
-        const conv = await chatDb.getConversation(cid);
+        if (!pinnedConversationId) return [];
+        const conv = await chatDb.getConversation(pinnedConversationId);
         return conv?.todos || [];
       },
       setTodos: async (todos) => {
-        const cid = getAgentContext().conversationId;
-        if (!cid) return;
-        await chatDb.updateConversation(cid, {
+        if (!pinnedConversationId) return;
+        await chatDb.updateConversation(pinnedConversationId, {
           todos,
           updatedAt: Date.now(),
         });
@@ -561,9 +576,12 @@ function toSDKTool<TInput, TOutput>(
     input: TInput,
     options: { toolCallId: string; experimental_context?: unknown },
   ) => {
-    // Capture cid once at entry so all resolveTabFromInput calls below
-    // (pre- and post-execute) hit the same conversation map even if the
-    // user switches conversations mid-tool.
+    // Capture cid once at entry. Every chatDb / handle-map operation
+    // reachable from this tool call — both inside the wrapper
+    // (resolveTabFromInput, capture stores) and inside the tool's own
+    // execute via `ctx.session` — pins to this snapshot. So if the user
+    // switches conversations mid-tool-await, the in-flight call still
+    // writes to the conversation that originated it.
     const cid = agentConversationId;
     if (isTabTool) {
       agentActive = true;
@@ -585,12 +603,12 @@ function toSDKTool<TInput, TOutput>(
       }
     }
     try {
-      // Threaded ToolContext from the SDK's experimental_context channel.
-      // Tools that haven't migrated still receive (input) — TS allows
-      // dropping the second param. Once all tools read ctx the cast can
-      // tighten to a non-optional check.
-      const ctx = (options.experimental_context as ToolContext | undefined)
-        ?? buildExtensionToolContext();
+      // Build the ToolContext fresh for this call, pinned to the cid we
+      // captured above. We deliberately ignore `options.experimental_context`
+      // — every tool registered with the agent flows through this wrapper,
+      // so building here gives us per-call pinning without relying on a
+      // construction-time global read.
+      const ctx = buildExtensionToolContext(cid);
       const result = await t.execute(input, ctx);
       toolResultStore.set(options.toolCallId, result);
       if (isTabTool) {
@@ -654,9 +672,24 @@ function toSDKTool<TInput, TOutput>(
         const imageDataUrl = (output as { imageDataUrl?: string })
           .imageDataUrl;
         if (!imageDataUrl) {
-          // Tool errored or otherwise produced no image; let the SDK fall
-          // back to the default JSON output by returning undefined.
-          return undefined;
+          // Tool errored, produced no image, or had its base64 data
+          // stripped during compaction (`stripScreenshotsFromParts`
+          // replaces the output with `{ removed: "..." }`).
+          //
+          // Returning `undefined` here used to delegate to the SDK's
+          // default JSON serializer, but AI SDK v5 (`createToolModelOutput`)
+          // now passes `undefined` straight through to the prompt, so
+          // the resulting `tool-result` content has `output: undefined`
+          // and `standardizePrompt`'s strict Zod validation throws
+          // `AI_InvalidPromptError` on the next turn (visible to the
+          // user as "Invalid prompt: messages do not match the
+          // ModelMessage[] schema"). Emit an explicit JSON fallback
+          // ourselves so every screenshot tool-result has a well-formed
+          // `output` regardless of whether image data is present.
+          return {
+            type: "json" as const,
+            value: output as JSONValue,
+          };
         }
         const base64 = imageDataUrl.replace(/^data:image\/png;base64,/, "");
         return {
@@ -677,7 +710,14 @@ function toSDKTool<TInput, TOutput>(
   return {
     description: t.description,
     inputSchema: t.parameters,
-    outputSchema: t.outputSchema,
+    // Tools throwing inside `execute` (e.g. navigate timing out) get caught
+    // above and serialized as `{ error: string }`. The AI SDK validates the
+    // returned value against `outputSchema`, so we widen the schema with an
+    // error-shaped variant; otherwise validation rejects graceful failures
+    // and surfaces a hard framework error in the UI.
+    outputSchema: t.outputSchema
+      ? t.outputSchema.or(z.object({ error: z.string() }))
+      : undefined,
     strict: true,
     execute,
     needsApproval,
@@ -730,6 +770,61 @@ export async function createAgentTransport(
   const model = await provider.createLanguageModel(config, actualModelId);
   setCurrentAgentModel(model);
 
+  // Tell the compaction trigger about the model's actual context window
+  // and max-output budget. Without this, `needsCompaction()` falls back
+  // to the conservative default (~100K usable tokens) regardless of
+  // model capability — which fires `stopWhen` after a single step on
+  // any conversation past 100K, producing the "agent stops after one
+  // tool call" symptom on long-context models like Gemini 2.5 Flash
+  // (1M window) or Claude Sonnet 4.5 (200K window).
+  const modelDef = provider.models.find((m) => m.id === actualModelId);
+  setCurrentModelDef(modelDef);
+
+  // Resolve the evaluator model once at transport build time. When
+  // settings.completionCheck.evaluatorModel is unset (the recommended
+  // default), the gate falls back to the executor's current model with
+  // a fresh context — Anthropic's "same-model-fresh-window" pattern.
+  // We set this to `null` explicitly so the gate's call site can read
+  // "no override; use current agent model" without a separate flag.
+  let evaluatorLanguageModel: LanguageModel | null = null;
+  const evaluatorModelId = settings.completionCheck?.evaluatorModel;
+  if (evaluatorModelId) {
+    try {
+      const [evalProviderId, ...evalIdParts] = evaluatorModelId.split(":");
+      const evalActualModelId =
+        evalIdParts.length > 0 ? evalIdParts.join(":") : evaluatorModelId;
+      const evalProvider =
+        (evalIdParts.length > 0
+          ? providers.find((p) => p.id === evalProviderId)
+          : undefined) ??
+        providers.find((p) => p.models.some((m) => m.id === evalActualModelId));
+      if (evalProvider) {
+        const evalConfig = settings.providerConfigs[evalProvider.id] ?? {};
+        const evalRequired =
+          evalProvider.configSchema?.filter((f) => f.required) ?? [];
+        if (evalRequired.every((f) => !!evalConfig[f.key])) {
+          evaluatorLanguageModel = await evalProvider.createLanguageModel(
+            evalConfig,
+            evalActualModelId,
+          );
+        } else {
+          console.warn(
+            `[completion-check] evaluator override ${evaluatorModelId} is not configured (missing required fields); falling back to executor model`,
+          );
+        }
+      } else {
+        console.warn(
+          `[completion-check] evaluator override ${evaluatorModelId} did not resolve to a known provider; falling back to executor model`,
+        );
+      }
+    } catch (err) {
+      console.warn(
+        "[completion-check] failed to construct evaluator override; falling back to executor model:",
+        err,
+      );
+    }
+  }
+
   const fsTools = createFsTools(conversationId);
 
   const browserTools: Record<string, ToolSet[string]> = {
@@ -762,6 +857,34 @@ export async function createAgentTransport(
     LS: toSDKTool(fsTools.lsTool, "LS"),
   };
 
+  // Read-only subset for the completion-check evaluator. The evaluator
+  // may call these to ground factual claims (e.g. verify a price the
+  // executor cited actually appears on the page) before deciding the
+  // verdict. Excluded:
+  //  - clickElement, typeInElement, navigate, scrollPage, selectTab —
+  //    page-state mutations.
+  //  - executeOnPage, executeCode — arbitrary side effects.
+  //  - todoWrite — plan ownership belongs to the executor.
+  //  - saveMemory/updateMemory/deleteMemory — write-mode memory ops.
+  //  - install_skill/create_skill — config mutation.
+  //  - Write, Edit — filesystem mutations.
+  //  - MCP tools — out of scope for Phase 5; many are write-mode.
+  // The evaluator's system prompt explicitly tells it the tools are
+  // read-only and that it should call them sparingly.
+  const evaluatorReadOnlyTools: Record<string, ToolSet[string]> = {
+    snapshot: browserTools.snapshot,
+    readPage: browserTools.readPage,
+    screenshot: browserTools.screenshot,
+    listTabs: browserTools.listTabs,
+    extract: browserTools.extract,
+    recallMemory: browserTools.recallMemory,
+    Read: browserTools.Read,
+    Glob: browserTools.Glob,
+    Grep: browserTools.Grep,
+    LS: browserTools.LS,
+    read_opfs_file: browserTools.read_opfs_file,
+  };
+
   const mcpTools = getMcpRegistry().toSDKTools();
 
   const mcpToolsList = getMcpRegistry().getAllTools();
@@ -771,6 +894,31 @@ export async function createAgentTransport(
   if (spaceId && spaceName) {
     instructions += `\n\nYou are chatting from the space "${spaceName}" (id: ${spaceId}). When saving space-scoped memories, use this spaceId.`;
   }
+
+  // Completion check: every final assistant response is reviewed by a
+  // separate skeptical evaluator before reaching the user. On
+  // rejection, a synthetic user-role message prefixed with
+  // "[Completion check]" is appended to the executor's context with
+  // the concerns to address. The prompt section below tells the
+  // executor (a) that the check happens, (b) how to recognize the
+  // synthetic feedback, and (c) what to do with it.
+  //
+  // Always injected — the check is always-on and there is no
+  // user-facing toggle.
+  instructions += `\n\n## Completion checks
+
+Your final response (text emitted without a tool call) will be reviewed by a skeptical evaluator before the user sees it. If the evaluator finds the response incomplete or unsupported, it will reject and you will receive a synthetic user-role message starting with the prefix \`[Completion check]\` containing structured concerns.
+
+When you receive a \`[Completion check]\` message, treat it as a continuation directive, not a fresh user request. Address each listed concern by taking whatever tool calls are needed, then produce a corrected final response. Do not respond with apologies or restatements; just fix the gaps and continue.
+
+Concerns are tagged by dimension:
+- **completeness**: the response did not fulfill the original request end-to-end.
+- **planClosure**: open todos contradict the claim of completion.
+- **evidenceGrounding**: a factual claim is not supported by tool observations from this turn.
+- **noPrematureHandoff**: the response punts work back to the user that was within scope.
+- **surfaceAccuracy**: the page state described in the response disagrees with what a verification call observed.
+
+To minimize wasted rejection rounds: before producing a final response, re-read the original request, verify each factual claim was actually observed via a tool call this turn, and confirm your todo list is fully closed out.`;
 
   // Inject current todo plan into system prompt
   const conv = agentConversationId
@@ -962,11 +1110,12 @@ export async function createAgentTransport(
     tools,
     instructions,
     ...(providerOptions && { providerOptions }),
-    // Per-call ToolContext threaded through `experimental_context` →
-    // `ToolExecutionOptions.experimental_context` → our `toSDKTool` wrapper.
-    // Session helpers read live agent state via getters so the same context
-    // object stays valid across conversation switches.
-    experimental_context: buildExtensionToolContext(),
+    // Note: we deliberately do NOT thread an `experimental_context` here.
+    // Every tool registered with this agent is wrapped by `toSDKTool`,
+    // which builds a fresh `ToolContext` per tool call pinned to the
+    // conversation id captured synchronously at execute-entry. This
+    // guarantees pinning at the per-tool-call grain, which is the only
+    // grain that survives mid-stream conversation switches.
     // Append a fresh tab legend on every model call. The SDK invokes
     // prepareCall right before each generate/stream, so this picks up
     // tabs added by `navigate`, removed by closure, etc. — even
@@ -1001,6 +1150,78 @@ export async function createAgentTransport(
     agent,
     onSendStart: () => {
       needsMidStreamCompaction = false;
+    },
+    // Capture the active cid synchronously at the top of every
+    // `sendMessages`. The transport pins it for the duration of the loop
+    // and threads it to `buildCompletionCheckInput`, so a mid-stream
+    // `setAgentContext(other)` cannot redirect the gate's chatDb reads.
+    getActiveConversationId: () => agentConversationId,
+    // Wire the completion-check gate. Returns `undefined` when no
+    // conversationId is bound, so the gate sits dormant for transient
+    // (non-persisted) runs (e.g. the chat title generator).
+    buildCompletionCheckInput: async ({
+      sendMessages,
+      finalText,
+      toolCallTrace,
+      pinnedConversationId,
+    }) => {
+      const cid = pinnedConversationId;
+      if (!cid) return undefined;
+
+      // Last user-role message in the SDK message list is the original
+      // request that drove this turn. Bail if for any reason there is
+      // no user turn (defensive — the SDK shouldn't ever invoke
+      // sendMessages without one).
+      const lastUser = [...sendMessages]
+        .reverse()
+        .find((m) => m.role === "user");
+      if (!lastUser) return undefined;
+      const originalRequest = lastUser.parts
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("\n")
+        .trim();
+
+      // Turn ordinal: count of user-role messages up to and including
+      // the most recent one. 0-indexed for telemetry consistency with
+      // arrays.
+      const turnIndex = Math.max(
+        0,
+        sendMessages.filter((m) => m.role === "user").length - 1,
+      );
+
+      // Snapshot todos at gate time. The gate's trigger heuristic
+      // (todos-or-tool-calls) needs this to decide whether to run.
+      let todos: import("../types").TodoItem[] = [];
+      try {
+        const conv = await chatDb.getConversation(cid);
+        todos = conv?.todos ?? [];
+      } catch (err) {
+        // Best-effort: if chat-db read fails, fall back to no todos.
+        // The gate will likely skip but the user's response isn't
+        // blocked.
+        console.warn("[completion-check] todo lookup failed:", err);
+      }
+
+      return {
+        conversationId: cid,
+        turnIndex,
+        // Rejection rounds are managed by the rejection loop in the
+        // transport; the gate invocation here is always for the
+        // current round, which the transport tracks.
+        rejectionRound: 0,
+        originalRequest,
+        draftedResponse: finalText,
+        todos,
+        toolCallTrace,
+        // Threaded once at transport build; null means "fall back to
+        // the executor's current model" inside the evaluator.
+        evaluatorModel: evaluatorLanguageModel,
+        // Read-only tool subset for grounded verification. The
+        // evaluator's `allowTools` flips on automatically when this is
+        // non-empty; the system prompt branches accordingly.
+        evaluatorTools: evaluatorReadOnlyTools as unknown as import("ai").ToolSet,
+      };
     },
   });
 }

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -782,11 +782,13 @@ export async function createAgentTransport(
 
   // Resolve the evaluator model once at transport build time. When
   // settings.completionCheck.evaluatorModel is unset (the recommended
-  // default), the gate falls back to the executor's current model with
-  // a fresh context — Anthropic's "same-model-fresh-window" pattern.
-  // We set this to `null` explicitly so the gate's call site can read
-  // "no override; use current agent model" without a separate flag.
-  let evaluatorLanguageModel: LanguageModel | null = null;
+  // default), the gate uses THIS transport's executor model — same
+  // model, fresh context window. We pin to the local `model` rather
+  // than letting the gate fall back to the module-global
+  // `currentAgentModel` so concurrent transports (e.g. side panel +
+  // popup window) don't race when one calls `setCurrentAgentModel`
+  // mid-stream of the other.
+  let evaluatorLanguageModel: LanguageModel = model;
   const evaluatorModelId = settings.completionCheck?.evaluatorModel;
   if (evaluatorModelId) {
     try {

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -16,6 +16,20 @@ import {
   prunePartsAtSendTime,
   stripScreenshotsFromParts,
 } from "./compaction";
+import {
+  runCompletionCheck,
+  shouldGate,
+  type RunCompletionCheckInput,
+} from "./completion-check";
+import type {
+  EvaluatorVerdict,
+  GateOutcome,
+  ToolCallTraceEntry,
+} from "./completion-check/types";
+import {
+  TRACE_INPUT_TRUNCATE_CHARS,
+  TRACE_OUTPUT_TRUNCATE_CHARS,
+} from "./completion-check/types";
 
 interface Options<TOOLS extends ToolSet> {
   agent: Agent<never, TOOLS, never>;
@@ -25,6 +39,48 @@ interface Options<TOOLS extends ToolSet> {
    * the next step's onStepFinish can re-trigger it cleanly.
    */
   onSendStart?: () => void;
+  /**
+   * Snapshot the active conversation id at the moment `sendMessages` is
+   * invoked. The transport captures this synchronously at the top of
+   * `sendMessages` and threads it through to `buildCompletionCheckInput`
+   * so the gate's chatDb reads (todos lookup, telemetry) target the
+   * conversation that started the loop, even if the user switches
+   * conversations mid-stream.
+   *
+   * Decoupled as a getter rather than a constructor value because the
+   * transport instance is shared across conversations within a space —
+   * pinning at construction would tie one transport to one cid forever.
+   */
+  getActiveConversationId?: () => string | null;
+  /**
+   * Constructs the input for the completion-check gate after each agent
+   * iteration finishes. Called once per iteration with the messages as
+   * they were when that iteration started, plus the iteration's
+   * accumulated final-text and tool-call trace, plus the cid pinned at
+   * `sendMessages` entry.
+   *
+   * The transport uses the returned input to run `runCompletionCheck`.
+   * On a rejection verdict (within the budget), it appends a synthetic
+   * completion-check-feedback user message to the local message list and
+   * re-runs the agent. On approve / skip / force-emit / max-rounds, the
+   * loop exits and the stream closes.
+   *
+   * Returning `undefined` means "no gate configured for this run" — the
+   * loop runs exactly one agent iteration and exits, identical to the
+   * pre-gate behavior.
+   *
+   * Async because the builder typically reads conversation state (e.g.
+   * todos) from IndexedDB.
+   */
+  buildCompletionCheckInput?: (args: {
+    sendMessages: AgentUIMessage[];
+    finalText: string;
+    toolCallTrace: ToolCallTraceEntry[];
+    pinnedConversationId: string | null;
+  }) =>
+    | Promise<RunCompletionCheckInput | undefined>
+    | RunCompletionCheckInput
+    | undefined;
 }
 
 /**
@@ -72,10 +128,19 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
 {
   private readonly agent: Agent<never, TOOLS, never>;
   private readonly onSendStart?: () => void;
+  private readonly getActiveConversationId?: () => string | null;
+  private readonly buildCompletionCheckInput?: Options<TOOLS>["buildCompletionCheckInput"];
 
-  constructor({ agent, onSendStart }: Options<TOOLS>) {
+  constructor({
+    agent,
+    onSendStart,
+    getActiveConversationId,
+    buildCompletionCheckInput,
+  }: Options<TOOLS>) {
     this.agent = agent;
     this.onSendStart = onSendStart;
+    this.getActiveConversationId = getActiveConversationId;
+    this.buildCompletionCheckInput = buildCompletionCheckInput;
   }
 
   async sendMessages({
@@ -85,6 +150,10 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
     ReadableStream<UIMessageChunk>
   > {
     this.onSendStart?.();
+    // Pin cid synchronously, before any await. Every chatDb read driven
+    // by the gate inside this loop targets this cid even if
+    // `setAgentContext(...)` is called by the UI mid-stream.
+    const pinnedConversationId = this.getActiveConversationId?.() ?? null;
     const rewritten = rewriteForLLM(messages);
 
     // Tie validateUIMessages' inferred UI_MESSAGE to *this transport's*
@@ -102,22 +171,151 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
       tools: this.agent.tools,
     });
 
-    const modelMessages = await convertToModelMessages(validatedMessages, {
-      tools: this.agent.tools,
-    });
+    // Fast path: no gate configured. One agent iteration, no rejection
+    // loop, no observation overhead. Identical behavior to pre-Phase-1.
+    if (!this.buildCompletionCheckInput) {
+      const modelMessages = await convertModelMessagesWithDiag(
+        validatedMessages,
+        this.agent.tools,
+        "transport.fast-path",
+      );
+      try {
+        const result = await this.agent.stream({
+          prompt: modelMessages,
+          abortSignal,
+        });
+        return result.toUIMessageStream();
+      } catch (err) {
+        // Re-log with the converted ModelMessage[] payload, since
+        // standardizePrompt failures inside agent.stream don't include
+        // any indication of which message blew up otherwise.
+        console.error(
+          "[transport] agent.stream failed on fast-path:",
+          err instanceof Error ? err.message : String(err),
+        );
+        console.error(
+          "[transport] ModelMessage[] payload at failure:",
+          modelMessages,
+        );
+        throw err;
+      }
+    }
 
-    const result = await this.agent.stream({
-      prompt: modelMessages,
+    // Gate path: open a manually-controlled stream and run the rejection
+    // loop in the background. Each iteration's chunks are forwarded to
+    // the controller as they arrive; if the gate rejects (within budget)
+    // we append synthetic completion-check feedback and run another iteration.
+    return runWithRejectionLoop({
+      // The SDK's full `Agent` returns a `PromiseLike` from `stream()`
+      // (specifically `StreamTextResult`), which is structurally
+      // assignable to `Promise<{ toUIMessageStream() }>` at runtime but
+      // TS is strict about `PromiseLike` vs `Promise`. The
+      // `RejectionLoopAgent` interface deliberately uses `Promise` to
+      // keep the test stub simple; cast through the structural shape.
+      agent: this.agent as unknown as RejectionLoopAgent,
+      validatedMessages: validatedMessages as AgentUIMessage[],
+      sendMessagesAtCall: messages,
       abortSignal,
+      pinnedConversationId,
+      buildCompletionCheckInput: this.buildCompletionCheckInput,
     });
-
-    return result.toUIMessageStream();
   }
 
   reconnectToStream(): Promise<ReadableStream<UIMessageChunk> | null> {
     // Reconnection is not supported for in-process direct agent transport.
     return Promise.resolve(null);
   }
+}
+
+/**
+ * Wrap `convertToModelMessages` with diagnostic logging. The AI SDK
+ * throws "Invalid prompt: The messages do not match the ModelMessage[]
+ * schema." with no detail about *which* message or part is malformed,
+ * which makes downstream healing/transport bugs near-impossible to
+ * diagnose from a user error report alone.
+ *
+ * On failure we log a compact shape summary (id, role, part type, tool
+ * state) for every message that was about to be sent, plus the parsed
+ * error, then re-throw the original error so existing UI error handling
+ * is unchanged. The full UIMessage payload is logged at debug level so
+ * a developer can grab it from the panel devtools without bloating the
+ * default console.
+ *
+ * `label` lets us tell apart the two transport paths (fast path vs.
+ * rejection-loop iteration) in the log. Once the shape problem is
+ * identified and fixed, this wrapper can be inlined back to a plain
+ * `convertToModelMessages` call.
+ */
+async function convertModelMessagesWithDiag(
+  messages: AgentUIMessage[],
+  tools: ToolSet,
+  label: string,
+): Promise<Awaited<ReturnType<typeof convertToModelMessages>>> {
+  try {
+    return await convertToModelMessages(messages, { tools });
+  } catch (err) {
+    const shape = messages.map((m, i) => ({
+      i,
+      id: m.id,
+      role: m.role,
+      partCount: m.parts.length,
+      parts: m.parts.map((p) => {
+        const pp = p as { type: string; state?: string; toolName?: string };
+        const out: Record<string, unknown> = { type: pp.type };
+        if (pp.state) out.state = pp.state;
+        if (pp.toolName) out.toolName = pp.toolName;
+        return out;
+      }),
+    }));
+    console.error(
+      `[convertToModelMessages] failed at ${label}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    console.error(
+      `[convertToModelMessages] message shape (${messages.length} messages):`,
+      shape,
+    );
+    // The error path (`path: [N]`) refers to the *converted* model
+    // messages, not the source UIMessages, so a direct lookup may not
+    // align — but in practice the converter walks UIMessages 1:1 with
+    // an interleaved tool-role row for each tool call/result pair, so
+    // the misbehaving UIMessage is usually within a small window of
+    // the failing index. Print that window to make root-cause obvious
+    // without dumping the entire payload.
+    const causedByPath = extractCausedByPath(err);
+    if (causedByPath != null) {
+      const lo = Math.max(0, causedByPath - 2);
+      const hi = Math.min(messages.length, causedByPath + 3);
+      console.error(
+        `[convertToModelMessages] window around model-message index ${causedByPath} ` +
+          `(UIMessage range ~${lo}..${hi - 1}):`,
+        messages.slice(lo, hi),
+      );
+    }
+    console.debug(
+      `[convertToModelMessages] full UIMessage payload:`,
+      messages,
+    );
+    throw err;
+  }
+}
+
+/**
+ * Extract a numeric `path[0]` from the AI SDK's nested AI_TypeValidationError
+ * cause chain. Returns null when no usable index is found.
+ */
+function extractCausedByPath(err: unknown): number | null {
+  let cur: unknown = err;
+  for (let depth = 0; depth < 5 && cur; depth++) {
+    const e = cur as { cause?: unknown; issues?: unknown };
+    const issues = (e as { issues?: { path?: unknown[] }[] }).issues;
+    if (Array.isArray(issues) && issues.length > 0) {
+      const first = issues[0]?.path?.[0];
+      if (typeof first === "number") return first;
+    }
+    cur = e.cause;
+  }
+  return null;
 }
 
 /**
@@ -190,7 +388,168 @@ export function rewriteForLLM(messages: AgentUIMessage[]): AgentUIMessage[] {
   // Final safety net: drop any message that still ended up with empty
   // parts after substitution + pruning. Should be unreachable now that
   // `excludeBrokenCompactionEvents` runs first, but cheap insurance.
-  return rewritten.filter((m) => m.parts.length > 0);
+  const filtered = rewritten.filter((m) => m.parts.length > 0);
+
+  // Defensive tool-state heal: convertToModelMessages requires every
+  // tool part to be in a terminal state with the data it needs to
+  // produce a valid model message (`output` for output-available,
+  // `errorText` for output-error, etc.). The chat hook's
+  // `healPendingTools` runs at edit/retry/regenerate time, but a tool
+  // part can also reach the transport in a non-terminal state on a
+  // mid-stream abort that happens *between* the chat hook's heal pass
+  // and this rewrite — for example, the user editing while a tool's
+  // output is still streaming, then immediately resending. Heal here
+  // as a last line of defense; the failure mode otherwise is an
+  // opaque "Invalid prompt: messages do not match the ModelMessage[]
+  // schema" thrown from convertToModelMessages with no detail about
+  // which part is malformed.
+  return filtered.map(healNonTerminalToolParts);
+}
+
+const TERMINAL_TOOL_STATES = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+]);
+
+const TRANSPORT_HEAL_TEXT =
+  "Tool execution was interrupted before it returned a result";
+
+/**
+ * Repair a single tool UIPart so that `convertToModelMessages` can map
+ * it to a fully-valid `ModelMessage`. The AI SDK's `standardizePrompt`
+ * (which runs inside `streamText`) validates the converted messages
+ * against a strict Zod schema; a part that's nominally in a "terminal"
+ * state but missing required fields (`input` on every tool part,
+ * `output` on `output-available`, `errorText` on `output-error`,
+ * `approval.approved` on `output-denied`) produces a
+ * `ModelMessage[]` that fails validation downstream — with no
+ * indication of which message was malformed.
+ *
+ * The healer enforces three invariants:
+ *
+ *  1. `input` is always present. Tool calls aborted before the model
+ *     finished streaming arguments may have `input: undefined`. Default
+ *     to `{}` so the resulting `tool-call` content has a well-formed
+ *     `input` object.
+ *
+ *  2. State is terminal. Any non-terminal state collapses to
+ *     `output-error` with `errorText: TRANSPORT_HEAL_TEXT` and the
+ *     existing `output` (if any) discarded.
+ *
+ *  3. The terminal-state-specific required field is present:
+ *      - `output-available` requires `output`. If missing, downgrade
+ *        to `output-error` so we have a defined errorText carrier.
+ *      - `output-error` requires `errorText`. If missing, fill with
+ *        the heal text.
+ *      - `output-denied` requires `approval` with `approved: false`.
+ *        If missing, fall back to `output-error`.
+ */
+function repairToolPart(
+  part: AgentUIMessage["parts"][number],
+): AgentUIMessage["parts"][number] {
+  const p = part as { type?: unknown; state?: unknown };
+  const isTool =
+    p.type === "dynamic-tool" ||
+    (typeof p.type === "string" && p.type.startsWith("tool-"));
+  if (!isTool) return part;
+
+  const raw = part as Record<string, unknown>;
+  const state = typeof raw.state === "string" ? raw.state : undefined;
+
+  // Ensure `input` is always defined for any tool part. Even
+  // `output-error` parts go through convertToModelMessages's
+  // tool-call/tool-result pair generation, and the assistant tool-call
+  // entry it produces requires `input`.
+  let input: unknown = raw.input;
+  if (input === undefined || input === null) {
+    input = {};
+  }
+
+  // Non-terminal state → collapse to output-error. Drop any partial
+  // output so the part is unambiguous.
+  if (!state || !TERMINAL_TOOL_STATES.has(state)) {
+    return {
+      ...raw,
+      input,
+      state: "output-error",
+      errorText: TRANSPORT_HEAL_TEXT,
+      output: undefined,
+    } as typeof part;
+  }
+
+  // Terminal state: enforce the per-state required field. Mutate
+  // toward output-error if the canonical field is missing — that's
+  // safer than letting an unfilled `output-available` reach the
+  // converter.
+  if (state === "output-available") {
+    if (raw.output === undefined || raw.output === null) {
+      return {
+        ...raw,
+        input,
+        state: "output-error",
+        errorText: TRANSPORT_HEAL_TEXT,
+        output: undefined,
+      } as typeof part;
+    }
+    if (raw.input === undefined || raw.input === null) {
+      return { ...raw, input } as typeof part;
+    }
+    return part;
+  }
+
+  if (state === "output-error") {
+    const errorText =
+      typeof raw.errorText === "string" && raw.errorText.length > 0
+        ? raw.errorText
+        : TRANSPORT_HEAL_TEXT;
+    if (raw.input !== input || raw.errorText !== errorText) {
+      return {
+        ...raw,
+        input,
+        state: "output-error",
+        errorText,
+      } as typeof part;
+    }
+    return part;
+  }
+
+  if (state === "output-denied") {
+    const approval = raw.approval as
+      | { id?: unknown; approved?: unknown; reason?: unknown }
+      | undefined;
+    const hasValidApproval =
+      approval &&
+      typeof approval.id === "string" &&
+      typeof approval.approved === "boolean";
+    if (!hasValidApproval) {
+      return {
+        ...raw,
+        input,
+        state: "output-error",
+        errorText: TRANSPORT_HEAL_TEXT,
+        output: undefined,
+      } as typeof part;
+    }
+    if (raw.input !== input) {
+      return { ...raw, input } as typeof part;
+    }
+    return part;
+  }
+
+  // Defensive default — unreachable given TERMINAL_TOOL_STATES above.
+  return part;
+}
+
+function healNonTerminalToolParts(message: AgentUIMessage): AgentUIMessage {
+  let changed = false;
+  const newParts = message.parts.map((part) => {
+    const repaired = repairToolPart(part);
+    if (repaired !== part) changed = true;
+    return repaired;
+  });
+  if (!changed) return message;
+  return { ...message, parts: newParts };
 }
 
 /**
@@ -292,4 +651,606 @@ function substituteCompactionPart(
     }
   }
   return changed ? out : parts;
+}
+
+/**
+ * Minimal contract the rejection loop needs from an `Agent`. We don't
+ * import the SDK's full `Agent` here so this function can be exercised
+ * by tests with a tiny stub instead of a real `ToolLoopAgent`.
+ */
+export interface RejectionLoopAgent {
+  /** Tool set passed to `convertToModelMessages` for tool-aware validation. */
+  tools: ToolSet;
+  stream(args: {
+    prompt: Awaited<ReturnType<typeof convertToModelMessages>>;
+    abortSignal?: AbortSignal;
+  }): Promise<{
+    toUIMessageStream(): ReadableStream<UIMessageChunk>;
+  }>;
+}
+
+/**
+ * Drives the gate-aware rejection loop. Returns a single output
+ * `ReadableStream<UIMessageChunk>` composed of the concatenated
+ * chunks from every agent iteration this turn produces, in order.
+ *
+ * The chat layer (`useAgentChat`) sees this as one assistant message;
+ * rejection events are emitted as `data-completion-check-rejection`
+ * parts so the UI can render an inline completion-check block per
+ * round.
+ *
+ * Loop termination:
+ *  - approved | skipped | force-emitted: close the output stream
+ *    and return.
+ *  - rejected and within budget: append a synthetic completion-check-feedback
+ *    user message to the local copy of the message list, increment
+ *    rejection round, restart the loop.
+ *  - Loop body throws: error the controller; the chat hook surfaces
+ *    the failure as it would for any agent error.
+ *
+ * Abort behavior: the outer `abortSignal` is threaded into every
+ * `agent.stream` call. A user-initiated stop terminates the in-flight
+ * iteration; the loop exits the next time it observes the signal.
+ *
+ * Exported as a free function (rather than a method) so unit tests can
+ * exercise the full loop with a stub `RejectionLoopAgent` and a
+ * controlled `buildCompletionCheckInput`.
+ */
+export function runWithRejectionLoop(args: {
+  agent: RejectionLoopAgent;
+  validatedMessages: AgentUIMessage[];
+  sendMessagesAtCall: AgentUIMessage[];
+  abortSignal: AbortSignal | undefined;
+  pinnedConversationId: string | null;
+  buildCompletionCheckInput: (params: {
+    sendMessages: AgentUIMessage[];
+    finalText: string;
+    toolCallTrace: ToolCallTraceEntry[];
+    pinnedConversationId: string | null;
+  }) =>
+    | Promise<RunCompletionCheckInput | undefined>
+    | RunCompletionCheckInput
+    | undefined;
+}): ReadableStream<UIMessageChunk> {
+  const { agent, abortSignal, buildCompletionCheckInput, pinnedConversationId } = args;
+
+  return new ReadableStream<UIMessageChunk>({
+    start: async (controller) => {
+      // Local-copy semantics: we mutate `messages` (append synthetic
+      // user turns) without affecting the chat layer's view, since
+      // these synthetic turns are internal to the rejection loop and
+      // must not be persisted to chat history.
+      let messages: AgentUIMessage[] = args.validatedMessages.slice();
+      const sendMessagesAtCall = args.sendMessagesAtCall;
+
+      let rejectionRound = 0;
+
+      try {
+        // Bounded loop guard. The gate enforces its own
+        // maxRejectionRounds, but a defensive ceiling here protects
+        // against a misconfiguration that lets every verdict fall
+        // through to "rejected" without the gate noticing budget.
+        // 16 is far above any sensible production setting (~3).
+        const HARD_CEILING = 16;
+        for (let i = 0; i < HARD_CEILING; i++) {
+          if (abortSignal?.aborted) {
+            controller.close();
+            return;
+          }
+
+          const modelMessages = await convertModelMessagesWithDiag(
+            messages,
+            agent.tools,
+            `rejection-loop.iter-${i}`,
+          );
+          let result;
+          try {
+            result = await agent.stream({
+              prompt: modelMessages,
+              abortSignal,
+            });
+          } catch (err) {
+            console.error(
+              `[transport] agent.stream failed on rejection-loop.iter-${i}:`,
+              err instanceof Error ? err.message : String(err),
+            );
+            console.error(
+              "[transport] ModelMessage[] payload at failure:",
+              modelMessages,
+            );
+            throw err;
+          }
+
+          const observed = await pipeAndObserve(
+            result.toUIMessageStream(),
+            controller,
+          );
+
+          const input = await buildCompletionCheckInput({
+            sendMessages: sendMessagesAtCall,
+            finalText: observed.finalText,
+            toolCallTrace: observed.toolCallTrace,
+            pinnedConversationId,
+          });
+
+          if (!input) {
+            controller.close();
+            return;
+          }
+
+          // Pre-check the trigger heuristic before announcing a running
+          // indicator. Skipped turns (no final text or trivial Q&A
+          // with no tool calls) shouldn't flash a "Running quality
+          // check…" pill that immediately vanishes.
+          const gateDecision = shouldGate({
+            finalText: input.draftedResponse,
+            todos: input.todos,
+            toolCallTrace: input.toolCallTrace,
+          });
+
+          let outcome: GateOutcome;
+          if (!gateDecision.gate) {
+            // The gate would skip; call runCompletionCheck anyway to
+            // record telemetry consistently with the non-skipped path.
+            // The function is idempotent on its skip decision —
+            // shouldGate is deterministic, so the outcome here will
+            // always match.
+            outcome = await runCompletionCheck({
+              ...input,
+              rejectionRound,
+            });
+          } else {
+            // Real evaluator call: surface the running indicator for
+            // its lifetime so the user knows why the message hasn't
+            // closed yet.
+            const runningId = crypto.randomUUID();
+            emitCompletionCheckRunningChunk(controller, {
+              id: runningId,
+              phase: "evaluating",
+            });
+            let resolvedOutcome: GateOutcome | undefined;
+            try {
+              resolvedOutcome = await runCompletionCheck({
+                ...input,
+                rejectionRound,
+              });
+            } finally {
+              // Always flip the indicator off — even if
+              // `runCompletionCheck` threw — so the UI doesn't show a
+              // perpetual spinner. On the throw path, we report
+              // "force-emitted" so the UI hides cleanly; the outer
+              // try/catch will surface the real error to the
+              // controller.
+              emitCompletionCheckRunningChunk(controller, {
+                id: runningId,
+                phase: "done",
+                outcome: resolvedOutcome?.kind ?? "force-emitted",
+              });
+            }
+            outcome = resolvedOutcome;
+          }
+
+          if (outcome.kind !== "rejected") {
+            // approved | skipped | force-emitted — done.
+            // For force-emitted, surface a final rejection-comment so
+            // the user can see what concerns the agent ended on.
+            if (outcome.kind === "force-emitted") {
+              emitCompletionCheckRejectionChunk(controller, {
+                rejectionRound: rejectionRound + 1,
+                reasoning: outcome.verdict.reasoning,
+                concerns: outcome.verdict.concerns.map((c) => ({
+                  dimension: c.dimension,
+                  detail: c.detail,
+                  userSummary: c.userSummary,
+                  evidence: c.evidence,
+                })),
+                forceEmittedNext: true,
+                // Threading `outcome.reason` lets the UI distinguish
+                // "real concerns the user should see" (max-rounds) from
+                // "evaluator itself failed" (evaluator-error). The
+                // latter renders as a subtle gray note rather than an
+                // alarming red banner because the agent's actual
+                // response is unaffected.
+                reason: outcome.reason,
+              });
+            }
+            controller.close();
+            return;
+          }
+
+          // Rejected and within budget. Emit a visible completion-check
+          // data part so the chat UI can render the concerns inline,
+          // then append synthetic completion-check feedback as a user-role
+          // message and loop.
+          emitCompletionCheckRejectionChunk(controller, {
+            rejectionRound: rejectionRound + 1,
+            reasoning: outcome.verdict.reasoning,
+            concerns: outcome.verdict.concerns.map((c) => ({
+              dimension: c.dimension,
+              detail: c.detail,
+              userSummary: c.userSummary,
+              evidence: c.evidence,
+            })),
+            forceEmittedNext: false,
+          });
+          const synthetic = buildCompletionCheckFeedbackMessage(
+            outcome.verdict,
+            rejectionRound + 1,
+          );
+          messages = [...messages, synthetic];
+          rejectionRound++;
+        }
+
+        console.warn(
+          "[completion-check] rejection loop hit hard ceiling; closing stream",
+        );
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+}
+
+/**
+ * Mutates the observer state for one streaming chunk. Extracted from the
+ * transform handler so the chunk-shape switch is testable in isolation
+ * (no streams or transports required).
+ *
+ * Recognized chunk types follow the AI SDK v5 UIMessageChunk shape.
+ * Unknown chunk types are ignored — the observer only needs the subset
+ * relevant to gate input. Schema drift in the SDK would silently drop
+ * gate signal but never break the stream.
+ *
+ * Tool-call lifecycle:
+ *  - `tool-input-available` / `dynamic-tool-input-available` / `tool-call`
+ *    creates an entry keyed by `toolCallId`, captures the input, and
+ *    sets state to `"pending"`.
+ *  - `tool-output-available` / `dynamic-tool-output-available` flips the
+ *    matching entry's state to `"completed"` and captures the output
+ *    (truncated to {@link TRACE_OUTPUT_TRUNCATE_CHARS}).
+ *  - `tool-output-error` / `dynamic-tool-output-error` flips to
+ *    `"errored"` and captures the error text in `outputSummary`.
+ *  - `tool-output-denied` flips to `"denied"`; `outputSummary` stays null.
+ *  - Tool calls without a matching `toolCallId` (orphans) are ignored
+ *    on the output side — the input chunk's entry stays `"pending"` and
+ *    surfaces that to the evaluator. Unknown `toolCallId`s in output
+ *    chunks (output before input — shouldn't happen, but defensively
+ *    handled) are dropped.
+ */
+export function observeChunkForCompletionCheck(
+  chunk: UIMessageChunk,
+  state: {
+    textBuffers: Map<string, string>;
+    setLastTextMessageId: (id: string) => void;
+    toolCalls: Map<string, ToolCallTraceEntry>;
+    /**
+     * Insertion-order list of toolCallIds. Used to materialize the
+     * final trace array in chunk-arrival order regardless of `Map`
+     * iteration semantics (well-defined in modern JS, but we keep an
+     * explicit list to make the contract obvious to readers).
+     */
+    toolCallOrder: string[];
+  },
+): void {
+  // The SDK's UIMessageChunk is a discriminated union. Narrow defensively;
+  // we only care about a few variants.
+  const c = chunk as { type: string; [k: string]: unknown };
+  switch (c.type) {
+    case "text-start": {
+      const id = typeof c.id === "string" ? c.id : undefined;
+      if (id) {
+        state.setLastTextMessageId(id);
+        if (!state.textBuffers.has(id)) state.textBuffers.set(id, "");
+      }
+      break;
+    }
+    case "text-delta": {
+      const id = typeof c.id === "string" ? c.id : undefined;
+      const delta = typeof c.delta === "string" ? c.delta : "";
+      if (id) {
+        state.setLastTextMessageId(id);
+        state.textBuffers.set(id, (state.textBuffers.get(id) ?? "") + delta);
+      }
+      break;
+    }
+    case "tool-input-available":
+    case "dynamic-tool-input-available":
+    case "tool-call": {
+      const name =
+        typeof c.toolName === "string"
+          ? c.toolName
+          : typeof c.name === "string"
+            ? c.name
+            : "(unknown-tool)";
+      const inputSummary = stringifyTruncate(
+        c.input ?? c.args ?? c.parameters ?? c.toolInput,
+        TRACE_INPUT_TRUNCATE_CHARS,
+      );
+
+      // Use toolCallId when available (real SDK chunks always have it).
+      // Fall back to a synthetic key for legacy `tool-call` shapes used
+      // in some tests so they still produce a unique entry per chunk.
+      const toolCallId =
+        typeof c.toolCallId === "string" && c.toolCallId.length > 0
+          ? c.toolCallId
+          : `__synthetic-${state.toolCallOrder.length}`;
+
+      // Defensive: a duplicate input chunk for the same call shouldn't
+      // happen but if it did we'd want to keep the first observation.
+      if (!state.toolCalls.has(toolCallId)) {
+        state.toolCalls.set(toolCallId, {
+          name,
+          inputSummary,
+          outputSummary: null,
+          state: "pending",
+        });
+        state.toolCallOrder.push(toolCallId);
+      }
+      break;
+    }
+    case "tool-output-available":
+    case "dynamic-tool-output-available": {
+      const toolCallId =
+        typeof c.toolCallId === "string" ? c.toolCallId : undefined;
+      if (!toolCallId) break;
+      const entry = state.toolCalls.get(toolCallId);
+      if (!entry) break;
+      entry.outputSummary = stringifyTruncate(
+        c.output,
+        TRACE_OUTPUT_TRUNCATE_CHARS,
+      );
+      entry.state = "completed";
+      break;
+    }
+    case "tool-output-error":
+    case "dynamic-tool-output-error": {
+      const toolCallId =
+        typeof c.toolCallId === "string" ? c.toolCallId : undefined;
+      if (!toolCallId) break;
+      const entry = state.toolCalls.get(toolCallId);
+      if (!entry) break;
+      const errorText =
+        typeof c.errorText === "string" && c.errorText.length > 0
+          ? c.errorText
+          : "(tool error)";
+      entry.outputSummary =
+        errorText.length > TRACE_OUTPUT_TRUNCATE_CHARS
+          ? errorText.slice(0, TRACE_OUTPUT_TRUNCATE_CHARS) + "… (truncated)"
+          : errorText;
+      entry.state = "errored";
+      break;
+    }
+    case "tool-output-denied": {
+      const toolCallId =
+        typeof c.toolCallId === "string" ? c.toolCallId : undefined;
+      if (!toolCallId) break;
+      const entry = state.toolCalls.get(toolCallId);
+      if (!entry) break;
+      entry.outputSummary = null;
+      entry.state = "denied";
+      break;
+    }
+    default:
+      // Other chunk types (errors, finish, reasoning, etc.) don't
+      // contribute to gate input. Intentional no-op.
+      break;
+  }
+}
+
+/**
+ * Stringify and truncate a value for inclusion in the tool-call trace.
+ * Strings pass through; everything else is JSON.stringified. Returns
+ * the empty string for `undefined`/serialization failures so the
+ * resulting `inputSummary`/`outputSummary` is always a string.
+ *
+ * Truncation appends `"… (truncated)"` so the evaluator can detect when
+ * content was cut and avoid drawing conclusions from the tail.
+ */
+function stringifyTruncate(value: unknown, maxChars: number): string {
+  if (value === undefined || value === null) return "";
+  let str: string;
+  try {
+    str = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return "(not serializable)";
+  }
+  if (str === undefined) return "";
+  return str.length > maxChars
+    ? str.slice(0, maxChars) + "… (truncated)"
+    : str;
+}
+
+/**
+ * Reads every chunk from `input`, forwards it to `controller`, and
+ * accumulates gate-relevant signal (final text + tool-call trace) via
+ * {@link observeChunkForCompletionCheck}. Returns the accumulated signal
+ * once the input stream closes.
+ *
+ * Used inside the rejection-loop driver: each agent iteration's chunks
+ * stream through to the user-visible output, then we have the full
+ * final text + trace to hand to the gate. Errors during observation
+ * are logged and never break the user-visible stream.
+ */
+export async function pipeAndObserve(
+  input: ReadableStream<UIMessageChunk>,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+): Promise<{
+  finalText: string;
+  toolCallTrace: ToolCallTraceEntry[];
+}> {
+  const textBuffers = new Map<string, string>();
+  let lastTextMessageId: string | undefined;
+  const toolCalls = new Map<string, ToolCallTraceEntry>();
+  const toolCallOrder: string[] = [];
+
+  const reader = input.getReader();
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      controller.enqueue(value);
+      try {
+        observeChunkForCompletionCheck(value, {
+          textBuffers,
+          setLastTextMessageId: (id) => {
+            lastTextMessageId = id;
+          },
+          toolCalls,
+          toolCallOrder,
+        });
+      } catch (err) {
+        console.warn("[completion-check] observer error:", err);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const finalText =
+    (lastTextMessageId && textBuffers.get(lastTextMessageId)) ?? "";
+  // Materialize in chunk-arrival order. Entries without a matching
+  // toolCallId in the order list (defensive — shouldn't happen) are
+  // dropped to keep the trace deterministic.
+  const toolCallTrace = toolCallOrder
+    .map((id) => toolCalls.get(id))
+    .filter((e): e is ToolCallTraceEntry => e !== undefined);
+  return { finalText, toolCallTrace };
+}
+
+/**
+ * Constants the executor sees when completion-check feedback is injected. Kept
+ * as exported constants so the system prompt and the synthetic-message
+ * builder share one definition — drift between "what the prompt
+ * promises" and "what the loop emits" is the most likely source of
+ * subtle behavioral bugs here.
+ */
+export const COMPLETION_CHECK_PREFIX = "[Completion check]";
+
+/**
+ * Format an `EvaluatorVerdict` (decision="reject") into a user-role
+ * `AgentUIMessage` that gets appended to the agent's context for the
+ * next rejection-loop iteration.
+ *
+ * The format is intentionally machine-shaped: a fixed prefix, then a
+ * bullet per concern with `dimension: detail`. The system prompt tells
+ * the executor to expect this shape and to treat it as a continuation
+ * directive (not a fresh user request). Having a stable prefix also
+ * makes the synthetic messages identifiable in chat-history dumps if a
+ * future debug tool wants to filter them out.
+ *
+ * The synthetic message is given a fresh uuid so the AI SDK's
+ * deduplication-by-id logic doesn't collapse it with anything.
+ */
+export function buildCompletionCheckFeedbackMessage(
+  verdict: EvaluatorVerdict,
+  rejectionRound: number,
+): AgentUIMessage {
+  const concernLines = verdict.concerns
+    .map((c) => {
+      const ev = c.evidence ? `\n   Evidence: ${c.evidence}` : "";
+      return `- ${c.dimension}: ${c.detail}${ev}`;
+    })
+    .join("\n");
+
+  const text =
+    `${COMPLETION_CHECK_PREFIX} (round ${rejectionRound})\n` +
+    `${verdict.reasoning}\n\n` +
+    `Concerns to address before this turn is complete:\n${concernLines}\n\n` +
+    `Continue working until each concern is resolved. Do not produce a final response that leaves any of these unaddressed.`;
+
+  return {
+    id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+  } as AgentUIMessage;
+}
+
+/**
+ * Emit a `data-completion-check-rejection` chunk into the live UI stream.
+ *
+ * The Vercel AI SDK accumulates `data-${string}` chunks into a
+ * matching part on the active assistant message — so this single
+ * chunk produces a `{ type: "data-completion-check-rejection", id, data }`
+ * entry in `message.parts`, which the UI can detect and render as a
+ * completion-check block. The same part is then persisted to chat-db
+ * by the chat hook's `onFinish` because it serializes the full parts
+ * array, so the comment survives reloads.
+ *
+ * `transient: false` (the default) keeps the part attached to the
+ * message in the UI's message list. We use `false` deliberately —
+ * users should be able to scroll back and see why the agent kept
+ * working past its first draft.
+ *
+ * The `id` is deterministic per chunk (uuid) so two consecutive
+ * rejection rounds produce two distinct parts rather than the SDK
+ * collapsing them by id.
+ */
+export function emitCompletionCheckRejectionChunk(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  data: {
+    rejectionRound: number;
+    reasoning: string;
+    concerns: {
+      dimension: string;
+      detail: string;
+      userSummary: string;
+      evidence?: string;
+    }[];
+    forceEmittedNext?: boolean;
+    reason?: "max-rounds-exceeded" | "evaluator-error";
+  },
+): void {
+  // Cast through `never` because the AI SDK types its data-part chunks
+  // as `data-${string}` with `data: unknown` — TS can't statically
+  // associate our specific `completion-check-rejection` key with the
+  // `CompletionCheckRejectionData` shape from `AgentDataParts`. The
+  // shape *is* registered there; the cast is a TS limitation, not a
+  // runtime risk.
+  controller.enqueue({
+    type: "data-completion-check-rejection",
+    id: crypto.randomUUID(),
+    data,
+  } as never);
+}
+
+/**
+ * Emit a `data-completion-check-running` chunk to surface the live
+ * status of an in-flight evaluator call.
+ *
+ * Lifecycle (one stable `id` per gate invocation):
+ *  1. Just before `runCompletionCheck` runs, call this with
+ *     `phase: "evaluating"` and a fresh uuid. The UI shows an inline
+ *     "Running quality check…" pill.
+ *  2. After the verdict resolves, call again with the SAME `id` and
+ *     `phase: "done"` plus the resolved `outcome` kind. The AI SDK
+ *     mutates the existing part's data in place (same `id` + same
+ *     type → overwrite, see `process-ui-message-stream.ts:817-831`),
+ *     so no second part is appended.
+ *
+ * The "evaluating" → "done" transition surviving a reload (because
+ * the part persists with whatever `phase` it ended on) is the reason
+ * the UI also gates render on `isStreaming`: aborted streams that
+ * leave the part stuck at "evaluating" should not render a fake live
+ * spinner forever.
+ *
+ * Skipped turns (trigger heuristic returned `gate: false`) are
+ * pre-checked in the rejection loop and never emit running chunks at
+ * all — see the `shouldGate` call in `runWithRejectionLoop`.
+ */
+export function emitCompletionCheckRunningChunk(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  data: {
+    id: string;
+    phase: "evaluating" | "done";
+    outcome?: "approved" | "skipped" | "rejected" | "force-emitted";
+  },
+): void {
+  // The chunk's `id` field MUST match the data's `id` so the SDK's
+  // overwrite-by-id semantics work for the evaluating → done update.
+  controller.enqueue({
+    type: "data-completion-check-running",
+    id: data.id,
+    data,
+  } as never);
 }

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -22,6 +22,7 @@ import {
   type RunCompletionCheckInput,
 } from "./completion-check";
 import type {
+  ConcernDimension,
   EvaluatorVerdict,
   GateOutcome,
   ToolCallTraceEntry,
@@ -518,10 +519,13 @@ function repairToolPart(
     const approval = raw.approval as
       | { id?: unknown; approved?: unknown; reason?: unknown }
       | undefined;
+    // Strict denial shape: state=output-denied REQUIRES `approved: false`.
+    // `approved: true` paired with that state is contradictory and gets
+    // healed to a clean output-error rather than carried forward.
     const hasValidApproval =
       approval &&
       typeof approval.id === "string" &&
-      typeof approval.approved === "boolean";
+      approval.approved === false;
     if (!hasValidApproval) {
       return {
         ...raw,
@@ -1192,7 +1196,7 @@ export function emitCompletionCheckRejectionChunk(
     rejectionRound: number;
     reasoning: string;
     concerns: {
-      dimension: string;
+      dimension: ConcernDimension;
       detail: string;
       userSummary: string;
       evidence?: string;

--- a/apps/extension/src/lib/agent/completion-check/evaluator.ts
+++ b/apps/extension/src/lib/agent/completion-check/evaluator.ts
@@ -1,0 +1,374 @@
+import {
+  generateObject,
+  generateText,
+  NoOutputGeneratedError,
+  Output,
+  stepCountIs,
+  type LanguageModel,
+  type StepResult,
+  type ToolSet,
+} from "ai";
+import { z } from "zod";
+import { getCurrentAgentModel } from "../current-agent-model";
+import {
+  buildEvaluatorSystemPrompt,
+  buildEvaluatorUserPrompt,
+  type EvaluatorUserPromptInput,
+} from "./prompt";
+import {
+  TRACE_OUTPUT_TRUNCATE_CHARS,
+  type ConcernDimension,
+  type EvaluatorVerdict,
+} from "./types";
+
+/**
+ * Input shape for the evaluator entry point. Same across no-op and real
+ * evaluator implementations so the gate orchestrator can swap them
+ * without changing call sites.
+ */
+export interface RunEvaluatorInput extends EvaluatorUserPromptInput {
+  /**
+   * Pre-resolved language model to use for the evaluator call.
+   *
+   * When `undefined` or `null`, the evaluator falls back to the
+   * executor's currently-active model via `getCurrentAgentModel()` —
+   * giving "same-model-fresh-context" behavior, Anthropic's recommended
+   * default per their March 2026 harness post.
+   *
+   * Tests pass a mock LanguageModel here to drive deterministic
+   * verdicts; production callers (`agent-transport.ts`) resolve a
+   * provider override (settings.completionCheck.evaluatorModel) before
+   * calling.
+   */
+  model?: LanguageModel | null;
+  /**
+   * When true AND `tools` is non-empty, the evaluator runs via
+   * `generateText` with the provided tools available and a
+   * structured-output spec. The model may call read-only browser /
+   * filesystem tools to ground factual claims (especially for
+   * `surfaceAccuracy` and `evidenceGrounding` concerns) before
+   * committing to a verdict. The `stopWhen: stepCountIs(N)` cap
+   * bounds the research budget per evaluator call.
+   *
+   * When false or `tools` is empty/undefined, the evaluator runs via
+   * `generateObject` with no tools — pure context-based judgment.
+   */
+  allowTools?: boolean;
+  /**
+   * Read-only tool subset the evaluator may call. The caller is
+   * responsible for filtering destructive tools (clickElement,
+   * navigate, executeOnPage, todoWrite, memory writes, etc.) — the
+   * evaluator does not validate this list. Production wiring lives in
+   * `agent-transport.ts` and only includes snapshot/readPage/screenshot/
+   * extract/listTabs from browser tools and Read/Glob/Grep/LS from
+   * filesystem tools.
+   */
+  tools?: ToolSet;
+  /**
+   * Hard cap on evaluator research steps when `allowTools` is true.
+   * Each step is one LLM round-trip (potentially with tool calls).
+   * Default: 20 — generous enough that a properly-prompted evaluator
+   * never hits the cap while still bounding pathological loops. The
+   * earlier 5-step cap was prone to mid-tool-call cap-hits that
+   * produced `NoOutputGeneratedError`; the two-stage fallback (see
+   * below) is the actual safety net, so this cap exists only to bound
+   * runaway calls.
+   */
+  maxSteps?: number;
+  /**
+   * Optional abort signal. The transport hands this through from the
+   * outer agent run so a user-initiated stop also cancels the evaluator
+   * call rather than orphaning a request to the provider.
+   */
+  abortSignal?: AbortSignal;
+}
+
+const DEFAULT_EVALUATOR_MAX_STEPS = 20;
+
+// ---------------------------------------------------------------------------
+// Zod schema describing the verdict shape we ask the LLM to emit.
+//
+// Kept structurally aligned with the `EvaluatorVerdict` TS type but does
+// NOT include the reserved Phase 6 fields (`scores`, `trend`). The model
+// shouldn't be encouraged to fabricate scores in binary mode; if/when we
+// add scored mode we extend the schema then.
+//
+// Concern shape mirrors `Concern` in types.ts. We don't import the TS
+// type directly because Zod can't widen-then-narrow it — we'd lose the
+// dimension union. We do enforce a known dimension at the Zod layer so
+// providers that emit free-form strings get a useful validation error.
+// ---------------------------------------------------------------------------
+
+const CONCERN_DIMENSIONS: readonly ConcernDimension[] = [
+  "completeness",
+  "planClosure",
+  "evidenceGrounding",
+  "noPrematureHandoff",
+  "surfaceAccuracy",
+] as const;
+
+const concernSchema = z.object({
+  dimension: z.enum(CONCERN_DIMENSIONS as readonly [string, ...string[]]),
+  detail: z
+    .string()
+    .min(1)
+    .describe(
+      "Internal: specific, actionable description of the concern in evaluator voice. Used to construct follow-up feedback for the agent and the audit-trail export. Cite exact text where possible.",
+    ),
+  userSummary: z
+    .string()
+    .min(1)
+    .max(180)
+    .describe(
+      "REQUIRED. User-facing one-sentence summary of the concern, in plain observation voice. Do NOT address 'the agent' or use prescriptive verbs ('should', 'needs to', 'must'). NO internal jargon (dimension names, tool names, snapshot refs). Frame as observations the user can understand. Examples — good: 'Hours might be inaccurate — site shows 7am–8pm weekends, not 7pm'. Bad: 'The agent needs to verify the cafe's hours.' Soft cap ~25 words, hard cap 180 chars.",
+    ),
+  evidence: z
+    .string()
+    .optional()
+    .describe(
+      "Optional supporting quote or snapshot reference. Internal/export only — not surfaced in the inline UI.",
+    ),
+});
+
+const verdictSchema = z.object({
+  decision: z.enum(["approve", "reject"]),
+  concerns: z.array(concernSchema),
+  reasoning: z
+    .string()
+    .min(1)
+    .describe("One-paragraph plain-language summary of the verdict."),
+  confidence: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("Self-reported confidence on [0, 1]."),
+});
+
+/**
+ * Evaluator entry point.
+ *
+ * Two execution modes, chosen at call time:
+ *
+ *  1. **No-tools mode** (default): one-shot `generateObject` against the
+ *     evaluator model. Pure context-based judgment from the original
+ *     request, drafted response, todo list, and tool-call trace.
+ *
+ *  2. **With-tools mode**: `generateText` with a read-only tool subset
+ *     plus an `Output.object` spec, capped by `stepCountIs(maxSteps)`.
+ *     The evaluator may take a few verification calls (snapshot,
+ *     extract, readPage, etc.) to ground factual claims before
+ *     committing to a verdict. Especially useful for the
+ *     `surfaceAccuracy` and `evidenceGrounding` concern dimensions.
+ *
+ * Both modes return a verdict validated against {@link verdictSchema}.
+ * The schema enforces the binary `decision` + dimensional concerns
+ * shape; concerns with unknown dimensions are rejected at validation
+ * time so downstream gate logic can trust
+ * `verdict.concerns[].dimension` to be a known `ConcernDimension`.
+ *
+ * Failure modes — handled, not propagated:
+ *  - No model available: returns optimistic approve with confidence 0
+ *    and a "no model configured" reasoning string. The user's response
+ *    is never blocked by an evaluator unavailability.
+ *  - LLM call throws: re-thrown. The gate orchestrator catches and
+ *    converts to `force-emitted` (reason: "evaluator-error").
+ *  - Schema validation failure on the LLM output: the AI SDK retries
+ *    internally; if it still fails, the error reaches the gate
+ *    orchestrator and is treated as "evaluator-error".
+ *
+ * Internal-consistency normalization:
+ *  - If the LLM returns `decision: "reject"` with an empty concerns
+ *    array, we promote that to a single synthetic concern in the
+ *    `completeness` bucket so the rejection feedback isn't empty.
+ *  - If the LLM returns `decision: "approve"` with non-empty concerns,
+ *    we keep concerns but trust the decision (the LLM may have
+ *    flagged minor caveats while still concluding approval). The
+ *    rejection-loop wiring only triggers on `decision === "reject"`.
+ */
+export async function runEvaluator(
+  input: RunEvaluatorInput,
+): Promise<EvaluatorVerdict> {
+  const model = input.model ?? getCurrentAgentModel();
+  if (!model) {
+    return {
+      decision: "approve",
+      concerns: [],
+      reasoning:
+        "(evaluator unavailable: no language model configured for this run)",
+      confidence: 0,
+    };
+  }
+
+  const useTools =
+    !!input.allowTools && !!input.tools && Object.keys(input.tools).length > 0;
+
+  const system = buildEvaluatorSystemPrompt({ hasTools: useTools });
+  const prompt = buildEvaluatorUserPrompt({
+    originalRequest: input.originalRequest,
+    draftedResponse: input.draftedResponse,
+    todos: input.todos,
+    toolCallTrace: input.toolCallTrace,
+  });
+
+  let raw: z.infer<typeof verdictSchema>;
+  if (useTools) {
+    // generateText + Output.object lets the model take a few
+    // verification tool calls before committing to a structured
+    // verdict in a single API surface. The `stepCountIs` cap bounds
+    // research depth.
+    const result = await generateText({
+      model,
+      system,
+      prompt,
+      tools: input.tools,
+      stopWhen: stepCountIs(input.maxSteps ?? DEFAULT_EVALUATOR_MAX_STEPS),
+      output: Output.object({ schema: verdictSchema }),
+      abortSignal: input.abortSignal,
+    });
+
+    // Two-stage commit: `result.output` throws `NoOutputGeneratedError`
+    // when the final step's `finishReason !== "stop"` — which happens
+    // most often when the model runs out of step budget mid-tool-call
+    // and never gets a chance to emit the structured verdict. Rather
+    // than letting that bubble up as an "evaluator-error" force-emit,
+    // run a follow-up `generateObject` (no tools) that asks the model
+    // to commit a verdict from the verification work it already did.
+    // The accumulated tool calls and outputs from `result.steps` are
+    // included so the second-stage call has full context.
+    //
+    // Schema-validation errors (the model committed a verdict but it
+    // didn't match the schema) are NOT recoverable here and propagate.
+    try {
+      // The SDK types `result.output` as `InferCompleteOutput<OUTPUT>`
+      // which resolves to the schema's inferred type, but Output's
+      // generic propagation through `generateText`'s return type tends
+      // to lose the tight type. Re-validate against our Zod schema for
+      // both runtime safety and a tighter compile-time shape.
+      raw = verdictSchema.parse(result.output);
+    } catch (err) {
+      if (!NoOutputGeneratedError.isInstance(err)) throw err;
+
+      console.warn(
+        "[completion-check] evaluator hit step cap without committing; running second-stage commit",
+      );
+      const stepTranscript = summarizeEvaluatorSteps(result.steps);
+      const followupPrompt = `${prompt}\n\n## Your verification work so far\n\nYou used your full research budget. The captured tool calls and outputs from your verification work this turn are below. Commit a verdict NOW from this evidence — you may not request more tools.\n\n${stepTranscript}`;
+      const followup = await generateObject({
+        model,
+        schema: verdictSchema,
+        system,
+        prompt: followupPrompt,
+        abortSignal: input.abortSignal,
+      });
+      raw = followup.object;
+    }
+  } else {
+    const result = await generateObject({
+      model,
+      schema: verdictSchema,
+      system,
+      prompt,
+      abortSignal: input.abortSignal,
+    });
+    raw = result.object;
+  }
+
+  // The Zod enum was widened to `string` to accept arbitrary providers'
+  // outputs at parse time; narrow back to ConcernDimension here. Any
+  // unknown dimension was already rejected by the schema, so this cast
+  // is safe.
+  const concerns = raw.concerns.map((c) => ({
+    dimension: c.dimension as ConcernDimension,
+    detail: c.detail,
+    userSummary: c.userSummary,
+    evidence: c.evidence,
+  }));
+
+  // Repair an internally-inconsistent reject-with-no-concerns verdict.
+  if (raw.decision === "reject" && concerns.length === 0) {
+    concerns.push({
+      dimension: "completeness",
+      detail:
+        "Evaluator rejected without enumerating concerns; rejection treated as completeness gap.",
+      userSummary: "The response may be incomplete.",
+      evidence: undefined,
+    });
+  }
+
+  return {
+    decision: raw.decision,
+    concerns,
+    reasoning: raw.reasoning,
+    confidence: raw.confidence,
+  };
+}
+
+/**
+ * Compress the steps from a `generateText` run into a flat transcript
+ * for the second-stage commit prompt.
+ *
+ * Each step contributes the tool calls it made (name + truncated input)
+ * and the tool results it received (truncated). We deliberately drop
+ * the model's interstitial text/reasoning — only the verification
+ * evidence matters for the commit-now prompt, and including reasoning
+ * tends to bias the second-stage call to mirror the first-stage's
+ * incomplete thought process.
+ *
+ * Truncation reuses {@link TRACE_OUTPUT_TRUNCATE_CHARS} so the trace
+ * stays bounded. The transcript is plain text formatted for the LLM,
+ * not a structured shape; tests assert on substrings rather than shape.
+ */
+function summarizeEvaluatorSteps(
+  steps: ReadonlyArray<StepResult<ToolSet>>,
+): string {
+  if (steps.length === 0) {
+    return "(no verification work was completed)";
+  }
+
+  const lines: string[] = [];
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const toolCalls = step.toolCalls ?? [];
+    const toolResults = step.toolResults ?? [];
+
+    if (toolCalls.length === 0 && toolResults.length === 0) continue;
+
+    lines.push(`### Step ${i + 1}`);
+    for (const call of toolCalls) {
+      const name = call.toolName ?? "(unknown)";
+      let inputStr: string;
+      try {
+        inputStr =
+          typeof call.input === "string"
+            ? call.input
+            : JSON.stringify(call.input ?? {});
+      } catch {
+        inputStr = "(input not serializable)";
+      }
+      const inputTruncated =
+        inputStr.length > 200 ? inputStr.slice(0, 200) + "… (truncated)" : inputStr;
+      lines.push(`- called \`${name}\` with: ${inputTruncated}`);
+    }
+    for (const result of toolResults) {
+      const name = result.toolName ?? "(unknown)";
+      // `result.output` is the shape returned by the tool; can be
+      // anything (string, object, array). Stringify and truncate.
+      let outputStr: string;
+      try {
+        const out =
+          (result as { output?: unknown }).output ??
+          (result as { result?: unknown }).result;
+        outputStr = typeof out === "string" ? out : JSON.stringify(out ?? null);
+      } catch {
+        outputStr = "(output not serializable)";
+      }
+      const outputTruncated =
+        outputStr.length > TRACE_OUTPUT_TRUNCATE_CHARS
+          ? outputStr.slice(0, TRACE_OUTPUT_TRUNCATE_CHARS) + "… (truncated)"
+          : outputStr;
+      lines.push(`  → \`${name}\` returned: ${outputTruncated}`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join("\n") : "(no tool calls observed)";
+}

--- a/apps/extension/src/lib/agent/completion-check/index.ts
+++ b/apps/extension/src/lib/agent/completion-check/index.ts
@@ -1,0 +1,255 @@
+/**
+ * Completion-check gate orchestration.
+ *
+ * The gate sits between the executor agent's drafted final response and
+ * the user. For each candidate response, the gate decides:
+ *
+ *  1. Whether to evaluate at all ({@link shouldGate}).
+ *  2. If yes, runs the evaluator and produces a verdict.
+ *  3. Records telemetry on the outcome regardless of decision.
+ *
+ * What the orchestrator does NOT do (lives in the transport):
+ *  - Pause/resume the executor loop on rejection
+ *  - Inject synthetic reviewer-feedback turns
+ *  - Manage the rejection-round counter across loop iterations
+ *
+ * The orchestrator's job is "given a candidate response, produce a
+ * verdict and record telemetry."
+ */
+
+import type { LanguageModel, ToolSet } from "ai";
+import type { TodoItem } from "../../types";
+import { runEvaluator } from "./evaluator";
+import { completionCheckTelemetry } from "./telemetry";
+import {
+  MAX_REJECTION_ROUNDS,
+  type EvaluatorVerdict,
+  type GateOutcome,
+  type SkipReason,
+  type ToolCallTraceEntry,
+} from "./types";
+
+// Re-export for the few consumers that imported these types directly
+// from the orchestrator module under the old `goal-contract` name.
+export type { SkipReason, CompletionCheckSettings } from "./types";
+
+/**
+ * Pure decision: should the gate evaluate this candidate response?
+ *
+ * Encapsulated as a separate function so the trigger heuristic can be
+ * unit-tested without spinning up an evaluator. Mirrors the structure of
+ * `shouldCompact` in `compaction.ts`.
+ *
+ * The trigger fires when ALL of the following hold:
+ *  - There is non-empty final text (otherwise the model only produced
+ *    tool calls; nothing to evaluate yet).
+ *  - The turn was non-trivial: either the conversation has todos
+ *    (planned multi-step task) OR the executor made tool calls this
+ *    turn (acted on the world). Pure Q&A turns with no tools and no
+ *    plan skip the gate cheaply.
+ *
+ * @returns `{ gate: true }` if the gate should run; `{ gate: false, reason }`
+ *          otherwise so callers can pass the reason through to telemetry.
+ */
+export function shouldGate(
+  candidate: {
+    /** Final assistant text, after stream completes. */
+    finalText: string;
+    /** Conversation's current todo list. */
+    todos: TodoItem[];
+    /** Tool calls produced by the executor in this turn. */
+    toolCallTrace: ToolCallTraceEntry[];
+  },
+): { gate: true } | { gate: false; reason: SkipReason } {
+  if (!candidate.finalText.trim()) {
+    return { gate: false, reason: "no-final-text" };
+  }
+
+  // Non-trivial turn heuristic: either the agent planned (todos) or
+  // acted (tool calls). Trivial Q&A turns get skipped to save cost.
+  const hasTodos = candidate.todos.length > 0;
+  const hasToolCalls = candidate.toolCallTrace.length > 0;
+  if (!hasTodos && !hasToolCalls) {
+    return { gate: false, reason: "trigger-not-met" };
+  }
+
+  return { gate: true };
+}
+
+export interface RunCompletionCheckInput {
+  conversationId: string;
+  /** 0-indexed turn ordinal in the conversation. */
+  turnIndex: number;
+  /**
+   * 0-indexed rejection round within the current turn. 0 = first
+   * verdict; 1+ = subsequent rounds after rejection.
+   */
+  rejectionRound: number;
+  /** The original user request that kicked off this turn. */
+  originalRequest: string;
+  /** The drafted final assistant text under review. */
+  draftedResponse: string;
+  /** Conversation's todo state at gate time. */
+  todos: TodoItem[];
+  /** Tool calls produced by the executor in this turn. */
+  toolCallTrace: ToolCallTraceEntry[];
+  /**
+   * Pre-resolved evaluator language model. When undefined, the
+   * evaluator falls back to the executor's currently-active model
+   * (same-context-fresh-window behavior).
+   */
+  evaluatorModel?: LanguageModel | null;
+  /**
+   * Read-only tool subset the evaluator may use to ground factual
+   * claims. When undefined or empty, the evaluator runs without tools
+   * (pure context-based judgment). When set, the gate enables
+   * with-tools mode in the evaluator.
+   */
+  evaluatorTools?: ToolSet;
+  /**
+   * Hard cap on evaluator research steps when tools are enabled.
+   * Each step is one LLM round-trip plus optional tool calls. Default
+   * is in the evaluator (5).
+   */
+  evaluatorMaxSteps?: number;
+  /**
+   * Abort signal for the evaluator call. Threading the agent's outer
+   * abort signal here ensures a user-initiated stop also cancels the
+   * evaluator.
+   */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Run the gate end-to-end: decide, optionally evaluate, record telemetry.
+ *
+ * Always returns a `GateOutcome`. Telemetry is best-effort: if the
+ * IndexedDB write fails (e.g. fake-indexeddb edge case in tests), we log
+ * and continue. The user's response should never be blocked by a
+ * telemetry failure.
+ */
+export async function runCompletionCheck(
+  input: RunCompletionCheckInput,
+): Promise<GateOutcome> {
+  const decision = shouldGate({
+    finalText: input.draftedResponse,
+    todos: input.todos,
+    toolCallTrace: input.toolCallTrace,
+  });
+
+  if (!decision.gate) {
+    const outcome: GateOutcome = {
+      kind: "skipped",
+      reason: decision.reason,
+    };
+    await recordTelemetrySafe({
+      conversationId: input.conversationId,
+      turnIndex: input.turnIndex,
+      rejectionRound: input.rejectionRound,
+      outcomeKind: "skipped",
+      verdict: null,
+      skipReason: decision.reason,
+    });
+    return outcome;
+  }
+
+  let verdict: EvaluatorVerdict;
+  try {
+    const hasTools =
+      !!input.evaluatorTools &&
+      Object.keys(input.evaluatorTools).length > 0;
+    verdict = await runEvaluator({
+      originalRequest: input.originalRequest,
+      draftedResponse: input.draftedResponse,
+      todos: input.todos.map((t) => ({
+        content: t.content,
+        status: t.status,
+      })),
+      toolCallTrace: input.toolCallTrace,
+      model: input.evaluatorModel,
+      // With-tools mode activates when the caller explicitly provided a
+      // tool subset. The evaluator does its own no-op-if-empty check
+      // but we predicate `allowTools` on the caller's intent so the
+      // system prompt branches correctly.
+      allowTools: hasTools,
+      tools: hasTools ? input.evaluatorTools : undefined,
+      maxSteps: input.evaluatorMaxSteps,
+      abortSignal: input.abortSignal,
+    });
+  } catch (err) {
+    // Evaluator failure is treated as force-emit-with-warning rather
+    // than blocking. We don't want a transient evaluator error to
+    // break the user's task. The error is recorded in telemetry so
+    // the user can see it in the diagnostics UI.
+    console.warn("[completion-check] evaluator threw:", err);
+    const fallbackVerdict: EvaluatorVerdict = {
+      decision: "approve",
+      concerns: [],
+      reasoning: `Evaluator error: ${err instanceof Error ? err.message : String(err)}. Forcing emit with warning.`,
+      confidence: 0,
+    };
+    await recordTelemetrySafe({
+      conversationId: input.conversationId,
+      turnIndex: input.turnIndex,
+      rejectionRound: input.rejectionRound,
+      outcomeKind: "force-emitted",
+      verdict: fallbackVerdict,
+    });
+    return {
+      kind: "force-emitted",
+      verdict: fallbackVerdict,
+      rejectionRound: input.rejectionRound,
+      reason: "evaluator-error",
+    };
+  }
+
+  const isApproved = verdict.decision === "approve";
+
+  // Hit the rejection-round budget? Force-emit with the verdict's
+  // concerns surfaced as a warning so the user can see what was caught.
+  const exceededBudget =
+    !isApproved && input.rejectionRound + 1 >= MAX_REJECTION_ROUNDS;
+
+  let outcome: GateOutcome;
+  if (isApproved) {
+    outcome = { kind: "approved", verdict };
+  } else if (exceededBudget) {
+    outcome = {
+      kind: "force-emitted",
+      verdict,
+      rejectionRound: input.rejectionRound,
+      reason: "max-rounds-exceeded",
+    };
+  } else {
+    outcome = {
+      kind: "rejected",
+      verdict,
+      rejectionRound: input.rejectionRound,
+    };
+  }
+
+  await recordTelemetrySafe({
+    conversationId: input.conversationId,
+    turnIndex: input.turnIndex,
+    rejectionRound: input.rejectionRound,
+    outcomeKind: outcome.kind,
+    verdict,
+  });
+
+  return outcome;
+}
+
+async function recordTelemetrySafe(args: {
+  conversationId: string;
+  turnIndex: number;
+  rejectionRound: number;
+  outcomeKind: GateOutcome["kind"];
+  verdict: EvaluatorVerdict | null;
+  skipReason?: SkipReason;
+}): Promise<void> {
+  try {
+    await completionCheckTelemetry.record(args);
+  } catch (err) {
+    console.warn("[completion-check] telemetry write failed:", err);
+  }
+}

--- a/apps/extension/src/lib/agent/completion-check/index.ts
+++ b/apps/extension/src/lib/agent/completion-check/index.ts
@@ -179,13 +179,17 @@ export async function runCompletionCheck(
   } catch (err) {
     // Evaluator failure is treated as force-emit-with-warning rather
     // than blocking. We don't want a transient evaluator error to
-    // break the user's task. The error is recorded in telemetry so
-    // the user can see it in the diagnostics UI.
+    // break the user's task. Detailed error info goes to the console
+    // (for developer diagnostics) but NOT into the persisted/
+    // user-facing `reasoning` field — error messages from provider
+    // SDKs sometimes carry request payloads or other internal
+    // details we don't want flowing into chatDb or markdown exports.
     console.warn("[completion-check] evaluator threw:", err);
     const fallbackVerdict: EvaluatorVerdict = {
       decision: "approve",
       concerns: [],
-      reasoning: `Evaluator error: ${err instanceof Error ? err.message : String(err)}. Forcing emit with warning.`,
+      reasoning:
+        "Evaluator encountered an internal error; proceeding with warning.",
       confidence: 0,
     };
     await recordTelemetrySafe({

--- a/apps/extension/src/lib/agent/completion-check/prompt.ts
+++ b/apps/extension/src/lib/agent/completion-check/prompt.ts
@@ -1,0 +1,239 @@
+import type { ConcernDimension, ToolCallTraceEntry } from "./types";
+
+/**
+ * Evaluator system prompt for the completion-check gate.
+ *
+ * Phase 1 ships the prompt skeleton even though no real evaluator call
+ * happens yet (the no-op evaluator always approves). Pre-shipping the
+ * prompt lets us:
+ *  - Snapshot-test the prompt builder for regressions
+ *  - Iterate on wording from real telemetry once Phase 2 enables real
+ *    LLM calls
+ *  - Keep the prompt content reviewed alongside the type surface it
+ *    encodes
+ *
+ * Design principles, drawn from Anthropic's March 2026 harness work:
+ *  - Default to skepticism. The evaluator is biased toward approval by
+ *    default; the prompt explicitly counters that.
+ *  - Concerns must be specific and actionable, not vibes ("looks
+ *    incomplete").
+ *  - Each concern names exactly one dimension. Mixed-dimension concerns
+ *    get split into multiple entries.
+ *  - The evaluator is allowed to use read-only tools (Phase 3+) to
+ *    ground factual claims, but is not required to. Phase 2 evaluators
+ *    have no tools at all.
+ */
+
+const DIMENSION_DESCRIPTIONS: Record<ConcernDimension, string> = {
+  completeness:
+    "The drafted response does not fulfill the original user request end-to-end. Examples: claimed 'top 3' but listed 2; promised a summary but described one item; promised a price comparison but only quoted one source.",
+  planClosure:
+    "The conversation has open todos (status 'pending' or 'in_progress') that contradict the claim of completion. The executor either should have closed them, explicitly cancelled them, or should not be claiming completion yet.",
+  evidenceGrounding:
+    "A specific factual claim in the drafted response (price, count, page text, URL, product name, date, etc.) is not supported by any tool observation in this turn. The fact may be invented or carried from stale context. Do not flag claims that are clearly opinions or general background; only flag claims that purport to describe specific observations.",
+  noPrematureHandoff:
+    "The drafted response punts work back to the user that was within the original scope. Phrases like 'you can now do X yourself', 'I'll let you handle the rest', or stopping after partial fulfillment when the user asked for full completion. Not a flag for legitimate clarifying questions about genuinely ambiguous requirements.",
+  surfaceAccuracy:
+    "The drafted response describes the page state but a verification tool call (snapshot/extract/readPage) shows the page disagrees. Only raise this concern if you actually performed a verification call this turn and observed a mismatch.",
+};
+
+/**
+ * Builds the system prompt the evaluator LLM call will use. Pure function;
+ * snapshot-tested.
+ *
+ * @param hasTools - Whether the evaluator was given any read-only tools
+ *                  this run. Toggles whether the prompt encourages
+ *                  surface-accuracy verification.
+ */
+export function buildEvaluatorSystemPrompt({
+  hasTools,
+}: {
+  hasTools: boolean;
+}): string {
+  const dimensionList = (
+    Object.entries(DIMENSION_DESCRIPTIONS) as [ConcernDimension, string][]
+  )
+    .map(([key, desc]) => `- **${key}**: ${desc}`)
+    .join("\n");
+
+  const toolGuidance = hasTools
+    ? `\n## Tools\n\nYou have access to a read-only subset of the browser agent's tools (page-state inspection: snapshot, readPage, screenshot, extract, listTabs; filesystem read: Read, Glob, Grep, LS, read_opfs_file; recallMemory). The tool-call trace in your input already includes the captured output of every tool the executor ran this turn — judge most factual claims from those outputs directly. Only call a tool yourself when a specific claim genuinely cannot be checked from the trace (e.g. the executor never inspected the relevant element). Don't re-verify what the trace already shows. You have a generous research budget but reserve your final response to commit a structured verdict; do not start a new tool call once you have enough evidence to decide.`
+    : `\n## Tools\n\nYou have no tools available in this run. Evaluate strictly from the conversation context, the executor's drafted response, and the tool-call trace included in your input — including the captured tool outputs. If a factual claim cannot be verified from the trace, raise an \`evidenceGrounding\` concern rather than approving by default.`;
+
+  return `You are a skeptical reviewer for an AI browser agent's work. Your job is to verify, before the user sees it, that the agent has actually completed the task it claims to have completed.
+
+Default to skepticism. LLM-generated work is biased to look complete; your job is to push back when it isn't. A response can look polished and still be wrong on substance. When in doubt, raise a concern — the executor will get one more chance to address it before the user sees the response.
+
+## Your decision
+
+Return a structured verdict with:
+- **decision**: "approve" or "reject"
+- **concerns**: zero or more specific, actionable concerns (empty array on approve)
+- **reasoning**: a one-paragraph plain-language summary of your judgment
+- **confidence**: your self-reported confidence in this verdict on [0, 1]
+
+A reject verdict must contain at least one concern. An approve verdict must contain zero concerns.
+
+## Concern dimensions
+
+Every concern is tagged with exactly one of these dimensions:
+
+${dimensionList}
+
+If a problem spans multiple dimensions (e.g. an unverified claim that also leaves the user with unfinished work), file separate concerns — one per dimension — so the executor's fix is targeted.
+
+## Writing useful concerns
+
+Each concern carries TWO description fields, both required:
+
+### \`detail\` (technical, internal voice)
+
+Names the exact problem and points at evidence — written for an audience
+of "the agent" who will revise the response. Cite text precisely.
+
+- Bad:  "response is incomplete".
+- Good: "Drafted response says 'I found the cheapest 3 options' but only lists 2 (Logitech MX, Keychron K2). The third item is missing."
+
+Where possible, include an \`evidence\` field quoting the offending text
+from the drafted response or referencing a snapshot ID (\`@e3\`) you
+inspected.
+
+### \`userSummary\` (user-facing, plain language)
+
+One sentence the END USER will see in their chat UI. The user does NOT
+see "the agent" as a separate party — they see their own conversation.
+Phrasing the summary as if scolding a third party breaks the experience.
+
+Hard rules:
+
+1. **Observation voice.** Frame as a fact about the world, not a
+   directive to anyone. "Hours might be off" — not "The agent should
+   verify the hours".
+2. **Never mention "the agent".** Never use prescriptive verbs
+   ("should", "needs to", "must").
+3. **No internal jargon.** Don't say "completeness", "evidenceGrounding",
+   "tool call", "snapshot", "drafted response". Speak the user's domain.
+4. **One concern, one sentence.** Soft cap ~25 words.
+
+Good \`userSummary\` examples:
+
+- "Hours might be off — site shows 7am–8pm on weekends, not 7pm daily."
+- "Only 2 cafes listed but you asked for 3."
+- "The price quoted ($149) wasn't actually verified on any page this turn."
+- "The summary covers reviews but not the locations you asked about."
+
+Bad \`userSummary\` examples (DO NOT EMIT):
+
+- "The agent needs to verify the cafe's hours."  ← addresses the agent
+- "completeness: missing item."  ← jargon
+- "The drafted response fails to satisfy the surfaceAccuracy criterion." ← jargon
+- "The agent should look for cafes that remain open past 7:00 PM."  ← directive voice + addresses agent
+
+## What to NOT flag
+
+- Style or tone preferences. The executor's voice is the user's choice.
+- Length: terse responses are fine if the task is simple.
+- Hypotheticals or recommendations the executor explicitly framed as "you might also consider…".
+- Genuine clarifying questions about ambiguous requirements (those are not premature handoffs).
+- Already-completed todos. Only \`pending\`/\`in_progress\` items count toward planClosure.
+
+If everything checks out, approve cleanly with empty concerns. Don't manufacture problems to look diligent.
+${toolGuidance}`;
+}
+
+/**
+ * Builds the user-message body for the evaluator call. Combines the
+ * original user request, the executor's drafted response, current todo
+ * state, and a compressed tool-call trace.
+ *
+ * Kept as a separate builder so the prompt can be snapshot-tested
+ * independent of any conversation fixture.
+ */
+export interface EvaluatorUserPromptInput {
+  originalRequest: string;
+  draftedResponse: string;
+  todos: Array<{
+    content: string;
+    status: "pending" | "in_progress" | "completed" | "cancelled";
+  }>;
+  /**
+   * Per-tool-call trace from the executor's turn. Includes the call's
+   * input, the captured output (or error), and the lifecycle state.
+   * Captured live by `observeChunkForCompletionCheck` in the transport.
+   *
+   * The output capture is the single biggest input to evaluator quality:
+   * with it, most factual claims can be judged from context without the
+   * evaluator having to re-call tools to see the same page state.
+   */
+  toolCallTrace: ToolCallTraceEntry[];
+}
+
+export function buildEvaluatorUserPrompt(
+  input: EvaluatorUserPromptInput,
+): string {
+  const todoBlock =
+    input.todos.length === 0
+      ? "(no todos in this conversation)"
+      : input.todos
+          .map(
+            (t, i) =>
+              `${i + 1}. [${t.status.toUpperCase()}] ${t.content}`,
+          )
+          .join("\n");
+
+  // Render each tool call as `<n>. <name> [<state>]` with `input:` and
+  // `output:` sub-lines. Outputs are already truncated by the observer;
+  // we don't re-truncate here. The state tag lets the evaluator
+  // distinguish completed/errored/denied/pending without parsing the
+  // output text.
+  const traceBlock =
+    input.toolCallTrace.length === 0
+      ? "(no tool calls in this turn)"
+      : input.toolCallTrace
+          .map((c, i) => {
+            const stateTag = c.state === "completed" ? "" : ` [${c.state}]`;
+            const inputLine = `   input: ${c.inputSummary || "(no input)"}`;
+            let outputLine: string;
+            switch (c.state) {
+              case "completed":
+                outputLine = `   output: ${c.outputSummary ?? "(no output)"}`;
+                break;
+              case "errored":
+                outputLine = `   error: ${c.outputSummary ?? "(unknown error)"}`;
+                break;
+              case "denied":
+                outputLine = `   (user denied this tool call — no output produced)`;
+                break;
+              case "pending":
+                outputLine = `   (call did not complete before the turn ended)`;
+                break;
+            }
+            return `${i + 1}. ${c.name}${stateTag}\n${inputLine}\n${outputLine}`;
+          })
+          .join("\n");
+
+  return `## Original user request
+
+${input.originalRequest}
+
+## Drafted final response (under review)
+
+${input.draftedResponse}
+
+## Current todo state
+
+${todoBlock}
+
+## Tool-call trace from this turn
+
+Each entry below records what the executor did this turn AND what the
+tool returned. Use the captured outputs to judge factual claims
+directly — only call verification tools yourself if a claim cannot be
+checked against the trace.
+
+${traceBlock}
+
+## Your task
+
+Decide whether the drafted final response should be sent to the user. Apply the rubric in your system prompt. Be specific in concerns; cite evidence when possible.`;
+}

--- a/apps/extension/src/lib/agent/completion-check/telemetry.ts
+++ b/apps/extension/src/lib/agent/completion-check/telemetry.ts
@@ -1,0 +1,231 @@
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import type {
+  ConcernDimension,
+  EvaluatorVerdict,
+  GateOutcome,
+  SkipReason,
+} from "./types";
+
+/**
+ * Telemetry store for completion-check gate verdicts.
+ *
+ * Lives in its own IndexedDB database (separate from `chat-db`) so:
+ *  - Schema can evolve independently as the verdict shape grows
+ *  - Wiping telemetry doesn't risk touching conversation transcripts
+ *  - Future "export anonymized telemetry" / "clear telemetry" UI can act
+ *    on a clean store without rebuilding the whole chat database
+ *
+ * Local-only: nothing here is uploaded anywhere. The data exists so the
+ * future telemetry UI can show users what the evaluator has been doing
+ * on their behalf, and so prompt-tuning can read aggregated
+ * rejection-reason distributions.
+ *
+ * Design choices:
+ *  - One row per verdict (one conversation turn may produce multiple rows
+ *    if rejected and retried). `id` is a fresh uuid per row, not derived
+ *    from the conversation, so an append-only log is straightforward.
+ *  - We store the verdict as a denormalized blob. It's small (~few KB
+ *    worst case) and avoids cross-store joins for analysis.
+ *  - We extract concern dimensions into an indexed array so common
+ *    queries ("how often did we reject for evidenceGrounding?") don't
+ *    scan every row.
+ */
+
+export interface CompletionCheckTelemetryRow {
+  /** Random uuid; NOT correlated with conversation/turn ids. */
+  id: string;
+  conversationId: string;
+  /**
+   * 0-indexed turn within the conversation. Used to group multiple rows
+   * (rejection rounds) belonging to the same logical turn.
+   */
+  turnIndex: number;
+  /**
+   * 0 for the first verdict in a turn, 1 for the second (after first
+   * rejection), and so on. Together with `turnIndex` uniquely identifies
+   * a verdict within a conversation.
+   */
+  rejectionRound: number;
+  /** Wall-clock at the moment the verdict was recorded, ms since epoch. */
+  timestamp: number;
+  /**
+   * Coarse outcome bucket; redundant with `verdict.decision` for
+   * approve/reject but also captures skipped and force-emitted cases
+   * which don't have a meaningful `decision`.
+   */
+  outcomeKind: GateOutcome["kind"];
+  /**
+   * The structured verdict, when one was produced. Null when the gate
+   * was skipped (`outcomeKind === "skipped"`).
+   */
+  verdict: EvaluatorVerdict | null;
+  /**
+   * Distinct concern dimensions raised in this verdict, lifted out for
+   * indexing. Empty array when the verdict approved or was skipped.
+   */
+  concernDimensions: ConcernDimension[];
+  /**
+   * Why the gate skipped, if it did. Lets us distinguish "no final
+   * text" from "trigger said skip" without parsing the verdict.
+   */
+  skipReason?: SkipReason;
+}
+
+interface TelemetryDB extends DBSchema {
+  verdicts: {
+    key: string; // row id
+    value: CompletionCheckTelemetryRow;
+    indexes: {
+      "by-conversation": string;
+      "by-timestamp": number;
+      "by-outcome": string;
+    };
+  };
+}
+
+const DB_NAME = "openbrowse-completion-check-telemetry";
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBPDatabase<TelemetryDB>> | null = null;
+
+function getDb(): Promise<IDBPDatabase<TelemetryDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<TelemetryDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains("verdicts")) {
+          const store = db.createObjectStore("verdicts", { keyPath: "id" });
+          store.createIndex("by-conversation", "conversationId");
+          store.createIndex("by-timestamp", "timestamp");
+          store.createIndex("by-outcome", "outcomeKind");
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+/**
+ * Convenience constructor that derives `concernDimensions` from a
+ * verdict and fills in the row id + timestamp. Callers usually use this
+ * over building rows by hand.
+ */
+function buildRow(
+  args: Omit<
+    CompletionCheckTelemetryRow,
+    "id" | "timestamp" | "concernDimensions"
+  > & { id?: string; timestamp?: number },
+): CompletionCheckTelemetryRow {
+  const dimensions = new Set<ConcernDimension>();
+  for (const c of args.verdict?.concerns ?? []) {
+    dimensions.add(c.dimension);
+  }
+  return {
+    id: args.id ?? crypto.randomUUID(),
+    timestamp: args.timestamp ?? Date.now(),
+    concernDimensions: [...dimensions],
+    ...args,
+  };
+}
+
+export const completionCheckTelemetry = {
+  /**
+   * Append a new verdict row. Returns the row id so callers can
+   * cross-reference (e.g. for later "this verdict was wrong" feedback).
+   */
+  async record(
+    args: Omit<
+      CompletionCheckTelemetryRow,
+      "id" | "timestamp" | "concernDimensions"
+    > & { id?: string; timestamp?: number },
+  ): Promise<string> {
+    const row = buildRow(args);
+    const db = await getDb();
+    await db.put("verdicts", row);
+    return row.id;
+  },
+
+  /**
+   * All verdict rows for a conversation, sorted by timestamp ascending.
+   * Most callers want the conversation-scoped view; the global view
+   * (`listAll`) is for the future telemetry-aggregation UI.
+   */
+  async listForConversation(
+    conversationId: string,
+  ): Promise<CompletionCheckTelemetryRow[]> {
+    const db = await getDb();
+    const rows = await db.getAllFromIndex(
+      "verdicts",
+      "by-conversation",
+      conversationId,
+    );
+    return rows.sort((a, b) => a.timestamp - b.timestamp);
+  },
+
+  /**
+   * All verdict rows globally, sorted newest-first. Used by the future
+   * settings telemetry pane to show recent activity. Unbounded; UI is
+   * expected to limit/scroll. We don't paginate here because IndexedDB
+   * cursor pagination is more complex than we need for what is, in
+   * practice, low-volume.
+   */
+  async listAll(): Promise<CompletionCheckTelemetryRow[]> {
+    const db = await getDb();
+    const rows = await db.getAllFromIndex("verdicts", "by-timestamp");
+    return rows.reverse();
+  },
+
+  /**
+   * Aggregate stats for the settings UI: counts by outcome kind and by
+   * concern dimension, optionally scoped to a sliding window.
+   */
+  async aggregate(opts?: { sinceMs?: number }): Promise<{
+    totalVerdicts: number;
+    byOutcome: Record<GateOutcome["kind"], number>;
+    byDimension: Record<ConcernDimension, number>;
+  }> {
+    const rows = await this.listAll();
+    const cutoff = opts?.sinceMs ?? 0;
+    const filtered = cutoff > 0 ? rows.filter((r) => r.timestamp >= cutoff) : rows;
+
+    const byOutcome: Record<GateOutcome["kind"], number> = {
+      skipped: 0,
+      approved: 0,
+      rejected: 0,
+      "force-emitted": 0,
+    };
+    const byDimension: Record<ConcernDimension, number> = {
+      completeness: 0,
+      planClosure: 0,
+      evidenceGrounding: 0,
+      noPrematureHandoff: 0,
+      surfaceAccuracy: 0,
+    };
+    for (const row of filtered) {
+      byOutcome[row.outcomeKind] = (byOutcome[row.outcomeKind] ?? 0) + 1;
+      for (const d of row.concernDimensions) {
+        byDimension[d] = (byDimension[d] ?? 0) + 1;
+      }
+    }
+    return {
+      totalVerdicts: filtered.length,
+      byOutcome,
+      byDimension,
+    };
+  },
+
+  /**
+   * Drop all telemetry rows. Backs the "Clear telemetry" settings button.
+   */
+  async clear(): Promise<void> {
+    const db = await getDb();
+    await db.clear("verdicts");
+  },
+
+  /**
+   * Test/debug helper. Reset the in-memory db handle so a fresh
+   * `indexedDB` (e.g. fake-indexeddb in tests) is opened on next call.
+   */
+  _resetForTests(): void {
+    dbPromise = null;
+  },
+};

--- a/apps/extension/src/lib/agent/completion-check/types.ts
+++ b/apps/extension/src/lib/agent/completion-check/types.ts
@@ -1,0 +1,275 @@
+/**
+ * Types for the verify-gated completion ("Completion check") system.
+ *
+ * The completion-check pattern intercepts the executor agent's final
+ * response and runs a separate skeptical evaluator pass before letting
+ * the response reach the user. If the evaluator finds problems, it
+ * returns concerns partitioned by dimension; the harness then re-injects
+ * those concerns as a synthetic completion-check turn so the executor
+ * can address them.
+ *
+ * Design notes:
+ *  - Always-on. There is no `enabled` toggle. To match the convention
+ *    of comparable agents (Manus, Comet, Devin) the check fires on
+ *    every gateable turn. The only user-facing configuration is the
+ *    evaluator model.
+ *  - The verdict shape carries optional `scores`/`trend` fields reserved
+ *    for a future scored-mode (Phase 7 in the rollout plan). They are
+ *    unused today but live on the type so adding them later is
+ *    non-breaking.
+ *  - Concerns are dimension-tagged so the executor's rejection feedback
+ *    can be partitioned ("completeness: ..." vs "evidenceGrounding:
+ *    ...") rather than a single opaque rejection string. This is the
+ *    "binary verdict + structured concerns" hybrid chosen over pure
+ *    binary or full numeric scoring; see the SOTA research synthesis
+ *    for rationale.
+ */
+
+/**
+ * Dimensions an evaluator may flag a concern against.
+ *
+ * Keep this list small and orthogonal. Adding a new dimension is a real
+ * change: the evaluator prompt, settings UI, telemetry store, and
+ * rejection feedback formatter all key off this enum.
+ */
+export type ConcernDimension =
+  /**
+   * The drafted response doesn't fulfill the original user request
+   * end-to-end. Examples: claimed "top 3" but listed 2; promised a
+   * comparison but only described one item.
+   */
+  | "completeness"
+  /**
+   * Todo state contradicts the claimed completion. Pending or in-progress
+   * todos still exist that should have been closed (or explicitly
+   * cancelled) before the executor declared done.
+   */
+  | "planClosure"
+  /**
+   * A factual claim in the drafted response (price, count, page content,
+   * URL, etc.) is not supported by any tool observation produced this turn.
+   * The executor either invented the fact or carried it from stale context.
+   */
+  | "evidenceGrounding"
+  /**
+   * The response punts work back to the user that was within the original
+   * scope. Phrases like "you can now do X yourself" when X was the asked-for
+   * outcome.
+   */
+  | "noPrematureHandoff"
+  /**
+   * The response describes the page state but the evaluator's own snapshot
+   * disagrees. Only populated when the evaluator chose to ground via
+   * read-only tool calls.
+   */
+  | "surfaceAccuracy";
+
+/**
+ * A single concern raised by the evaluator. Each rejection verdict typically
+ * contains 1–4 concerns; if there are no concerns, the verdict is approve.
+ */
+export interface Concern {
+  dimension: ConcernDimension;
+  /**
+   * Specific, actionable description of the problem in evaluator
+   * voice. Used internally for two purposes:
+   *
+   * 1. The synthetic "completion-check feedback" message sent back to
+   *    the executor agent for the next loop iteration. The agent
+   *    needs the precise technical framing here to ground its
+   *    revision (cite text, name elements, point at evidence).
+   * 2. The markdown export's audit trail (full technical detail).
+   *
+   * NOT shown directly in the inline chat UI — see {@link userSummary}
+   * for the user-facing rewrite.
+   *
+   * Bad:  "incomplete"
+   * Good: "Drafted response says 'top 3 results' but only lists 2 items."
+   */
+  detail: string;
+  /**
+   * User-facing one-sentence summary of the concern, in plain
+   * observation voice. Surfaced inline in the chat UI under the
+   * "Refining answer" / "This response may have issues" pill.
+   *
+   * Hard requirements (enforced via the evaluator's structured-output
+   * schema and reinforced in the system prompt):
+   *  - Observation voice. NOT addressed to "the agent". The user
+   *    reading their chat doesn't see the agent as a separate party;
+   *    third-person evaluator-to-agent framing breaks the illusion.
+   *  - No prescriptive verbs ("should", "needs to", "must"). Frame as
+   *    observations, not commands.
+   *  - No internal jargon: don't surface dimension names
+   *    ("completeness", "evidenceGrounding"), tool names, snapshot
+   *    references, etc.
+   *  - One sentence per concern. Soft cap ~25 words. Hard cap 180
+   *    chars (Zod-enforced).
+   *
+   * Bad:  "The agent needs to verify the cafe's hours."
+   * Good: "Hours might be inaccurate — site shows 7am–8pm weekends, not 7pm."
+   */
+  userSummary: string;
+  /**
+   * Optional supporting quote: a snippet of the drafted response, a tool
+   * output excerpt, or a snapshot reference (`@e3`) the evaluator inspected
+   * while raising the concern. Helps the executor target the fix and helps
+   * humans audit the evaluator's judgment via telemetry.
+   *
+   * NOT surfaced in the inline UI; flows through to the markdown export
+   * and the synthetic feedback message.
+   */
+  evidence?: string;
+}
+
+/**
+ * The structured verdict returned by the evaluator LLM call.
+ *
+ * `decision` is binary in the current implementation. The `scores`/`trend`
+ * fields are reserved for the (potentially never-shipped) scored mode and
+ * ignored by the rest of the system today.
+ */
+export interface EvaluatorVerdict {
+  decision: "approve" | "reject";
+  /**
+   * Empty array when `decision === "approve"`. One entry per distinct issue
+   * when `decision === "reject"`; multiple concerns may share a dimension
+   * if they're independently actionable.
+   */
+  concerns: Concern[];
+  /**
+   * Plain-language one-paragraph summary of the verdict. Shown to the user
+   * in the completion-check UI block on rejection so they can see what
+   * caught the evaluator's eye even before the executor responds.
+   */
+  reasoning: string;
+  /**
+   * Self-reported confidence on `[0, 1]`. Used for telemetry.
+   */
+  confidence: number;
+
+  // ---- Reserved for future scored mode; unpopulated today. ----
+
+  /**
+   * Per-dimension numeric scores when in scored mode. Each dimension may
+   * carry its own threshold so the verdict's `decision` is a deterministic
+   * function of `score >= threshold` for all populated dimensions.
+   */
+  scores?: Partial<
+    Record<ConcernDimension, { score: number; threshold: number }>
+  >;
+  /**
+   * Cross-iteration trend if the evaluator was given prior verdicts. Drives
+   * the future "refine vs pivot vs ship" decision.
+   */
+  trend?: "improving" | "stable" | "degrading";
+}
+
+/**
+ * Outcome returned by the gate orchestrator. Distinct from
+ * `EvaluatorVerdict` because the gate may decide to skip evaluation
+ * entirely (the trigger heuristic returned false), in which case there
+ * is no verdict to report.
+ */
+export type GateOutcome =
+  | { kind: "skipped"; reason: "trigger-not-met" | "no-final-text" }
+  | { kind: "approved"; verdict: EvaluatorVerdict }
+  | { kind: "rejected"; verdict: EvaluatorVerdict; rejectionRound: number }
+  | {
+      kind: "force-emitted";
+      verdict: EvaluatorVerdict;
+      rejectionRound: number;
+      reason: "max-rounds-exceeded" | "evaluator-error";
+    };
+
+/**
+ * User-facing settings for the completion-check feature. Lives at
+ * `Settings.completionCheck` so it can be persisted alongside other
+ * agent configuration.
+ *
+ * Single field: `evaluatorModel`. The check itself is always on — there
+ * is no enable/disable toggle. The trigger heuristic and rejection
+ * budget are hardcoded internal constants in `index.ts`.
+ *
+ *  - undefined  → use executor model with fresh context (default;
+ *                 matches Anthropic Mar 2026 same-model-fresh-context
+ *                 recommendation)
+ *  - "<provider>:<modelId>" → run the evaluator on the specified
+ *                 model (e.g. a cheaper model than the executor for
+ *                 cost optimization; PayZen 2026 reports 59% of
+ *                 production agents use 2+ models)
+ */
+export interface CompletionCheckSettings {
+  evaluatorModel?: string;
+}
+
+/**
+ * Hard cap on rejection rounds before the gate force-emits with a
+ * warning. Hardcoded constant (not a user-facing setting). Matches the
+ * convergent default across the 2026 production literature: Anthropic
+ * Mar 2026 evaluator-error fallback, Hopwood Dec 2025 production
+ * recommendation, and PayZen 2026 production-survey median.
+ */
+export const MAX_REJECTION_ROUNDS = 3;
+
+/**
+ * Why the gate skipped, when it did. The two states correspond to the
+ * two early-exits in `shouldGate`:
+ *  - "no-final-text": tool-only step; no draft to evaluate yet.
+ *  - "trigger-not-met": trivial Q&A turn (no todos, no tool calls).
+ */
+export type SkipReason = "trigger-not-met" | "no-final-text";
+
+/**
+ * One entry in the trace of tool calls the executor made during the
+ * turn under review. Captured live by `observeChunkForCompletionCheck`
+ * and handed to the evaluator so it can see *what the executor saw*,
+ * not just *what the executor did*.
+ *
+ * The output capture is the single biggest input to evaluator quality:
+ * without it, the evaluator must re-call tools to verify any claim,
+ * which burns the per-eval research budget. With it, the evaluator can
+ * judge most claims from context alone.
+ *
+ * `state` distinguishes:
+ *  - "completed":  tool ran and returned an output (output captured in
+ *                  `outputSummary`, hard-truncated)
+ *  - "errored":    tool ran but returned an error (`outputSummary`
+ *                  contains the error text, hard-truncated)
+ *  - "denied":     tool was approval-gated and the user denied it
+ *                  (`outputSummary` is null)
+ *  - "pending":    input was emitted but no output/error/denial chunk
+ *                  arrived before the stream closed (orphaned call;
+ *                  `outputSummary` is null)
+ *
+ * Outputs are JSON.stringified and hard-truncated per call to
+ * `TRACE_OUTPUT_TRUNCATE_CHARS` to keep prompt size predictable. The
+ * snapshot/readPage/extract tools can produce 10–50KB of payload; we
+ * deliberately drop the tail rather than implementing a smarter budget.
+ */
+export interface ToolCallTraceEntry {
+  /** Tool name (e.g. "snapshot", "extract"). */
+  name: string;
+  /**
+   * Stringified input arguments, hard-truncated. Mirrors the
+   * pre-Phase-6 `summary` field — kept under the new name for clarity
+   * now that we also capture outputs.
+   */
+  inputSummary: string;
+  /**
+   * Stringified tool output (or error text), hard-truncated. `null`
+   * when the tool was denied or the call was orphaned at stream close.
+   */
+  outputSummary: string | null;
+  /** Terminal lifecycle state of the call by the time the stream ended. */
+  state: "completed" | "errored" | "denied" | "pending";
+}
+
+/**
+ * Hard char cap applied to each `inputSummary` and `outputSummary` in
+ * the tool-call trace. Truncation is suffix-based ("… (truncated)") so
+ * the evaluator can tell when content was cut. Inputs use a smaller
+ * budget than outputs because input args are typically short while
+ * outputs (snapshots, page text) can be huge.
+ */
+export const TRACE_INPUT_TRUNCATE_CHARS = 200;
+export const TRACE_OUTPUT_TRUNCATE_CHARS = 800;

--- a/apps/extension/src/lib/agent/current-agent-model.ts
+++ b/apps/extension/src/lib/agent/current-agent-model.ts
@@ -1,0 +1,37 @@
+/**
+ * Module-scoped holder for the currently-active executor `LanguageModel`.
+ *
+ * Lives in its own small module (rather than `agent-transport.ts`) so
+ * tools and the Goal Contract evaluator can read the active model
+ * without transitively importing the full agent-transport dependency
+ * tree — which pulls in `chrome.runtime` at module-load time and breaks
+ * unit tests running in Node.
+ *
+ * The transport is the sole writer; readers should never write here
+ * outside of testing helpers (the existing `setCurrentAgentModel` is
+ * exported for that reason).
+ */
+
+import type { LanguageModel } from "ai";
+
+let currentAgentModel: LanguageModel | null = null;
+
+/**
+ * Returns the executor model for the currently-active agent run, or
+ * `null` if no agent run is active. Tools (`extract`) and the Goal
+ * Contract evaluator read this when they need an LLM but don't have
+ * one threaded explicitly.
+ */
+export function getCurrentAgentModel(): LanguageModel | null {
+  return currentAgentModel;
+}
+
+/**
+ * Set the active model. Called by `createAgentTransport` when it
+ * resolves the user's chosen agent model. Tests may also call this
+ * directly to inject a mock model when exercising tools or the
+ * evaluator in isolation.
+ */
+export function setCurrentAgentModel(model: LanguageModel | null): void {
+  currentAgentModel = model;
+}

--- a/apps/extension/src/lib/agent/message-types.ts
+++ b/apps/extension/src/lib/agent/message-types.ts
@@ -27,6 +27,7 @@ export type SerializedUIPart =
   | { type: "source-url"; sourceId: string; url: string; title?: string }
   | { type: "step-start" }
   | CompactionPart
+  | CompletionCheckRejectionPart
   | SerializedToolPart;
 
 /**
@@ -54,6 +55,129 @@ export interface CompactionData {
 }
 
 /**
+ * Marker part inserted when the completion-check evaluator rejects the
+ * executor's drafted final response. The next executor turn is driven by
+ * this concern list (the transport substitutes the part with structured
+ * completion-check feedback text before sending to the model). The UI
+ * renders it as a distinct comment block so users can see why the loop
+ * continued.
+ *
+ * `rejectionRound` is 1-indexed and useful both for UI ordering and for
+ * detecting when we're approaching the max-rounds cap.
+ *
+ * `concerns` is duplicated from the underlying `EvaluatorVerdict` so the
+ * UI doesn't need to look up a separate verdict store; we keep the part
+ * self-contained.
+ */
+export interface CompletionCheckRejectionPart {
+  type: "data-completion-check-rejection";
+  data: CompletionCheckRejectionData;
+}
+
+export interface CompletionCheckRejectionData {
+  rejectionRound: number;
+  reasoning: string;
+  concerns: {
+    dimension: string;
+    /**
+     * Internal/export-only technical description of the concern.
+     * Surfaced in the markdown export and in the synthetic feedback
+     * message sent to the agent. NOT shown directly in the inline
+     * chat UI.
+     */
+    detail: string;
+    /**
+     * User-facing one-sentence summary, in plain observation voice.
+     * Surfaced inline in the rejection block. See the `Concern.userSummary`
+     * JSDoc in `completion-check/types.ts` for the formatting contract
+     * the evaluator must follow.
+     */
+    userSummary: string;
+    evidence?: string;
+  }[];
+  /**
+   * True when this is the final allowed rejection — the next turn is the
+   * force-emit case. The UI may render a "force-emitted" badge so users
+   * understand the response shipped despite open concerns.
+   */
+  forceEmittedNext?: boolean;
+  /**
+   * Why the gate emitted this block. Used by the UI to render the
+   * appropriate visual variant:
+   *
+   *  - undefined / "max-rounds-exceeded": real evaluator concerns the
+   *    user should see (red/amber banner, expandable concern list).
+   *  - "evaluator-error": the evaluator itself failed to commit a
+   *    verdict (model hit step cap without finalizing, network blip,
+   *    etc.). The agent's response is unaffected; render as a quiet
+   *    gray informational note rather than an alarming error.
+   *
+   * Always undefined for in-loop rejections that triggered another
+   * round; only set on terminal force-emit blocks.
+   */
+  reason?: "max-rounds-exceeded" | "evaluator-error";
+}
+
+/**
+ * Live status indicator for an active completion-check evaluator call.
+ *
+ * Emitted by the rejection loop driver in `compacting-transport.ts` to
+ * fill the silent window between "assistant draft finished streaming"
+ * and "evaluator produced a verdict." Without this, an evaluator call
+ * that takes 5–30s leaves the UI looking stuck — the message is fully
+ * visible but the gate is invisibly running.
+ *
+ * Lifecycle (one stable `id` per gate invocation):
+ *  1. Just before `runCompletionCheck` runs: emit
+ *     `{ id, phase: "evaluating" }`. The UI renders an inline
+ *     "Running quality check…" pill.
+ *  2. After the verdict resolves: emit
+ *     `{ id, phase: "done", outcome: "approved" | "rejected" | ... }`
+ *     using the SAME id so the SDK overwrites the existing part's
+ *     data. The UI then renders nothing — done is a terminal hide
+ *     for every outcome (rejected/force-emitted are surfaced by the
+ *     sibling rejection block; approved/skipped are silent).
+ *
+ * Multi-round rejection loops emit one running entry per round (each
+ * with a fresh id) so the user sees the gate run on each iteration.
+ *
+ * Skipped turns (trigger heuristic returned `gate: false`) do NOT emit
+ * a running entry — the transport pre-checks `shouldGate` before
+ * starting the lifecycle so we never flash a pill that immediately
+ * vanishes.
+ *
+ * Persistence: running parts are STRIPPED at serialize time
+ * (`useAgentChat.ts` `serializeParts`). They never round-trip to
+ * chatDb. The data is purely a live-stream concern.
+ */
+export interface CompletionCheckRunningData {
+  /**
+   * UUID generated per gate invocation. Stable across the
+   * "evaluating" → "done" transition so the SDK overwrites in place
+   * rather than appending a second part.
+   */
+  id: string;
+  /**
+   * Current phase of the gate call.
+   *  - "evaluating": the LLM call is in flight; UI shows the spinner.
+   *  - "done":       a verdict has been produced. UI renders nothing
+   *                  (concerns, when present, are surfaced by the
+   *                  sibling rejection block; clean approves are silent).
+   */
+  phase: "evaluating" | "done";
+  /**
+   * The gate's resolved outcome kind. Set only when `phase === "done"`.
+   *
+   * The UI ignores this field today — every outcome on `done` renders
+   * nothing — but it's preserved on the wire (a) so the rejection-
+   * loop tests can assert the transport reports outcomes correctly,
+   * and (b) so a future telemetry/diagnostics surface can read it
+   * without re-plumbing.
+   */
+  outcome?: "approved" | "skipped" | "rejected" | "force-emitted";
+}
+
+/**
  * Custom `DATA_PARTS` map for our `UIMessage`. Keying `compaction` here
  * registers a `data-compaction` variant on `UIMessagePart<AgentDataParts, ...>`
  * with `data: CompactionData`. This is what lets us narrow on
@@ -65,6 +189,8 @@ export interface CompactionData {
  */
 export type AgentDataParts = {
   compaction: CompactionData;
+  "completion-check-rejection": CompletionCheckRejectionData;
+  "completion-check-running": CompletionCheckRunningData;
 };
 
 /**

--- a/apps/extension/src/lib/agent/message-types.ts
+++ b/apps/extension/src/lib/agent/message-types.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import type { ConcernDimension } from "./completion-check/types";
 
 export interface ChatMessage {
   id: string;
@@ -78,7 +79,7 @@ export interface CompletionCheckRejectionData {
   rejectionRound: number;
   reasoning: string;
   concerns: {
-    dimension: string;
+    dimension: ConcernDimension;
     /**
      * Internal/export-only technical description of the concern.
      * Surfaced in the markdown export and in the synthetic feedback

--- a/apps/extension/src/lib/agent/tools/extract.ts
+++ b/apps/extension/src/lib/agent/tools/extract.ts
@@ -1,6 +1,6 @@
 import { generateObject, jsonSchema } from "ai";
 import { z } from "zod";
-import { getCurrentAgentModel } from "../agent-transport";
+import { getCurrentAgentModel } from "../current-agent-model";
 import { resolveTabOrThrow } from "../driver";
 import { captureSnapshot, captureSnapshotWithUrlIds } from "../snapshot-capture";
 import type { BrowserTool } from "../types";

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -358,7 +358,20 @@ export const chatDb = {
       conversationId,
     );
     const target = msgs.find((m) => m.id === messageId);
-    if (!target) return;
+    if (!target) {
+      // Loud rather than silent: a missing target almost always means the
+      // caller passed an id from one source (e.g. the AI SDK's in-memory
+      // chat state) that does not match the id stored in chatDb. The
+      // historical "edit user message leaves stale tail in chat-db"
+      // bug was caused by exactly this kind of id mismatch in
+      // `handleSubmit` / queue-flush, and went undetected for months
+      // because this function returned silently. Surface it now so the
+      // next regression is visible at the first repro.
+      console.warn(
+        `[chatDb] deleteMessagesFrom: messageId ${messageId} not found in conversation ${conversationId}; nothing deleted`,
+      );
+      return;
+    }
     const toDelete = msgs.filter((m) => m.createdAt >= target.createdAt);
     const tx = db.transaction("messages", "readwrite");
     for (const msg of toDelete) {

--- a/apps/extension/src/lib/format-markdown.ts
+++ b/apps/extension/src/lib/format-markdown.ts
@@ -1,10 +1,49 @@
-import type { AgentUIMessage } from "./types";
+import type { CompletionCheckRejectionData } from "./types";
 
 export function formatPartAsMarkdown(part: any): string | null {
   if (part.type === "text" && part.text.trim()) {
     return part.text;
   }
-  
+
+  // Completion-check rejection block: render as a blockquote section so
+  // the export reflects what the user saw in the UI.
+  //
+  // We intentionally do NOT also render the synthetic "follow-up sent
+  // to agent" message here. That payload duplicates the reasoning and
+  // concerns already shown above, and the only unique content (the
+  // round number and the boilerplate "Continue working…" directive)
+  // doesn't earn its keep — the directive is a fixed constant, and
+  // round numbers are a UX leak per earlier preference.
+  //
+  // Force-emit and evaluator-error variants share the same render
+  // path; they just don't have a "follow-up" concept anyway because
+  // the loop terminates without sending anything.
+  if (part.type === "data-completion-check-rejection") {
+    const data = part.data as CompletionCheckRejectionData;
+
+    if (data.reason === "evaluator-error") {
+      return `> _Quality check skipped — evaluator could not complete._`;
+    }
+
+    const heading = data.forceEmittedNext
+      ? "**Completion check failed**"
+      : "**Completion check**";
+    const lines: string[] = [`> ${heading}`, `>`];
+    if (data.reasoning) lines.push(`> ${data.reasoning}`, `>`);
+    for (const c of data.concerns) {
+      lines.push(`> - **${c.dimension}**: ${c.detail}`);
+      if (c.evidence) lines.push(`>   _Evidence:_ ${c.evidence}`);
+    }
+    return lines.join("\n");
+  }
+
+  // Running indicator (spinner): per user preference, exports carry
+  // only rejection blocks. Drop the running indicator entirely so
+  // clean turns don't add a line of noise to the export.
+  if (part.type === "data-completion-check-running") {
+    return null;
+  }
+
   if (
     part.type === "dynamic-tool" ||
     (typeof part.type === "string" &&

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import type { CompletionCheckSettings } from "./agent/completion-check/types";
 import type { McpServerConfig } from "./mcp/types";
 
 export interface FavoriteTab {
@@ -57,6 +58,12 @@ export interface Settings {
 
   // Connectors
   mcpServers: McpServerConfig[];
+
+  // Completion check (verify-gated completion). The check is always on
+  // by default; the only user-facing knob is the evaluator model.
+  // Optional for backward compatibility with persisted Settings records
+  // that pre-date this feature.
+  completionCheck?: CompletionCheckSettings;
 
   // DEPRECATED — kept for migration only
   aiProvider?: AIProvider;


### PR DESCRIPTION
## What's new

A separate skeptical evaluator now reviews each drafted response before
it reaches you. If the response is incomplete or claims something the
agent didn't actually verify, the evaluator asks the agent to revise.

You'll see two new states inline:

- **Refining answer** — compact pill that appears when the evaluator
  caught something and asked the agent to take another pass. Click to
  see what was raised.
- **This response may have issues** — soft warning when the agent
  shipped despite open concerns (after a few rounds of revision).

Approved responses are silent — no badge, no extra UI noise.

## Settings

A new **Completion check model** dropdown in Settings → General lets
you pick a cheaper or faster model for the reviewer. Defaults to your
agent model with a fresh context.

## Exports

Chat exports and the per-message Copy button now include the rejection
block alongside the response, so the audit trail travels with the
conversation.

## Reliability fixes bundled in

- Tab handles persist across mid-stream conversation switches.
- Stranded tool calls heal cleanly on edit/retry instead of breaking
  conversation resume.
- Approving a tool while others are still running no longer drops the
  auto-resume.
- chat-db now warns when editing fails to find the target message id.

---

294 tests passing. Two changesets included: minor for the feature,
patch for the reliability fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Response verification gate with a skeptical evaluator (mid-loop “Refining answer” updates), per-message rejection UI and exported rejection block, plus a new setting to choose the completion-check model.
  * Inline “Running quality check…” indicator while evaluating.

* **UI**
  * Tool-call UI shows explicit errored state; exports omit running indicators.

* **Bug Fixes**
  * Pinning tool execution/evaluation to a conversation snapshot to avoid cross-window drift; healed stranded tool calls and preserved auto-resume on partial approvals; logs a warning when editing a missing message id.

* **Tests**
  * Adds extensive unit/integration tests covering verification, pinning, healing, serialization, exports, and telemetry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->