### PR TITLE
feat(bench): add --tasks-file flag to CLI

### DIFF
--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -30,6 +30,12 @@ pnpm --filter @openbrowse/bench bench --suite webbench-mini --driver kernel
 
 The first run will download Playwright's Chromium binary if it isn't cached.
 
+```bash
+# Example: Run a subset of tasks from a text file
+echo "example-com-heading" > my-tasks.txt
+pnpm --filter @openbrowse/bench bench --tasks-file my-tasks.txt
+```
+
 ## Resuming an interrupted run
 
 If a suite crashes, times out, or you kill it manually, you can resume it. The runner will automatically skip tasks that already have a trial JSON in the directory. 

--- a/packages/bench/src/cli.ts
+++ b/packages/bench/src/cli.ts
@@ -22,6 +22,8 @@ interface CliArgs {
   taskId?: string;
   /** Run a whole suite by source (e.g. "webbench", "custom"). */
   suite?: "webbench-mini" | "webbench" | "custom" | "all";
+  /** Read newline-delimited task IDs from a file. */
+  tasksFile?: string;
   modelId: string;
   modelLabel: string;
   headless: boolean;
@@ -85,6 +87,13 @@ function parseArgs(argv: string[]): CliArgs {
         out.suite = v as any;
         break;
       }
+      case "--tasks-file":
+        if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+          console.error("--tasks-file requires a file path argument");
+          process.exit(2);
+        }
+        out.tasksFile = argv[++i];
+        break;
       case "--model":
         out.modelId = argv[++i];
         out.modelLabel = out.modelId;
@@ -172,10 +181,13 @@ function printHelp(): void {
 Usage:
   bench --task <task-id> [options]              # single task
   bench --suite <name>  [options]               # run an entire suite
+  bench --tasks-file <path> [options]           # run tasks from a list
 
 Options:
   --task <id>         Single task id from any registered suite
   --suite <name>      Run all tasks in a suite. One of: webbench-mini, webbench, custom, all
+  --tasks-file <path> File containing one task ID per line. Comments (#)
+                      and blank lines are ignored.
   --model <id>        Provider model id (default: claude-sonnet-4-5-20250929)
                       Examples:
                         claude-sonnet-4-5-20250929  (Anthropic)
@@ -239,6 +251,7 @@ async function main(): Promise<void> {
     { WEBBENCH_REVISION },
     { LLM_JUDGE_VERSION, JUDGE_MODEL_ID },
     { sampleTasks },
+    { loadTasksFromFile },
   ] = await Promise.all([
     import("@ai-sdk/anthropic"),
     import("@ai-sdk/google"),
@@ -252,6 +265,7 @@ async function main(): Promise<void> {
     import("./tasks/webbench/revision"),
     import("./judges/llm-judge"),
     import("./tasks/sample"),
+    import("./tasks/from-file"),
   ]);
 
   type LanguageModel = Awaited<ReturnType<typeof anthropic>>;
@@ -266,7 +280,7 @@ async function main(): Promise<void> {
     );
   }
 
-  if (!args.taskId && !args.suite) {
+  if (!args.taskId && !args.suite && !args.tasksFile) {
     printHelp();
     console.log(`\nAvailable tasks (custom):`);
     for (const t of await tasksBySource("custom")) {
@@ -276,6 +290,18 @@ async function main(): Promise<void> {
     for (const t of await tasksBySource("webbench-mini")) {
       console.log(`  ${t.id.padEnd(40)}  ${truncate(t.instruction, 60)}`);
     }
+    process.exit(2);
+  }
+
+  const selectionMechanisms = [
+    args.taskId ? "--task" : null,
+    args.suite ? "--suite" : null,
+    args.tasksFile ? "--tasks-file" : null,
+  ].filter(Boolean);
+  if (selectionMechanisms.length > 1) {
+    console.error(
+      `These flags are mutually exclusive: ${selectionMechanisms.join(", ")}. Pick exactly one.`,
+    );
     process.exit(2);
   }
 
@@ -321,9 +347,16 @@ async function main(): Promise<void> {
   }
 
   // Resolve the task list. Single-task mode picks one; suite mode picks
-  // every task whose source matches.
+  // every task whose source matches; tasks-file mode reads a custom list.
   let tasks: any[];
-  if (args.taskId) {
+  if (args.tasksFile) {
+    try {
+      tasks = await loadTasksFromFile(args.tasksFile, findTask);
+    } catch (e: any) {
+      console.error(e.message);
+      process.exit(2);
+    }
+  } else if (args.taskId) {
     const task = await findTask(args.taskId);
     if (!task) {
       console.error(`Unknown task id: ${args.taskId}`);

--- a/packages/bench/src/tasks/from-file.test.ts
+++ b/packages/bench/src/tasks/from-file.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTasksFromFile } from "./from-file";
+import type { BenchmarkTask } from "./types";
+
+describe("loadTasksFromFile", () => {
+  it("reads a list of task IDs and resolves them via the provided lookup", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bench-tasks-"));
+    const p = join(tmp, "tasks.txt");
+    writeFileSync(
+      p,
+      `
+# A comment
+task-1
+
+task-2
+# Another comment
+    `,
+    );
+
+    const mockLookup = async (id: string) => {
+      if (id === "task-1") return { id: "task-1" } as BenchmarkTask;
+      if (id === "task-2") return { id: "task-2" } as BenchmarkTask;
+      return undefined;
+    };
+
+    const tasks = await loadTasksFromFile(p, mockLookup);
+    
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0].id).toBe("task-1");
+    expect(tasks[1].id).toBe("task-2");
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("throws if any task ID cannot be resolved", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bench-tasks-"));
+    const p = join(tmp, "tasks.txt");
+    writeFileSync(p, "task-1\nmissing-1\nmissing-2");
+
+    const mockLookup = async (id: string) => {
+      if (id === "task-1") return { id: "task-1" } as BenchmarkTask;
+      return undefined;
+    };
+
+    await expect(loadTasksFromFile(p, mockLookup)).rejects.toThrow(
+      /Unknown task ids.*missing-1.*missing-2/s,
+    );
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("throws if the file does not exist", async () => {
+    await expect(
+      loadTasksFromFile("/does/not/exist/tasks.txt", async () => undefined),
+    ).rejects.toThrow(/ENOENT/);
+  });
+});

--- a/packages/bench/src/tasks/from-file.ts
+++ b/packages/bench/src/tasks/from-file.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { BenchmarkTask } from "./types";
+
+/**
+ * Read a newline-delimited list of task IDs from a file and resolve them
+ * into actual tasks. Ignores blank lines and comments (lines starting
+ * with `#`). Throws if the file is unreadable or if any ID fails to resolve.
+ */
+export async function loadTasksFromFile(
+  path: string,
+  findTask: (id: string) => Promise<BenchmarkTask | undefined>,
+): Promise<BenchmarkTask[]> {
+  const raw = readFileSync(resolve(path), "utf-8");
+  const ids = raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s && !s.startsWith("#"));
+
+  const found: BenchmarkTask[] = [];
+  const missing: string[] = [];
+
+  for (const id of ids) {
+    const t = await findTask(id);
+    if (t) found.push(t);
+    else missing.push(id);
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Unknown task ids in ${path}:\n  ${missing.join("\n  ")}`);
+  }
+
+  return found;
+}


### PR DESCRIPTION
Adds a `--tasks-file <path>` flag to load a newline-delimited list of task IDs.
This allows running custom subsets of tasks without needing to register a new suite in the codebase and recompile.

Features:
- Ignores blank lines and comments (lines starting with `#`)
- Mutually exclusive with `--task` and `--suite`
- Composes correctly with `--sample-size`
- Fails fast before launching trials if any task ID in the file cannot be resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --tasks-file CLI flag to run benchmark trials from a newline-delimited file of task IDs
  * File supports comments (prefixed with #) and blank lines; mutually exclusive with --task and --suite

* **Tests**
  * Added tests covering task-file loading, missing IDs, and missing-file errors

* **Documentation**
  * Updated README with an example for running task subsets from a file

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->