### PR TITLE
feat(docs): add changelog page

### DIFF
--- a/apps/docs/app/changelog/layout.tsx
+++ b/apps/docs/app/changelog/layout.tsx
@@ -1,0 +1,13 @@
+import { Nav } from "@/components/landing/nav";
+import { Footer } from "@/components/landing/footer";
+import type { ReactNode } from "react";
+
+export default function ChangelogLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-6xl px-6 py-12">{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/docs/app/changelog/page.tsx
+++ b/apps/docs/app/changelog/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import { getReleases, RELEASES_URL } from "@/lib/changelog";
+import { ReleaseEntry } from "@/components/changelog/release-entry";
+
+export const metadata: Metadata = {
+  title: "Changelog",
+  description: "Every release shipped to OpenBrowse, straight from GitHub.",
+};
+
+export default async function ChangelogPage() {
+  const releases = await getReleases();
+  const latest = releases[0];
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <header className="border-b pb-10">
+        <h1 className="font-mono text-3xl font-bold tracking-tight">Changelog</h1>
+        <p className="mt-2 text-muted-foreground">
+          Every release shipped to OpenBrowse, straight from GitHub.
+        </p>
+        <div className="mt-4 flex items-center gap-3 text-sm">
+          {latest && (
+            <span className="inline-flex items-center gap-1.5 rounded-[0.125rem] border px-2 py-1 font-mono">
+              Latest <span className="text-primary">{latest.name}</span>
+            </span>
+          )}
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            GitHub Releases →
+          </a>
+        </div>
+      </header>
+
+      {releases.length > 0 ? (
+        <div className="mt-10 flex flex-col">
+          {releases.map((release) => (
+            <ReleaseEntry key={release.tag} release={release} />
+          ))}
+        </div>
+      ) : (
+        <p className="py-16 text-muted-foreground">
+          No releases yet.{" "}
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            Follow along on GitHub
+          </a>
+          .
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -109,3 +109,165 @@
 [role="tooltip"] {
   box-shadow: none !important;
 }
+
+/* Changelog release-notes body */
+.changelog-prose {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.changelog-prose h1,
+.changelog-prose h2 {
+  margin-top: 1.75rem;
+  margin-bottom: 0.625rem;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.changelog-prose h2:first-child,
+.changelog-prose h1:first-child {
+  margin-top: 0;
+}
+/* Reset the first child's top margin regardless of element type so the gap
+   below the version header stays constant whether the body is clamped
+   (overflow:hidden creates a BFC that would otherwise preserve the margin)
+   or fully expanded. */
+.changelog-prose > :first-child {
+  margin-top: 0;
+}
+.changelog-prose h3,
+.changelog-prose h4 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.changelog-prose p {
+  margin: 0.5rem 0;
+  color: var(--muted-foreground);
+}
+.changelog-prose ul,
+.changelog-prose ol {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+  color: var(--muted-foreground);
+}
+.changelog-prose ul { list-style: disc; }
+.changelog-prose ol { list-style: decimal; }
+.changelog-prose li { margin: 0.25rem 0; }
+.changelog-prose a {
+  color: var(--primary);
+  text-underline-offset: 2px;
+  overflow-wrap: anywhere;
+}
+.changelog-prose a:hover { text-decoration: underline; }
+.changelog-prose code {
+  border-radius: 0.125rem;
+  background: var(--muted);
+  padding: 0.1rem 0.3rem;
+  font-size: 0.8125rem;
+  overflow-wrap: anywhere;
+}
+.changelog-prose pre {
+  margin: 0.75rem 0;
+  overflow-x: auto;
+  border-radius: 0.125rem;
+  border: 1px solid var(--border);
+  background: var(--muted);
+  padding: 0.75rem;
+  font-size: 0.8125rem;
+}
+.changelog-prose pre code {
+  background: transparent;
+  padding: 0;
+  overflow-wrap: normal;
+}
+.changelog-prose img { max-width: 100%; height: auto; }
+.changelog-prose hr {
+  margin: 1.5rem 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+/* Changelog: collapsible long releases.
+   The prose is a normally-painted sibling (never inside <details>, which would
+   hide it via content-visibility). The <details> acts purely as a no-JS toggle
+   and controls the sibling clip through :has().
+
+   The clip wrapper is a single-row grid; animating the row track between a
+   fixed preview height and 1fr gives a smooth expand/collapse (the same
+   technique shadcn/Radix Collapsible uses for 0fr<->1fr), without needing JS
+   or animating to max-height:none. */
+.changelog-body-wrap:has(.changelog-toggle) {
+  padding-bottom: 2rem;
+}
+.changelog-prose-clip {
+  display: grid;
+  grid-template-rows: 1fr;
+}
+.changelog-body-wrap:has(.changelog-toggle) .changelog-prose-clip {
+  grid-template-rows: minmax(0, 1fr);
+  overflow: hidden;
+  transition: grid-template-rows 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.changelog-body-wrap:has(.changelog-toggle:not([open])) .changelog-prose-clip {
+  /* Collapsed preview height. Track the clip, not the prose, so it animates. */
+  grid-template-rows: minmax(0, 22rem);
+}
+.changelog-prose-clip > .changelog-prose {
+  min-height: 0;
+  overflow: hidden;
+}
+/* Fade overlay while collapsed (fades out as it expands) */
+.changelog-body-wrap:has(.changelog-toggle)::after {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  bottom: 2rem;
+  height: 4rem;
+  background: linear-gradient(to bottom, transparent, var(--background));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.32s ease;
+}
+.changelog-body-wrap:has(.changelog-toggle:not([open]))::after {
+  opacity: 1;
+}
+.changelog-toggle {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+.changelog-toggle > summary {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  transition: color 0.15s;
+}
+.changelog-toggle > summary:hover {
+  color: var(--foreground);
+}
+.changelog-toggle > summary::marker,
+.changelog-toggle > summary::-webkit-details-marker {
+  display: none;
+  content: "";
+}
+.changelog-toggle > summary::after {
+  content: "Expand release \25BE";
+}
+.changelog-toggle[open] > summary::after {
+  content: "Collapse \25B4";
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .changelog-body-wrap:has(.changelog-toggle) .changelog-prose-clip,
+  .changelog-body-wrap:has(.changelog-toggle)::after {
+    transition: none;
+  }
+}

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -115,7 +115,6 @@
   font-size: 0.875rem;
   line-height: 1.6;
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 .changelog-prose h1,
 .changelog-prose h2 {

--- a/apps/docs/components/changelog/release-entry.tsx
+++ b/apps/docs/components/changelog/release-entry.tsx
@@ -72,7 +72,11 @@ export function ReleaseEntry({ release }: { release: Release }) {
         </div>
         {isLong && (
           <details className="changelog-toggle">
-            <summary />
+            {/* Visible label is supplied via CSS ::after; this gives screen
+                readers an accessible name without duplicating it visually. */}
+            <summary>
+              <span className="sr-only">Toggle release details</span>
+            </summary>
           </details>
         )}
       </div>

--- a/apps/docs/components/changelog/release-entry.tsx
+++ b/apps/docs/components/changelog/release-entry.tsx
@@ -1,0 +1,81 @@
+import type { Release } from "@/lib/changelog";
+import { GitCompare } from "lucide-react";
+
+// Releases with notes longer than this (in rendered HTML chars) are collapsed
+// behind an "Expand release" toggle to keep the timeline scannable.
+const COLLAPSE_THRESHOLD = 1600;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function CompareButton({ release }: { release: Release }) {
+  if (!release.compareUrl) return null;
+  return (
+    <a
+      href={release.compareUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mt-4 inline-flex w-fit items-center gap-2 rounded-[0.125rem] border px-3 py-1.5 font-mono text-[0.8125rem] text-foreground transition-colors hover:border-muted-foreground hover:bg-muted"
+    >
+      <GitCompare className="size-3.5" />
+      Full Changelog
+      {release.compareRange && (
+        <span className="text-muted-foreground">{release.compareRange}</span>
+      )}
+    </a>
+  );
+}
+
+export function ReleaseEntry({ release }: { release: Release }) {
+  const isLong = release.bodyHtml.length > COLLAPSE_THRESHOLD;
+
+  return (
+    <article
+      data-collapsible={isLong ? "" : undefined}
+      className="changelog-entry border-t border-dashed py-10 first:border-t-0 first:pt-0"
+    >
+      <header className="changelog-sticky-header sticky top-14 z-10 -mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b border-border/60 bg-background pt-2 pb-2">
+        <a
+          href={release.htmlUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${release.name} release notes on GitHub (opens in new tab)`}
+          className="font-mono text-2xl font-bold tracking-tight text-foreground transition-colors hover:text-primary"
+        >
+          {release.name}
+        </a>
+        <time
+          dateTime={release.date}
+          className="font-mono text-xs text-muted-foreground"
+        >
+          {formatDate(release.date)}
+        </time>
+        {release.isPrerelease && (
+          <span className="inline-flex rounded-[0.125rem] border px-1.5 py-0.5 text-xs text-muted-foreground">
+            Pre-release
+          </span>
+        )}
+      </header>
+
+      <div className="changelog-body-wrap relative mt-5">
+        <div className="changelog-prose-clip">
+          <div
+            className="changelog-prose max-w-none"
+            dangerouslySetInnerHTML={{ __html: release.bodyHtml }}
+          />
+          <CompareButton release={release} />
+        </div>
+        {isLong && (
+          <details className="changelog-toggle">
+            <summary />
+          </details>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/docs/components/landing/footer.tsx
+++ b/apps/docs/components/landing/footer.tsx
@@ -32,6 +32,9 @@ export function Footer() {
             <a href="https://github.com/openbrowse-ai/openbrowse" target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground">
               GitHub
             </a>
+            <Link href="/changelog" className="text-muted-foreground hover:text-foreground">
+              Changelog
+            </Link>
             <Link href="/docs/contributing" className="text-muted-foreground hover:text-foreground">
               Contributing
             </Link>

--- a/apps/docs/components/landing/nav.tsx
+++ b/apps/docs/components/landing/nav.tsx
@@ -23,6 +23,12 @@ export function Nav() {
         </Link>
         <nav className="flex items-center gap-6 text-sm">
           <Link
+            href="/changelog"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Changelog
+          </Link>
+          <Link
             href="/docs"
             className="text-muted-foreground transition-colors hover:text-foreground"
           >

--- a/apps/docs/content/changelog-snapshot.json
+++ b/apps/docs/content/changelog-snapshot.json
@@ -1,0 +1,108 @@
+[
+  {
+    "tag": "openbrowse@0.4.2",
+    "name": "v0.4.2",
+    "date": "2026-05-30T20:00:35Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.4.2",
+    "bodyHtml": "<h3>Patch Changes</h3>\n<ul>\n<li>610c535: Aux model picker shows all configured models; token-AND model search; fix approval-interrupt bug; expose executePython; improved MCP approval + skill-install UX.</li>\n</ul>\n<h2>What's Changed</h2>\n<ul>\n<li>feat(extension): configurable aux model picker, token-AND search, and approval fixes by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/70\">#70</a></li>\n<li>chore(release): version packages by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/71\">#71</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/openbrowse@0.4.1...openbrowse@0.4.2",
+    "compareRange": "0.4.1 → 0.4.2"
+  },
+  {
+    "tag": "openbrowse@0.4.1",
+    "name": "v0.4.1",
+    "date": "2026-05-30T16:05:26Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.4.1",
+    "bodyHtml": "<h3>Patch Changes</h3>\n<ul>\n<li>\n<p>6010425: Fix tool-approval \"Always allow\", add other-tab awareness, and assorted abort/UX fixes:</p>\n<ul>\n<li>Respect \"Always allow\" by calling <code>needsApproval</code> with the AI SDK's positional <code>input</code> argument (previously <code>input</code> was always <code>undefined</code>, so the same-origin allowlist was never consulted and approval was always required).</li>\n<li>Surface the user's other open tabs to the agent as an awareness-only <code>## Other open tabs</code> block. Titles/URLs are sanitized (newlines/control chars collapsed, length-capped) before reaching the system prompt to prevent prompt injection, and only <code>http(s)</code> URLs are exposed.</li>\n<li>Bind the shared active tab on the first message of a new conversation so the legend marks it <code>[active]</code> immediately; the bind now honors a <code>{ ok: false }</code> background response instead of pinning an unbound tab.</li>\n<li>Skip the completion check when the user aborts generation (the SDK emits an <code>abort</code> chunk and closes cleanly, which previously caused the check to grade an abandoned draft).</li>\n<li>Stop TipTap from nesting pasted markdown links on each copy/paste/resend cycle.</li>\n<li>Disable per-word stagger in the markdown renderer to fix concurrent/parallel reveal of streamed sections.</li>\n</ul>\n</li>\n</ul>\n<h2>What's Changed</h2>\n<ul>\n<li>fix(ci): resolve release tag from input, not event_name by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/65\">#65</a></li>\n<li>fix: always-allow approval, tab awareness, and abort/UX fixes by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/66\">#66</a></li>\n<li>chore: refresh models.dev snapshot by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/69\">#69</a></li>\n<li>chore(release): version packages by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/67\">#67</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/openbrowse@0.4.0...openbrowse@0.4.1",
+    "compareRange": "0.4.0 → 0.4.1"
+  },
+  {
+    "tag": "openbrowse@0.4.0",
+    "name": "v0.4.0",
+    "date": "2026-05-29T18:58:16Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.4.0",
+    "bodyHtml": "<h3>Minor Changes</h3>\n<ul>\n<li>\n<p>dbbda3c: Subagents: the chat agent can now delegate focused tasks to specialized subagents that run with fresh context, their own tool allowlist, and isolated tab/window state.</p>\n<ul>\n<li><strong><code>explore</code></strong> — read-only research subagent. Use for background investigation that should not mutate state.</li>\n<li><strong><code>general</code></strong> — read/write subagent for general-purpose delegation when the parent's tools fit but the work would bloat the parent's context with verbose output.</li>\n</ul>\n<p>Each delegation appears inline as a collapsible trace block with a live transcript, a step counter, and a phase title the subagent updates as it works. Subagents run with isolation: <code>peer</code> puts the child in its own tab group within the same window (default), and <code>incognito</code> opens a fresh incognito window with no shared cookies/auth/storage that auto-closes when done. Stop now correctly cancels in-flight subagents along with the parent.</p>\n</li>\n</ul>\n<h2>What's Changed</h2>\n<ul>\n<li>feat(extension): subagents - explore and general agents by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/62\">#62</a></li>\n<li>chore(release): version packages by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/63\">#63</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/openbrowse@0.3.2...openbrowse@0.4.0",
+    "compareRange": "0.3.2 → 0.4.0"
+  },
+  {
+    "tag": "openbrowse@0.3.2",
+    "name": "openbrowse@0.3.2",
+    "date": "2026-05-29T09:52:51Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.3.2",
+    "bodyHtml": "<h3>Patch Changes</h3>\n<ul>\n<li>\n<p>402b8d0: Add Attio as a built-in MCP connector (new \"CRM\" category) with OAuth, all 37 tools, and light/dark icons. Also fixes MCP reliability:</p>\n<ul>\n<li>OAuth flow now sends a <code>state</code> parameter, required by strict providers like Attio (previously failed with \"Authorization page could not be loaded\").</li>\n<li>Connected MCP servers are no longer torn down and reconnected on every home.html load — this eliminated a multi-second window where the agent saw zero MCP tools.</li>\n<li>An active chat conversation now rebinds to the latest transport when MCP tools finish loading, so newly connected tools become available without a refresh.</li>\n<li>Settings → Connectors left panel border now spans the full height.</li>\n</ul>\n</li>\n</ul>"
+  },
+  {
+    "tag": "openbrowse@0.3.1",
+    "name": "v0.3.1",
+    "date": "2026-05-28T22:31:59Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.3.1",
+    "bodyHtml": "<h3>Patch Changes</h3>\n<ul>\n<li>\n<p>b5717e9: Fix three small chat issues:</p>\n<ul>\n<li>Completion check no longer runs while a tool call is paused on human approval. The drafted text at that point is mid-narration (\"I'll now run X to do Y\") and isn't a final response — the gate now waits for the next iteration after approval, when the tool actually has output.</li>\n<li>Long tool error logs collapse to ~10 visual lines with an inline expand toggle. Single-line errors that wrapped to dozens of visual lines now collapse correctly (the previous clamp only counted <code>\\n</code>-delimited lines). Applied to executeCode/executeOnPage/executePython error output, the skill tool's error block, and the top-level chat error banner.</li>\n<li>\"Always allow on \" now reliably persists before the agent resumes. The previous implementation fired the storage write and the approval synchronously, so the next tool call's <code>needsApproval</code> check could race the write and re-prompt — most reproducible on home.html with back-to-back executeOnPage calls.</li>\n</ul>\n</li>\n</ul>\n<h2>What's Changed</h2>\n<ul>\n<li>fix: completion-check pending tools, error log clamp, always-allow race by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/55\">#55</a></li>\n<li>ci(release): build extension zip from changesets workflow by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/53\">#53</a></li>\n<li>chore(release): version packages by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/56\">#56</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/openbrowse@0.3.0...openbrowse@0.3.1",
+    "compareRange": "0.3.0 → 0.3.1"
+  },
+  {
+    "tag": "openbrowse@0.3.0",
+    "name": "v0.3.0",
+    "date": "2026-05-27T23:53:33Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.3.0",
+    "bodyHtml": "<h3>Minor Changes</h3>\n<ul>\n<li>2604829: Agent: a separate skeptical evaluator now reviews each drafted final response before it reaches you, and asks the agent to revise if the response is incomplete or unsupported by what was actually observed. Mid-loop refinements show as a compact \"Refining answer\" pill; unresolved concerns surface as a soft warning. Choose a cheaper or faster evaluator model in Settings → General, or leave it on the default. Chat exports and the per-message Copy button now include the rejection block as part of the audit trail.</li>\n</ul>\n<h3>Patch Changes</h3>\n<ul>\n<li>\n<p>2604829: Agent reliability fixes:</p>\n<ul>\n<li>Tab handles now persist across mid-stream conversation switches, so in-flight tool calls in the previous chat don't lose the tab they were targeting.</li>\n<li>Stranded tool calls left over from interrupted streams heal cleanly on edit/retry/regenerate instead of breaking the conversation on resume.</li>\n<li>Approving a tool call while other tools are still running in the same step no longer drops the auto-resume — the agent now picks up the approved call once the rest of the step completes.</li>\n<li>Editing a user message in chat-db now logs a warning when the target id can't be found, surfacing the historical \"stale tail after edit\" failure mode at first repro instead of silently months later.</li>\n<li>The completion-check evaluator now pins to its transport instance, so multiple concurrent agent windows can't drift across each other's models mid-stream.</li>\n<li>Evaluator-error fallback messages no longer expose internal error details to the chat or markdown export; detailed errors stay in the developer console.</li>\n</ul>\n</li>\n</ul>\n<h2>What's Changed</h2>\n<ul>\n<li>chore: refresh models.dev snapshot by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/48\">#48</a></li>\n<li>feat(bench): optional Cloudflare R2 upload for run artifacts by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/49\">#49</a></li>\n<li>feat: completion check — review and refine drafted responses before they ship by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/50\">#50</a></li>\n<li>chore(release): version packages by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/52\">#52</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/openbrowse@0.2.2...openbrowse@0.3.0",
+    "compareRange": "0.2.2 → 0.3.0"
+  },
+  {
+    "tag": "openbrowse@0.2.2",
+    "name": "v0.2.2",
+    "date": "2026-05-27T00:24:54Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/openbrowse%400.2.2",
+    "bodyHtml": "<h3>Patch Changes</h3>\n<ul>\n<li>98f6004: Agent: tab arguments on browser tools are now explicit (<code>tab: \"t1\"</code>) instead of relying on an implicit \"active tab\". Fixes the \"Always allow on this domain\" approval button not appearing when the agent acted from the home tab. Conversation tab handles persist across service worker restarts. (#39)</li>\n</ul>\n<h2>What's Changed</h2>\n<ul>\n<li>chore: OSS foundation by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/26\">#26</a></li>\n<li>chore(actions): bump marocchino/sticky-pull-request-comment from 2.9.4 to 3.0.4 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/27\">#27</a></li>\n<li>chore(actions): bump actions/checkout from 4.2.2 to 6.0.2 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/29\">#29</a></li>\n<li>chore(actions): bump actions/setup-node from 4.4.0 to 6.4.0 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/30\">#30</a></li>\n<li>chore(actions): bump actions/upload-artifact from 4.6.2 to 7.0.1 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/31\">#31</a></li>\n<li>chore(actions): bump peter-evans/create-pull-request from 6.1.0 to 8.1.1 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/28\">#28</a></li>\n<li>chore(deps)(deps): bump dotenv from 16.6.1 to 17.4.2 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/34\">#34</a></li>\n<li>chore(deps)(deps-dev): bump @types/node from 22.19.19 to 25.9.1 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/37\">#37</a></li>\n<li>chore(deps)(deps-dev): bump vitest from 2.1.9 to 4.1.7 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/35\">#35</a></li>\n<li>chore(deps)(deps): bump @openrouter/ai-sdk-provider from 1.5.4 to 2.9.0 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/33\">#33</a></li>\n<li>fix(bench): drop deprecated baseUrl from tsconfig by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/38\">#38</a></li>\n<li>chore(deps)(deps-dev): bump typescript from 5.9.3 to 6.0.3 by @dependabot[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/36\">#36</a></li>\n<li>feat(agent): explicit tab args + fix Always-allow-on-domain approval button by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/39\">#39</a></li>\n<li>chore(release): make package.json the version source of truth by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/40\">#40</a></li>\n<li>chore: add changeset for v0.3.0 by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/41\">#41</a></li>\n<li>Revert \"chore(release): make package.json the version source of truth (#40)\" by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/42\">#42</a></li>\n<li>chore(release): make package.json the version source of truth by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/43\">#43</a></li>\n<li>fix(ci): use <code>pnpm run version</code> in Changesets workflow by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/44\">#44</a></li>\n<li>chore(release): version packages by @github-actions[bot] in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/45\">#45</a></li>\n<li>chore(release): adopt Changesets workspace tag format by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/47\">#47</a></li>\n</ul>\n<h2>New Contributors</h2>\n<ul>\n<li>@dependabot[bot] made their first contribution in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/27\">#27</a></li>\n<li>@github-actions[bot] made their first contribution in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/45\">#45</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/v0.2.1...openbrowse@0.2.2",
+    "compareRange": "v0.2.1 → 0.2.2"
+  },
+  {
+    "tag": "v0.2.1",
+    "name": "v0.2.1",
+    "date": "2026-05-24T07:15:23Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/v0.2.1",
+    "bodyHtml": "<h2>What's Changed</h2>\n<ul>\n<li>fix(extension): rail layout mount and agent-transport compound keys by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/24\">#24</a></li>\n<li>chore(release): bump extension to v0.2.1 by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/25\">#25</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/v0.2.0...v0.2.1",
+    "compareRange": "v0.2.0 → v0.2.1"
+  },
+  {
+    "tag": "v0.2.0",
+    "name": "v0.2.0",
+    "date": "2026-05-24T02:11:05Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/v0.2.0",
+    "bodyHtml": "<h2>What's Changed</h2>\n<ul>\n<li>feat(extension): add webFetch tool + provider/model UX fixes by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/17\">#17</a></li>\n<li>feat: per-conversation file uploads to OPFS workspace by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/18\">#18</a></li>\n<li>feat(extension): Working folder viewers, resizable side-panel, and OPFS uploads by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/21\">#21</a></li>\n<li>feat: OpenBrowse offline evaluation harness &#x26; runner hardening by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/20\">#20</a></li>\n<li>feat(extension): message queueing while agent is streaming by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/22\">#22</a></li>\n<li>chore(release): bump extension to v0.2.0 by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/23\">#23</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/v0.1.1...v0.2.0",
+    "compareRange": "v0.1.1 → v0.2.0"
+  },
+  {
+    "tag": "v0.1.1",
+    "name": "v0.1.1",
+    "date": "2026-05-23T02:38:21Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/v0.1.1",
+    "bodyHtml": "<h2>What's Changed</h2>\n<ul>\n<li>feat(landing): mono headline, refined widths, manual-install CTA by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/15\">#15</a></li>\n<li>fix(extension): heal broken chat sessions and stranded tool calls by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/16\">#16</a></li>\n</ul>",
+    "compareUrl": "https://github.com/openbrowse-ai/openbrowse/compare/v0.1.0...v0.1.1",
+    "compareRange": "v0.1.0 → v0.1.1"
+  },
+  {
+    "tag": "v0.1.0",
+    "name": "v0.1.0",
+    "date": "2026-05-23T00:08:57Z",
+    "isPrerelease": false,
+    "htmlUrl": "https://github.com/openbrowse-ai/openbrowse/releases/tag/v0.1.0",
+    "bodyHtml": "<h2>What's Changed</h2>\n<ul>\n<li>feat: Add agent task planning UI and todowrite tool by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/1\">#1</a></li>\n<li>feat(overlay): unified ranked search with personalized shortcuts by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/2\">#2</a></li>\n<li>feat: detachable side panel popover with per-tab scoping by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/3\">#3</a></li>\n<li>docs: restructure site (sidebar, sections, new pages) by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/4\">#4</a></li>\n<li>feat: landing page redesign and self-hosted typography by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/5\">#5</a></li>\n<li>feat: add Option+Space global chat popup with conversation/draft persistence by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/6\">#6</a></li>\n<li>fix(agent): message-based compaction + reduce mid-task reluctance by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/7\">#7</a></li>\n<li>fix(overlay/search): rank open tabs above frecent history by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/8\">#8</a></li>\n<li>feat: agent skill system, virtual workspace, and OPFS filesystem tools by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/9\">#9</a></li>\n<li>refactor: convert to pnpm monorepo (apps/* + packages/*) by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/10\">#10</a></li>\n<li>feat: add Python execution sandbox via Pyodide and UI improvements by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/11\">#11</a></li>\n<li>feat(registry): dynamic provider registry powered by models.dev by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/12\">#12</a></li>\n<li>fix: auto-update bundled skills when extension is upgraded by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/13\">#13</a></li>\n<li>Docs update + manual install + release &#x26; CI workflows by @aschung01 in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/14\">#14</a></li>\n</ul>\n<h2>New Contributors</h2>\n<ul>\n<li>@aschung01 made their first contribution in <a href=\"https://github.com/openbrowse-ai/openbrowse/pull/1\">#1</a></li>\n</ul>\n<p><strong>Full Changelog</strong>: <a href=\"https://github.com/openbrowse-ai/openbrowse/commits/v0.1.0\">https://github.com/openbrowse-ai/openbrowse/commits/v0.1.0</a></p>"
+  }
+]

--- a/apps/docs/lib/changelog.ts
+++ b/apps/docs/lib/changelog.ts
@@ -1,0 +1,93 @@
+import { renderMarkdown } from "@/lib/markdown";
+import { extractCompareUrl, shortCompareRange } from "@/lib/remark-github-links";
+import snapshot from "@/content/changelog-snapshot.json";
+
+const OWNER = "openbrowse-ai";
+const REPO = "openbrowse";
+
+export type Release = {
+  tag: string;
+  name: string;
+  date: string; // ISO published_at
+  isPrerelease: boolean;
+  htmlUrl: string;
+  bodyHtml: string; // sanitized HTML
+  compareUrl?: string; // GitHub compare URL for this release, if present
+  compareRange?: string; // shortened range, e.g. "0.4.1 → 0.4.2"
+};
+
+export const RELEASES_URL = `https://github.com/${OWNER}/${REPO}/releases`;
+
+type GitHubRelease = {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  draft: boolean;
+  prerelease: boolean;
+  html_url: string;
+  published_at: string | null;
+  created_at: string;
+};
+
+export async function fetchFromGitHub(): Promise<Release[]> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const res = await fetch(
+    `https://api.github.com/repos/${OWNER}/${REPO}/releases?per_page=100`,
+    { headers },
+  );
+  if (!res.ok) {
+    throw new Error(`GitHub releases fetch failed: ${res.status}`);
+  }
+
+  const raw = (await res.json()) as GitHubRelease[];
+  if (!Array.isArray(raw)) {
+    throw new Error("GitHub releases response was not an array");
+  }
+  const published = raw.filter((r) => !r.draft);
+
+  const releases = await Promise.all(
+    published.map(async (r): Promise<Release> => {
+      const body = r.body ?? "";
+      const compareUrl = extractCompareUrl(body);
+      return {
+        tag: r.tag_name,
+        name: r.name?.trim() || r.tag_name,
+        date: r.published_at ?? r.created_at,
+        isPrerelease: r.prerelease,
+        htmlUrl: r.html_url,
+        bodyHtml: await renderMarkdown(body),
+        compareUrl,
+        compareRange: compareUrl ? shortCompareRange(compareUrl) : undefined,
+      };
+    }),
+  );
+
+  releases.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return releases;
+}
+
+/**
+ * Returns releases for the changelog page.
+ * Fetches live from GitHub at build time; on any failure falls back to the
+ * committed snapshot so the build never breaks.
+ */
+export async function getReleases(): Promise<Release[]> {
+  try {
+    const releases = await fetchFromGitHub();
+    if (releases.length > 0) return releases;
+    return snapshot as Release[];
+  } catch (err) {
+    console.warn(
+      `[changelog] live fetch failed, using snapshot fallback:`,
+      err instanceof Error ? err.message : err,
+    );
+    return snapshot as Release[];
+  }
+}

--- a/apps/docs/lib/changelog.ts
+++ b/apps/docs/lib/changelog.ts
@@ -40,7 +40,7 @@ export async function fetchFromGitHub(): Promise<Release[]> {
 
   const res = await fetch(
     `https://api.github.com/repos/${OWNER}/${REPO}/releases?per_page=100`,
-    { headers },
+    { headers, signal: AbortSignal.timeout(10_000) },
   );
   if (!res.ok) {
     throw new Error(`GitHub releases fetch failed: ${res.status}`);

--- a/apps/docs/lib/markdown.ts
+++ b/apps/docs/lib/markdown.ts
@@ -1,0 +1,26 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import { remarkGithubLinks } from "@/lib/remark-github-links";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkGithubLinks)
+  .use(remarkRehype)
+  .use(rehypeSanitize)
+  .use(rehypeStringify);
+
+/**
+ * Convert GitHub-Flavored Markdown to sanitized HTML.
+ * Sanitization is required because release bodies may contain
+ * untrusted content (e.g. community PR descriptions).
+ */
+export async function renderMarkdown(markdown: string): Promise<string> {
+  if (!markdown || markdown.trim() === "") return "";
+  const file = await processor.process(markdown);
+  return String(file);
+}

--- a/apps/docs/lib/remark-github-links.ts
+++ b/apps/docs/lib/remark-github-links.ts
@@ -95,15 +95,33 @@ export function remarkGithubLinks() {
     });
 
     // Pass 2: drop the "Full Changelog" compare paragraph from the prose; it's
-    // rendered as a separate React pill from structured release fields.
+    // rendered as a separate React pill from structured release fields. Narrow
+    // the match to the auto-generated footer specifically — it must contain a
+    // compare link AND the "Full Changelog" marker — so we never delete a
+    // release author's own prose that happens to reference a compare URL.
     visit(tree, "paragraph", (para: Paragraph, index, parent) => {
       if (index === undefined || !parent) return;
       const hasCompare = para.children.some(
         (c) => c.type === "link" && isCompareUrl((c as Link).url),
       );
       if (!hasCompare) return;
+      // "Full Changelog" is emitted inside a `strong` node, so collect text
+      // from nested children — not just top-level `text` nodes.
+      const text = collectText(para).toLowerCase().replace(/\s+/g, " ").trim();
+      if (!text.includes("full changelog")) return;
       parent.children.splice(index, 1);
       return index; // re-visit the node now at this index
     });
   };
+}
+
+/** Concatenate the visible text of a node tree (text + nested children). */
+function collectText(node: unknown): string {
+  if (!node || typeof node !== "object") return "";
+  const n = node as { value?: unknown; children?: unknown };
+  if (typeof n.value === "string") return n.value;
+  if (Array.isArray(n.children)) {
+    return n.children.map((c) => collectText(c)).join("");
+  }
+  return "";
 }

--- a/apps/docs/lib/remark-github-links.ts
+++ b/apps/docs/lib/remark-github-links.ts
@@ -1,0 +1,109 @@
+import type { Root, Link, Text, PhrasingContent, Paragraph } from "mdast";
+import { visit } from "unist-util-visit";
+
+const OWNER = "openbrowse-ai";
+const REPO = "openbrowse";
+const REPO_PREFIX = `https://github.com/${OWNER}/${REPO}`;
+
+/** True when a link points at this repo's compare view. */
+export function isCompareUrl(url: string): boolean {
+  return (
+    url.startsWith(REPO_PREFIX) &&
+    /^\/compare\/.+/.test(url.slice(REPO_PREFIX.length))
+  );
+}
+
+/**
+ * Turn a compare range into a short, readable label.
+ * `openbrowse@0.3.2...openbrowse@0.4.0` -> `0.3.2 → 0.4.0`
+ * Falls back to the decoded raw range when it isn't a `name@version` pair.
+ */
+export function shortCompareRange(url: string): string {
+  const raw = decodeURIComponent(
+    url.slice(REPO_PREFIX.length).replace(/^\/compare\//, "").replace(/\/$/, ""),
+  );
+  const parts = raw.split("...");
+  if (parts.length !== 2) return raw;
+  const strip = (s: string) => s.replace(new RegExp(`^${REPO}@`), "");
+  return `${strip(parts[0])} → ${strip(parts[1])}`;
+}
+
+/**
+ * Extract this repo's compare URL from raw release-note markdown, if present.
+ * GitHub auto-generated notes end with `**Full Changelog**: <compare-url>`.
+ */
+export function extractCompareUrl(markdown: string): string | undefined {
+  const match = markdown.match(
+    new RegExp(`${REPO_PREFIX.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}/compare/\\S+`),
+  );
+  if (!match) return undefined;
+  return match[0].replace(/[).,]+$/, "");
+}
+
+/**
+ * Produce a short, human-friendly label for a GitHub URL pointing at this repo.
+ * Returns null when the URL should keep its existing text.
+ */
+function shortLabel(url: string): string | null {
+  if (!url.startsWith(REPO_PREFIX)) return null;
+  const rest = url.slice(REPO_PREFIX.length);
+
+  // Pull request: /pull/123  ->  #123
+  const pull = rest.match(/^\/pull\/(\d+)\/?$/);
+  if (pull) return `#${pull[1]}`;
+
+  // Issue: /issues/123  ->  #123
+  const issue = rest.match(/^\/issues\/(\d+)\/?$/);
+  if (issue) return `#${issue[1]}`;
+
+  // Commit: /commit/<sha>  ->  <sha7>
+  const commit = rest.match(/^\/commit\/([0-9a-f]{7,40})\/?$/i);
+  if (commit) return commit[1].slice(0, 7);
+
+  return null;
+}
+
+/**
+ * remark plugin for changelog release notes.
+ *
+ * 1. Rewrites the visible text of bare GitHub links pointing at this repo to
+ *    compact references (`#65`, a short SHA) so long raw URLs don't overflow.
+ * 2. Removes the auto-generated "Full Changelog" compare paragraph entirely.
+ *    That line is rendered separately as a Lucide-iconed pill button in the
+ *    React component, using the structured `compareUrl`/`compareRange` fields.
+ *
+ * Link hrefs are always preserved.
+ */
+export function remarkGithubLinks() {
+  return (tree: Root) => {
+    // Pass 1: compact bare PR / issue / commit links.
+    visit(tree, "link", (node: Link) => {
+      const label = shortLabel(node.url);
+      if (!label) return;
+
+      const onlyChild = node.children.length === 1 ? node.children[0] : null;
+      const childText =
+        onlyChild && onlyChild.type === "text" ? (onlyChild as Text).value : null;
+      const isBare =
+        node.children.length === 0 ||
+        (childText !== null && childText.trim() === node.url.trim());
+
+      if (!isBare) return;
+
+      const replacement: PhrasingContent = { type: "text", value: label };
+      node.children = [replacement];
+    });
+
+    // Pass 2: drop the "Full Changelog" compare paragraph from the prose; it's
+    // rendered as a separate React pill from structured release fields.
+    visit(tree, "paragraph", (para: Paragraph, index, parent) => {
+      if (index === undefined || !parent) return;
+      const hasCompare = para.children.some(
+        (c) => c.type === "link" && isCompareUrl((c as Link).url),
+      );
+      if (!hasCompare) return;
+      parent.children.splice(index, 1);
+      return index; // re-visit the node now at this index
+    });
+  };
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "postinstall": "fumadocs-mdx"
+    "postinstall": "fumadocs-mdx",
+    "changelog:snapshot": "tsx scripts/update-changelog-snapshot.ts"
   },
   "dependencies": {
     "@openbrowse/connectors": "workspace:*",
@@ -22,14 +23,23 @@
     "next-themes": "^0.4.6",
     "react": "^19",
     "react-dom": "^19",
-    "tailwind-merge": "^3.5.0"
+    "rehype-sanitize": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "tailwind-merge": "^3.5.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "latest",
+    "@types/mdast": "^4.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "postcss": "latest",
     "tailwindcss": "^4",
+    "tsx": "^4.22.3",
     "typescript": "^6"
   }
 }

--- a/apps/docs/scripts/update-changelog-snapshot.ts
+++ b/apps/docs/scripts/update-changelog-snapshot.ts
@@ -1,0 +1,32 @@
+/**
+ * Refreshes content/changelog-snapshot.json from live GitHub Releases.
+ * Run intentionally via: pnpm --filter openbrowse-docs changelog:snapshot
+ * The Next.js build never writes this file; this script is the only writer.
+ *
+ * Uses fetchFromGitHub (not getReleases) so a failed fetch surfaces as a
+ * non-zero exit instead of silently re-writing the existing snapshot.
+ */
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { fetchFromGitHub } from "../lib/changelog.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = join(__dirname, "..", "content", "changelog-snapshot.json");
+
+async function main() {
+  const releases = await fetchFromGitHub();
+  if (releases.length === 0) {
+    console.error(
+      "[changelog] refusing to write empty snapshot. Aborting.",
+    );
+    process.exit(1);
+  }
+  await writeFile(OUT, JSON.stringify(releases, null, 2) + "\n", "utf8");
+  console.log(`[changelog] wrote ${releases.length} releases to ${OUT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,13 +59,37 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.5(react@19.2.5)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.2
+        version: 11.1.2
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.1.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: latest
         version: 4.3.0
+      '@types/mdast':
+        specifier: ^4.0.0
+        version: 4.0.4
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -78,6 +102,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.3.0
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ^6
         version: 6.0.3
@@ -6066,6 +6093,9 @@ packages:
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -13218,6 +13248,12 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a `/changelog` page to the marketing site (`apps/docs`) that renders the
repo's GitHub Releases as an animated, mobile-friendly timeline.

- Build-time fetch of GitHub Releases (REST API) with a committed JSON snapshot
  fallback so the build never fails. Refresh via
  `pnpm --filter openbrowse-docs changelog:snapshot`.
- Sanitized GFM->HTML (remark/rehype + rehype-sanitize); a remark plugin
  compacts PR/issue/commit links to `#65` chips and extracts the "Full
  Changelog" compare link into structured fields.
- Timeline UI: sticky bold version headers, dashed dividers, animated
  `grid-rows` expand/collapse for long releases, and a lucide GitCompare
  "Full Changelog" pill. Linked from the nav and footer.

## Testing

- `pnpm --filter openbrowse-docs build` succeeds; `/changelog` is statically
  prerendered.
- Build resilience verified: a forced GitHub 401 falls back to the snapshot and
  still builds `/changelog`.
- Sanitization verified (`<script>`, `onerror`, `javascript:` stripped);
  `tsc --noEmit` clean; checked desktop + mobile, light + dark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated changelog page showing release history with metadata and “Latest” badge linking to releases
  * “Changelog” added to main navigation and footer for easy access
  * Release entries show formatted dates, pre-release badges, and full release notes (HTML-rendered)
  * Long release notes are collapsible with accessible expand/collapse behavior and reduced-motion support
  * Site falls back to a committed snapshot when live release fetches fail; snapshot updater added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->