### PR TITLE
fix(ci): resolve release tag from input, not event_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ name: Release extension
 #     is why the Changesets workflow uses workflow_call below.)
 #   - `workflow_call` — invoked by `changesets.yml` after it creates
 #     a release tag. This is the primary path for normal releases.
+#     NOTE: inside a called workflow, `github.event_name` reflects the
+#     CALLER's event (here: `push` to main), NOT `workflow_call`. So
+#     the tag is resolved from the `tag` input, never by branching on
+#     the event name — see the Resolve tag step below.
 #   - `workflow_dispatch` — manual escape hatch for re-running the
 #     build/upload against an existing tag (e.g. transient CI failure
 #     that left a release without its zip).
@@ -58,18 +62,21 @@ jobs:
         # controlled and would otherwise be substituted before the shell
         # parses the script — i.e. a classic command-injection vector.
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          # workflow_dispatch and workflow_call both populate INPUT_TAG;
-          # push events fall back to the ref. We branch on event_name to
-          # make the intent explicit rather than relying on INPUT_TAG
-          # being empty for push events.
-          case "$EVENT_NAME" in
-            workflow_dispatch) TAG="$INPUT_TAG" ;;
-            workflow_call)     TAG="$INPUT_TAG" ;;
-            *)                 TAG="${GITHUB_REF#refs/tags/}" ;;
-          esac
+          # workflow_dispatch and workflow_call both populate INPUT_TAG,
+          # which is the source of truth whenever it is set. We do NOT
+          # branch on github.event_name: in a workflow_call'd reusable
+          # workflow it reflects the CALLER's event (here `push`), not
+          # `workflow_call`, so an event-name switch would wrongly fall
+          # through to the push arm and read refs/heads/main as the tag.
+          # A real tag-push event leaves INPUT_TAG empty, so we fall
+          # back to the pushed ref in that case.
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
           # Validate format before doing anything with TAG. Accept the
           # two formats this repo actually produces: 'vX.Y.Z' (legacy)
           # and 'openbrowse@X.Y.Z' (Changesets workspace tag), each


### PR DESCRIPTION
## Problem

The automatic release-zip publishing has been silently broken. When a **Version Packages** PR is merged, `changesets.yml` creates the tag + GitHub Release and then invokes the reusable `release.yml` via `workflow_call` to build and attach the extension zip. That `workflow_call` job has been **failing every time**:

```
EVENT_NAME: push
INPUT_TAG:  openbrowse@0.4.0
::error::Invalid tag format: 'refs/heads/main' (expected vX.Y.Z or openbrowse@X.Y.Z)
```

Confirmed failing on:
- run [26656332679](https://github.com/openbrowse-ai/openbrowse/actions/runs/26656332679) (Changesets #34, `openbrowse@0.4.0`)
- run [26630585661](https://github.com/openbrowse-ai/openbrowse/actions/runs/26630585661) (`openbrowse@0.3.2`)

## Root cause

`release.yml`'s **Resolve tag** step branched on `github.event_name`:

```bash
case "$EVENT_NAME" in
  workflow_dispatch) TAG="$INPUT_TAG" ;;
  workflow_call)     TAG="$INPUT_TAG" ;;
  *)                 TAG="${GITHUB_REF#refs/tags/}" ;;
esac
```

But in a **reusable workflow invoked via `workflow_call`, `github.event_name` is the *caller's* event** — here `push` to `main` — not the literal `"workflow_call"`. So the `workflow_call` arm was unreachable, execution fell through to `*)`, and `TAG` became `refs/heads/main`, which fails the format regex. `INPUT_TAG` was correctly set to `openbrowse@0.4.0` the whole time; it just wasn't read.

Impact: each release required a manual `workflow_dispatch` re-run to attach the zip (see `release.yml` runs 26656979347, 26606642005 — both manual).

## Fix

Resolve the tag from `INPUT_TAG` whenever it is set (both `workflow_dispatch` and `workflow_call` populate it), falling back to the pushed ref only for genuine tag-push events:

```bash
if [ -n "$INPUT_TAG" ]; then
  TAG="$INPUT_TAG"
else
  TAG="${GITHUB_REF#refs/tags/}"
fi
```

The command-injection-safe env-var passing is preserved. `EVENT_NAME` is no longer needed and is removed.

## Verification

Simulated the resolve-tag logic for all paths:

| Path | Input | `GITHUB_REF` | Result |
|---|---|---|---|
| workflow_call (caller=push) | `openbrowse@0.4.0` | `refs/heads/main` | ✅ version `0.4.0` |
| workflow_dispatch | `openbrowse@0.3.2` | `refs/heads/main` | ✅ version `0.3.2` |
| tag-push (legacy) | — | `refs/tags/v0.2.1` | ✅ version `0.2.1` |
| tag-push (prerelease) | — | `refs/tags/openbrowse@1.2.3-beta.1` | ✅ version `1.2.3-beta.1` |

The previously-broken `workflow_call` case now passes. YAML validated.

The live end-to-end test is the next Version Packages merge cycle; the `workflow_dispatch` escape hatch remains unchanged as a fallback.

## Notes

- No backfill of the `openbrowse@0.3.2` release zip — it's superseded by `0.4.0`, which already has its zip attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability by refining tag-resolution logic to ensure consistent behavior during automated releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->