### PR TITLE
fix: completion-check pending tools, error log clamp, always-allow race

### DIFF
--- a/.changeset/fix-tool-ui-bundle.md
+++ b/.changeset/fix-tool-ui-bundle.md
@@ -1,0 +1,9 @@
+---
+"openbrowse": patch
+---
+
+Fix three small chat issues:
+
+- Completion check no longer runs while a tool call is paused on human approval. The drafted text at that point is mid-narration ("I'll now run X to do Y") and isn't a final response — the gate now waits for the next iteration after approval, when the tool actually has output.
+- Long tool error logs collapse to ~10 visual lines with an inline expand toggle. Single-line errors that wrapped to dozens of visual lines now collapse correctly (the previous clamp only counted `\n`-delimited lines). Applied to executeCode/executeOnPage/executePython error output, the skill tool's error block, and the top-level chat error banner.
+- "Always allow on <site>" now reliably persists before the agent resumes. The previous implementation fired the storage write and the approval synchronously, so the next tool call's `needsApproval` check could race the write and re-prompt — most reproducible on home.html with back-to-back executeOnPage calls.

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -5,6 +5,7 @@ import {
 } from "./ChatInput";
 import { ChatMessage } from "./ChatMessage";
 import { CompactionDivider } from "./CompactionDivider";
+import { ExpandableText } from "./tool-results/expandable-text";
 import {
   Conversation,
   ConversationContent,
@@ -896,9 +897,19 @@ function ErrorMessage({
             <p className="text-xs text-destructive font-medium">
               Something went wrong
             </p>
-            <p className="text-xs text-muted-foreground mt-0.5 break-words">
-              {error.message}
-            </p>
+            {/*
+              * Provider SDK errors can carry full request payloads,
+              * stack traces, or upstream HTML responses — easily
+              * dozens of visual lines. Clamp to ~10 visual lines with
+              * an inline expand toggle. `font-sans` overrides
+              * ExpandableText's <pre> default so the banner keeps the
+              * surrounding chat font; `text-muted-foreground` and
+              * `break-words` reproduce the previous styling.
+              */}
+            <ExpandableText
+              text={error.message}
+              className="text-xs text-muted-foreground mt-0.5 break-words font-sans"
+            />
             <div className="flex items-center gap-2 mt-1.5">
               <button
                 type="button"

--- a/apps/extension/src/components/chat/ToolApprovalBlock.tsx
+++ b/apps/extension/src/components/chat/ToolApprovalBlock.tsx
@@ -1,5 +1,5 @@
 import { Check, ShieldCheck, X } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { getToolPreview } from "./tool-previews";
 import { DefaultPreview } from "./tool-previews/primitives";
 import { TabBadge } from "./ToolCallBlock";
@@ -12,11 +12,62 @@ interface ToolApprovalBlockProps {
   siteOrigin?: string;
   onApprove: (id: string) => void;
   onDeny: (id: string) => void;
-  onAlwaysAllow?: (toolName: string, origin: string) => void;
+  /**
+   * Persist "Always allow on <site>" for this tool/origin pair.
+   *
+   * Returns a `Promise` because the implementation writes to
+   * `chrome.storage.local`, which is async. Callers MUST await this
+   * promise before resuming the agent — otherwise the next tool call's
+   * `needsApproval` callback may read the pre-write allowlist and
+   * prompt the user again. The race manifested most reliably on
+   * home.html where back-to-back `executeOnPage` calls hit the
+   * `needsApproval` check before the storage write landed.
+   */
+  onAlwaysAllow?: (toolName: string, origin: string) => Promise<void> | void;
+}
+
+/**
+ * Extracted handler for the "Always allow on <site>" button click so
+ * it's exercisable in unit tests without React Testing Library.
+ *
+ * Contract: ALWAYS approve the in-flight call after attempting the
+ * persist, even on persist failure. The user's intent (approve this
+ * call) is independent of the cross-call grant; failing the grant
+ * silently is preferable to leaving the agent stuck.
+ *
+ * Order is load-bearing: the persist must complete before approve so
+ * the next tool call's `needsApproval` reads the new allowlist. See
+ * the comment in the component body for context.
+ *
+ * Exported for unit tests.
+ */
+export async function handleAlwaysAllow(args: {
+  toolName: string;
+  origin: string;
+  approvalId: string;
+  onAlwaysAllow: (toolName: string, origin: string) => Promise<void> | void;
+  onApprove: (id: string) => void;
+  /** Test seam for capturing console warnings on persist failure. */
+  warn?: (...parts: unknown[]) => void;
+}): Promise<void> {
+  try {
+    await args.onAlwaysAllow(args.toolName, args.origin);
+  } catch (err) {
+    (args.warn ?? console.warn)(
+      "[approval] failed to persist 'always allow' grant; approving anyway",
+      err,
+    );
+  } finally {
+    args.onApprove(args.approvalId);
+  }
 }
 
 export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, siteOrigin, onApprove, onDeny, onAlwaysAllow }: ToolApprovalBlockProps) {
   const customPreview = getToolPreview(toolName);
+  // True between the user clicking "Always allow on <site>" and the
+  // storage write resolving. Disables both approval buttons during the
+  // window so a quick second click can't bypass the await.
+  const [persistingAllowlist, setPersistingAllowlist] = useState(false);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -47,7 +98,8 @@ export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, site
             <button
               type="button"
               onClick={() => onDeny(approvalId)}
-              className="flex items-center gap-1.5 whitespace-nowrap rounded px-2.5 py-1.5 text-xs font-medium bg-muted text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              disabled={persistingAllowlist}
+              className="flex items-center gap-1.5 whitespace-nowrap rounded px-2.5 py-1.5 text-xs font-medium bg-muted text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none"
             >
               <X className="size-3.5 shrink-0" />
               Deny
@@ -55,7 +107,8 @@ export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, site
             <button
               type="button"
               onClick={() => onApprove(approvalId)}
-              className="flex items-center gap-1.5 whitespace-nowrap rounded px-2.5 py-1.5 text-xs font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
+              disabled={persistingAllowlist}
+              className="flex items-center gap-1.5 whitespace-nowrap rounded px-2.5 py-1.5 text-xs font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors disabled:opacity-60 disabled:pointer-events-none"
             >
               <Check className="size-3.5 shrink-0" />
               Allow
@@ -67,11 +120,24 @@ export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, site
           {displayOrigin && onAlwaysAllow && (
             <button
               type="button"
-              onClick={() => {
-                onAlwaysAllow(toolName, siteOrigin!);
-                onApprove(approvalId);
+              disabled={persistingAllowlist}
+              onClick={async () => {
+                if (persistingAllowlist) return;
+                setPersistingAllowlist(true);
+                // CRITICAL: persist must complete BEFORE approving.
+                // The previous implementation fired both calls
+                // synchronously, racing the chrome.storage.local
+                // write against the next tool call's needsApproval
+                // callback. See `handleAlwaysAllow` JSDoc.
+                await handleAlwaysAllow({
+                  toolName,
+                  origin: siteOrigin!,
+                  approvalId,
+                  onAlwaysAllow,
+                  onApprove,
+                });
               }}
-              className="flex items-center justify-center gap-1.5 w-full rounded px-2.5 py-1.5 text-xs font-medium bg-muted text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              className="flex items-center justify-center gap-1.5 w-full rounded px-2.5 py-1.5 text-xs font-medium bg-muted text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-60 disabled:pointer-events-none"
             >
               <ShieldCheck className="size-3.5 shrink-0" />
               Always allow on {displayOrigin}

--- a/apps/extension/src/components/chat/ToolApprovalBlock.tsx
+++ b/apps/extension/src/components/chat/ToolApprovalBlock.tsx
@@ -72,13 +72,28 @@ export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, site
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        // Mirror the disabled state of the click buttons. While
+        // `persistingAllowlist` is true, the click handler is
+        // awaiting the chrome.storage.local write before calling
+        // onApprove itself; bypassing that via Cmd+Enter would race
+        // the next tool call's needsApproval against the in-flight
+        // write (the exact bug fixed for the click path). Swallow
+        // the shortcut entirely until the persist resolves.
+        if (persistingAllowlist) {
+          e.preventDefault();
+          return;
+        }
         e.preventDefault();
         onApprove(approvalId);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [approvalId, onApprove]);
+    // `persistingAllowlist` is intentionally in the deps array: the
+    // effect re-registers on each transition (false → true → false)
+    // so the closure captures the latest value. addEventListener /
+    // removeEventListener are O(1); the re-register cost is trivial.
+  }, [approvalId, onApprove, persistingAllowlist]);
 
   const displayOrigin = siteOrigin ? new URL(siteOrigin).hostname : undefined;
 

--- a/apps/extension/src/components/chat/__tests__/expandable-text.test.ts
+++ b/apps/extension/src/components/chat/__tests__/expandable-text.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { estimateVisualLines } from "../tool-results/expandable-text";
+
+/**
+ * Pure-function tests for the visual-line estimator. The component's
+ * collapse decision keys off this estimate, so the branches we care
+ * about — short newline-rich strings, long single-line strings, mixed
+ * — are exercised here without React Testing Library setup.
+ *
+ * Background: before this change, `ExpandableText` only collapsed when
+ * `text.split("\n").length > maxLines`, so a 1-line, 600-char tool
+ * error wrapped to 7-8 visual lines but the clamp never fired. The
+ * estimator counts both `\n`-delimited lines and visually-wrapped long
+ * lines so the new gate `estimateVisualLines(text) > maxLines` catches
+ * both shapes.
+ */
+
+const COL_WIDTH = 80; // matches the component's default
+
+describe("estimateVisualLines", () => {
+  it("returns 0 for empty input", () => {
+    expect(estimateVisualLines("")).toBe(0);
+  });
+
+  it("counts each \\n-delimited line as at least one visual line", () => {
+    expect(estimateVisualLines("a\nb\nc")).toBe(3);
+  });
+
+  it("treats a blank line as one visual line (preserves spacing)", () => {
+    expect(estimateVisualLines("a\n\nb")).toBe(3);
+  });
+
+  it("estimates a single long line by character-width wrapping", () => {
+    // 600 chars / 80 per line = 8 visual lines.
+    const text = "x".repeat(600);
+    expect(estimateVisualLines(text, COL_WIDTH)).toBe(Math.ceil(600 / 80));
+  });
+
+  it("rounds up partial lines (a 100-char line is 2 visual lines)", () => {
+    expect(estimateVisualLines("y".repeat(100), COL_WIDTH)).toBe(2);
+  });
+
+  it("sums newline-delimited segments individually rather than wrapping the whole string", () => {
+    // Two short lines separated by \n should be 2 visual lines, NOT
+    // ceil(total/80) — preserves the user's authored line breaks.
+    const text = `${"a".repeat(50)}\n${"b".repeat(50)}`;
+    expect(estimateVisualLines(text, COL_WIDTH)).toBe(2);
+  });
+
+  it("handles a long line followed by short lines", () => {
+    const text = `${"a".repeat(200)}\nb\nc`;
+    // 200/80 = 3 lines for the first segment, +1 +1 for the rest.
+    expect(estimateVisualLines(text, COL_WIDTH)).toBe(5);
+  });
+
+  // Regression: the original component bug. A 1-line, 600-char error
+  // had visualLines=8 but lines.length=1, so the old gate
+  // (`lines.length > maxLines`) returned false. The new estimator
+  // returns 8, so a `> 10` cap still doesn't fire here — which is
+  // correct, the new behavior should match the old `lines.length`
+  // count when content is short — but the clamp with `maxLines: 7`
+  // demonstrates the case the old code missed.
+  it("would clamp a single 600-char line at maxLines=7 (old behavior would not)", () => {
+    const text = "x".repeat(600);
+    const visualLines = estimateVisualLines(text, COL_WIDTH);
+    expect(visualLines).toBeGreaterThan(7);
+    // Old behavior: text.split("\n").length === 1 → never clamps.
+    expect(text.split("\n").length).toBe(1);
+  });
+
+  it("uses a configurable charsPerLine when callers want a tighter clamp", () => {
+    expect(estimateVisualLines("a".repeat(40), 40)).toBe(1);
+    expect(estimateVisualLines("a".repeat(41), 40)).toBe(2);
+  });
+});

--- a/apps/extension/src/components/chat/__tests__/expandable-text.test.ts
+++ b/apps/extension/src/components/chat/__tests__/expandable-text.test.ts
@@ -18,8 +18,14 @@ import { estimateVisualLines } from "../tool-results/expandable-text";
 const COL_WIDTH = 80; // matches the component's default
 
 describe("estimateVisualLines", () => {
-  it("returns 0 for empty input", () => {
-    expect(estimateVisualLines("")).toBe(0);
+  // The JSDoc contract: "Always returns at least 1 (empty strings
+  // still occupy a line of layout)." Callers that want zero rows for
+  // empty input must short-circuit at the call site — `ExpandableText`
+  // itself returns `null` before calling, so this branch is currently
+  // unreachable in practice but the contract is preserved for any
+  // future caller.
+  it("returns 1 for empty input (one line of layout)", () => {
+    expect(estimateVisualLines("")).toBe(1);
   });
 
   it("counts each \\n-delimited line as at least one visual line", () => {

--- a/apps/extension/src/components/chat/__tests__/tool-approval-block.test.ts
+++ b/apps/extension/src/components/chat/__tests__/tool-approval-block.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleAlwaysAllow } from "../ToolApprovalBlock";
+
+/**
+ * Tests for the "Always allow on <site>" click ordering.
+ *
+ * The bug: previous implementation fired `onAlwaysAllow` (async — writes
+ * to chrome.storage.local) and `onApprove` synchronously, so the agent
+ * resumed before the storage write landed. The next tool call's
+ * `needsApproval` callback then read the pre-write allowlist and
+ * prompted the user again — observed reliably on home.html where the
+ * agent issues back-to-back executeOnPage calls.
+ *
+ * The fix: handleAlwaysAllow awaits the persist before invoking
+ * onApprove, even when the persist throws (rare; storage quota
+ * exhausted). The user's intent to approve THIS call is independent of
+ * the cross-call grant.
+ */
+
+describe("handleAlwaysAllow", () => {
+  it("awaits the persist before calling onApprove", async () => {
+    const events: string[] = [];
+
+    let resolvePersist!: () => void;
+    const persistPromise = new Promise<void>((resolve) => {
+      resolvePersist = resolve;
+    });
+
+    const onAlwaysAllow = vi.fn(async () => {
+      events.push("persist:start");
+      await persistPromise;
+      events.push("persist:end");
+    });
+    const onApprove = vi.fn(() => {
+      events.push("approve");
+    });
+
+    const handlerPromise = handleAlwaysAllow({
+      toolName: "executeOnPage",
+      origin: "https://bookface.ycombinator.com",
+      approvalId: "ap-1",
+      onAlwaysAllow,
+      onApprove,
+    });
+
+    // Synchronously after kicking the handler off, persist has started
+    // but onApprove hasn't been called yet. This is the load-bearing
+    // ordering — the previous implementation called onApprove here.
+    expect(events).toEqual(["persist:start"]);
+    expect(onApprove).not.toHaveBeenCalled();
+
+    resolvePersist();
+    await handlerPromise;
+
+    expect(events).toEqual(["persist:start", "persist:end", "approve"]);
+    expect(onApprove).toHaveBeenCalledExactlyOnceWith("ap-1");
+    expect(onAlwaysAllow).toHaveBeenCalledExactlyOnceWith(
+      "executeOnPage",
+      "https://bookface.ycombinator.com",
+    );
+  });
+
+  it("still approves when the persist throws (storage quota etc.)", async () => {
+    const onAlwaysAllow = vi.fn(async () => {
+      throw new Error("QUOTA_BYTES exceeded");
+    });
+    const onApprove = vi.fn();
+    const warn = vi.fn();
+
+    await handleAlwaysAllow({
+      toolName: "executeOnPage",
+      origin: "https://bookface.ycombinator.com",
+      approvalId: "ap-2",
+      onAlwaysAllow,
+      onApprove,
+      warn,
+    });
+
+    expect(onApprove).toHaveBeenCalledExactlyOnceWith("ap-2");
+    // Persist failure is logged but not re-thrown — the agent's task
+    // shouldn't fail just because the cross-call grant couldn't be
+    // recorded.
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toMatch(/failed to persist/i);
+  });
+
+  it("supports synchronous onAlwaysAllow implementations", async () => {
+    // The prop type allows `void | Promise<void>` for callers who
+    // want to skip persistence (e.g. tests or in-memory grants).
+    const onAlwaysAllow = vi.fn();
+    const onApprove = vi.fn();
+
+    await handleAlwaysAllow({
+      toolName: "executeOnPage",
+      origin: "https://example.com",
+      approvalId: "ap-3",
+      onAlwaysAllow,
+      onApprove,
+    });
+
+    expect(onAlwaysAllow).toHaveBeenCalledOnce();
+    expect(onApprove).toHaveBeenCalledExactlyOnceWith("ap-3");
+  });
+});

--- a/apps/extension/src/components/chat/tool-results/expandable-text.tsx
+++ b/apps/extension/src/components/chat/tool-results/expandable-text.tsx
@@ -35,7 +35,12 @@ export function estimateVisualLines(
   text: string,
   charsPerLine: number = ESTIMATED_CHARS_PER_VISUAL_LINE,
 ): number {
-  if (!text) return 0;
+  // Per the contract above, even an empty string occupies one line of
+  // layout. The split below produces `[""]` for empty input, the loop
+  // runs once, and `Math.max(1, …)` yields 1 — so we don't need a
+  // dedicated empty-string branch. Callers that want zero rows for
+  // empty input should short-circuit at the call site (see
+  // `ExpandableText` itself, which returns `null` before calling).
   const lines = text.split("\n");
   let total = 0;
   for (const line of lines) {

--- a/apps/extension/src/components/chat/tool-results/expandable-text.tsx
+++ b/apps/extension/src/components/chat/tool-results/expandable-text.tsx
@@ -4,18 +4,83 @@ import { cn } from "@/lib/utils";
 
 interface ExpandableTextProps {
   text: string;
+  /**
+   * Soft cap on visible lines when collapsed. Both `\n`-delimited lines
+   * and visually-wrapped long lines count: a 1-line, 600-character
+   * tool error wraps to ~7-8 visual lines at typical chat width and
+   * still gets clamped (without this rule, a single long line never
+   * collapsed because `text.split("\n").length === 1`).
+   */
   maxLines?: number;
   className?: string;
 }
 
-export function ExpandableText({ text, maxLines = 10, className }: ExpandableTextProps) {
+/**
+ * Approximate column width used to estimate the number of visual lines
+ * a single long string will wrap to. Tool error messages render in the
+ * chat at roughly this width with the current font/size — close enough
+ * for a clamp threshold; we don't need pixel-perfect measurement.
+ */
+const ESTIMATED_CHARS_PER_VISUAL_LINE = 80;
+
+/**
+ * Estimate how many visual lines `text` will occupy at the given column
+ * width, treating `\n` as a hard wrap and assuming naive whole-character
+ * wrapping for the rest. Always returns at least 1 (empty strings still
+ * occupy a line of layout).
+ *
+ * Exported for unit tests.
+ */
+export function estimateVisualLines(
+  text: string,
+  charsPerLine: number = ESTIMATED_CHARS_PER_VISUAL_LINE,
+): number {
+  if (!text) return 0;
+  const lines = text.split("\n");
+  let total = 0;
+  for (const line of lines) {
+    // Each \n-delimited segment occupies at least one visual line, even
+    // if empty (preserves blank-line spacing in the rendered <pre>).
+    total += Math.max(1, Math.ceil(line.length / charsPerLine));
+  }
+  return total;
+}
+
+export function ExpandableText({
+  text,
+  maxLines = 10,
+  className,
+}: ExpandableTextProps) {
   const [expanded, setExpanded] = useState(false);
-  
+
   if (!text) return null;
 
   const lines = text.split("\n");
-  const isExpandable = lines.length > maxLines;
-  const displayText = (!isExpandable || expanded) ? text : lines.slice(0, maxLines).join("\n");
+  const visualLines = estimateVisualLines(text);
+  const isExpandable = visualLines > maxLines;
+
+  // When collapsed, prefer slicing on `\n` boundaries when there are
+  // enough of them; fall back to a character slice for the
+  // single-long-line case so we never render the full string when the
+  // clamp wants to hide content.
+  let displayText: string;
+  if (!isExpandable || expanded) {
+    displayText = text;
+  } else if (lines.length > maxLines) {
+    displayText = lines.slice(0, maxLines).join("\n");
+  } else {
+    const sliceChars = maxLines * ESTIMATED_CHARS_PER_VISUAL_LINE;
+    displayText = text.slice(0, sliceChars);
+  }
+
+  // Toggle label depends on which clamp branch fired. Newline-bounded
+  // collapse can give an exact "Show N more lines" count; the single-
+  // long-line case has no meaningful line count, so use a generic
+  // label.
+  const showMoreLabel =
+    lines.length > maxLines
+      ? `Show ${lines.length - maxLines} more lines`
+      : "Show full output";
 
   return (
     <div className="relative group">
@@ -33,7 +98,7 @@ export function ExpandableText({ text, maxLines = 10, className }: ExpandableTex
             </>
           ) : (
             <>
-              <ChevronDown className="size-3" /> Show {lines.length - maxLines} more lines
+              <ChevronDown className="size-3" /> {showMoreLabel}
             </>
           )}
         </button>

--- a/apps/extension/src/components/chat/tool-results/skill.tsx
+++ b/apps/extension/src/components/chat/tool-results/skill.tsx
@@ -1,5 +1,6 @@
 import { BookOpen } from "lucide-react";
 import Markdown from "react-markdown";
+import { ExpandableText } from "./expandable-text";
 
 interface Props {
   args: Record<string, unknown>;
@@ -21,7 +22,17 @@ export function SkillResult({ args, result }: Props) {
         <div className="bg-background/50 max-h-64 overflow-y-auto styled-scrollbar">
           {resultObj.error ? (
             <div className="px-3 py-2">
-              <pre className="whitespace-pre-wrap font-mono text-red-400">{resultObj.error}</pre>
+              {/*
+                * Skill errors can be long stack traces or wrapped
+                * underlying errors. Use ExpandableText to clamp at
+                * 10 visual lines with an inline expand toggle —
+                * matches the executeCode / executePython error
+                * surfaces.
+                */}
+              <ExpandableText
+                text={resultObj.error}
+                className="font-mono text-red-400"
+              />
             </div>
           ) : resultObj.content ? (
             <div className="px-3 py-2 prose prose-sm dark:prose-invert max-w-none text-foreground/80 prose-p:leading-snug prose-pre:bg-muted/50">

--- a/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
@@ -139,6 +139,59 @@ describe("shouldGate", () => {
     });
     expect(r).toEqual({ gate: true });
   });
+
+  // Iteration paused mid-task on a tool that needs human approval.
+  // The SDK closes the stream after `tool-input-available` +
+  // `tool-approval-request` without ever emitting an output chunk, so
+  // the trace entry is left in `state: "pending"`. The drafted text
+  // is mid-narration ("I'll now run X to do Y") and shouldn't trigger
+  // the evaluator — the gate fires on the next iteration after
+  // approval, when the tool actually has output.
+  it("skips when any tool call is still pending (e.g. awaiting approval)", () => {
+    const r = shouldGate({
+      finalText: "I'll run executeOnPage to inspect the page now.",
+      todos: [],
+      toolCallTrace: [makeTrace("executeOnPage", { state: "pending" })],
+    });
+    expect(r).toEqual({
+      gate: false,
+      reason: "pending-tool-calls" satisfies SkipReason,
+    });
+  });
+
+  // A pending entry poisons the gate even when other tools in the
+  // same iteration completed. Multi-tool steps where one auto-allowed
+  // tool ran and the next is approval-gated would otherwise leak
+  // through.
+  it("skips when at least one tool call is pending alongside completed ones", () => {
+    const r = shouldGate({
+      finalText: "Found the price; about to verify.",
+      todos: [],
+      toolCallTrace: [
+        makeTrace("snapshot", { state: "completed" }),
+        makeTrace("executeOnPage", { state: "pending" }),
+      ],
+    });
+    expect(r).toEqual({
+      gate: false,
+      reason: "pending-tool-calls" satisfies SkipReason,
+    });
+  });
+
+  // Pending takes priority over the trivial-turn skip too — a tool
+  // call exists, just not in a terminal state. Prefer the more
+  // specific "still in flight" reason for telemetry.
+  it("skips with pending-tool-calls when the only trace entry is pending and no todos", () => {
+    const r = shouldGate({
+      finalText: "Running…",
+      todos: [],
+      toolCallTrace: [makeTrace("executeOnPage", { state: "pending" })],
+    });
+    expect(r).toEqual({
+      gate: false,
+      reason: "pending-tool-calls" satisfies SkipReason,
+    });
+  });
 });
 
 describe("runEvaluator (real, mocked LLM)", () => {
@@ -855,6 +908,38 @@ describe("runCompletionCheck (real evaluator with mocked LLM)", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].outcomeKind).toBe("skipped");
     expect(rows[0].skipReason).toBe("trigger-not-met");
+  });
+
+  // Reproduces the bug where the gate fired against an iteration
+  // that was paused on tool approval. The drafted text is non-empty
+  // and the trace has a tool call, but the call is in `pending`
+  // state because the user hasn't clicked Allow yet. Skip cleanly
+  // and record the new telemetry skip reason.
+  it("skips with pending-tool-calls when the iteration is paused on tool approval", async () => {
+    const out = await runCompletionCheck({
+      conversationId: "c-pending",
+      turnIndex: 0,
+      rejectionRound: 0,
+      originalRequest: "open bookface and find a profile",
+      draftedResponse: "I'll run executeOnPage to inspect the listing.",
+      todos: [],
+      toolCallTrace: [
+        {
+          name: "executeOnPage",
+          inputSummary: '{"tab":"t1"}',
+          outputSummary: null,
+          state: "pending",
+        },
+      ],
+    });
+    expect(out.kind).toBe("skipped");
+    if (out.kind === "skipped") {
+      expect(out.reason).toBe("pending-tool-calls");
+    }
+    const rows = await completionCheckTelemetry.listForConversation("c-pending");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcomeKind).toBe("skipped");
+    expect(rows[0].skipReason).toBe("pending-tool-calls");
   });
 
   it("approves when the trigger fires and the evaluator approves", async () => {

--- a/apps/extension/src/lib/agent/completion-check/index.ts
+++ b/apps/extension/src/lib/agent/completion-check/index.ts
@@ -43,6 +43,15 @@ export type { SkipReason, CompletionCheckSettings } from "./types";
  * The trigger fires when ALL of the following hold:
  *  - There is non-empty final text (otherwise the model only produced
  *    tool calls; nothing to evaluate yet).
+ *  - All of the iteration's tool calls reached a terminal state
+ *    (`completed` / `errored` / `denied`). Any entry left in
+ *    `pending` means the iteration paused mid-task — most commonly
+ *    waiting for human tool approval (`tool-approval-request` chunk
+ *    closed the stream without ever emitting `tool-output-available`).
+ *    The drafted text at that point is mid-narration ("I'll now run X
+ *    to do Y") and isn't the agent's final response. The gate will
+ *    fire on the next iteration after approval, when the tool
+ *    actually has output.
  *  - The turn was non-trivial: either the conversation has todos
  *    (planned multi-step task) OR the executor made tool calls this
  *    turn (acted on the world). Pure Q&A turns with no tools and no
@@ -63,6 +72,16 @@ export function shouldGate(
 ): { gate: true } | { gate: false; reason: SkipReason } {
   if (!candidate.finalText.trim()) {
     return { gate: false, reason: "no-final-text" };
+  }
+
+  // Iteration paused on a non-terminal tool call (most commonly an
+  // approval-gated tool waiting for the user). The "drafted response"
+  // here is mid-task narration, not a final answer; evaluating it
+  // would burn evaluator tokens against incomplete content and risk
+  // false rejections that loop the agent before the human even
+  // approves the tool. Skip; the gate fires on the next iteration.
+  if (candidate.toolCallTrace.some((t) => t.state === "pending")) {
+    return { gate: false, reason: "pending-tool-calls" };
   }
 
   // Non-trivial turn heuristic: either the agent planned (todos) or

--- a/apps/extension/src/lib/agent/completion-check/types.ts
+++ b/apps/extension/src/lib/agent/completion-check/types.ts
@@ -171,7 +171,10 @@ export interface EvaluatorVerdict {
  * is no verdict to report.
  */
 export type GateOutcome =
-  | { kind: "skipped"; reason: "trigger-not-met" | "no-final-text" }
+  | {
+      kind: "skipped";
+      reason: "trigger-not-met" | "no-final-text" | "pending-tool-calls";
+    }
   | { kind: "approved"; verdict: EvaluatorVerdict }
   | { kind: "rejected"; verdict: EvaluatorVerdict; rejectionRound: number }
   | {
@@ -212,12 +215,25 @@ export interface CompletionCheckSettings {
 export const MAX_REJECTION_ROUNDS = 3;
 
 /**
- * Why the gate skipped, when it did. The two states correspond to the
- * two early-exits in `shouldGate`:
+ * Why the gate skipped, when it did. The three states correspond to the
+ * three early-exits in `shouldGate`:
  *  - "no-final-text": tool-only step; no draft to evaluate yet.
+ *  - "pending-tool-calls": at least one tool call ended the iteration in
+ *    `state: "pending"` — its input was emitted but no output/error/denial
+ *    chunk arrived before the stream closed. The most common cause is
+ *    a tool that requires human approval: the SDK pauses the iteration
+ *    after `tool-input-available` + `tool-approval-request` and never
+ *    emits `tool-output-available` until the user clicks Allow. The
+ *    drafted text at that point is mid-task ("I'll now run X to do Y")
+ *    and shouldn't be evaluated as a final response. The gate fires on
+ *    the next iteration (after approval) when the tool actually has
+ *    output.
  *  - "trigger-not-met": trivial Q&A turn (no todos, no tool calls).
  */
-export type SkipReason = "trigger-not-met" | "no-final-text";
+export type SkipReason =
+  | "trigger-not-met"
+  | "no-final-text"
+  | "pending-tool-calls";
 
 /**
  * One entry in the trace of tool calls the executor made during the


### PR DESCRIPTION
Three independent chat-UI bugs you flagged in one session, fixed together because they all touch the tool-call path. Each is a small, focused change with tests; they're combined per your request.

## 1. Completion check ran while a tool awaited approval

When AI SDK v5 emits `tool-input-available` + `tool-approval-request`, it closes the stream without ever emitting `tool-output-available`. The observer correctly leaves the trace entry in `state: "pending"`, but `shouldGate` only checked `finalText` non-empty + non-trivial turn — so it fired against the agent's mid-task narration ("I'll now run executeOnPage to inspect the page"). The evaluator then ran on incomplete content, sometimes flagged false rejections, and even briefly flashed the "Running quality check…" pill while the user was looking at the approval prompt.

Fix: add a `"pending-tool-calls"` skip reason. Any trace entry left in `pending` poisons the gate. The gate fires on the next iteration after approval, when the tool actually has output.

- `apps/extension/src/lib/agent/completion-check/types.ts` — extend `SkipReason` and `GateOutcome["skipped"]["reason"]`.
- `apps/extension/src/lib/agent/completion-check/index.ts` — new guard in `shouldGate`.
- `apps/extension/src/lib/agent/__tests__/completion-check.test.ts` — three new `shouldGate` cases (pending only, mixed pending+completed, pending+empty todos) and one `runCompletionCheck` integration case asserting telemetry records the new skip reason.

## 2. Long error logs collapse to ~10 visual lines with expand toggle

The existing `ExpandableText` only counted `\n`-delimited lines, so a 1-line, 600-char tool error wrapped to ~8 visual lines but the clamp never fired. Several error surfaces also bypassed `ExpandableText` entirely.

Fix: add a character-count fallback in `ExpandableText` (~80 chars per visual line) so single long lines collapse correctly. Apply the component to the two surfaces that were rendering raw `<pre>`:

- `apps/extension/src/components/chat/tool-results/expandable-text.tsx` — `estimateVisualLines` helper, character-slice fallback on collapse, "Show full output" label when no newlines.
- `apps/extension/src/components/chat/tool-results/skill.tsx` — replace raw `<pre>` for skill tool errors.
- `apps/extension/src/components/chat/ChatView.tsx` — wrap the top-level `ErrorMessage` banner's `error.message`. Override font to `font-sans` to keep the surrounding chat font.
- `apps/extension/src/components/chat/__tests__/expandable-text.test.ts` — pure-function tests for the estimator across short, long-single-line, and mixed inputs.

## 3. "Always allow on <site>" didn't stick on home.html

The button's onClick fired `onAlwaysAllow` (async — `chrome.storage.local.set`) and `onApprove` synchronously. The SDK resumed the agent before the storage write landed; the next executeOnPage's `needsApproval` read the pre-write allowlist and re-prompted. Observed reliably on home.html where back-to-back tool calls hit the race window.

Fix: extract the click logic into `handleAlwaysAllow`, await the persist before invoking `onApprove`, disable the buttons during the await. Still approve if the persist throws (storage quota etc.) — the user's intent for THIS call is independent of the cross-call grant.

- `apps/extension/src/components/chat/ToolApprovalBlock.tsx` — extracted handler, button disabled state, prop type now `Promise<void> | void`.
- `apps/extension/src/components/chat/__tests__/tool-approval-block.test.ts` — three cases: ordering (assert `onApprove` only fires after persist resolves), persist-throws-still-approves, sync handler support.

## Verification

- `pnpm --filter openbrowse compile` — clean.
- `pnpm --filter openbrowse test` — 312 passed (incl. 7 new).
- `pnpm --filter openbrowse build` — clean WXT build.

Manual repro steps:
- From home.html, run a task that calls `executeOnPage` on bookface twice. First prompt: click "Always allow on bookface". Second call should run without prompting.
- Run a task that triggers a long error from `executeOnPage` (e.g. point at a tab that throws a stack trace) and confirm the new clamp + expand toggle works.
- Approve a tool mid-stream and confirm no "Running quality check…" pill appears between the tool-call card and the approval prompt.

## Out of scope

- Telemetry retention / PII scrubbing in `completion-check/telemetry.ts` (separate task).
- A dedicated `state: "awaiting-approval"` for `ToolCallTraceEntry` — `pending` already captures the signal.

Includes a `patch` changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long error/stack traces now collapse with an inline "show more" that respects visual line wrapping.
* **Bug Fixes**
  * "Always allow on <site>" now reliably persists before resuming tool execution.
  * Completion checks are deferred while tool calls are pending human approval.
  * Approval UI disables shortcuts/buttons while "always allow" persistence is in progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->