### PR TITLE
feat(extension): configurable aux model picker, token-AND search, and approval fixes

### DIFF
--- a/.changeset/aux-model-picker-and-approval-fix.md
+++ b/.changeset/aux-model-picker-and-approval-fix.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": patch
+---
+
+Aux model picker shows all configured models; token-AND model search; fix approval-interrupt bug; expose executePython; improved MCP approval + skill-install UX.

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -1,17 +1,7 @@
 import { NoAutoLink } from "@/components/tiptap/link-extension";
 import { SkillSlash } from "@/components/tiptap/skill-slash-extension";
 import { TabMention } from "@/components/tiptap/tab-mention-extension";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxGroup,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxLabel,
-  ComboboxList,
-} from "@/components/ui/combobox";
 import { Kbd } from "@/components/ui/kbd";
-import { RegistryIcon } from "@/components/ui/registry-icon";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
@@ -39,42 +29,25 @@ import StarterKit from "@tiptap/starter-kit";
 import {
   ArrowUp,
   BrainIcon,
-  ChevronDown,
   Paperclip,
   Plus,
   Square,
-  Star,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
 import { computeButtonMode } from "./chat-input-mode";
+import {
+  ModelPicker,
+  type ModelOption,
+  type ProviderModels,
+} from "./ModelPicker";
 
 // Derived alias kept for back-compat with call sites that destructure
 // images: ImagePreview[] from onSubmit. Tasks 5-6 migrate those sites;
 // once they're gone we can delete the alias and the re-export.
 type ImagePreview = Extract<Attachment, { kind: "image" }>;
-
-interface ModelOption {
-  id: string;
-  name: string;
-  description?: string;
-  intelligence?: "high" | "medium" | "low";
-  speed?: "fast" | "medium" | "slow";
-  contextWindow?: number;
-  maxOutputTokens?: number;
-  pricing?: { inputPer1M: number; outputPer1M: number };
-  capabilities?: string[];
-  recommended?: boolean;
-}
-
-interface ProviderModels {
-  provider: string;
-  label: string;
-  models: ModelOption[];
-  enabled: boolean;
-}
 
 interface ChatInputProps {
   value: string;
@@ -323,105 +296,6 @@ export function ChatInput({
   );
   const lastExternalValue = useRef(value);
   const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
-  const [highlightedModelId, setHighlightedModelId] = useState<string | null>(
-    null,
-  );
-  const [modelSearchQuery, setModelSearchQuery] = useState("");
-  const modelButtonRef = useRef<HTMLButtonElement>(null);
-
-  const allModelItems = useMemo(() => {
-    if (!providerModels) return [];
-    return providerModels.flatMap((g) =>
-      g.models.map((m) => `${g.provider}:${m.id}`),
-    );
-  }, [providerModels]);
-
-  const modelIdToName = useMemo(() => {
-    const map = new Map<string, string>();
-    if (!providerModels) return map;
-    for (const group of providerModels) {
-      for (const m of group.models) {
-        map.set(`${group.provider}:${m.id}`, m.name);
-      }
-    }
-    return map;
-  }, [providerModels]);
-
-  const modelIdToProvider = useMemo(() => {
-    const map = new Map<string, { provider: string; enabled: boolean }>();
-    if (!providerModels) return map;
-    for (const group of providerModels) {
-      for (const m of group.models) {
-        map.set(`${group.provider}:${m.id}`, {
-          provider: group.provider,
-          enabled: group.enabled,
-        });
-      }
-    }
-    return map;
-  }, [providerModels]);
-
-  const pickerSections = useMemo(() => {
-    if (!providerModels)
-      return { favorites: [], recommended: [], providers: [] };
-    const q = modelSearchQuery.toLowerCase().trim();
-
-    // Helper to filter models
-    const filterModels = (
-      models: (typeof providerModels)[0]["models"],
-      groupLabel: string,
-    ) => {
-      if (!q) return models;
-      return models.filter(
-        (m) =>
-          m.name.toLowerCase().includes(q) ||
-          groupLabel.toLowerCase().includes(q),
-      );
-    };
-
-    // 1. Favorites
-    const favoriteItems: Array<
-      (typeof providerModels)[0]["models"][0] & {
-        providerId: string;
-        providerLabel: string;
-        enabled: boolean;
-      }
-    > = [];
-    // 2. Recommended
-    const recommendedItems: typeof favoriteItems = [];
-
-    // We will collect all models into these arrays
-    for (const group of providerModels) {
-      const models = filterModels(group.models, group.label);
-      for (const m of models) {
-        const item = {
-          ...m,
-          providerId: group.provider,
-          providerLabel: group.label,
-          enabled: group.enabled,
-        };
-        if (favoriteModels.includes(`${group.provider}:${m.id}`)) {
-          favoriteItems.push(item);
-        } else if (m.recommended) {
-          recommendedItems.push(item);
-        }
-      }
-    }
-
-    // 3. Provider Groups
-    const providerGroups = providerModels
-      .map((group) => ({
-        ...group,
-        models: filterModels(group.models, group.label),
-      }))
-      .filter((group) => group.models.length > 0);
-
-    return {
-      favorites: favoriteItems,
-      recommended: recommendedItems,
-      providers: providerGroups,
-    };
-  }, [providerModels, modelSearchQuery, favoriteModels]);
 
   const addFiles = useCallback(
     async (files: FileList | File[]) => {
@@ -827,19 +701,6 @@ export function ChatInput({
     }
   }, [editor, disabled, autoFocus]);
 
-  const selectedModelName = useMemo(() => {
-    if (!providerModels || !selectedModel) return selectedModel;
-    const [providerId, ...modelIdParts] = selectedModel.split(":");
-    const actualModelId =
-      modelIdParts.length > 0 ? modelIdParts.join(":") : selectedModel;
-    for (const group of providerModels) {
-      if (modelIdParts.length > 0 && group.provider !== providerId) continue;
-      const found = group.models.find((m) => m.id === actualModelId);
-      if (found) return found.name;
-    }
-    return actualModelId;
-  }, [providerModels, selectedModel]);
-
   return (
     <div
       onDragEnter={handleContainerDragEnter}
@@ -935,301 +796,73 @@ export function ChatInput({
         {/* Model selector */}
         <div>
           {providerModels && providerModels.length > 0 && onModelChange && (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    ref={modelButtonRef}
-                    type="button"
-                    onClick={() => setModelSelectorOpen(!modelSelectorOpen)}
-                    className="flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-                  >
-                    <span className="truncate max-w-[140px]">
-                      {selectedModelName}
-                    </span>
-                    <ChevronDown className="size-3 shrink-0" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
+            <ModelPicker
+              trigger="chat"
+              providerModels={providerModels}
+              value={selectedModel}
+              onValueChange={onModelChange}
+              favoriteModels={favoriteModels}
+              onFavoriteToggle={onFavoriteToggle}
+              showRecommended
+              placeholder="Select a model..."
+              open={modelSelectorOpen}
+              onOpenChange={setModelSelectorOpen}
+              triggerTooltip={
+                <>
                   Switch model <Kbd>⌥/</Kbd>
-                </TooltipContent>
-              </Tooltip>
-              <Combobox
-                open={modelSelectorOpen}
-                onOpenChange={(open) => {
-                  setModelSelectorOpen(open);
-                  if (!open) {
-                    setHighlightedModelId(null);
-                    setModelSearchQuery("");
-                  }
-                }}
-                onInputValueChange={(value) => setModelSearchQuery(value)}
-                value={selectedModel ?? ""}
-                onValueChange={(val) => {
-                  if (val) {
-                    const info = modelIdToProvider.get(val);
-                    if (info?.enabled) {
-                      onModelChange(val);
+                </>
+              }
+              renderModelInfo={(model) => <ModelInfoContent model={model} />}
+              footer={
+                <div className="p-1 border-t border-border mt-1">
+                  <button
+                    type="button"
+                    onClick={() => {
                       setModelSelectorOpen(false);
-                    }
-                  }
-                }}
-                items={allModelItems}
-                itemToStringLabel={(id) => modelIdToName.get(id) ?? id}
-                autoHighlight
-              >
-                <ComboboxContent
-                  side="top"
-                  sideOffset={4}
-                  anchor={modelButtonRef}
-                  className="w-[320px] border border-border shadow-lg"
-                >
-                  <ComboboxInput
-                    placeholder="Select a model..."
-                    showTrigger={false}
-                  />
-                  <ComboboxList className="max-h-[300px] overflow-y-auto">
-                    {pickerSections.favorites.length === 0 &&
-                      pickerSections.recommended.length === 0 &&
-                      pickerSections.providers.length === 0 && (
-                        <div className="flex w-full justify-center py-2 text-center text-sm text-muted-foreground">
-                          No models found
-                        </div>
-                      )}
-
-                    {pickerSections.favorites.length > 0 && (
-                      <ComboboxGroup>
-                        <ComboboxLabel className="sticky top-0 z-10 bg-popover/95 backdrop-blur-sm">
-                          Favorites
-                        </ComboboxLabel>
-                        {pickerSections.favorites.map((model) => {
-                          const compoundId = `${model.providerId}:${model.id}`;
-                          return (
-                            <Tooltip
-                              key={compoundId}
-                              open={highlightedModelId === compoundId}
-                            >
-                              <TooltipTrigger asChild>
-                                <ComboboxItem
-                                  value={compoundId}
-                                  disabled={!model.enabled}
-                                  onPointerMove={() =>
-                                    setHighlightedModelId(compoundId)
-                                  }
-                                  onFocus={() =>
-                                    setHighlightedModelId(compoundId)
-                                  }
-                                >
-                                  <RegistryIcon
-                                    id={model.providerId}
-                                    className="size-1.5 mr-1.5 shrink-0"
-                                  />
-                                  <span className="flex-1 truncate">
-                                    {model.name}
-                                  </span>
-                                  <button
-                                    type="button"
-                                    onClick={(e) => {
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      onFavoriteToggle?.(compoundId);
-                                    }}
-                                    className="order-last ml-2 text-primary hover:scale-110 transition-transform"
-                                  >
-                                    <Star className="size-3.5 fill-current" />
-                                  </button>
-                                </ComboboxItem>
-                              </TooltipTrigger>
-                              <TooltipContent
-                                side="right"
-                                sideOffset={12}
-                                hideArrow
-                                className="max-w-none w-auto p-3 bg-popover text-popover-foreground border border-border shadow-lg"
-                              >
-                                <ModelInfoContent model={model} />
-                              </TooltipContent>
-                            </Tooltip>
-                          );
-                        })}
-                      </ComboboxGroup>
-                    )}
-
-                    {pickerSections.recommended.length > 0 && (
-                      <ComboboxGroup>
-                        <ComboboxLabel className="sticky top-0 z-10 bg-popover/95 backdrop-blur-sm">
-                          Recommended
-                        </ComboboxLabel>
-                        {pickerSections.recommended.map((model) => {
-                          const compoundId = `${model.providerId}:${model.id}`;
-                          return (
-                            <Tooltip
-                              key={compoundId}
-                              open={highlightedModelId === compoundId}
-                            >
-                              <TooltipTrigger asChild>
-                                <ComboboxItem
-                                  value={compoundId}
-                                  disabled={!model.enabled}
-                                  onPointerMove={() =>
-                                    setHighlightedModelId(compoundId)
-                                  }
-                                  onFocus={() =>
-                                    setHighlightedModelId(compoundId)
-                                  }
-                                >
-                                  <RegistryIcon
-                                    id={model.providerId}
-                                    className="size-[10px] mr-1.5 shrink-0 opacity-60 grayscale"
-                                  />
-                                  <span className="flex-1 truncate">
-                                    {model.name}
-                                  </span>
-                                  <button
-                                    type="button"
-                                    onClick={(e) => {
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      onFavoriteToggle?.(compoundId);
-                                    }}
-                                    className="order-last ml-2 text-muted-foreground hover:text-primary transition-colors"
-                                  >
-                                    <Star className="size-3.5" />
-                                  </button>
-                                </ComboboxItem>
-                              </TooltipTrigger>
-                              <TooltipContent
-                                side="right"
-                                sideOffset={12}
-                                hideArrow
-                                className="max-w-none w-auto p-3 bg-popover text-popover-foreground border border-border shadow-lg"
-                              >
-                                <ModelInfoContent model={model} />
-                              </TooltipContent>
-                            </Tooltip>
-                          );
-                        })}
-                      </ComboboxGroup>
-                    )}
-
-                    {pickerSections.providers.map((group) => (
-                      <ComboboxGroup key={group.provider}>
-                        <ComboboxLabel className="sticky top-0 z-10 bg-popover/95 backdrop-blur-sm">
-                          {group.label}
-                        </ComboboxLabel>
-                        {group.models.map((model) => {
-                          const compoundId = `${group.provider}:${model.id}`;
-                          const isFavorite =
-                            favoriteModels.includes(compoundId);
-                          return (
-                            <Tooltip
-                              key={compoundId}
-                              open={highlightedModelId === compoundId}
-                            >
-                              <TooltipTrigger asChild>
-                                <ComboboxItem
-                                  value={compoundId}
-                                  disabled={!group.enabled}
-                                  onPointerMove={() =>
-                                    setHighlightedModelId(compoundId)
-                                  }
-                                  onFocus={() =>
-                                    setHighlightedModelId(compoundId)
-                                  }
-                                >
-                                  <RegistryIcon
-                                    id={group.provider}
-                                    className="size-[10px] mr-1.5 shrink-0 opacity-60 grayscale"
-                                  />
-                                  <span className="flex-1 truncate">
-                                    {model.name}
-                                  </span>
-                                  {!group.enabled && (
-                                    <span className="text-[10px] text-muted-foreground mr-2">
-                                      Not configured
-                                    </span>
-                                  )}
-                                  <button
-                                    type="button"
-                                    onClick={(e) => {
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      onFavoriteToggle?.(compoundId);
-                                    }}
-                                    className={`order-last ml-2 transition-colors ${isFavorite ? "text-primary" : "text-transparent group-hover/command-item:text-muted-foreground hover:!text-primary"}`}
-                                  >
-                                    <Star
-                                      className={`size-3.5 ${isFavorite ? "fill-current" : ""}`}
-                                    />
-                                  </button>
-                                </ComboboxItem>
-                              </TooltipTrigger>
-                              <TooltipContent
-                                side="right"
-                                sideOffset={12}
-                                hideArrow
-                                className="max-w-none w-auto p-3 bg-popover text-popover-foreground border border-border shadow-lg"
-                              >
-                                <ModelInfoContent model={model} />
-                              </TooltipContent>
-                            </Tooltip>
-                          );
-                        })}
-                      </ComboboxGroup>
-                    ))}
-                  </ComboboxList>
-
-                  <div className="p-1 border-t border-border mt-1">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setModelSelectorOpen(false);
-                        chrome.tabs.create({
-                          url: chrome.runtime.getURL(
-                            "/settings.html?tab=models",
-                          ),
-                        });
-                      }}
+                      chrome.tabs.create({
+                        url: chrome.runtime.getURL("/settings.html?tab=models"),
+                      });
+                    }}
                     className="w-full flex items-center justify-center gap-2 rounded-sm px-2 py-1 text-xs outline-hidden select-none hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                   >
-                    Configure <Kbd className="ml-1 text-[10px] h-4 py-0">⌥⇧C</Kbd>
+                    Configure{" "}
+                    <Kbd className="ml-1 text-[10px] h-4 py-0">⌥⇧C</Kbd>
                   </button>
-                  </div>
-
-                  {selectedModelCapabilities?.includes("thinking") && (
-                    <div className="flex items-center gap-2 px-2 py-1.5 border-t border-border">
-                      <BrainIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                      <Switch
-                        checked={thinkingEnabled ?? false}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            const defaultConfig = getDefaultThinkingConfig(
-                              selectedModel ?? "",
-                            );
-                            onThinkingChange?.(true, defaultConfig);
-                          } else {
-                            onThinkingChange?.(false, undefined);
-                          }
-                        }}
-                        className="scale-75 origin-left"
+                </div>
+              }
+              footerExtra={
+                selectedModelCapabilities?.includes("thinking") ? (
+                  <div className="flex items-center gap-2 px-2 py-1.5 border-t border-border">
+                    <BrainIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    <Switch
+                      checked={thinkingEnabled ?? false}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          const defaultConfig = getDefaultThinkingConfig(
+                            selectedModel ?? "",
+                          );
+                          onThinkingChange?.(true, defaultConfig);
+                        } else {
+                          onThinkingChange?.(false, undefined);
+                        }
+                      }}
+                      className="scale-75 origin-left"
+                    />
+                    {thinkingEnabled ? (
+                      <ThinkingControl
+                        config={thinkingConfig}
+                        modelId={selectedModel ?? ""}
+                        onChange={(config) => onThinkingChange?.(true, config)}
                       />
-                      {thinkingEnabled ? (
-                        <ThinkingControl
-                          config={thinkingConfig}
-                          modelId={selectedModel ?? ""}
-                          onChange={(config) =>
-                            onThinkingChange?.(true, config)
-                          }
-                        />
-                      ) : (
-                        <span className="text-xs text-muted-foreground">
-                          Thinking
-                        </span>
-                      )}
-                    </div>
-                  )}
-                </ComboboxContent>
-              </Combobox>
-            </>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">
+                        Thinking
+                      </span>
+                    )}
+                  </div>
+                ) : null
+              }
+            />
           )}
         </div>
 

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -30,6 +30,7 @@ import {
 import { Logo } from "@/components/ui/logo";
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { useProviders } from "@/hooks/useProviders";
+import { useConfiguredModels } from "@/hooks/useConfiguredModels";
 import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
 import { cn } from "@/lib/utils";
 import { classifyFile } from "@/lib/vfs/file-classify";
@@ -235,45 +236,7 @@ export function ChatView({
 
   const { providers } = useProviders();
 
-  const providerModels = useMemo(() => {
-    return providers
-      .map((provider) => {
-        let enabled = true;
-        let availableModels = provider.models;
-
-        if (provider.setup === "byok") {
-          const config = settings.providerConfigs[provider.id] ?? {};
-          const requiredFields =
-            provider.configSchema?.filter((f) => f.required) ?? [];
-          enabled = requiredFields.every((f) => !!config[f.key]);
-          if (!enabled) return null;
-        } else if (provider.setup === "web-llm") {
-          availableModels = provider.models.filter((m) =>
-            settings.downloadedModels.includes(m.id),
-          );
-          enabled = availableModels.length > 0;
-          if (!enabled) return null;
-        } else if (provider.setup === "browser-ai") {
-          availableModels = provider.models.filter((m) =>
-            settings.downloadedModels.includes(m.id),
-          );
-          enabled = availableModels.length > 0;
-          if (!enabled) return null;
-        }
-
-        return {
-          provider: provider.id,
-          label: provider.name,
-          models: availableModels,
-          enabled,
-        };
-      })
-      .filter((p): p is NonNullable<typeof p> => p !== null);
-  }, [
-    providers,
-    settings.providerConfigs,
-    settings.downloadedModels,
-  ]);
+  const providerModels = useConfiguredModels(settings);
 
   // Auto-select a default model when none is set and at least one
   // provider is now configured. Mirrors the same effect in LandingPage

--- a/apps/extension/src/components/chat/ModelPicker.tsx
+++ b/apps/extension/src/components/chat/ModelPicker.tsx
@@ -1,0 +1,515 @@
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxTrigger,
+} from "@/components/ui/combobox";
+import { RegistryIcon } from "@/components/ui/registry-icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Star } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+
+export interface ModelOption {
+  id: string;
+  name: string;
+  description?: string;
+  intelligence?: "high" | "medium" | "low";
+  speed?: "fast" | "medium" | "slow";
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  pricing?: { inputPer1M: number; outputPer1M: number };
+  capabilities?: string[];
+  recommended?: boolean;
+}
+
+export interface ProviderModels {
+  provider: string;
+  label: string;
+  models: ModelOption[];
+  enabled: boolean;
+}
+
+/**
+ * A leading non-model option (e.g. "Same as agent model") rendered at
+ * the top of the list. Selecting it calls `onValueChange(value)`.
+ */
+export interface ModelPickerDefaultOption {
+  value: string;
+  label: string;
+}
+
+interface ModelPickerProps {
+  providerModels: ProviderModels[];
+  /** Current selection — a `provider:modelId` compound id, the
+   * `defaultOption.value` sentinel, or undefined when unset. */
+  value: string | undefined;
+  onValueChange: (value: string) => void;
+
+  /**
+   * When provided, renders a Favorites section (and per-row star
+   * toggles). Omit in surfaces that don't expose favoriting (e.g. the
+   * settings auxiliary-model pickers).
+   */
+  favoriteModels?: string[];
+  onFavoriteToggle?: (modelKey: string) => void;
+  /** Render a Recommended section for models flagged `recommended`. */
+  showRecommended?: boolean;
+  /** Optional leading non-model option (e.g. "Same as agent model"). */
+  defaultOption?: ModelPickerDefaultOption;
+
+  placeholder?: string;
+  /**
+   * Trigger style:
+   *  - `"chat"`: compact inline pill (used in the chat composer).
+   *  - `"settings"`: full-width bordered button (used in settings).
+   */
+  trigger?: "chat" | "settings";
+  /** Tooltip + keyboard hint shown on the chat trigger. */
+  triggerTooltip?: ReactNode;
+
+  /** Optional extra UI rendered above each model row's tooltip card. */
+  renderModelInfo?: (model: ModelOption) => ReactNode;
+  /** Optional footer rendered below the list (e.g. Configure button). */
+  footer?: ReactNode;
+  /** Optional extra block under the footer (e.g. thinking toggle). */
+  footerExtra?: ReactNode;
+
+  /** Controlled open state (e.g. driven by a keyboard shortcut). */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+
+  disabled?: boolean;
+}
+
+/**
+ * Build the lowercased searchable text for a model: display name + the
+ * compound `provider:modelId` (so provider id and raw model id are
+ * searchable) + the human provider label.
+ *
+ * Exported for unit testing.
+ */
+export function buildModelHaystack(
+  name: string,
+  compoundId: string,
+  providerLabel: string,
+): string {
+  return `${name} ${compoundId} ${providerLabel}`.toLowerCase();
+}
+
+/**
+ * Token-AND substring match: every whitespace-separated term in `query`
+ * must appear somewhere in `haystack`. Order-independent and
+ * partial-token friendly, so "flash 3.5" matches "Gemini 3.5 Flash".
+ * An empty/whitespace query matches everything.
+ *
+ * Exported for unit testing.
+ */
+export function matchesModelQuery(haystack: string, query: string): boolean {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return true;
+  return terms.every((t) => haystack.includes(t));
+}
+
+function resolveLabel(
+  providerModels: ProviderModels[],
+  value: string | undefined,
+  defaultOption: ModelPickerDefaultOption | undefined,
+  placeholder: string,
+): string {
+  if (!value) return placeholder;
+  if (defaultOption && value === defaultOption.value)
+    return defaultOption.label;
+  const [providerId, ...modelIdParts] = value.split(":");
+  const actualModelId =
+    modelIdParts.length > 0 ? modelIdParts.join(":") : value;
+  for (const group of providerModels) {
+    if (modelIdParts.length > 0 && group.provider !== providerId) continue;
+    const found = group.models.find((m) => m.id === actualModelId);
+    if (found) return found.name;
+  }
+  return actualModelId;
+}
+
+/**
+ * Searchable, provider-grouped model picker shared by the chat composer
+ * and the settings auxiliary-model selectors (tidy / compaction /
+ * completion-check).
+ *
+ * The chat composer passes `favoriteModels`/`onFavoriteToggle` +
+ * `showRecommended` + a thinking-toggle `footerExtra`; the settings
+ * surfaces pass a `defaultOption` ("Same as agent model") and omit
+ * favoriting. Both draw from the same `providerModels` list — the set of
+ * selectable models from *configured* providers — so settings no longer
+ * shows only favorited models.
+ */
+export function ModelPicker({
+  providerModels,
+  value,
+  onValueChange,
+  favoriteModels,
+  onFavoriteToggle,
+  showRecommended = false,
+  defaultOption,
+  placeholder = "Select a model…",
+  trigger = "settings",
+  triggerTooltip,
+  renderModelInfo,
+  footer,
+  footerExtra,
+  open: controlledOpen,
+  onOpenChange,
+  disabled = false,
+}: ModelPickerProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (onOpenChange) onOpenChange(next);
+    else setUncontrolledOpen(next);
+  };
+  const [highlightedModelId, setHighlightedModelId] = useState<string | null>(
+    null,
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const favorites = favoriteModels ?? [];
+
+  const allModelItems = useMemo(() => {
+    const items = providerModels.flatMap((g) =>
+      g.models.map((m) => `${g.provider}:${m.id}`),
+    );
+    if (defaultOption) return [defaultOption.value, ...items];
+    return items;
+  }, [providerModels, defaultOption]);
+
+  const modelIdToName = useMemo(() => {
+    const map = new Map<string, string>();
+    if (defaultOption) map.set(defaultOption.value, defaultOption.label);
+    for (const group of providerModels) {
+      for (const m of group.models) {
+        map.set(`${group.provider}:${m.id}`, m.name);
+      }
+    }
+    return map;
+  }, [providerModels, defaultOption]);
+
+  const modelIdToEnabled = useMemo(() => {
+    const map = new Map<string, boolean>();
+    if (defaultOption) map.set(defaultOption.value, true);
+    for (const group of providerModels) {
+      for (const m of group.models) {
+        map.set(`${group.provider}:${m.id}`, group.enabled);
+      }
+    }
+    return map;
+  }, [providerModels, defaultOption]);
+
+  // Precomputed searchable text per compound id. Used by base-ui's
+  // internal `filter` (below) so its highlight/keyboard-nav set agrees
+  // exactly with what the manual `sections` filter renders.
+  const modelIdToHaystack = useMemo(() => {
+    const map = new Map<string, string>();
+    if (defaultOption) {
+      map.set(
+        defaultOption.value,
+        buildModelHaystack(defaultOption.label, defaultOption.value, ""),
+      );
+    }
+    for (const group of providerModels) {
+      for (const m of group.models) {
+        const compoundId = `${group.provider}:${m.id}`;
+        map.set(compoundId, buildModelHaystack(m.name, compoundId, group.label));
+      }
+    }
+    return map;
+  }, [providerModels, defaultOption]);
+
+
+  const sections = useMemo(() => {
+    const q = searchQuery.trim();
+    const filterModels = (
+      models: ModelOption[],
+      providerId: string,
+      groupLabel: string,
+    ) => {
+      if (!q) return models;
+      return models.filter((m) =>
+        matchesModelQuery(
+          buildModelHaystack(m.name, `${providerId}:${m.id}`, groupLabel),
+          q,
+        ),
+      );
+    };
+
+    type Item = ModelOption & {
+      providerId: string;
+      providerLabel: string;
+      enabled: boolean;
+    };
+    const favoriteItems: Item[] = [];
+    const recommendedItems: Item[] = [];
+
+    for (const group of providerModels) {
+      const models = filterModels(group.models, group.provider, group.label);
+      for (const m of models) {
+        const item: Item = {
+          ...m,
+          providerId: group.provider,
+          providerLabel: group.label,
+          enabled: group.enabled,
+        };
+        if (favorites.includes(`${group.provider}:${m.id}`)) {
+          favoriteItems.push(item);
+        } else if (showRecommended && m.recommended) {
+          recommendedItems.push(item);
+        }
+      }
+    }
+
+    const providerGroups = providerModels
+      .map((group) => ({
+        ...group,
+        models: filterModels(group.models, group.provider, group.label),
+      }))
+      .filter((group) => group.models.length > 0);
+
+    return {
+      favorites: favoriteItems,
+      recommended: recommendedItems,
+      providers: providerGroups,
+    };
+  }, [providerModels, searchQuery, favorites, showRecommended]);
+
+  const label = resolveLabel(providerModels, value, defaultOption, placeholder);
+
+  const triggerButton =
+    trigger === "chat" ? (
+      <ComboboxTrigger
+        disabled={disabled}
+        className="flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+      >
+        <span className="max-w-35 truncate">{label}</span>
+      </ComboboxTrigger>
+    ) : (
+      <ComboboxTrigger
+        disabled={disabled}
+        className="flex h-8 w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50"
+      >
+        <span className={value ? "truncate" : "truncate text-muted-foreground"}>
+          {label}
+        </span>
+      </ComboboxTrigger>
+    );
+
+  const renderRow = (item: {
+    id: string;
+    name: string;
+    providerId: string;
+    enabled: boolean;
+    model: ModelOption;
+    starState: "filled" | "outline" | "hover";
+  }) => {
+    const compoundId = `${item.providerId}:${item.id}`;
+    const row = (
+      <ComboboxItem
+        value={compoundId}
+        disabled={!item.enabled}
+        onPointerMove={() => setHighlightedModelId(compoundId)}
+        onFocus={() => setHighlightedModelId(compoundId)}
+      >
+        <RegistryIcon
+          id={item.providerId}
+          className={
+            item.starState === "filled"
+              ? "size-1.5 mr-1.5 shrink-0"
+              : "size-2.5 mr-1.5 shrink-0 opacity-60 grayscale"
+          }
+        />
+        <span className="flex-1 truncate">{item.name}</span>
+        {!item.enabled && (
+          <span className="mr-2 text-[10px] text-muted-foreground">
+            Not configured
+          </span>
+        )}
+        {onFavoriteToggle && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onFavoriteToggle(compoundId);
+            }}
+            className={
+              item.starState === "filled"
+                ? "order-last ml-2 text-primary transition-transform hover:scale-110"
+                : item.starState === "outline"
+                  ? "order-last ml-2 text-muted-foreground transition-colors hover:text-primary"
+                  : "order-last ml-2 text-transparent transition-colors group-hover/command-item:text-muted-foreground hover:text-primary!"
+            }
+          >
+            <StarGlyph filled={item.starState === "filled"} />
+          </button>
+        )}
+      </ComboboxItem>
+    );
+    if (!renderModelInfo) {
+      return <span key={compoundId}>{row}</span>;
+    }
+    return (
+      <Tooltip key={compoundId} open={highlightedModelId === compoundId}>
+        <TooltipTrigger asChild>{row}</TooltipTrigger>
+        <TooltipContent
+          side="right"
+          sideOffset={12}
+          hideArrow
+          className="w-auto max-w-none border border-border bg-popover p-3 text-popover-foreground shadow-lg"
+        >
+          {renderModelInfo(item.model)}
+        </TooltipContent>
+      </Tooltip>
+    );
+  };
+
+  const empty =
+    sections.favorites.length === 0 &&
+    sections.recommended.length === 0 &&
+    sections.providers.length === 0;
+
+  return (
+    <Combobox
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) {
+          setHighlightedModelId(null);
+          setSearchQuery("");
+        }
+      }}
+      onInputValueChange={(v) => setSearchQuery(v)}
+      value={value ?? ""}
+      onValueChange={(val) => {
+        if (!val) return;
+        if (modelIdToEnabled.get(val) === false) return;
+        onValueChange(val);
+        setOpen(false);
+      }}
+      items={allModelItems}
+      itemToStringLabel={(id) => modelIdToName.get(id) ?? id}
+      filter={(itemValue, query) =>
+        matchesModelQuery(
+          modelIdToHaystack.get(itemValue) ??
+            buildModelHaystack(
+              modelIdToName.get(itemValue) ?? itemValue,
+              itemValue,
+              "",
+            ),
+          query,
+        )
+      }
+      autoHighlight
+    >
+      {triggerTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{triggerButton}</TooltipTrigger>
+          <TooltipContent>{triggerTooltip}</TooltipContent>
+        </Tooltip>
+      ) : (
+        triggerButton
+      )}
+      <ComboboxContent
+        side={trigger === "chat" ? "top" : "bottom"}
+        sideOffset={4}
+        className="w-[320px] border border-border shadow-lg"
+      >
+          <ComboboxInput placeholder="Select a model..." showTrigger={false} />
+          <ComboboxList className="max-h-75 overflow-y-auto">
+            {empty && (
+              <div className="flex w-full justify-center py-2 text-center text-sm text-muted-foreground">
+                No models found
+              </div>
+            )}
+
+            {defaultOption && !searchQuery.trim() && (
+              <ComboboxGroup>
+                <ComboboxItem value={defaultOption.value}>
+                  <span className="flex-1 truncate">{defaultOption.label}</span>
+                </ComboboxItem>
+              </ComboboxGroup>
+            )}
+
+            {sections.favorites.length > 0 && (
+              <ComboboxGroup>
+                <ComboboxLabel className="sticky top-0 z-10 bg-popover/95 backdrop-blur-sm">
+                  Favorites
+                </ComboboxLabel>
+                {sections.favorites.map((m) =>
+                  renderRow({
+                    id: m.id,
+                    name: m.name,
+                    providerId: m.providerId,
+                    enabled: m.enabled,
+                    model: m,
+                    starState: "filled",
+                  }),
+                )}
+              </ComboboxGroup>
+            )}
+
+            {sections.recommended.length > 0 && (
+              <ComboboxGroup>
+                <ComboboxLabel className="sticky top-0 z-10 bg-popover/95 backdrop-blur-sm">
+                  Recommended
+                </ComboboxLabel>
+                {sections.recommended.map((m) =>
+                  renderRow({
+                    id: m.id,
+                    name: m.name,
+                    providerId: m.providerId,
+                    enabled: m.enabled,
+                    model: m,
+                    starState: "outline",
+                  }),
+                )}
+              </ComboboxGroup>
+            )}
+
+            {sections.providers.map((group) => (
+              <ComboboxGroup key={group.provider}>
+                <ComboboxLabel className="sticky top-0 z-10 bg-popover/95 backdrop-blur-sm">
+                  {group.label}
+                </ComboboxLabel>
+                {group.models.map((model) =>
+                  renderRow({
+                    id: model.id,
+                    name: model.name,
+                    providerId: group.provider,
+                    enabled: group.enabled,
+                    model,
+                    starState: favorites.includes(
+                      `${group.provider}:${model.id}`,
+                    )
+                      ? "filled"
+                      : "hover",
+                  }),
+                )}
+              </ComboboxGroup>
+            ))}
+          </ComboboxList>
+
+          {footer}
+          {footerExtra}
+        </ComboboxContent>
+    </Combobox>
+  );
+}
+
+function StarGlyph({ filled }: { filled: boolean }) {
+  return <Star className={`size-3.5 ${filled ? "fill-current" : ""}`} />;
+}

--- a/apps/extension/src/components/chat/ToolApprovalBlock.tsx
+++ b/apps/extension/src/components/chat/ToolApprovalBlock.tsx
@@ -1,7 +1,9 @@
 import { Check, ShieldCheck, X } from "lucide-react";
 import { useEffect, useState } from "react";
+import { RegistryIcon } from "@/components/ui/registry-icon";
 import { getToolPreview } from "./tool-previews";
 import { DefaultPreview } from "./tool-previews/primitives";
+import { resolveMcpToolDisplay } from "./mcp-tool-display";
 import { TabBadge } from "./ToolCallBlock";
 
 interface ToolApprovalBlockProps {
@@ -64,6 +66,11 @@ export async function handleAlwaysAllow(args: {
 
 export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, siteOrigin, onApprove, onDeny, onAlwaysAllow }: ToolApprovalBlockProps) {
   const customPreview = getToolPreview(toolName);
+  // Resolve MCP connector logo + human-readable name so the approval
+  // header matches the non-approval tool-call rows instead of showing a
+  // raw `mcp_<serverId>_<toolName>` identifier.
+  const { mcpInfo, readableNameSentence } = resolveMcpToolDisplay(toolName);
+  const displayName = readableNameSentence ?? toolName;
   // True between the user clicking "Always allow on <site>" and the
   // storage write resolving. Disables both approval buttons during the
   // window so a quick second click can't bypass the await.
@@ -100,9 +107,16 @@ export function ToolApprovalBlock({ toolName, toolCallId, args, approvalId, site
   return (
     <div className="flex flex-col w-full">
       <div className="flex items-center gap-1.5 py-0.5">
-        <span className="size-1.5 rounded-full shrink-0 bg-amber-500 animate-pulse" />
+        {mcpInfo ? (
+          <RegistryIcon
+            id={mcpInfo.connector.id}
+            className="size-3.5 shrink-0"
+          />
+        ) : (
+          <span className="size-1.5 rounded-full shrink-0 bg-amber-500 animate-pulse" />
+        )}
         <span className="text-sm text-muted-foreground">
-          {toolName} — waiting for approval
+          {displayName} — waiting for approval
         </span>
         <TabBadge toolCallId={toolCallId} />
       </div>

--- a/apps/extension/src/components/chat/ToolCallBlock.tsx
+++ b/apps/extension/src/components/chat/ToolCallBlock.tsx
@@ -5,9 +5,8 @@ import {
 } from "@/components/ui/collapsible";
 import { RegistryIcon } from "@/components/ui/registry-icon";
 import { toolResultStore, toolTabInfoStore } from "@/lib/agent/agent-transport";
-import { getMcpRegistry } from "@/lib/mcp";
 import { cn } from "@/lib/utils";
-import { getConnectorForMcpTool } from "@openbrowse/connectors";
+import { resolveMcpToolDisplay } from "./mcp-tool-display";
 import { AlertCircle, ChevronRight, Globe, X } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
@@ -22,6 +21,7 @@ import {
 } from "./tool-results/fs";
 import { ScreenshotResult } from "./tool-results/screenshot";
 import { SkillResult } from "./tool-results/skill";
+import { InstallSkillResult } from "./tool-results/install-skill";
 import { SnapshotResult } from "./tool-results/snapshot";
 import { WebFetchResult } from "./tool-results/web-fetch";
 
@@ -55,6 +55,7 @@ const BUILTIN_RESULT_RENDERERS: Record<string, ResultRenderer> = {
   Grep: ({ args, result }) => <GrepResult args={args} result={result} />,
   LS: ({ args, result }) => <LSResult args={args} result={result} />,
   skill: ({ args, result }) => <SkillResult args={args} result={result} />,
+  install_skill: ({ result }) => <InstallSkillResult result={result} />,
   delegate: ({ args, result, toolCallId, state, errorText }) => (
     <DelegateResult
       args={args}
@@ -155,12 +156,6 @@ export function TabBadge({ toolCallId }: { toolCallId: string }) {
   );
 }
 
-function parseMcpToolName(toolKey: string): string | null {
-  const match = toolKey.match(/^mcp_[^_]+_(.+)$/);
-  if (!match) return null;
-  return match[1].replace(/_/g, " ").replace(/-/g, " ");
-}
-
 /**
  * Build a webFetch-specific label that includes the request URL's host
  * (and path if short enough). Falls back to the static label when the
@@ -201,22 +196,14 @@ export function ToolCallBlock({
   const denied = state === "denied";
   const errored = state === "errored";
   const resolvedResult = result ?? toolResultStore.get(toolCallId);
-  const serverIdMatch = toolName.match(/^mcp_([^_]+)_/);
-  const serverUrl = serverIdMatch
-    ? getMcpRegistry()
-        .getStates()
-        .find((s) => s.config.id === serverIdMatch[1])?.config.url
-    : undefined;
-  const mcpInfo = getConnectorForMcpTool(toolName, serverUrl);
-  const mcpName = mcpInfo
-    ? mcpInfo.toolName.replace(/_/g, " ").replace(/-/g, " ")
-    : parseMcpToolName(toolName);
+  const { mcpInfo, readableName, readableNameSentence } =
+    resolveMcpToolDisplay(toolName);
   const connectorLabels =
     mcpInfo?.connector.formatLabel?.(mcpInfo.toolName, resolvedResult) ?? null;
   const labels = TOOL_LABELS[toolName] ??
     connectorLabels ?? {
-      pending: mcpName ? `Running ${mcpName}...` : `${toolName}...`,
-      done: mcpName ? mcpName : toolName,
+      pending: readableName ? `Running ${readableName}...` : `${toolName}...`,
+      done: readableNameSentence ? readableNameSentence : toolName,
     };
 
   // For webFetch, splice in the requested URL's host so the collapsed

--- a/apps/extension/src/components/chat/__tests__/mcp-tool-display.test.ts
+++ b/apps/extension/src/components/chat/__tests__/mcp-tool-display.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mocked deps — the helper resolves the connector + server URL through
+// these. We control both so the test is deterministic and doesn't depend
+// on the live MCP registry or the real connector catalog.
+const getStates = vi.fn();
+vi.mock("@/lib/mcp", () => ({
+  getMcpRegistry: () => ({ getStates }),
+}));
+
+const getConnectorForMcpTool = vi.fn();
+vi.mock("@openbrowse/connectors", () => ({
+  getConnectorForMcpTool: (...args: unknown[]) =>
+    getConnectorForMcpTool(...args),
+}));
+
+import {
+  resolveMcpToolDisplay,
+  parseMcpToolName,
+} from "../mcp-tool-display";
+
+beforeEach(() => {
+  getStates.mockReset();
+  getConnectorForMcpTool.mockReset();
+  getStates.mockReturnValue([]);
+  getConnectorForMcpTool.mockReturnValue(null);
+});
+
+describe("parseMcpToolName", () => {
+  it("extracts and normalizes the tool name from an MCP key", () => {
+    expect(parseMcpToolName("mcp_589509c2-85fb-429b-988a-9d8a21401201_create-record")).toBe(
+      "create record",
+    );
+    expect(parseMcpToolName("mcp_attio_list_records")).toBe("list records");
+  });
+
+  it("returns null for non-MCP tool names", () => {
+    expect(parseMcpToolName("navigate")).toBeNull();
+    expect(parseMcpToolName("executeOnPage")).toBeNull();
+  });
+});
+
+describe("resolveMcpToolDisplay", () => {
+  it("unmatched MCP server (UUID id, no connector) → readable name, no icon", () => {
+    // The exact case from the screenshot: a generic MCP server whose id
+    // is a UUID and doesn't map to a known connector.
+    const out = resolveMcpToolDisplay(
+      "mcp_589509c2-85fb-429b-988a-9d8a21401201_create-record",
+    );
+    expect(out.mcpInfo).toBeNull();
+    expect(out.readableName).toBe("create record");
+    expect(out.readableNameSentence).toBe("Create record");
+  });
+
+  it("connector-matched MCP tool → connector + sentence-cased name", () => {
+    const connector = { id: "attio", name: "Attio" };
+    getConnectorForMcpTool.mockReturnValue({
+      connector,
+      toolName: "create-record",
+    });
+    const out = resolveMcpToolDisplay("mcp_attio_create-record");
+    expect(out.mcpInfo?.connector).toBe(connector);
+    expect(out.readableName).toBe("create record");
+    expect(out.readableNameSentence).toBe("Create record");
+  });
+
+  it("threads the resolved server URL into getConnectorForMcpTool", () => {
+    getStates.mockReturnValue([
+      { config: { id: "589509c2", url: "https://mcp.example.com" } },
+    ]);
+    resolveMcpToolDisplay("mcp_589509c2_create-record");
+    expect(getConnectorForMcpTool).toHaveBeenCalledWith(
+      "mcp_589509c2_create-record",
+      "https://mcp.example.com",
+    );
+  });
+
+  it("non-MCP built-in tool → all readable fields null", () => {
+    const out = resolveMcpToolDisplay("navigate");
+    expect(out.mcpInfo).toBeNull();
+    expect(out.readableName).toBeNull();
+    expect(out.readableNameSentence).toBeNull();
+  });
+});

--- a/apps/extension/src/components/chat/__tests__/model-picker-search.test.ts
+++ b/apps/extension/src/components/chat/__tests__/model-picker-search.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelHaystack,
+  matchesModelQuery,
+} from "../ModelPicker";
+
+describe("buildModelHaystack", () => {
+  it("combines name, compound id, and provider label, lowercased", () => {
+    expect(
+      buildModelHaystack("Gemini 3.5 Flash", "google:gemini-3.5-flash", "Google"),
+    ).toBe("gemini 3.5 flash google:gemini-3.5-flash google");
+  });
+});
+
+describe("matchesModelQuery", () => {
+  const haystack = buildModelHaystack(
+    "Gemini 3.5 Flash",
+    "google:gemini-3.5-flash",
+    "Google",
+  );
+
+  it("matches reordered terms (the reported bug)", () => {
+    expect(matchesModelQuery(haystack, "flash 3.5")).toBe(true);
+    expect(matchesModelQuery(haystack, "3.5 flash")).toBe(true);
+  });
+
+  it("matches in-order and single terms", () => {
+    expect(matchesModelQuery(haystack, "gemini 3.5 flash")).toBe(true);
+    expect(matchesModelQuery(haystack, "flash")).toBe(true);
+    expect(matchesModelQuery(haystack, "gemini")).toBe(true);
+  });
+
+  it("matches partial tokens", () => {
+    expect(matchesModelQuery(haystack, "gem fl")).toBe(true);
+  });
+
+  it("matches against provider label and raw model id", () => {
+    expect(matchesModelQuery(haystack, "google flash")).toBe(true);
+    expect(matchesModelQuery(haystack, "gemini-3.5")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchesModelQuery(haystack, "FLASH Gemini")).toBe(true);
+  });
+
+  it("collapses extra whitespace between terms", () => {
+    expect(matchesModelQuery(haystack, "  flash    3.5 ")).toBe(true);
+  });
+
+  it("empty / whitespace-only query matches everything", () => {
+    expect(matchesModelQuery(haystack, "")).toBe(true);
+    expect(matchesModelQuery(haystack, "   ")).toBe(true);
+  });
+
+  it("returns false when any term is absent", () => {
+    expect(matchesModelQuery(haystack, "flash opus")).toBe(false);
+    expect(matchesModelQuery(haystack, "claude")).toBe(false);
+  });
+});

--- a/apps/extension/src/components/chat/__tests__/skill-source-display.test.ts
+++ b/apps/extension/src/components/chat/__tests__/skill-source-display.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { resolveSkillSourceDisplay } from "../skill-source-display";
+
+describe("resolveSkillSourceDisplay", () => {
+  it("owner/repo/subpath shorthand → name from subpath, github link", () => {
+    const out = resolveSkillSourceDisplay("sales-skills/sales/sales-attio");
+    expect(out.kind).toBe("github");
+    expect(out.skillName).toBe("Sales attio");
+    expect(out.owner).toBe("sales-skills");
+    expect(out.repoUrl).toBe("https://github.com/sales-skills/sales");
+    expect(out.avatarUrl).toBe("https://github.com/sales-skills.png");
+    expect(out.ownerRepoLabel).toBe("sales-skills/sales/sales-attio");
+  });
+
+  it("github: shorthand at repo root → name from repo", () => {
+    const out = resolveSkillSourceDisplay("github:anthropics/claude-skills");
+    expect(out.kind).toBe("github");
+    expect(out.skillName).toBe("Claude skills");
+    expect(out.repoUrl).toBe("https://github.com/anthropics/claude-skills");
+    expect(out.ownerRepoLabel).toBe("anthropics/claude-skills");
+  });
+
+  it("https github url with tree path → name from last subpath segment", () => {
+    const out = resolveSkillSourceDisplay(
+      "https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices",
+    );
+    expect(out.kind).toBe("github");
+    expect(out.skillName).toBe("React best practices");
+    expect(out.owner).toBe("vercel-labs");
+    expect(out.repoUrl).toBe("https://github.com/vercel-labs/agent-skills");
+  });
+
+  it("raw SKILL.md url → name from containing folder + owner avatar", () => {
+    const out = resolveSkillSourceDisplay(
+      "https://raw.githubusercontent.com/acme/skills/main/cool-skill/SKILL.md",
+    );
+    expect(out.kind).toBe("raw-skill-md");
+    expect(out.skillName).toBe("Cool skill");
+    expect(out.owner).toBe("acme");
+    expect(out.avatarUrl).toBe("https://github.com/acme.png");
+    expect(out.repoUrl).toBe(
+      "https://raw.githubusercontent.com/acme/skills/main/cool-skill/SKILL.md",
+    );
+  });
+
+  it("unrecognized source → invalid, raw shown, no links/avatar", () => {
+    const out = resolveSkillSourceDisplay("not a real source");
+    expect(out.kind).toBe("invalid");
+    expect(out.skillName).toBe("not a real source");
+    expect(out.raw).toBe("not a real source");
+    expect(out.repoUrl).toBeUndefined();
+    expect(out.avatarUrl).toBeUndefined();
+  });
+});

--- a/apps/extension/src/components/chat/mcp-tool-display.ts
+++ b/apps/extension/src/components/chat/mcp-tool-display.ts
@@ -1,0 +1,80 @@
+import { getMcpRegistry } from "@/lib/mcp";
+import {
+  getConnectorForMcpTool,
+  type ConnectorDefinition,
+} from "@openbrowse/connectors";
+
+/**
+ * Parse the human-readable tool name out of an MCP tool key of the form
+ * `mcp_<serverId>_<toolName>`, normalizing separators to spaces.
+ *
+ * Returns the lowercase, space-separated name (e.g. "create record")
+ * or `null` when `toolKey` is not an MCP tool.
+ */
+export function parseMcpToolName(toolKey: string): string | null {
+  const match = toolKey.match(/^mcp_[^_]+_(.+)$/);
+  if (!match) return null;
+  return match[1].replace(/_/g, " ").replace(/-/g, " ");
+}
+
+/** Sentence-case: capitalize the first character only. */
+function toSentenceCase(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export interface McpToolDisplay {
+  /**
+   * Connector match for the MCP server, when the tool maps to a known
+   * connector (used to render the connector logo). `null` for unmatched
+   * MCP servers (generic/UUID server ids) and for non-MCP built-in tools.
+   */
+  mcpInfo: { connector: ConnectorDefinition; toolName: string } | null;
+  /**
+   * Lowercase, space-separated readable name (e.g. "create record").
+   * Suitable for embedding mid-sentence ("Running {name}…"). `null` for
+   * non-MCP tools.
+   */
+  readableName: string | null;
+  /**
+   * Sentence-cased standalone readable name (e.g. "Create record").
+   * Suitable for standalone labels (approval header, done row). `null`
+   * for non-MCP tools.
+   */
+  readableNameSentence: string | null;
+}
+
+/**
+ * Resolve the display metadata for a tool name, with first-class support
+ * for MCP tools (`mcp_<serverId>_<toolName>`).
+ *
+ * Shared by `ToolCallBlock` (the non-approval renderer) and
+ * `ToolApprovalBlock` so both surface the same connector logo and
+ * human-readable name. Previously this logic was inline in
+ * `ToolCallBlock` only, so approval prompts showed the raw
+ * `mcp_<uuid>_<tool>` identifier with no icon.
+ *
+ * For non-MCP tools, all readable-name fields are `null` and callers
+ * fall back to the raw `toolName`.
+ */
+export function resolveMcpToolDisplay(toolName: string): McpToolDisplay {
+  const serverIdMatch = toolName.match(/^mcp_([^_]+)_/);
+  const serverUrl = serverIdMatch
+    ? getMcpRegistry()
+        .getStates()
+        .find((s) => s.config.id === serverIdMatch[1])?.config.url
+    : undefined;
+  const mcpInfo = getConnectorForMcpTool(toolName, serverUrl);
+
+  // Prefer the connector's clean tool name when matched; otherwise parse
+  // the raw MCP key. Either way normalize separators to spaces.
+  const rawName = mcpInfo
+    ? mcpInfo.toolName.replace(/_/g, " ").replace(/-/g, " ")
+    : parseMcpToolName(toolName);
+
+  return {
+    mcpInfo,
+    readableName: rawName,
+    readableNameSentence: rawName ? toSentenceCase(rawName) : null,
+  };
+}

--- a/apps/extension/src/components/chat/skill-source-display.tsx
+++ b/apps/extension/src/components/chat/skill-source-display.tsx
@@ -1,0 +1,142 @@
+import { parseSource } from "@/lib/skills/source-parser";
+import { DownloadCloud } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface SkillSourceDisplay {
+  kind: "github" | "raw-skill-md" | "invalid";
+  /** Humanized skill name derived from the source (last subpath segment,
+   * else repo, else the raw source). */
+  skillName: string;
+  owner?: string;
+  /** Repo root URL, suitable for an external link. */
+  repoUrl?: string;
+  /** GitHub owner avatar URL. */
+  avatarUrl?: string;
+  /** "owner/repo" (+ "/subpath" when present) for the source link label. */
+  ownerRepoLabel?: string;
+  /** Original source string, for fallback display. */
+  raw: string;
+}
+
+/**
+ * Humanize a slug like "sales-attio" → "Sales attio", "react_best_practices"
+ * → "React best practices". Capitalizes the first character only — keeps
+ * intentionally-cased multi-word slugs intact.
+ */
+function humanize(slug: string): string {
+  if (!slug) return slug;
+  const cleaned = slug.replace(/[-_]/g, " ").trim();
+  if (!cleaned) return slug;
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/** Last non-empty path segment, e.g. "sales/sales-attio" → "sales-attio". */
+function lastSegment(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+/**
+ * Derive display metadata for a skill `source` string at install time.
+ *
+ * Used by both the install-skill approval card and the post-install
+ * result card so they present a consistent name / publisher / link.
+ * Built on the same `parseSource` the install pipeline uses, so the
+ * derived owner/repo always match what actually gets fetched.
+ */
+export function resolveSkillSourceDisplay(source: string): SkillSourceDisplay {
+  const raw = source;
+  const parsed = parseSource(source);
+
+  if (parsed.kind === "github") {
+    const { owner, repo, subpath } = parsed;
+    // Prefer the skill's own folder (subpath) for the name; fall back to
+    // the repo when the source points at a repo root.
+    const nameSlug = subpath ? lastSegment(subpath) : repo;
+    return {
+      kind: "github",
+      skillName: humanize(nameSlug),
+      owner,
+      repoUrl: `https://github.com/${owner}/${repo}`,
+      avatarUrl: `https://github.com/${owner}.png`,
+      ownerRepoLabel: subpath
+        ? `${owner}/${repo}/${subpath}`
+        : `${owner}/${repo}`,
+      raw,
+    };
+  }
+
+  if (parsed.kind === "raw-skill-md") {
+    // raw.githubusercontent.com/<owner>/<repo>/<ref>/.../SKILL.md
+    let skillName = "Skill";
+    let owner: string | undefined;
+    let avatarUrl: string | undefined;
+    try {
+      const url = new URL(parsed.url);
+      const segs = url.pathname.split("/").filter(Boolean);
+      // [owner, repo, ref, ...path, "SKILL.md"] → name from the folder
+      // holding SKILL.md.
+      if (segs.length >= 2) {
+        owner = segs[0];
+        avatarUrl = `https://github.com/${owner}.png`;
+      }
+      const folder = segs.length >= 2 ? segs[segs.length - 2] : undefined;
+      if (folder) skillName = humanize(folder);
+    } catch {
+      // keep defaults
+    }
+    return {
+      kind: "raw-skill-md",
+      skillName,
+      owner,
+      repoUrl: parsed.url,
+      avatarUrl,
+      ownerRepoLabel: owner,
+      raw,
+    };
+  }
+
+  // invalid / unrecognized → show the raw source verbatim.
+  return {
+    kind: "invalid",
+    skillName: raw,
+    raw,
+  };
+}
+
+/**
+ * Owner avatar for a skill source, with a graceful fallback to the
+ * download-cloud glyph when there's no avatar URL or the image fails to
+ * load (blocked request, 404, offline). Shared by the approval card and
+ * the install result card so they look identical.
+ */
+export function SkillSourceAvatar({
+  avatarUrl,
+  className,
+}: {
+  avatarUrl?: string;
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const box = cn(
+    "shrink-0 grid place-items-center rounded-md overflow-hidden size-7 bg-muted",
+    className,
+  );
+  if (!avatarUrl || failed) {
+    return (
+      <div className={box}>
+        <DownloadCloud className="size-4 text-primary" />
+      </div>
+    );
+  }
+  return (
+    <img
+      src={avatarUrl}
+      alt=""
+      className={cn(box, "object-cover")}
+      onError={() => setFailed(true)}
+    />
+  );
+}
+

--- a/apps/extension/src/components/chat/tool-previews/install-skill.tsx
+++ b/apps/extension/src/components/chat/tool-previews/install-skill.tsx
@@ -1,5 +1,9 @@
-import { DownloadCloud } from "lucide-react";
+import { ExternalLink, ShieldAlert } from "lucide-react";
 import { registerToolPreview } from "./registry";
+import {
+  resolveSkillSourceDisplay,
+  SkillSourceAvatar,
+} from "./../skill-source-display";
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
@@ -8,21 +12,58 @@ function readString(value: unknown): string | undefined {
 registerToolPreview("install_skill", (args) => {
   const source = readString(args.source);
 
+  if (!source) {
+    return (
+      <div className="px-3 py-2 bg-background/50 text-xs text-muted-foreground italic">
+        No source provided
+      </div>
+    );
+  }
+
+  const info = resolveSkillSourceDisplay(source);
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2 text-sm">
-        <DownloadCloud className="w-4 h-4 text-primary" />
-        <span className="font-medium text-foreground">Install Skill</span>
+    <div className="px-3 py-2.5 bg-background/50 flex flex-col gap-2.5">
+      {/* Identity row: avatar + skill name + "Install skill" eyebrow */}
+      <div className="flex items-center gap-2.5">
+        <SkillSourceAvatar avatarUrl={info.avatarUrl} />
+        <div className="min-w-0 flex flex-col">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 leading-none">
+            Install skill
+          </span>
+          <span className="text-sm font-medium text-foreground truncate">
+            {info.skillName}
+          </span>
+        </div>
       </div>
 
-      {source && (
-        <div className="bg-muted rounded px-3 py-2 text-sm text-foreground break-all">
-          {source}
+      {/* Source attribution */}
+      {info.kind === "invalid" || !info.repoUrl ? (
+        <div className="text-xs text-muted-foreground break-all">
+          Source: <span className="font-mono text-foreground/80">{info.raw}</span>
+        </div>
+      ) : (
+        <div className="text-xs text-muted-foreground">
+          Source:{" "}
+          <a
+            href={info.repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-foreground hover:underline break-all"
+          >
+            {info.ownerRepoLabel ?? info.repoUrl}
+            <ExternalLink className="size-3 shrink-0" />
+          </a>
         </div>
       )}
 
-      <div className="text-xs text-amber-500 mt-1">
-        This will fetch files from the source and save them to the extension's local storage.
+      {/* Trust note */}
+      <div className="flex items-start gap-1.5 rounded bg-amber-500/10 border border-amber-500/30 px-2.5 py-1.5 text-[11px] text-amber-600 dark:text-amber-400">
+        <ShieldAlert className="size-3.5 shrink-0 mt-px" />
+        <div className="leading-relaxed">
+          Downloads this skill's files into OpenBrowse's local storage and makes
+          it available to the agent. Only install skills from sources you trust.
+        </div>
       </div>
     </div>
   );

--- a/apps/extension/src/components/chat/tool-results/install-skill.tsx
+++ b/apps/extension/src/components/chat/tool-results/install-skill.tsx
@@ -1,0 +1,99 @@
+import { ExternalLink, FileWarning } from "lucide-react";
+import type { InstalledSkill } from "@/lib/skills/types";
+import {
+  resolveSkillSourceDisplay,
+  SkillSourceAvatar,
+} from "./../skill-source-display";
+import { ExpandableText } from "./expandable-text";
+
+interface Props {
+  result: unknown;
+}
+
+type InstallResult =
+  | { success: true; installed: InstalledSkill[] }
+  | { error: string }
+  | undefined;
+
+export function InstallSkillResult({ result }: Props) {
+  const res = result as InstallResult;
+
+  if (res && "error" in res && res.error) {
+    return (
+      <div className="ml-3 mt-1 mb-1 rounded-md border border-border overflow-hidden text-xs">
+        <div className="px-3 py-2 bg-background/50">
+          <ExpandableText
+            text={res.error}
+            className="font-mono text-red-400"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const installed =
+    res && "success" in res && res.success ? res.installed : [];
+
+  if (installed.length === 0) {
+    return (
+      <div className="ml-3 mt-1 mb-1 rounded-md border border-border overflow-hidden text-xs">
+        <div className="px-3 py-2 bg-background/50 text-muted-foreground italic">
+          No skills installed
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ml-3 mt-1 mb-1 rounded-md border border-border overflow-hidden text-xs">
+      <div className="bg-background/50 divide-y divide-border">
+        {installed.map((skill) => {
+          const info = resolveSkillSourceDisplay(skill.source);
+          return (
+            <div key={skill.name} className="flex flex-col gap-2 px-3 py-2.5">
+              <div className="flex items-start gap-2.5">
+                <SkillSourceAvatar avatarUrl={info.avatarUrl} />
+                <div className="min-w-0 flex flex-col gap-0.5">
+                  <span className="text-sm font-medium text-foreground">
+                    {skill.name}
+                  </span>
+                  {skill.description && (
+                    <span className="text-xs text-muted-foreground leading-snug">
+                      {skill.description}
+                    </span>
+                  )}
+                  {info.repoUrl ? (
+                    <a
+                      href={info.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground hover:underline break-all"
+                    >
+                      {info.ownerRepoLabel ?? info.repoUrl}
+                      <ExternalLink className="size-2.5 shrink-0" />
+                    </a>
+                  ) : (
+                    <span className="text-[11px] text-muted-foreground/70 font-mono break-all">
+                      {info.raw}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {skill.hasScripts && (
+                <div className="flex items-start gap-1.5 rounded bg-amber-500/10 border border-amber-500/30 px-2.5 py-1.5 text-[11px] text-amber-600 dark:text-amber-400">
+                  <FileWarning className="size-3.5 shrink-0 mt-px" />
+                  <div className="leading-relaxed">
+                    Contains scripts ({skill.scriptTypes.join(", ")}). OpenBrowse
+                    runs in the browser and reads them as context only — it does
+                    not execute them.
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -351,7 +351,7 @@ export function LandingPage({
           {!isConfigured && (
             <button
               type="button"
-              onClick={() => chrome.tabs.create({ url: chrome.runtime.getURL("/settings.html") })}
+              onClick={() => chrome.tabs.create({ url: chrome.runtime.getURL("/settings.html?tab=models") })}
               className="mt-2 w-full text-center text-xs text-primary hover:underline"
             >
               Set up an AI model to get started

--- a/apps/extension/src/entrypoints/settings/GeneralTab.tsx
+++ b/apps/extension/src/entrypoints/settings/GeneralTab.tsx
@@ -10,8 +10,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import type { Settings, AgentSettings } from "@/lib/types";
-import { useProviders } from "@/hooks/useProviders";
-import { RegistryIcon } from "@/components/ui/registry-icon";
+import { useConfiguredModels } from "@/hooks/useConfiguredModels";
+import { ModelPicker } from "@/components/chat/ModelPicker";
 
 interface GeneralTabProps {
   settings: Settings;
@@ -20,15 +20,14 @@ interface GeneralTabProps {
   onAgentSettingsChange: (patch: Partial<AgentSettings>) => void;
 }
 
+const SAME_AS_AGENT = {
+  value: "__default__",
+  label: "Same as agent model",
+} as const;
+
 export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsChange }: GeneralTabProps) {
-  const { providers } = useProviders();
-  const enabledModelOptions = settings.favoriteModels.map((m) => {
-    const [providerId, ...rest] = m.split(":");
-    const modelId = rest.join(":");
-    const provider = providers.find((p) => p.id === providerId);
-    const model = provider?.models.find((md) => md.id === modelId);
-    return { value: m, label: model?.name ?? m, providerId: provider?.id };
-  });
+  const providerModels = useConfiguredModels(settings);
+  const hasConfiguredModels = providerModels.length > 0;
 
   return (
     <div className="space-y-6">
@@ -107,30 +106,19 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
 
       <div className="space-y-2">
         <Label>Tidy model</Label>
-        <Select
-          value={settings.tidyModel || undefined}
-          onValueChange={(v) => onChange({ tidyModel: v })}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Select a model for tidy" />
-          </SelectTrigger>
-          <SelectContent>
-            {enabledModelOptions.length === 0 ? (
-              <p className="px-2 py-1.5 text-sm text-muted-foreground">
-                Enable models in the Models tab first
-              </p>
-            ) : (
-              enabledModelOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  <span className="flex items-center gap-2">
-                    {opt.providerId && <RegistryIcon id={opt.providerId} className="size-4" />}
-                    {opt.label}
-                  </span>
-                </SelectItem>
-              ))
-            )}
-          </SelectContent>
-        </Select>
+        {hasConfiguredModels ? (
+          <ModelPicker
+            trigger="settings"
+            providerModels={providerModels}
+            value={settings.tidyModel || undefined}
+            onValueChange={(v) => onChange({ tidyModel: v })}
+            placeholder="Select a model for tidy"
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground rounded-md border border-input px-3 py-2">
+            Configure a provider in the Models tab first
+          </p>
+        )}
         <p className="text-xs text-muted-foreground">
           Model used for automatic tab tidying
         </p>
@@ -141,25 +129,24 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
         <p className="text-xs text-muted-foreground">
           Model used for summarizing conversation history when context limit is reached. Defaults to agent model.
         </p>
-        <Select
-          value={agentSettings.compactionModel || "__default__"}
-          onValueChange={(v) => onAgentSettingsChange({ compactionModel: v === "__default__" ? undefined : v })}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Same as agent model" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__default__">Same as agent model</SelectItem>
-            {enabledModelOptions.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                <span className="flex items-center gap-2">
-                  {opt.providerId && <RegistryIcon id={opt.providerId} className="size-4" />}
-                  {opt.label}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {hasConfiguredModels ? (
+          <ModelPicker
+            trigger="settings"
+            providerModels={providerModels}
+            value={agentSettings.compactionModel ?? SAME_AS_AGENT.value}
+            defaultOption={SAME_AS_AGENT}
+            onValueChange={(v) =>
+              onAgentSettingsChange({
+                compactionModel: v === SAME_AS_AGENT.value ? undefined : v,
+              })
+            }
+            placeholder="Same as agent model"
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground rounded-md border border-input px-3 py-2">
+            Configure a provider in the Models tab first
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -171,32 +158,27 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
           cheaper/faster model here to reduce per-turn cost — typically
           a smaller model from the same provider works well.
         </p>
-        <Select
-          value={settings.completionCheck?.evaluatorModel || "__default__"}
-          onValueChange={(v) =>
-            onChange({
-              completionCheck: {
-                ...settings.completionCheck,
-                evaluatorModel: v === "__default__" ? undefined : v,
-              },
-            })
-          }
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Same as agent model" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__default__">Same as agent model</SelectItem>
-            {enabledModelOptions.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                <span className="flex items-center gap-2">
-                  {opt.providerId && <RegistryIcon id={opt.providerId} className="size-4" />}
-                  {opt.label}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {hasConfiguredModels ? (
+          <ModelPicker
+            trigger="settings"
+            providerModels={providerModels}
+            value={settings.completionCheck?.evaluatorModel ?? SAME_AS_AGENT.value}
+            defaultOption={SAME_AS_AGENT}
+            onValueChange={(v) =>
+              onChange({
+                completionCheck: {
+                  ...settings.completionCheck,
+                  evaluatorModel: v === SAME_AS_AGENT.value ? undefined : v,
+                },
+              })
+            }
+            placeholder="Same as agent model"
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground rounded-md border border-input px-3 py-2">
+            Configure a provider in the Models tab first
+          </p>
+        )}
       </div>
 
       <div className="space-y-4 pt-4 border-t">

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -186,7 +186,30 @@ function healPendingTools(
     const pp = p as Record<string, unknown>;
     const state = pp.state;
     if (typeof state !== "string") return true;
+    // `approval-responded` is non-terminal but is a legitimate resume
+    // point — the SDK re-executes an approved call from this state via
+    // the `tool-approval-response` it emits during convertToModelMessages.
+    // An approved (approved === true), output-less call must therefore
+    // be left intact so the tool actually runs; healing it to
+    // output-error here is exactly the "Interrupted on approval" bug.
+    // A denied (approved === false) call still needs heal (folded to
+    // output-denied below). Malformed approvals fall through to heal.
+    if (state === "approval-responded") {
+      const ap = pp.approval as
+        | { id?: unknown; approved?: unknown }
+        | undefined;
+      if (
+        ap &&
+        typeof ap.id === "string" &&
+        ap.approved === true &&
+        pp.output === undefined
+      ) {
+        return false;
+      }
+      return true;
+    }
     if (!TERMINAL_TOOL_STATES.has(state)) return true;
+
     if (pp.input === undefined || pp.input === null) return true;
     if (state === "output-available") {
       return pp.output === undefined || pp.output === null;
@@ -238,6 +261,34 @@ function healPendingTools(
             input,
             state: "output-denied",
             approval: { id: approval.id, approved: false, reason: denyReason },
+          } as typeof part;
+        }
+      }
+
+      // A denied `approval-responded` (approved === false) folds to the
+      // canonical output-denied terminal shape, preserving the user's
+      // reason. (An approved one never reaches here — `needsHeal`
+      // exempts it so the SDK can re-execute the tool.)
+      if (state === "approval-responded" && p.approval) {
+        const approval = p.approval as {
+          id?: unknown;
+          approved?: unknown;
+          reason?: unknown;
+        };
+        if (typeof approval.id === "string" && approval.approved === false) {
+          changed = true;
+          return {
+            ...part,
+            input,
+            state: "output-denied",
+            approval: {
+              id: approval.id,
+              approved: false,
+              reason:
+                typeof approval.reason === "string"
+                  ? approval.reason
+                  : denyReason,
+            },
           } as typeof part;
         }
       }

--- a/apps/extension/src/hooks/useConfiguredModels.ts
+++ b/apps/extension/src/hooks/useConfiguredModels.ts
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import { useProviders } from "@/hooks/useProviders";
+import type { ProviderModels } from "@/components/chat/ModelPicker";
+
+/**
+ * Settings slice the configured-models computation depends on. Kept
+ * narrow (rather than the full `Settings`) so callers can pass whatever
+ * settings object they already hold without coupling to its full shape.
+ */
+export interface ConfiguredModelsSettings {
+  /** providerId → config values (api keys etc.). */
+  providerConfigs: Record<string, Record<string, string>>;
+  /** Locally-downloaded model ids (web-llm / browser-ai). */
+  downloadedModels: string[];
+}
+
+/**
+ * The set of selectable models grouped by provider, filtered to
+ * providers the user has actually configured.
+ *
+ * A provider is included when:
+ *  - `byok`: every required `configSchema` field is present in
+ *    `settings.providerConfigs[provider.id]`.
+ *  - `web-llm` / `browser-ai`: at least one of its models is in
+ *    `settings.downloadedModels` (and only those models are listed).
+ *  - any other setup: included as-is.
+ *
+ * This is the single source of truth shared by the chat composer's
+ * model selector and the settings auxiliary-model pickers (tidy /
+ * compaction / completion-check), so the latter no longer show only
+ * favorited models.
+ *
+ * Extracted from the logic previously inlined in `ChatView`.
+ */
+export function useConfiguredModels(
+  settings: ConfiguredModelsSettings,
+): ProviderModels[] {
+  const { providers } = useProviders();
+  return useMemo(() => {
+    return providers
+      .map((provider) => {
+        let enabled = true;
+        let availableModels = provider.models;
+
+        if (provider.setup === "byok") {
+          const config = settings.providerConfigs[provider.id] ?? {};
+          const requiredFields =
+            provider.configSchema?.filter((f) => f.required) ?? [];
+          enabled = requiredFields.every((f) => !!config[f.key]);
+          if (!enabled) return null;
+        } else if (provider.setup === "web-llm") {
+          availableModels = provider.models.filter((m) =>
+            settings.downloadedModels.includes(m.id),
+          );
+          enabled = availableModels.length > 0;
+          if (!enabled) return null;
+        } else if (provider.setup === "browser-ai") {
+          availableModels = provider.models.filter((m) =>
+            settings.downloadedModels.includes(m.id),
+          );
+          enabled = availableModels.length > 0;
+          if (!enabled) return null;
+        }
+
+        return {
+          provider: provider.id,
+          label: provider.name,
+          models: availableModels,
+          enabled,
+        } as ProviderModels;
+      })
+      .filter((p): p is ProviderModels => p !== null);
+  }, [providers, settings.providerConfigs, settings.downloadedModels]);
+}

--- a/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
@@ -159,6 +159,101 @@ describe("rewriteForLLM tool-state heal", () => {
     expect(part.state).toBe("output-error");
   });
 
+  // ── approval-responded: the resume point (NOT a heal target) ──
+
+  it("preserves an APPROVED approval-responded part so the SDK re-runs the tool (install_skill / MCP approval bug)", () => {
+    // The exact "Interrupted on approval" bug: user clicked Allow, the
+    // SDK marked the dynamic-tool part approval-responded(approved:true)
+    // and fired the resume. convertToModelMessages re-executes from this
+    // state via the tool-approval-response it emits — but ONLY if we
+    // leave the part intact. Collapsing it to output-error here means
+    // the tool never runs and the user sees "Interrupted".
+    const part = {
+      type: "dynamic-tool",
+      toolCallId: "install-1",
+      toolName: "install_skill",
+      state: "approval-responded",
+      input: { source: "sales-skills/sales/sales-attio" },
+      approval: { id: "ap1", approved: true },
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("install sales-attio"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    const healed = out[1].parts[0] as {
+      state: string;
+      approval: { id: string; approved: boolean };
+      errorText?: string;
+    };
+    expect(healed.state).toBe("approval-responded");
+    expect(healed.approval).toEqual({ id: "ap1", approved: true });
+    expect(healed.errorText).toBeUndefined();
+    // No mutation → same instance returned.
+    expect(out[1]).toBe(msgs[1]);
+  });
+
+  it("folds a DENIED approval-responded part to output-denied (preserving reason)", () => {
+    const part = {
+      type: "tool-navigate",
+      toolCallId: "denied-resp",
+      state: "approval-responded",
+      input: { url: "https://example.com" },
+      approval: { id: "ap1", approved: false, reason: "nope" },
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    const healed = out[1].parts[0] as {
+      state: string;
+      approval: { id: string; approved: boolean; reason?: string };
+    };
+    expect(healed.state).toBe("output-denied");
+    expect(healed.approval).toEqual({
+      id: "ap1",
+      approved: false,
+      reason: "nope",
+    });
+  });
+
+  it("defaults missing input on an approved approval-responded part to {}", () => {
+    const part = {
+      type: "dynamic-tool",
+      toolCallId: "install-no-input",
+      toolName: "install_skill",
+      state: "approval-responded",
+      approval: { id: "ap2", approved: true },
+      // input deliberately missing
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("install"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    const healed = out[1].parts[0] as { state: string; input: unknown };
+    expect(healed.state).toBe("approval-responded");
+    expect(healed.input).toEqual({});
+  });
+
+  it("heals an approval-responded part with malformed approval to output-error", () => {
+    const part = {
+      type: "tool-navigate",
+      toolCallId: "resp-bad",
+      state: "approval-responded",
+      input: { url: "https://example.com" },
+      approval: { id: undefined, approved: true },
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    const healed = out[1].parts[0] as { state: string };
+    expect(healed.state).toBe("output-error");
+  });
+
   it("preserves non-tool parts (text, data-*) regardless of healing", () => {
     const msgs: AgentUIMessage[] = [
       userMsg("hi"),

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -62,6 +62,7 @@ import {
 } from "./tools";
 import { createDelegateTool } from "./tools/delegate";
 import { createFsTools } from "./tools/fs";
+import { createPythonTool } from "./tools/execute-python";
 import { setTaskTitleTool } from "./tools/set-task-title";
 import type { BrowserTool } from "./types";
 
@@ -888,6 +889,7 @@ export async function createAgentTransport(
   }
 
   const fsTools = createFsTools(conversationId);
+  const pythonTool = createPythonTool(conversationId);
 
   const browserTools: Record<string, ToolSet[string]> = {
     snapshot: toSDKTool(snapshotTool, "snapshot"),
@@ -905,6 +907,7 @@ export async function createAgentTransport(
     deleteMemory: toSDKTool(deleteMemoryTool, "deleteMemory"),
     executeCode: toSDKTool(executeCodeTool, "executeCode"),
     executeOnPage: toSDKTool(executeOnPageTool, "executeOnPage"),
+    executePython: toSDKTool(pythonTool, "executePython"),
     extract: toSDKTool(extractTool, "extract"),
     todoWrite: toSDKTool(todoWriteTool, "todoWrite"),
     skill: toSDKTool(skillTool, "skill"),

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -467,6 +467,55 @@ function repairToolPart(
     input = {};
   }
 
+  // `approval-responded` is NOT a terminal state, but it is a
+  // legitimate intermediate the SDK resumes from — DON'T heal it away.
+  //
+  // When the user clicks Allow, the SDK marks the tool part
+  // `approval-responded` with `approval.approved === true` and fires the
+  // auto-resume. `convertToModelMessages` maps a preserved
+  // approval-responded part (with `approval.approved != null`) into a
+  // `tool-call` + `tool-approval-request` + `tool-approval-response`
+  // triple, and the SDK's `collect-tool-approvals` then re-executes the
+  // approved call. If we collapse it to `output-error` here (as the
+  // generic non-terminal branch below would), the tool NEVER runs and
+  // the user sees "Interrupted" the instant they approve. So:
+  //   - approved (approved === true), no output yet → pass through so
+  //     the SDK runs `execute`.
+  //   - explicitly denied (approved === false) → fold to output-denied,
+  //     the canonical terminal shape for a denial.
+  //   - malformed approval (no id / approved not boolean) → fall through
+  //     to the generic heal below (output-error).
+  if (state === "approval-responded") {
+    const approval = raw.approval as
+      | { id?: unknown; approved?: unknown; reason?: unknown }
+      | undefined;
+    if (approval && typeof approval.id === "string") {
+      if (approval.approved === true) {
+        // Awaiting execution — preserve verbatim (only default `input`).
+        if (raw.input !== input) {
+          return { ...raw, input } as typeof part;
+        }
+        return part;
+      }
+      if (approval.approved === false) {
+        return {
+          ...raw,
+          input,
+          state: "output-denied",
+          approval: {
+            id: approval.id,
+            approved: false,
+            ...(typeof approval.reason === "string"
+              ? { reason: approval.reason }
+              : {}),
+          },
+          output: undefined,
+        } as typeof part;
+      }
+    }
+    // Malformed approval shape → generic heal below.
+  }
+
   // Non-terminal state → collapse to output-error. Drop any partial
   // output so the part is unambiguous.
   if (!state || !TERMINAL_TOOL_STATES.has(state)) {

--- a/apps/extension/src/lib/agent/subagents/built-ins/general.ts
+++ b/apps/extension/src/lib/agent/subagents/built-ins/general.ts
@@ -21,6 +21,7 @@ export const generalAgent: AgentDefinition = {
     "screenshot",
     "extract",
     "executeOnPage",
+    "executePython",
     "scrollPage",
     "selectTab",
     "listTabs",

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -91,12 +91,15 @@ You are operating in a sandboxed, browser-based virtual file system (VFS). You h
 
 ## Code Execution
 
-You have two tools for running JavaScript (Note: these do NOT run in your Virtual Workspace):
+You have three tools for running code (Note: these do NOT run in your Virtual Workspace unless noted):
 
-- \`executeCode\`: Runs in an isolated sandbox. Use for computation, data transforms, API calls (fetch). No DOM access. Pass data via \`input\` parameter, access it as \`__input\` in your code. Use \`return\` to produce output.
-- \`executeOnPage({ tab, code, args? })\`: Runs in a specific tab's page context with full DOM access. Requires user approval before each execution. Use when you need to read or modify a page beyond what snapshot/clickElement/typeInElement provide — for example, scraping structured data from a product grid, or reading \`data-*\` attributes that don't appear in the accessibility tree.
+- \`executeCode\`: Runs JavaScript in an isolated sandbox. Use for computation, data transforms, API calls (fetch). No DOM access. Pass data via \`input\` parameter, access it as \`__input\` in your code. Use \`return\` to produce output.
+- \`executeOnPage({ tab, code, args? })\`: Runs JavaScript in a specific tab's page context with full DOM access. Requires user approval before each execution. Use when you need to read or modify a page beyond what snapshot/clickElement/typeInElement provide — for example, scraping structured data from a product grid, or reading \`data-*\` attributes that don't appear in the accessibility tree.
+- \`executePython({ code, input?, allow_network? })\`: Runs CPython 3 via Pyodide in a sandbox. Your conversation's workspace is mounted at \`/workspace\` (read/write) and \`/skills\` is mounted read-only. State (imports, globals) persists across calls in the same conversation. Network is OFF by default — set \`allow_network: true\` to install packages with micropip or make HTTP requests. Requires user approval. Code runs at module level (NO top-level \`return\`; the last expression is the result) and top-level await is supported. Load the \`python-env\` skill for the pre-built package list and Pyodide-specific idioms.
 
-Prefer the existing browser tools (snapshot, clickElement, etc.) for simple interactions. Use executeOnPage only when you need complex multi-step DOM manipulation or need to access page JavaScript variables/state.
+Guidance:
+- Prefer the existing browser tools (snapshot, clickElement, etc.) for simple interactions. Use executeOnPage only when you need complex multi-step DOM manipulation or need to access page JavaScript variables/state.
+- For data work — generating PDFs/Excel/Word, scientific computing, or anything needing Python libraries — prefer \`executePython\`. For quick JS-side computation, fetches, or transforms, use \`executeCode\`.
 
 ## Recovering from problems
 


### PR DESCRIPTION
### Summary
Adds a reusable model picker to settings (showing all configured models, not just favorites), token-AND search, and fixes an approval-interrupt bug — plus MCP approval and skill-install UX improvements.

### Changes
- Extract reusable `ModelPicker` + `useConfiguredModels`; settings aux-model selectors now list all configured models grouped by provider.
- Token-AND substring search in the model picker (e.g. "flash 3.5" matches "Gemini 3.5 Flash").
- Fix "Interrupted on approval" for install_skill/MCP tools (exempt approval-responded parts from healing).
- Surface connector logos + readable names in MCP tool approvals.
- Expose `executePython` to the main agent and `general` subagent.
- Redesign skill-install approval preview + post-install result card.
- "Set up an AI model" now deep-links to the Models settings tab.

### Testing
- `pnpm compile` and `pnpm test` pass (added unit tests for model-picker search, MCP tool display, skill source display, and tool-state heal).

### Checklist
- [ ] Tested locally with `pnpm dev`
- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Ran `pnpm changeset` if this PR changes user-facing behavior
- [x] No unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed Python code execution capability to agents
  * Added skill installation result display with trust information
  * Improved MCP tool approval interface with connector identification

* **Bug Fixes**
  * Fixed approval-interrupt handling in tool execution
  * Improved tool state recovery and healing logic

* **Improvements**
  * Enhanced model selection with configured models list and search functionality
  * Better display labels for MCP tools and skill sources
  * Improved model navigation shortcuts in settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->