### PR TITLE
feat(bench): declarative harness configs, headless subagents, and Kernel browser pools

### DIFF
--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -13,6 +13,7 @@ import {
   COMPACTION_USER_PROMPT,
   SCREENSHOT_PROTECTED_TURNS,
   findProtectedTailStart,
+  keepOnlyLatestScreenshot,
   prunePartsAtSendTime,
   stripScreenshotsFromParts,
 } from "./compaction";
@@ -40,6 +41,24 @@ interface Options<TOOLS extends ToolSet> {
    * the next step's onStepFinish can re-trigger it cleanly.
    */
   onSendStart?: () => void;
+  /**
+   * When true, every `sendMessages` call strips all but the most recent
+   * page-screenshot tool result from the message history, regardless of
+   * user-turn boundaries. Used by the bench harness — bench trials have
+   * a single user turn (the task instruction), so the default user-turn
+   * protected-tail policy never strips anything in bench, leading to
+   * context bloat from accumulated screenshots. The extension agent runs
+   * with this off (default) so users keep multi-turn visual recall.
+   */
+  keepOnlyLatestImage?: boolean;
+  /**
+   * Tool names whose output is a page-state image, for the
+   * `keepOnlyLatestImage` policy. Defaults to the module's
+   * `PAGE_SCREENSHOT_TOOLS` (`["screenshot"]`). Headless harnesses pass their
+   * own page-state image tool names (e.g. `["viewPage"]`) so the public
+   * extension never hardcodes experiment tool names.
+   */
+  screenshotToolNames?: string[];
   /**
    * Snapshot the active conversation id at the moment `sendMessages` is
    * invoked. The transport captures this synchronously at the top of
@@ -129,17 +148,25 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
 {
   private readonly agent: Agent<never, TOOLS, never>;
   private readonly onSendStart?: () => void;
+  private readonly keepOnlyLatestImage: boolean;
+  private readonly screenshotToolNames?: Set<string>;
   private readonly getActiveConversationId?: () => string | null;
   private readonly buildCompletionCheckInput?: Options<TOOLS>["buildCompletionCheckInput"];
 
   constructor({
     agent,
     onSendStart,
+    keepOnlyLatestImage,
+    screenshotToolNames,
     getActiveConversationId,
     buildCompletionCheckInput,
   }: Options<TOOLS>) {
     this.agent = agent;
     this.onSendStart = onSendStart;
+    this.keepOnlyLatestImage = keepOnlyLatestImage ?? false;
+    this.screenshotToolNames = screenshotToolNames
+      ? new Set(screenshotToolNames)
+      : undefined;
     this.getActiveConversationId = getActiveConversationId;
     this.buildCompletionCheckInput = buildCompletionCheckInput;
   }
@@ -155,7 +182,10 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
     // by the gate inside this loop targets this cid even if
     // `setAgentContext(...)` is called by the UI mid-stream.
     const pinnedConversationId = this.getActiveConversationId?.() ?? null;
-    const rewritten = rewriteForLLM(messages);
+    let rewritten = rewriteForLLM(messages);
+    if (this.keepOnlyLatestImage) {
+      rewritten = keepOnlyLatestScreenshot(rewritten, this.screenshotToolNames);
+    }
 
     // Tie validateUIMessages' inferred UI_MESSAGE to *this transport's*
     // TOOLS so its `tools` parameter resolves to the same shape as

--- a/apps/extension/src/lib/agent/compaction.test.ts
+++ b/apps/extension/src/lib/agent/compaction.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the screenshot/image compaction pruners in `compaction.ts`,
+ * focused on `keepOnlyLatestScreenshot` and its `allowlist` parameter.
+ *
+ * `keepOnlyLatestScreenshot` is the bench's primary context-bloat control:
+ * because a bench trial has a single user turn, the user-turn-based pruner
+ * never fires, so this "only keep the most recent page screenshot" pruner is
+ * what prevents perception images from accumulating across steps. It also
+ * accepts a caller-supplied allowlist so headless harnesses can prune images
+ * produced under non-`screenshot` tool names (e.g. `viewPage`) WITHOUT the
+ * public extension hardcoding experiment tool names.
+ *
+ * Critical invariants under test:
+ *   - The DEFAULT allowlist is `["screenshot"]` (extension behavior unchanged).
+ *   - A single screenshot is left untouched.
+ *   - With N>1 screenshots, only the LAST keeps its image; earlier ones are
+ *     replaced with the `{ removed }` placeholder.
+ *   - A custom allowlist matches its tool names and NOT `screenshot`.
+ *   - User-attached images / unrelated tool outputs are never stripped.
+ *   - Already-stripped (no `imageDataUrl`) results are not counted.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  keepOnlyLatestScreenshot,
+  PAGE_SCREENSHOT_TOOLS,
+} from "./compaction";
+import type { AgentUIMessage } from "./message-types";
+
+/** Build an assistant message wrapping a single tool-result part. */
+function toolResultMsg(
+  toolName: string,
+  output: unknown,
+  opts: { state?: string } = {},
+): AgentUIMessage {
+  return {
+    id: `m-${Math.random().toString(36).slice(2)}`,
+    role: "assistant",
+    parts: [
+      {
+        type: "dynamic-tool",
+        toolName,
+        toolCallId: `c-${Math.random().toString(36).slice(2)}`,
+        state: opts.state ?? "output-available",
+        input: {},
+        output,
+      } as AgentUIMessage["parts"][number],
+    ],
+  } as AgentUIMessage;
+}
+
+const img = (tag: string) => ({ imageDataUrl: `data:image/png;base64,${tag}` });
+
+/** Pull every tool part's output across all messages, in order. */
+function outputs(messages: AgentUIMessage[]): unknown[] {
+  const out: unknown[] = [];
+  for (const m of messages) {
+    for (const p of m.parts as any[]) {
+      if (p.type === "dynamic-tool") out.push(p.output);
+    }
+  }
+  return out;
+}
+
+function isStripped(output: unknown): boolean {
+  return (
+    !!output &&
+    typeof output === "object" &&
+    "removed" in (output as Record<string, unknown>) &&
+    !("imageDataUrl" in (output as Record<string, unknown>))
+  );
+}
+
+describe("PAGE_SCREENSHOT_TOOLS default", () => {
+  it("is exactly { screenshot } (extension default unchanged)", () => {
+    expect([...PAGE_SCREENSHOT_TOOLS]).toEqual(["screenshot"]);
+  });
+});
+
+describe("keepOnlyLatestScreenshot — default allowlist", () => {
+  it("leaves a single screenshot untouched (returns same array reference)", () => {
+    const messages = [toolResultMsg("screenshot", img("only"))];
+    const result = keepOnlyLatestScreenshot(messages);
+    expect(result).toBe(messages); // referential no-op
+    expect(outputs(result)).toEqual([img("only")]);
+  });
+
+  it("keeps only the LAST screenshot when several are present", () => {
+    const messages = [
+      toolResultMsg("screenshot", img("first")),
+      toolResultMsg("readPage", { text: "hello" }),
+      toolResultMsg("screenshot", img("second")),
+      toolResultMsg("screenshot", img("third")),
+    ];
+    const result = keepOnlyLatestScreenshot(messages);
+    const out = outputs(result);
+
+    // first + second stripped, third (latest) intact, readPage untouched.
+    expect(isStripped(out[0])).toBe(true);
+    expect(out[1]).toEqual({ text: "hello" });
+    expect(isStripped(out[2])).toBe(true);
+    expect(out[3]).toEqual(img("third"));
+  });
+
+  it("does not count already-stripped screenshots as live images", () => {
+    // One live image + one previously-stripped placeholder → 1 live image → no-op.
+    const messages = [
+      toolResultMsg("screenshot", { removed: "[older screenshot stripped]" }),
+      toolResultMsg("screenshot", img("live")),
+    ];
+    const result = keepOnlyLatestScreenshot(messages);
+    expect(result).toBe(messages); // only 1 live image ⇒ nothing to strip
+    expect(outputs(result)[1]).toEqual(img("live"));
+  });
+
+  it("ignores tool results that are not in the allowlist", () => {
+    // Two `viewPage` images but default allowlist is screenshot-only ⇒ no-op.
+    const messages = [
+      toolResultMsg("viewPage", img("vp1")),
+      toolResultMsg("viewPage", img("vp2")),
+    ];
+    const result = keepOnlyLatestScreenshot(messages);
+    expect(result).toBe(messages);
+    expect(outputs(result)).toEqual([img("vp1"), img("vp2")]);
+  });
+
+  it("ignores tool calls that are not yet output-available", () => {
+    const messages = [
+      toolResultMsg("screenshot", img("done1")),
+      toolResultMsg("screenshot", img("pending"), { state: "input-available" }),
+      toolResultMsg("screenshot", img("done2")),
+    ];
+    const result = keepOnlyLatestScreenshot(messages);
+    const out = outputs(result);
+    // Only the two output-available ones are candidates; the latest of those
+    // (done2) is kept, done1 stripped, the pending one is left as-is.
+    expect(isStripped(out[0])).toBe(true);
+    expect(out[1]).toEqual(img("pending"));
+    expect(out[2]).toEqual(img("done2"));
+  });
+});
+
+describe("keepOnlyLatestScreenshot — custom allowlist", () => {
+  it("prunes the allowlisted tool (viewPage) and not screenshot", () => {
+    const allowlist = new Set(["viewPage"]);
+    const messages = [
+      toolResultMsg("viewPage", img("vp1")),
+      toolResultMsg("screenshot", img("ss")), // NOT in custom allowlist
+      toolResultMsg("viewPage", img("vp2")),
+    ];
+    const result = keepOnlyLatestScreenshot(messages, allowlist);
+    const out = outputs(result);
+
+    expect(isStripped(out[0])).toBe(true); // earlier viewPage stripped
+    expect(out[1]).toEqual(img("ss")); // screenshot untouched (not allowlisted)
+    expect(out[2]).toEqual(img("vp2")); // latest viewPage kept
+  });
+
+  it("never strips user-attached images (no tool name match)", () => {
+    // A user message carrying an image part must be invisible to the pruner:
+    // it has no `dynamic-tool`/`toolName`, so it can't match any allowlist.
+    const userImageMsg = {
+      id: "u1",
+      role: "user",
+      parts: [
+        { type: "file", mediaType: "image/png", url: "data:image/png;base64,USER" },
+      ],
+    } as unknown as AgentUIMessage;
+
+    const messages = [
+      userImageMsg,
+      toolResultMsg("viewPage", img("vp1")),
+      toolResultMsg("viewPage", img("vp2")),
+    ];
+    const result = keepOnlyLatestScreenshot(messages, new Set(["viewPage"]));
+    const out = outputs(result); // only tool parts surface here
+
+    // The user file part is preserved verbatim.
+    expect((result[0].parts[0] as any).url).toBe("data:image/png;base64,USER");
+    // viewPage pruning still works around it.
+    expect(isStripped(out[0])).toBe(true);
+    expect(out[1]).toEqual(img("vp2"));
+  });
+});

--- a/apps/extension/src/lib/agent/compaction.ts
+++ b/apps/extension/src/lib/agent/compaction.ts
@@ -173,6 +173,15 @@ export function prunePartsAtSendTime(
       continue;
     }
 
+    // Skip image-bearing tools — their large `imageDataUrl` is intentional
+    // and gets stripped wholesale (not truncated mid-base64) by
+    // `stripScreenshotsFromParts` for older messages. Truncating here would
+    // produce a corrupt base64 string that the model can't decode.
+    if (part.toolName && STRIPPABLE_IMAGE_TOOLS.has(part.toolName)) {
+      out.push(part);
+      continue;
+    }
+
     const outputStr =
       typeof part.output === "string"
         ? part.output
@@ -193,6 +202,26 @@ export function prunePartsAtSendTime(
   return changed ? out : parts;
 }
 
+export const STRIPPABLE_IMAGE_TOOLS = new Set(["screenshot"]);
+
+/**
+ * Tools whose output is, by construction, a screenshot of the current page
+ * state. Used as the DEFAULT allowlist by {@link keepOnlyLatestScreenshot} to
+ * safely identify which tool-result parts may have their image stripped.
+ *
+ * The extension itself only produces `screenshot`. Headless harnesses (the
+ * bench) may produce page-state images under other tool names (e.g.
+ * `viewPage`) and pass their own allowlist into `keepOnlyLatestScreenshot` —
+ * the public extension never hardcodes experiment tool names.
+ *
+ * IMPORTANT: any allowlist MUST only contain tools that capture page state.
+ * It MUST NOT include user-attached images or any other image-bearing
+ * channel. The detection is tool-name-based (not output-shape-based)
+ * precisely to avoid accidentally stripping images that came from somewhere
+ * other than the agent's own perception calls.
+ */
+export const PAGE_SCREENSHOT_TOOLS = new Set(["screenshot"]);
+
 /**
  * Replaces the output of every completed `screenshot` tool call in
  * `parts` with the typed placeholder shape (`{ removed: "..." }`) that
@@ -211,7 +240,7 @@ export function stripScreenshotsFromParts(
     if (
       part.type === "dynamic-tool" &&
       part.state === "output-available" &&
-      part.toolName === "screenshot"
+      part.toolName && STRIPPABLE_IMAGE_TOOLS.has(part.toolName)
     ) {
       out.push({
         ...part,
@@ -223,6 +252,80 @@ export function stripScreenshotsFromParts(
     out.push(part);
   }
   return changed ? out : parts;
+}
+
+/**
+ * Strict "only-latest screenshot" pruner.
+ *
+ * Walks every part of every message back-to-front and finds the *latest*
+ * page-screenshot tool result (where `toolName ∈ PAGE_SCREENSHOT_TOOLS`).
+ * That part is left intact. Every *earlier* page-screenshot tool result has
+ * its `output` replaced with the placeholder shape.
+ *
+ * This is far more aggressive than {@link stripScreenshotsFromParts} +
+ * {@link findProtectedTailStart}, which keep N user-turns of screenshots
+ * intact. Bench trials have only one user turn (the task instruction), so
+ * the user-turn-based policy effectively never strips anything in bench —
+ * leading to context bloat from accumulated screenshots. This function fixes
+ * that by ensuring at most ONE page screenshot is alive in context at any
+ * time.
+ *
+ * Safety: only inspects parts where `part.type === "dynamic-tool"` AND
+ * `part.toolName ∈ PAGE_SCREENSHOT_TOOLS`. User-attached images, file parts,
+ * text parts, reasoning parts, and tool calls from any other tool are
+ * untouched. This is intentional: we never want to strip a user-uploaded
+ * image. Tool-name-based detection is the safest predicate — it would not
+ * match even if some unrelated tool happened to return an `imageDataUrl`
+ * field in its output.
+ *
+ * Returns a new messages array if anything changed; the original array
+ * (referentially) otherwise.
+ */
+export function keepOnlyLatestScreenshot(
+  messages: AgentUIMessage[],
+  allowlist: Set<string> = PAGE_SCREENSHOT_TOOLS,
+): AgentUIMessage[] {
+  // First pass: find indices of (messageIdx, partIdx) for every page-screenshot
+  // tool result with an `imageDataUrl` (non-stripped) output.
+  const screenshotLocs: Array<{ m: number; p: number }> = [];
+  for (let m = 0; m < messages.length; m++) {
+    const msg = messages[m];
+    for (let p = 0; p < msg.parts.length; p++) {
+      const part = msg.parts[p] as any;
+      if (
+        part?.type === "dynamic-tool"
+        && part.state === "output-available"
+        && typeof part.toolName === "string"
+        && allowlist.has(part.toolName)
+        && part.output
+        && typeof part.output === "object"
+        && "imageDataUrl" in part.output
+      ) {
+        screenshotLocs.push({ m, p });
+      }
+    }
+  }
+
+  // Nothing to strip: 0 or 1 screenshots present.
+  if (screenshotLocs.length <= 1) return messages;
+
+  // Mark all but the last for stripping.
+  const stripSet = new Set(
+    screenshotLocs.slice(0, -1).map((loc) => `${loc.m}:${loc.p}`),
+  );
+
+  return messages.map((msg, m) => {
+    let touched = false;
+    const newParts = msg.parts.map((part, p) => {
+      if (!stripSet.has(`${m}:${p}`)) return part;
+      touched = true;
+      return {
+        ...(part as any),
+        output: { removed: "[older screenshot stripped]" },
+      };
+    });
+    return touched ? { ...msg, parts: newParts } : msg;
+  });
 }
 
 /**
@@ -312,8 +415,8 @@ export function pruneMessages(
         }
 
         // Beyond threshold, start pruning
-        // Check if this is a screenshot tool
-        if (part.toolName === "screenshot") {
+        // Check if this is an image-bearing tool (screenshot, viewPage, etc.)
+        if (part.toolName && STRIPPABLE_IMAGE_TOOLS.has(part.toolName)) {
           // Replace output with placeholder
           newParts.push({
             ...part,

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -3,7 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Evaluation harness for the OpenBrowse agent. Runs the agent headlessly via Playwright across a matrix of model × prompt × tool-set configurations.",
+  "description": "Evaluation harness for the OpenBrowse agent. Runs the agent headlessly via Playwright under declarative harness configs (prompt × tools × model × subagents).",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "engines": {
     "node": ">=22.15"
   },

--- a/packages/bench/scripts/create-pool.ts
+++ b/packages/bench/scripts/create-pool.ts
@@ -1,0 +1,85 @@
+/**
+ * Create a Kernel browser pool for a high-concurrency bench run.
+ *
+ * Usage:
+ *   tsx packages/bench/scripts/create-pool.ts [--size N] [--name STR]
+ *
+ * This script writes ONLY the pool id to stdout (all progress/error output
+ * goes to stderr). HOWEVER, the project loads env via dotenvx, which prints
+ * its own banner ("injected env (N) from .env ...") to stdout. So a naive
+ * `POOL_ID=$(tsx ... create-pool.ts)` capture will include that banner line
+ * ahead of the id. Extract the id by pattern instead, e.g.:
+ *
+ *   POOL_ID=$(tsx ... create-pool.ts --size 50 | grep -oE '^[a-z0-9]{20,30}$' | tail -1)
+ *
+ * (Suppress the banner entirely with DOTENV_CONFIG_QUIET / dotenvx --quiet if
+ * your invocation supports it, but the grep is the robust default.)
+ */
+import { loadEnv } from "../src/env";
+loadEnv();
+import Kernel from "@onkernel/sdk";
+
+const args = process.argv.slice(2);
+let size = 50;
+let name: string | undefined;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--size") size = parseInt(args[++i], 10);
+  else if (args[i] === "--name") name = args[++i];
+}
+
+if (!Number.isFinite(size) || size < 1) {
+  console.error(`Invalid --size: ${size}`);
+  process.exit(2);
+}
+
+const apiKey = process.env.KERNEL_API_KEY;
+if (!apiKey) {
+  console.error("KERNEL_API_KEY not set");
+  process.exit(2);
+}
+
+const kernel = new Kernel({ apiKey });
+
+(async () => {
+  console.error(`Creating Kernel browser pool (size=${size}${name ? `, name=${name}` : ""})...`);
+  const pool = await kernel.browserPools.create({
+    size,
+    headless: false,
+    stealth: true,
+    // Default fill rate is 10%/min; bump higher (max 25%/min per Kernel)
+    // so the pool warms up fast enough that a 50-trial bench wave doesn't
+    // have to wait too long. At 25%/min, a size-50 pool is ~80% full after
+    // ~3-4 minutes.
+    fill_rate_per_minute: 25,
+    // Match prior per-trial idle timeout (10 min). Browsers that sit idle
+    // longer than this in the pool will be destroyed and recreated.
+    timeout_seconds: 600,
+    ...(name ? { name } : {}),
+  });
+  console.error(`Pool created: id=${pool.id}, target size=${pool.browser_pool_config.size}`);
+  console.error(`Waiting for pool to warm up (poll until available_count >= 1)...`);
+
+  // Poll until at least one browser is ready so the first acquire() call
+  // doesn't immediately have to wait the full acquire_timeout.
+  const startMs = Date.now();
+  const TIMEOUT_MS = 5 * 60_000;
+  while (true) {
+    const fresh = await kernel.browserPools.retrieve(pool.id);
+    process.stderr.write(
+      `  available=${fresh.available_count}/${fresh.browser_pool_config.size}, acquired=${fresh.acquired_count}\r`,
+    );
+    if (fresh.available_count >= 1) break;
+    if (Date.now() - startMs > TIMEOUT_MS) {
+      console.error(`\nTimed out waiting for pool warm-up after ${TIMEOUT_MS}ms`);
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 3_000));
+  }
+  console.error(`\nPool is warming. Proceeding with run.`);
+
+  // Print ONLY the id to stdout — bash captures this.
+  console.log(pool.id);
+})().catch((err) => {
+  console.error(`create-pool failed: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/packages/bench/scripts/create-pool.ts
+++ b/packages/bench/scripts/create-pool.ts
@@ -40,6 +40,10 @@ if (!apiKey) {
 
 const kernel = new Kernel({ apiKey });
 
+// Tracks a pool we successfully created so failure paths can delete it instead
+// of orphaning it. Set only after browserPools.create resolves.
+let createdPoolId: string | undefined;
+
 (async () => {
   console.error(`Creating Kernel browser pool (size=${size}${name ? `, name=${name}` : ""})...`);
   const pool = await kernel.browserPools.create({
@@ -56,6 +60,7 @@ const kernel = new Kernel({ apiKey });
     timeout_seconds: 600,
     ...(name ? { name } : {}),
   });
+  createdPoolId = pool.id;
   console.error(`Pool created: id=${pool.id}, target size=${pool.browser_pool_config.size}`);
   console.error(`Waiting for pool to warm up (poll until available_count >= 1)...`);
 
@@ -70,8 +75,7 @@ const kernel = new Kernel({ apiKey });
     );
     if (fresh.available_count >= 1) break;
     if (Date.now() - startMs > TIMEOUT_MS) {
-      console.error(`\nTimed out waiting for pool warm-up after ${TIMEOUT_MS}ms`);
-      process.exit(1);
+      throw new Error(`Timed out waiting for pool warm-up after ${TIMEOUT_MS}ms`);
     }
     await new Promise((r) => setTimeout(r, 3_000));
   }
@@ -79,7 +83,18 @@ const kernel = new Kernel({ apiKey });
 
   // Print ONLY the id to stdout — bash captures this.
   console.log(pool.id);
-})().catch((err) => {
-  console.error(`create-pool failed: ${err instanceof Error ? err.message : String(err)}`);
+})().catch(async (err) => {
+  console.error(`\ncreate-pool failed: ${err instanceof Error ? err.message : String(err)}`);
+  // Don't orphan a pool that was created but never became usable.
+  if (createdPoolId) {
+    console.error(`Cleaning up partially-created pool ${createdPoolId}...`);
+    await kernel.browserPools
+      .delete(createdPoolId, { force: true })
+      .catch((e) =>
+        console.error(
+          `  WARNING: failed to delete pool ${createdPoolId}: ${e instanceof Error ? e.message : String(e)}`,
+        ),
+      );
+  }
   process.exit(1);
 });

--- a/packages/bench/scripts/delete-pool.ts
+++ b/packages/bench/scripts/delete-pool.ts
@@ -1,0 +1,41 @@
+/**
+ * Delete a Kernel browser pool by id (and force-terminate any leased browsers).
+ *
+ * Usage:
+ *   tsx packages/bench/scripts/delete-pool.ts <pool-id>
+ *
+ * Idempotent: succeeds silently if the pool is already gone.
+ */
+import { loadEnv } from "../src/env";
+loadEnv();
+import Kernel from "@onkernel/sdk";
+
+const id = process.argv[2];
+if (!id) {
+  console.error("Usage: tsx delete-pool.ts <pool-id>");
+  process.exit(2);
+}
+
+const apiKey = process.env.KERNEL_API_KEY;
+if (!apiKey) {
+  console.error("KERNEL_API_KEY not set");
+  process.exit(2);
+}
+
+const kernel = new Kernel({ apiKey });
+
+(async () => {
+  try {
+    // force=true terminates any browsers still leased by stuck/aborted trials.
+    await kernel.browserPools.delete(id, { force: true });
+    console.error(`Deleted browser pool: ${id}`);
+  } catch (err: any) {
+    const msg = err?.message ?? String(err);
+    if (msg.includes("not found") || msg.includes("404")) {
+      console.error(`Pool ${id} already gone — nothing to do.`);
+      return;
+    }
+    console.error(`delete-pool failed: ${msg}`);
+    process.exit(1);
+  }
+})();

--- a/packages/bench/src/agent/bench-delegate.ts
+++ b/packages/bench/src/agent/bench-delegate.ts
@@ -1,0 +1,162 @@
+/**
+ * Bench `delegate` tool — headless analog of the extension's
+ * `tools/delegate.ts` + `createDelegateTool`.
+ *
+ * We can't reuse the extension's `createDelegateTool` because it imports
+ * `runSubagent` (→ chatDb) and `getChromeWindowsAPI` (→ chrome). Instead we
+ * build a raw AI-SDK tool here that calls the bench's headless
+ * `runBenchSubagent`. The tool's RAW output carries the subagent's trace +
+ * tokens (`_benchTrace` / `_benchTokens`) so the bench runner can attach a
+ * recursive sub-trace and aggregate tokens; `toModelOutput` projects ONLY the
+ * `finalText` (+ status) to the model so the parent's context isn't bloated.
+ */
+
+import { z } from "zod";
+import type { ToolSet } from "ai";
+import type { ToolContext } from "@agent/driver";
+import type { AgentDefinition, DelegationContext } from "@agent/subagents/types";
+import {
+  runBenchSubagent,
+  type BenchAgentLoopConfig,
+  type BenchAgentLoopResult,
+} from "./subagent-runner";
+import type { TraceEntry } from "../runner";
+
+const delegationContextSchema = z
+  .object({
+    task: z.string().optional(),
+    tabHandles: z.array(z.string()).optional(),
+    urls: z.array(z.string()).optional(),
+    workspaceFiles: z.array(z.string()).optional(),
+    parentTabHandle: z.string().optional(),
+    notes: z.string().optional(),
+  })
+  .partial();
+
+const parameters = z.object({
+  slug: z.string().describe("Identifier of the subagent to invoke."),
+  task: z
+    .string()
+    .describe("Concise description of the work to delegate. Becomes the subagent's first message."),
+  // Accepted for prompt-compatibility with the extension's delegate tool;
+  // ignored headlessly (bench has no windows / child-conversation rows).
+  isolation: z.enum(["peer", "incognito"]).optional(),
+  context: delegationContextSchema.optional(),
+});
+
+type DelegateInput = z.infer<typeof parameters>;
+
+/** Raw output shape; `_bench*` fields are stripped before reaching the model. */
+interface DelegateOutput {
+  finalText: string;
+  status: string;
+  errorMessage?: string;
+  _benchTrace: TraceEntry[];
+  _benchTokens: { in: number; out: number };
+}
+
+export interface CreateBenchDelegateToolOptions {
+  agentDefs: AgentDefinition[];
+  runAgentLoop: (cfg: BenchAgentLoopConfig) => Promise<BenchAgentLoopResult>;
+}
+
+/**
+ * Build the bench `delegate` tool as a raw AI-SDK ToolSet entry.
+ */
+export function createBenchDelegateTool(
+  opts: CreateBenchDelegateToolOptions,
+): ToolSet[string] {
+  const bySlug = new Map(opts.agentDefs.map((a) => [a.slug, a]));
+
+  return {
+    description: buildDelegateDescription(opts.agentDefs),
+    inputSchema: parameters,
+    execute: async (
+      input: DelegateInput,
+      options: { experimental_context?: unknown },
+    ): Promise<DelegateOutput> => {
+      const ctx = options.experimental_context as ToolContext;
+      const parentConversationId = ctx.session?.conversationId;
+
+      const fail = (message: string): DelegateOutput => ({
+        finalText: `Subagent '${input.slug}' could not run: ${message}`,
+        status: "failed",
+        errorMessage: message,
+        _benchTrace: [],
+        _benchTokens: { in: 0, out: 0 },
+      });
+
+      if (!parentConversationId) {
+        return fail("delegate requires an active conversation id in tool context.");
+      }
+      const agentDef = bySlug.get(input.slug);
+      if (!agentDef) {
+        const available = [...bySlug.keys()].join(", ");
+        return fail(`unknown agent '${input.slug}'. Available: ${available}`);
+      }
+
+      const delegationContext: DelegationContext = {
+        task: input.task,
+        tabHandles: input.context?.tabHandles,
+        urls: input.context?.urls,
+        workspaceFiles: input.context?.workspaceFiles,
+        parentTabHandle: input.context?.parentTabHandle,
+        notes: input.context?.notes,
+      };
+
+      try {
+        const result = await runBenchSubagent({
+          agentDef,
+          context: delegationContext,
+          parentConversationId,
+          parentToolContext: ctx,
+          abortSignal: ctx.signal,
+          runAgentLoop: opts.runAgentLoop,
+        });
+        return {
+          finalText: result.finalText,
+          status: result.status,
+          errorMessage: result.errorMessage,
+          _benchTrace: result.trace,
+          _benchTokens: result.tokens,
+        };
+      } catch (err) {
+        // Synchronous validation throws (depth/concurrency caps) → structured
+        // failure so the parent LLM can recover.
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    },
+    // Project only the model-relevant fields; strip bench-internal trace/tokens.
+    toModelOutput: ({ output }: { output: DelegateOutput }) => ({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            finalText: output.finalText,
+            status: output.status,
+            ...(output.errorMessage ? { errorMessage: output.errorMessage } : {}),
+          }),
+        },
+      ],
+    }),
+  } as unknown as ToolSet[string];
+}
+
+function buildDelegateDescription(agentDefs: AgentDefinition[]): string {
+  const lines: string[] = [
+    "Delegate a focused task to a specialized subagent. The subagent runs with",
+    "fresh context (no parent chat history), its own system prompt, and a",
+    "restricted tool allowlist. It returns a short summary you continue from.",
+    "",
+    "Caps: max 10 concurrent subagents per conversation; depth = 1 (subagents",
+    "cannot spawn other subagents).",
+    "",
+    "Available subagents:",
+  ];
+  for (const a of agentDefs) {
+    lines.push(`- ${a.slug} — ${a.description}`);
+    lines.push(`  When to use: ${a.whenToUse}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/bench/src/agent/build-agent.ts
+++ b/packages/bench/src/agent/build-agent.ts
@@ -327,7 +327,7 @@ export function buildBenchAgent(
       };
     } else if (typeof modelId === "string" && (modelId.startsWith("gpt") || modelId.startsWith("o"))) {
       providerOptions = {
-        openai: { reasoning: { effort: "medium" } },
+        openai: { reasoningEffort: "medium" },
       };
     }
   }

--- a/packages/bench/src/agent/build-agent.ts
+++ b/packages/bench/src/agent/build-agent.ts
@@ -24,31 +24,45 @@ import { scrollPageTool } from "@agent/tools/scroll-page";
 import { snapshotTool } from "@agent/tools/snapshot";
 import { todoWriteTool } from "@agent/tools/todowrite";
 import { typeInElementTool } from "@agent/tools/type-in-element";
-import type { BrowserTool } from "@agent/types";
 import type { ToolContext } from "@agent/driver";
 import { SYSTEM_PROMPT } from "@agent/system-prompt";
 import { shouldCompact } from "@agent/compaction";
 import { buildToolToastScript } from "../drivers/visualizing-driver";
+import {
+  DEFAULT_PAGE_STATE_FIELDS,
+  DEFAULT_PAGE_STATE_IMAGE_TOOLS,
+  type AnyBrowserTool,
+} from "../harness";
+import { buildBenchSubagentLoop } from "./subagent-runner";
+import { createBenchDelegateTool } from "./bench-delegate";
+import type { AgentDefinition } from "@agent/subagents/types";
 import type { TokenLimits } from "@agent/compaction";
 
 /**
- * Catalog of page-interacting tools available to bench trials. The matrix
- * executor selects subsets by name to test "snapshot vs. screenshot vs.
- * hybrid" tool-set permutations.
+ * Catalog of portable page-interacting tools the bench can run WITHOUT a
+ * harness (the unconfigured CLI path). Experiment-specific tools (SoM, etc.)
+ * are NOT registered here — they live in out-of-tree harness files and are
+ * passed in via `Harness.tools`.
  */
-export const BENCH_TOOL_CATALOG: Record<string, BrowserTool<unknown, unknown>> = {
-  snapshot: snapshotTool as BrowserTool<unknown, unknown>,
-  clickElement: clickElementTool as BrowserTool<unknown, unknown>,
-  typeInElement: typeInElementTool as BrowserTool<unknown, unknown>,
-  navigate: navigateTool as BrowserTool<unknown, unknown>,
-  screenshot: screenshotTool as BrowserTool<unknown, unknown>,
-  scrollPage: scrollPageTool as BrowserTool<unknown, unknown>,
-  readPage: readPageTool as BrowserTool<unknown, unknown>,
-  executeOnPage: executeOnPageTool as BrowserTool<unknown, unknown>,
-  listTabs: listTabsTool as BrowserTool<unknown, unknown>,
-  todoWrite: todoWriteTool as BrowserTool<unknown, unknown>,
-};
+export const BENCH_TOOL_CATALOG = {
+  snapshot: snapshotTool,
+  clickElement: clickElementTool,
+  typeInElement: typeInElementTool,
+  navigate: navigateTool,
+  screenshot: screenshotTool,
+  scrollPage: scrollPageTool,
+  readPage: readPageTool,
+  executeOnPage: executeOnPageTool,
+  listTabs: listTabsTool,
+  todoWrite: todoWriteTool,
+} satisfies Record<string, AnyBrowserTool>;
 
+/**
+ * Union of the catalog's tool names, e.g. `"snapshot" | "clickElement" | …`.
+ * Because the catalog uses `satisfies` (not a `Record<string, …>` annotation),
+ * `keyof` yields the literal union — so `DEFAULT_TOOL_SET` is checked and
+ * `BENCH_TOOL_CATALOG["typo"]` is a compile error with autocomplete.
+ */
 export type BenchToolName = keyof typeof BENCH_TOOL_CATALOG & string;
 
 export const DEFAULT_TOOL_SET: BenchToolName[] = [
@@ -64,16 +78,22 @@ export const DEFAULT_TOOL_SET: BenchToolName[] = [
 function stripSection(prompt: string, header: string): string {
   const startIndex = prompt.indexOf(header);
   if (startIndex === -1) return prompt;
-  
+
   // Find the next '## ' or end of string
   const nextHeaderIndex = prompt.indexOf("\n## ", startIndex + header.length);
-  
+
   if (nextHeaderIndex === -1) {
     return prompt.substring(0, startIndex).trimEnd();
   }
   return prompt.substring(0, startIndex) + prompt.substring(nextHeaderIndex + 1);
 }
 
+/**
+ * Default bench system prompt for the no-harness path: the production
+ * extension's `SYSTEM_PROMPT` with the workspace/code-execution sections
+ * stripped (bench trials have no OPFS workspace or code sandbox). Harness
+ * runs supply their own full `systemPrompt` and never call this.
+ */
 export function buildBenchSystemPrompt(): string {
   let prompt = SYSTEM_PROMPT;
   prompt = stripSection(prompt, "## Virtual Workspace");
@@ -85,8 +105,34 @@ import { CompactingChatTransport } from "@agent/compacting-transport";
 
 export interface BuildAgentOptions {
   model: LanguageModel;
+  /** Full system prompt. Defaults to `buildBenchSystemPrompt()` (no-harness path). */
   systemPrompt?: string;
-  toolNames?: BenchToolName[];
+  /**
+   * Tool instances available to the agent, in order. When omitted, the
+   * no-harness default (`DEFAULT_TOOL_SET` resolved via `BENCH_TOOL_CATALOG`)
+   * is used.
+   */
+   tools?: AnyBrowserTool[];
+  /**
+   * Whether action tools return fresh page state in their result. Default
+   * true. When false, `pageStateFields` are stripped from non-image-tool
+   * results so the agent only perceives state via explicit perception calls.
+   */
+  returnPageStateAfterAction?: boolean;
+  /** Fields stripped when `returnPageStateAfterAction` is false. */
+  pageStateFields?: string[];
+  /** Tool names whose output carries page state as image data. */
+  pageStateImageTools?: string[];
+  /** Tool names whose call terminates the agent loop after the call/result. */
+  terminalToolNames?: string[];
+  thinking?: { enabled: boolean; budget?: number };
+  /** Token limits for the mid-stream compaction threshold. */
+  limits?: { contextWindow?: number; maxOutputTokens?: number };
+  /**
+   * Subagent definitions. When non-empty, a `delegate` tool is added to the
+   * parent's tool set and wired to a headless subagent runner.
+   */
+  subagents?: AgentDefinition[];
   onStepFinish?: (step: Parameters<NonNullable<ConstructorParameters<typeof ToolLoopAgent>[0]["onStepFinish"]>>[0]) => void;
 }
 
@@ -95,7 +141,17 @@ export interface BuiltAgent {
   transport: CompactingChatTransport;
   getNeedsMidStreamCompaction: () => boolean;
   /** Names of tools registered, in registration order. */
-  toolNames: BenchToolName[];
+  toolNames: string[];
+}
+
+interface ToBenchToolOptions {
+  returnPageStateAfterAction: boolean;
+  pageStateFields: string[];
+  /** Set of tool names whose output is page state as an image. */
+  imageToolSet: Set<string>;
+  /** Set of tool names whose call terminates the loop. */
+  terminalToolSet: Set<string>;
+  onTerminal: () => void;
 }
 
 /**
@@ -107,8 +163,21 @@ export interface BuiltAgent {
  * The extension version layers in approval flows, indicator UI, tab pinning,
  * and toolResultStore bookkeeping — all extension-only concerns. The bench
  * harness needs none of that.
+ *
+ * Page-state delivery is harness-driven:
+ *   - When `returnPageStateAfterAction` is false, `pageStateFields` are
+ *     stripped from NON-image-tool results so a vision-only arm isn't
+ *     contaminated by auto-returned a11y text. The agent must call a
+ *     perception (image) tool itself to see post-action state.
+ *   - Image (page-state) tools route their `imageDataUrl` as a multimodal
+ *     image part via `toModelOutput`; everything else is text.
+ *   - Terminal tools flip the loop-stop flag after their call.
  */
-function toBenchSDKTool(t: BrowserTool<unknown, unknown>): ToolSet[string] {
+function toBenchSDKTool(
+  t: AnyBrowserTool,
+  opts: ToBenchToolOptions,
+): ToolSet[string] {
+  const isImageTool = opts.imageToolSet.has(t.name);
   return {
     description: t.description,
     inputSchema: t.parameters,
@@ -136,7 +205,28 @@ function toBenchSDKTool(t: BrowserTool<unknown, unknown>): ToolSet[string] {
       }
 
       try {
-        return await t.execute(input, ctx);
+        const result = await t.execute(input, ctx);
+
+        // Strip auto-returned page-state fields from non-image-tool results
+        // when the harness opts out of "return page state after action".
+        if (
+          !opts.returnPageStateAfterAction
+          && result
+          && typeof result === "object"
+          && !isImageTool
+        ) {
+          const resObj = result as Record<string, unknown>;
+          for (const field of opts.pageStateFields) {
+            if (field in resObj) delete resObj[field];
+          }
+        }
+
+        // Terminal tools break the agent loop after this call/result pair.
+        if (opts.terminalToolSet.has(t.name)) {
+          opts.onTerminal();
+        }
+
+        return result;
       } catch (err) {
         // Surface tool errors as structured results so the agent can recover
         // mid-loop instead of bailing the whole trial.
@@ -145,51 +235,156 @@ function toBenchSDKTool(t: BrowserTool<unknown, unknown>): ToolSet[string] {
         };
       }
     },
-  } as ToolSet[string];
+    // Route image (page-state) tools' `imageDataUrl` as a multimodal image
+    // part. All other tools just JSON-stringify their output as a text part.
+    toModelOutput: isImageTool
+      ? ({ output }: { output: any }) => {
+          const { imageDataUrl, ...rest } = output;
+          const base64 = imageDataUrl.replace(/^data:image\/png;base64,/, "");
+          return {
+            type: "content",
+            value: [
+              {
+                type: "image-data",
+                data: base64,
+                mediaType: "image/png",
+              },
+              {
+                type: "text",
+                text: JSON.stringify(rest),
+              },
+            ],
+          };
+        }
+      : undefined,
+  } as unknown as ToolSet[string];
 }
 
 export function buildBenchAgent(
   ctx: ToolContext,
   opts: BuildAgentOptions,
 ): BuiltAgent {
-  const toolNames = opts.toolNames ?? DEFAULT_TOOL_SET;
+  const toolInstances =
+    opts.tools ?? DEFAULT_TOOL_SET.map((name) => BENCH_TOOL_CATALOG[name]);
+
+  const returnPageStateAfterAction = opts.returnPageStateAfterAction ?? true;
+  const pageStateFields = opts.pageStateFields ?? DEFAULT_PAGE_STATE_FIELDS;
+  const imageToolSet = new Set(
+    opts.pageStateImageTools ?? DEFAULT_PAGE_STATE_IMAGE_TOOLS,
+  );
+  const terminalToolSet = new Set(opts.terminalToolNames ?? []);
+
+  // Set when the agent calls a terminal tool (e.g. a bot-block reporter).
+  // Read by `stopWhen` so the ToolLoopAgent breaks its inner loop after the
+  // terminal tool's call/result pair is emitted.
+  let taskReportedTerminal = false;
+  const onTerminal = () => {
+    taskReportedTerminal = true;
+  };
+
   const tools: ToolSet = {};
-  for (const name of toolNames) {
-    const t = BENCH_TOOL_CATALOG[name];
-    if (!t) throw new Error(`buildBenchAgent: unknown tool "${name}"`);
-    tools[name] = toBenchSDKTool(t);
+  const toolNames: string[] = [];
+  for (const t of toolInstances) {
+    if (!t) throw new Error("buildBenchAgent: encountered undefined tool");
+    tools[t.name] = toBenchSDKTool(t, {
+      returnPageStateAfterAction,
+      pageStateFields,
+      imageToolSet,
+      terminalToolSet,
+      onTerminal,
+    });
+    toolNames.push(t.name);
   }
 
+  const limits: TokenLimits = {
+    contextWindow: opts.limits?.contextWindow ?? 128000,
+    maxOutputTokens: opts.limits?.maxOutputTokens ?? 8000,
+  };
+
   let needsMidStreamCompaction = false;
+
+  // Build providerOptions for thinking/reasoning when enabled. We dispatch on
+  // the model id (which the AI SDK exposes via `(model as any).modelId`) so we
+  // can pick the correct provider-specific options shape.
+  let providerOptions: any | undefined;
+  if (opts.thinking?.enabled) {
+    const budget = opts.thinking.budget ?? 4096;
+    const modelId = (opts.model as any).modelId ?? (opts.model as any).id ?? "";
+    if (typeof modelId === "string" && modelId.startsWith("gemini-")) {
+      providerOptions = {
+        google: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: budget,
+          },
+        },
+      };
+    } else if (typeof modelId === "string" && modelId.startsWith("claude")) {
+      providerOptions = {
+        anthropic: {
+          thinking: { type: "adaptive", display: "summarized" },
+        },
+      };
+    } else if (typeof modelId === "string" && (modelId.startsWith("gpt") || modelId.startsWith("o"))) {
+      providerOptions = {
+        openai: { reasoning: { effort: "medium" } },
+      };
+    }
+  }
+
+  // Subagent wiring: when the harness declares subagents, add a `delegate`
+  // tool backed by the headless subagent runner. The loop filters from the
+  // parent's ALREADY-WRAPPED SDK tools (so subagents inherit the same
+  // page-state policy), minus `delegate` itself (depth cap = 1).
+  if (opts.subagents && opts.subagents.length > 0) {
+    const runAgentLoop = buildBenchSubagentLoop({
+      model: opts.model,
+      parentSdkTools: tools,
+      providerOptions,
+    });
+    tools["delegate"] = createBenchDelegateTool({
+      agentDefs: opts.subagents,
+      runAgentLoop,
+    });
+    toolNames.push("delegate");
+  }
 
   const agent = new ToolLoopAgent({
     model: opts.model,
     tools,
     instructions: opts.systemPrompt ?? buildBenchSystemPrompt(),
     experimental_context: ctx,
+    ...(providerOptions ? { providerOptions } : {}),
     onStepFinish: (stepResult) => {
       opts.onStepFinish?.(stepResult);
       const usage = stepResult.usage;
       const lastTotalTokens = (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
-      // Wait we need TokenLimits here. Let's just hardcode some reasonable token limits for the bench (128k context)
-      if (shouldCompact(lastTotalTokens, { contextWindow: 128000, maxOutputTokens: 8000 })) {
+      if (shouldCompact(lastTotalTokens, limits)) {
         needsMidStreamCompaction = true;
       }
     },
-    stopWhen: () => needsMidStreamCompaction,
+    stopWhen: () => needsMidStreamCompaction || taskReportedTerminal,
   });
 
   const transport = new CompactingChatTransport({
     agent,
+    // Bench trials have a single user turn (the task instruction). The
+    // default user-turn-based screenshot-stripping policy in the transport
+    // therefore never strips anything in bench, causing context bloat as
+    // perception images accumulate. Opt into the strict "only keep the
+    // latest image" policy, scoped to this harness's page-state image tools,
+    // so each send carries at most one image.
+    keepOnlyLatestImage: true,
+    screenshotToolNames: [...imageToolSet],
     onSendStart: () => {
       needsMidStreamCompaction = false;
     },
   });
 
-  return { 
-    agent, 
-    transport, 
-    getNeedsMidStreamCompaction: () => needsMidStreamCompaction, 
-    toolNames 
+  return {
+    agent,
+    transport,
+    getNeedsMidStreamCompaction: () => needsMidStreamCompaction,
+    toolNames,
   };
 }

--- a/packages/bench/src/agent/som-capture.ts
+++ b/packages/bench/src/agent/som-capture.ts
@@ -1,0 +1,267 @@
+import type { ToolContext } from "@agent/driver";
+import { captureSnapshot } from "@agent/snapshot-capture";
+import { getRefsForTab } from "@agent/ref-store";
+
+export interface CaptureViewOptions {
+  fullPage?: boolean;
+}
+
+export interface CapturedView {
+  imageDataUrl: string;
+  refCount: number;
+  url: string;
+  legend: string;
+  belowFoldCount: number;
+  warning?: string;
+  /**
+   * Viewport accessibility-tree text. Same content the `snapshot` tool returns
+   * with `mode: "viewport"`. Populated by `captureSnapshot` and surfaced to
+   * the hybrid SoM (`viewPageFull`) variant alongside the annotated image.
+   */
+  snapshot: string;
+}
+
+const COLOR_LEGEND = "buttons=blue, links=green, inputs=orange, other=gray";
+
+function colorForRole(role: string): string {
+  if (role === "button") return "rgba(0, 120, 255, 0.85)";
+  if (role === "link") return "rgba(40, 180, 80, 0.85)";
+  if (
+    role === "textbox" ||
+    role === "combobox" ||
+    role === "searchbox" ||
+    role === "spinbutton"
+  ) {
+    return "rgba(255, 140, 0, 0.85)";
+  }
+  return "rgba(100, 100, 100, 0.85)";
+}
+
+/**
+ * Shared implementation for the bench's SoM perception tools.
+ *
+ *   - Captures a viewport-only a11y snapshot to populate the ref-store and
+ *     produce the snapshot text for hybrid SoM.
+ *   - Captures a screenshot via CDP `Page.captureScreenshot`.
+ *   - Computes per-ref bounding boxes via CDP `DOM.getBoxModel`.
+ *   - Injects a canvas overlay into the page and draws labelled boxes.
+ *   - Re-captures the screenshot to include the labels.
+ *   - Cleans up the canvas.
+ *
+ * The viewportOnly snapshot mode is critical: without it the ref-store
+ * contains every interactive element on the page (often 100+ refs) but only
+ * the viewport-visible ones get drawn, leading the model to hallucinate refs
+ * for elements it cannot see.
+ *
+ * Both `viewPageTool` and `viewPageFullTool` call this helper. The "full"
+ * (hybrid) variant additionally surfaces the viewport a11y tree text via the
+ * `snapshot` field — `@ref` IDs in the text and on the image are guaranteed
+ * consistent because they come from the same captureSnapshot call.
+ */
+export async function captureViewPage(
+  ctx: ToolContext,
+  opts: CaptureViewOptions,
+): Promise<CapturedView> {
+  const tab = await ctx.driver.getActiveTab();
+  const tabId = tab.id;
+  const fullPage = opts.fullPage ?? false;
+
+  const { refs, belowFoldCount, snapshotText } = await captureSnapshot(
+    ctx.driver,
+    tabId,
+    {
+      mode: "interactive",
+      viewportOnly: true,
+    },
+  );
+
+  const captureParams: Record<string, unknown> = { format: "png" };
+  if (fullPage) {
+    captureParams.captureBeyondViewport = true;
+    const metrics = await ctx.driver.sendCommand<{
+      contentSize: { width: number; height: number };
+    }>(tabId, "Page.getLayoutMetrics");
+    captureParams.clip = {
+      x: 0,
+      y: 0,
+      width: metrics.contentSize.width,
+      height: metrics.contentSize.height,
+      scale: 1,
+    };
+  }
+
+  // Capture (with one retry) — Chrome occasionally returns -32000 mid-paint.
+  let screenshotResult: { data: string };
+  try {
+    screenshotResult = await ctx.driver.sendCommand<{ data: string }>(
+      tabId,
+      "Page.captureScreenshot",
+      captureParams,
+    );
+  } catch (firstErr) {
+    await new Promise((r) => setTimeout(r, 600));
+    try {
+      screenshotResult = await ctx.driver.sendCommand<{ data: string }>(
+        tabId,
+        "Page.captureScreenshot",
+        captureParams,
+      );
+    } catch (secondErr) {
+      throw new Error(
+        `Page.captureScreenshot failed twice — ${
+          secondErr instanceof Error ? secondErr.message : String(secondErr)
+        }`,
+      );
+    }
+  }
+
+  let imageData = screenshotResult.data;
+  let warning: string | undefined;
+
+  // Annotate by:
+  //   1. Asking Chrome for each ref's bounding box (via CDP)
+  //   2. Injecting a canvas overlay into the page
+  //   3. Drawing every box + label at the document-coordinate position
+  //   4. Re-capturing
+  //   5. Removing the canvas
+  try {
+    const activeRefs = getRefsForTab(tabId);
+    if (activeRefs && activeRefs.size > 0) {
+      const boxes: Array<{
+        ref: string;
+        role: string;
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        color: string;
+      }> = [];
+
+      const entries = Array.from(activeRefs.entries());
+      const BATCH = 16;
+      for (let i = 0; i < entries.length; i += BATCH) {
+        const slice = entries.slice(i, i + BATCH);
+        const results = await Promise.all(
+          slice.map(async ([ref, entry]) => {
+            try {
+              const box = await ctx.driver.sendCommand<{
+                model?: { content: number[] };
+              }>(tabId, "DOM.getBoxModel", {
+                backendNodeId: entry.backendNodeId,
+              });
+              if (!box.model?.content) return null;
+              const pts = box.model.content;
+              const xs = [pts[0], pts[2], pts[4], pts[6]];
+              const ys = [pts[1], pts[3], pts[5], pts[7]];
+              return {
+                ref,
+                role: entry.role,
+                x: Math.min(...xs),
+                y: Math.min(...ys),
+                w: Math.max(...xs) - Math.min(...xs),
+                h: Math.max(...ys) - Math.min(...ys),
+                color: colorForRole(entry.role),
+              };
+            } catch {
+              return null;
+            }
+          }),
+        );
+        for (const r of results) if (r) boxes.push(r);
+      }
+
+      // Inject and draw. Font size bumped 12 → 14, bold weight, 1px white
+      // text stroke for readability against any background, slightly
+      // thicker box outline. These changes substantially improve the
+      // model's ability to read ref labels off the screenshot.
+      const injectScript = `
+        (async () => {
+          const boxes = ${JSON.stringify(boxes)};
+          const canvas = document.createElement('canvas');
+          canvas.id = 'openbrowse-som-overlay';
+          canvas.style.position = 'absolute';
+          canvas.style.top = '0';
+          canvas.style.left = '0';
+          canvas.style.pointerEvents = 'none';
+          canvas.style.zIndex = '2147483647';
+          canvas.width = Math.max(document.documentElement.scrollWidth, window.innerWidth);
+          canvas.height = Math.max(document.documentElement.scrollHeight, window.innerHeight);
+          document.body.appendChild(canvas);
+
+          const ctx = canvas.getContext('2d');
+          ctx.font = 'bold 14px system-ui, -apple-system, sans-serif';
+          ctx.textBaseline = 'top';
+
+          let drawn = 0;
+          for (const b of boxes) {
+            if (b.w === 0 || b.h === 0) continue;
+
+            ctx.strokeStyle = b.color;
+            ctx.lineWidth = 2.5;
+            ctx.strokeRect(b.x, b.y, b.w, b.h);
+
+            const text = b.ref;
+            const padX = 6;
+            const badgeH = 20;
+            const metrics = ctx.measureText(text);
+            const badgeW = metrics.width + padX * 2;
+
+            // Badge background — the role color, fully opaque for label area
+            ctx.fillStyle = b.color;
+            ctx.fillRect(b.x, b.y, badgeW, badgeH);
+
+            // White outer stroke around the text for contrast
+            ctx.strokeStyle = 'white';
+            ctx.lineWidth = 3;
+            ctx.lineJoin = 'round';
+            ctx.strokeText(text, b.x + padX, b.y + 3);
+
+            // White text fill
+            ctx.fillStyle = 'white';
+            ctx.fillText(text, b.x + padX, b.y + 3);
+
+            drawn++;
+          }
+          return drawn;
+        })()
+      `;
+
+      const injectRes = await ctx.driver.sendCommand<{
+        result?: { value?: number };
+      }>(tabId, "Runtime.evaluate", {
+        expression: injectScript,
+        awaitPromise: true,
+        returnByValue: true,
+      });
+
+      const boxesDrawn = injectRes.result?.value ?? 0;
+
+      if (boxesDrawn > 0) {
+        const annotatedRes = await ctx.driver.sendCommand<{ data: string }>(
+          tabId,
+          "Page.captureScreenshot",
+          captureParams,
+        );
+        imageData = annotatedRes.data;
+
+        await ctx.driver.sendCommand(tabId, "Runtime.evaluate", {
+          expression: `document.getElementById('openbrowse-som-overlay')?.remove()`,
+        });
+      }
+    }
+  } catch (err) {
+    warning = `Annotation failed: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+  }
+
+  return {
+    imageDataUrl: `data:image/png;base64,${imageData}`,
+    refCount: refs.size,
+    url: tab.url ?? "",
+    legend: COLOR_LEGEND,
+    belowFoldCount,
+    warning,
+    snapshot: snapshotText,
+  };
+}

--- a/packages/bench/src/agent/subagent-runner.ts
+++ b/packages/bench/src/agent/subagent-runner.ts
@@ -1,0 +1,291 @@
+/**
+ * Headless subagent runner for the bench.
+ *
+ * This is the bench-side analog of the extension's
+ * `apps/extension/src/lib/agent/subagents/runner.ts` + the
+ * `runSubagentAgentLoop` closure in `agent-transport.ts`. We replicate that
+ * orchestration here rather than importing it because the extension version
+ * hard-imports `chatDb` (IndexedDB) and persists child-conversation rows —
+ * neither of which exists (or survives) in a headless Node trial.
+ *
+ * Same shared-leaf / replicated-assembly split the bench already uses for the
+ * parent agent (`build-agent.ts` ≈ stripped `agent-transport.ts`): we REUSE
+ * the pure pieces directly —
+ *   - `@agent/subagents/concurrency` (per-parent cap = 10),
+ *   - `@agent/subagents/types` (`AgentDefinition`, `DelegationContext`, ...),
+ * and REPLICATE the chatDb-coupled parts (child conversation persistence is
+ * simply dropped; the subagent transcript/trace is captured in-memory).
+ */
+
+import { ToolLoopAgent, stepCountIs, type LanguageModel, type ToolSet } from "ai";
+import {
+  acquireSubagentSlot,
+  releaseSubagentSlot,
+} from "@agent/subagents/concurrency";
+import type {
+  AgentDefinition,
+  DelegationContext,
+  SubagentStatus,
+} from "@agent/subagents/types";
+import type { ToolContext } from "@agent/driver";
+import type { TodoItem } from "../../../../apps/extension/src/lib/types";
+import type { TraceEntry } from "../runner";
+import { redactImageData } from "./trace-redact";
+
+/** Resolved config handed to the injected `runAgentLoop`. */
+export interface BenchAgentLoopConfig {
+  systemPrompt: string;
+  userMessage: string;
+  toolContext: ToolContext;
+  agentDef: AgentDefinition;
+  abortSignal?: AbortSignal;
+}
+
+/** What the injected `runAgentLoop` returns, including bench-only trace/tokens. */
+export interface BenchAgentLoopResult {
+  finalText: string;
+  status: Exclude<SubagentStatus, "running">;
+  errorMessage?: string;
+  /** The subagent's own tool-call trace (for the parent's recursive trace). */
+  trace: TraceEntry[];
+  /** The subagent's token usage (summed into the trial total by the runner). */
+  tokens: { in: number; out: number };
+}
+
+/** Final result returned by `runBenchSubagent` to the bench delegate tool. */
+export interface BenchSubagentResult {
+  finalText: string;
+  status: Exclude<SubagentStatus, "running">;
+  errorMessage?: string;
+  trace: TraceEntry[];
+  tokens: { in: number; out: number };
+}
+
+export interface RunBenchSubagentOptions {
+  agentDef: AgentDefinition;
+  context: DelegationContext;
+  parentConversationId: string;
+  parentToolContext: ToolContext;
+  abortSignal?: AbortSignal;
+  runAgentLoop: (cfg: BenchAgentLoopConfig) => Promise<BenchAgentLoopResult>;
+}
+
+/**
+ * Headless `runSubagent`. Enforces depth=1 + concurrency caps (reusing the
+ * pure extension `concurrency` module), builds a fresh child ToolContext with
+ * NO chatDb dependency, and delegates the model loop to the injected
+ * `runAgentLoop`. Captures trace + tokens in-memory.
+ */
+export async function runBenchSubagent(
+  opts: RunBenchSubagentOptions,
+): Promise<BenchSubagentResult> {
+  const {
+    agentDef,
+    context,
+    parentConversationId,
+    parentToolContext,
+    abortSignal,
+    runAgentLoop,
+  } = opts;
+
+  // Depth cap: subagents may not spawn other subagents.
+  const parentDepth = parentToolContext.session?.parent?.depth ?? 0;
+  if (parentDepth >= 1) {
+    throw new Error(
+      "Subagent depth cap exceeded — subagents may not spawn other subagents.",
+    );
+  }
+
+  // Concurrency cap (per parent). Reuses the pure extension module.
+  acquireSubagentSlot(parentConversationId);
+  try {
+    const childToolContext = buildBenchChildToolContext({
+      parentToolContext,
+      parentConversationId,
+    });
+    const userMessage = buildDelegationMessage(context);
+
+    let loopResult: BenchAgentLoopResult;
+    try {
+      loopResult = await runAgentLoop({
+        systemPrompt: agentDef.systemPrompt,
+        userMessage,
+        toolContext: childToolContext,
+        agentDef,
+        abortSignal,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        finalText: `Subagent '${agentDef.slug}' failed: ${message}`,
+        status: "failed",
+        errorMessage: message,
+        trace: [],
+        tokens: { in: 0, out: 0 },
+      };
+    }
+
+    return {
+      finalText: loopResult.finalText,
+      status: loopResult.status,
+      errorMessage: loopResult.errorMessage,
+      trace: loopResult.trace,
+      tokens: loopResult.tokens,
+    };
+  } finally {
+    releaseSubagentSlot(parentConversationId);
+  }
+}
+
+/**
+ * Build a child ToolContext for a headless subagent run. Unlike the
+ * extension's `buildChildToolContext` (which gives the child its own tab
+ * group + chatDb-backed conversation), the bench has a single shared browser
+ * and no tab groups — so the child INHERITS the parent's tab-handle mapping
+ * and driver, and only overrides: a fresh in-memory todo list, a child
+ * conversation id, and `session.parent.depth = 1` (so the depth cap fires if
+ * the subagent tries to delegate again). No chatDb calls.
+ */
+function buildBenchChildToolContext(args: {
+  parentToolContext: ToolContext;
+  parentConversationId: string;
+}): ToolContext {
+  const { parentToolContext, parentConversationId } = args;
+
+  // Fresh in-memory todos for the child (independent of the parent's).
+  let childTodos: TodoItem[] = [];
+
+  return {
+    ...parentToolContext,
+    session: {
+      ...parentToolContext.session,
+      conversationId: `bench-subagent-${parentConversationId}`,
+      parent: {
+        conversationId: parentConversationId,
+        depth: 1,
+      },
+      // Inherit the parent's identity tab-handle mapping + ownership check so
+      // the subagent perceives/acts on the SAME tabs the parent navigated to.
+      getTodos: async () => childTodos,
+      setTodos: async (todos) => {
+        childTodos = todos;
+      },
+    },
+  };
+}
+
+/**
+ * Assemble the single user message that becomes the subagent's first turn.
+ * No parent chat history is included — fresh-context contract. Mirrors the
+ * extension's `buildDelegationMessage`.
+ */
+function buildDelegationMessage(ctx: DelegationContext): string {
+  const lines: string[] = [`Task: ${ctx.task}`];
+  if (ctx.parentTabHandle) lines.push("", `Active tab: ${ctx.parentTabHandle}`);
+  if (ctx.tabHandles && ctx.tabHandles.length > 0) {
+    lines.push("", `Tab handles: ${ctx.tabHandles.join(", ")}`);
+  }
+  if (ctx.urls && ctx.urls.length > 0) {
+    lines.push("", "URLs:");
+    for (const url of ctx.urls) lines.push(`- ${url}`);
+  }
+  if (ctx.workspaceFiles && ctx.workspaceFiles.length > 0) {
+    lines.push("", "Workspace files:");
+    for (const path of ctx.workspaceFiles) lines.push(`- ${path}`);
+  }
+  if (ctx.notes) lines.push("", `Notes: ${ctx.notes}`);
+  return lines.join("\n");
+}
+
+/**
+ * Build the injected `runAgentLoop` — the headless analog of
+ * `agent-transport.ts:runSubagentAgentLoop`. Closes over the model,
+ * provider options, and the parent's ALREADY-WRAPPED SDK tools. Filters those
+ * tools by the subagent's `allowedTools`/`deniedTools` (always stripping
+ * `delegate`, depth cap = 1), spawns a nested `ToolLoopAgent`, and captures
+ * the subagent's tool-call trace + token usage in-memory.
+ */
+export function buildBenchSubagentLoop(args: {
+  model: LanguageModel;
+  /** Parent's wrapped SDK tools (the same objects the parent agent uses). */
+  parentSdkTools: ToolSet;
+  providerOptions?: unknown;
+}): (cfg: BenchAgentLoopConfig) => Promise<BenchAgentLoopResult> {
+  const { model, parentSdkTools, providerOptions } = args;
+
+  return async (cfg: BenchAgentLoopConfig): Promise<BenchAgentLoopResult> => {
+    const allow = new Set(cfg.agentDef.allowedTools);
+    const deny = new Set(cfg.agentDef.deniedTools ?? []);
+    const subagentTools: ToolSet = {};
+    for (const [name, sdkTool] of Object.entries(parentSdkTools)) {
+      if (name === "delegate") continue; // depth cap
+      if (!allow.has(name)) continue;
+      if (deny.has(name)) continue;
+      subagentTools[name] = sdkTool;
+    }
+
+    const maxSteps = cfg.agentDef.maxSteps ?? 30;
+    let stepCount = 0;
+    let tokensIn = 0;
+    let tokensOut = 0;
+    const trace: TraceEntry[] = [];
+
+    const subagent = new ToolLoopAgent({
+      model,
+      tools: subagentTools,
+      instructions: cfg.systemPrompt,
+      experimental_context: cfg.toolContext,
+      ...(providerOptions ? { providerOptions: providerOptions as never } : {}),
+      onStepFinish: (step) => {
+        stepCount += 1;
+        const u = step.usage;
+        if (u.inputTokens != null) tokensIn += u.inputTokens;
+        if (u.outputTokens != null) tokensOut += u.outputTokens;
+        for (const tc of step.toolCalls ?? []) {
+          const output =
+            step.toolResults?.find((r) => r.toolCallId === tc.toolCallId)?.output ??
+            null;
+          trace.push({ name: tc.toolName, input: tc.input, output: redactImageData(output) });
+        }
+      },
+      stopWhen: stepCountIs(maxSteps),
+    });
+
+    try {
+      const result = await subagent.generate({
+        prompt: cfg.userMessage,
+        ...(cfg.abortSignal && { abortSignal: cfg.abortSignal }),
+      });
+      const finalText =
+        (result.text && result.text.trim().length > 0)
+          ? result.text
+          : `(no final text returned; subagent ran ${stepCount} step(s))`;
+      const status: BenchAgentLoopResult["status"] =
+        stepCount >= maxSteps && (!result.text || result.text.length === 0)
+          ? "budget-exceeded"
+          : "completed";
+      return { finalText, status, trace, tokens: { in: tokensIn, out: tokensOut } };
+    } catch (err) {
+      const isAbort =
+        err instanceof Error &&
+        (err.name === "AbortError" || /aborted/i.test(err.message));
+      if (isAbort) {
+        return {
+          finalText: "(subagent cancelled)",
+          status: "cancelled",
+          errorMessage: "aborted",
+          trace,
+          tokens: { in: tokensIn, out: tokensOut },
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        finalText: `(subagent error: ${message})`,
+        status: "failed",
+        errorMessage: message,
+        trace,
+        tokens: { in: tokensIn, out: tokensOut },
+      };
+    }
+  };
+}

--- a/packages/bench/src/agent/trace-redact.ts
+++ b/packages/bench/src/agent/trace-redact.ts
@@ -1,0 +1,27 @@
+/**
+ * Trace redaction helpers shared by the runner and the headless subagent
+ * runner. Kept in its own module (rather than exported from `runner.ts`) so
+ * `subagent-runner.ts` can import it without a circular dependency.
+ */
+
+/**
+ * Replace a tool result's inline `imageDataUrl` with a size placeholder so
+ * stored traces don't carry megabytes of base64 image data. Returns the input
+ * unchanged (same reference) when there's no `imageDataUrl` field.
+ */
+export function redactImageData(output: unknown): unknown {
+  if (
+    output &&
+    typeof output === "object" &&
+    "imageDataUrl" in (output as Record<string, unknown>)
+  ) {
+    const url = (output as Record<string, unknown>).imageDataUrl;
+    const size =
+      typeof url === "string" ? Math.round(url.length / 1024) : 0;
+    return {
+      ...(output as Record<string, unknown>),
+      imageDataUrl: `<image data: ${size}KB removed from trace>`,
+    };
+  }
+  return output;
+}

--- a/packages/bench/src/bench.ts
+++ b/packages/bench/src/bench.ts
@@ -1,0 +1,697 @@
+/**
+ * Programmatic suite orchestration.
+ *
+ * `runBench(config)` is the public, in-process API for running a sweep —
+ * the same orchestration `cli.ts:main()` performs (task list resolution,
+ * pooled per-trial execution with resume, video conversion, summary write,
+ * and optional R2 upload), exposed as a single function so harness authors
+ * and integration tests can drive sweeps without spawning the CLI.
+ *
+ * The CLI is a thin shell over this: it loads env, parses argv, resolves the
+ * provider model instance, then constructs `BenchConfig` and calls `runBench`.
+ *
+ * Inputs are deliberately fully-resolved (the model is a `LanguageModel`
+ * instance, not an id string; tasks are `BenchmarkTask` objects, not ids):
+ * provider/env loading and task lookup belong to the caller. This keeps
+ * `runBench` free of dynamic imports, env coupling, and ESM hoist hazards.
+ */
+
+import type { LanguageModel } from "ai";
+import {
+  BENCH_TOOL_CATALOG,
+  buildBenchSystemPrompt,
+  DEFAULT_TOOL_SET,
+} from "./agent/build-agent";
+import type { Harness } from "./harness";
+import {
+  ensureRunDirExists,
+  createRunPaths,
+  makeRunId,
+  resolveRunDir,
+  type RunPaths,
+} from "./paths";
+import { runTrial, type TrialResult } from "./runner";
+import { readAllTrials, writeSummary, writeTrial, type RunSummary } from "./store";
+import type { BenchmarkTask } from "./tasks/types";
+import { convertAllInDir, ffmpegAvailable } from "./video";
+import { runInPool } from "./worker-pool";
+
+/**
+ * Thrown for invalid `BenchConfig` combinations (mutually-exclusive flags,
+ * upload requested without credentials/eval-set/arm). The CLI maps this to
+ * exit code 2 ("usage / misconfiguration"), distinct from exit code 1 used
+ * for genuine runtime failures (e.g. a failed upload mid-run). Preserves the
+ * exit-code contract the original cli.ts exposed before `runBench` was
+ * extracted.
+ */
+export class BenchConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BenchConfigError";
+  }
+}
+
+export interface BenchConfig {
+  /** Tasks to run. Already resolved (caller does the lookup). */
+  tasks: BenchmarkTask[];
+  /** Resolved language-model instance. */
+  model: LanguageModel;
+  /** Provider model id (e.g. "claude-sonnet-4-5-20250929"). */
+  modelId: string;
+  /** Display label for grouping (defaults to modelId when omitted). */
+  modelLabel?: string;
+  /** Harness config (when omitted, no-harness defaults are used). */
+  harness?: Harness;
+  /** Resolved thinking config (CLI/harness merge already done by caller). */
+  thinking?: { enabled: boolean; budget?: number };
+  /** Replicas per task. Defaults to 1. */
+  replicas?: number;
+  /** Headless Chromium. Defaults to false (headed). */
+  headless?: boolean;
+  /** Disable video recording. Defaults to false (videos on). */
+  noVideo?: boolean;
+  /** Disable click/type overlays in recorded video. Defaults to false. */
+  noVisualize?: boolean;
+  /** Keep raw .webm originals after MP4 conversion. Defaults to false. */
+  keepWebm?: boolean;
+  /** Resume an existing run by directory. Mutually exclusive with `outDir`. */
+  resumeDir?: string;
+  /** With `resumeDir`, skip previously-errored trials (default: re-attempt). */
+  keepErrors?: boolean;
+  /** Override the auto-generated run dir. */
+  outDir?: string;
+  /** Browser driver. Defaults to "local". */
+  driverKind?: "local" | "kernel";
+  /** Pre-existing Kernel browser pool id/name (with `driverKind: "kernel"`). */
+  kernelPoolId?: string;
+  /** Trial concurrency. 0 → defaults (local: CPU/2, kernel: 5). */
+  concurrency?: number;
+  /** R2 upload mode. Defaults to "auto" (env-driven). */
+  upload?: "auto" | "always" | "never";
+  /** Eval-set name; required when uploading. */
+  evalSet?: string;
+  /** Arm label within an eval-set; required when uploading. */
+  arm?: string;
+  /** Suite tag for run-id construction (purely cosmetic). */
+  suite?: "webbench-mini" | "webbench" | "custom" | "all";
+  /** Single-task tag for run-id construction (set when running one task). */
+  taskId?: string;
+  /** Pre-sample task count (suite size before sampling). */
+  preSampleCount?: number;
+  /** Sample size used (when sampling was applied). */
+  sampleSize?: number;
+  /** Sampling seed (when sampling was applied). */
+  seed?: number;
+}
+
+export interface BenchSummary {
+  /** Generated or resumed run id. */
+  runId: string;
+  /** Absolute run-dir path. */
+  runDir: string;
+  /** Absolute summary.json path. */
+  summaryPath: string;
+  /** Absolute trials/ dir. */
+  trialsDir: string;
+  /** Absolute videos/ dir (whether or not videos were recorded). */
+  videosDir: string;
+  /** Absolute manifest.json path when uploaded; else undefined. */
+  manifestPath?: string;
+  /** Roll-up numbers (mirrors what the CLI prints). */
+  totals: {
+    tasks: number;
+    replicas: number;
+    passed: number;
+    total: number;
+    passRate: number;
+    infrastructureFailures: number;
+    agentFailures: number;
+    botBlocked: number;
+    judgeRejects: number;
+    tokensIn: number;
+    tokensOut: number;
+    durationMs: number;
+  };
+  failuresByDomain: Record<string, number>;
+  /** True iff R2 upload succeeded. */
+  uploaded: boolean;
+}
+
+interface AggregateRow {
+  taskId: string;
+  passed: number;
+  total: number;
+  infrastructureFailures: number;
+  agentFailures: number;
+  botBlocked: number;
+  judgeRejects: number;
+  avgSteps: number;
+  avgTokensIn: number;
+  avgTokensOut: number;
+  avgDurationMs: number;
+  domain: string;
+  videoPaths: string[];
+  trialPaths: string[];
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+/**
+ * Run a complete bench sweep. See `BenchConfig` for inputs and `BenchSummary`
+ * for outputs. Identical behavior to the CLI: writes per-trial JSONs, a
+ * summary, optional videos, and uploads to R2 when configured.
+ *
+ * Throws synchronously on misconfigurations (mutually-exclusive flags,
+ * upload-without-eval-set, missing R2 env when `upload: "always"`).
+ */
+export async function runBench(config: BenchConfig): Promise<BenchSummary> {
+  const {
+    tasks: initialTasks,
+    model,
+    modelId,
+    modelLabel = modelId,
+    harness,
+    thinking,
+    replicas = 1,
+    headless = false,
+    noVideo = false,
+    noVisualize = false,
+    keepWebm = false,
+    resumeDir,
+    keepErrors = false,
+    outDir,
+    driverKind = "local",
+    kernelPoolId,
+    upload = "auto",
+    evalSet,
+    arm,
+    suite,
+    taskId,
+    preSampleCount,
+    sampleSize,
+    seed,
+  } = config;
+
+  if (resumeDir && outDir) {
+    throw new BenchConfigError("`resumeDir` and `outDir` are mutually exclusive.");
+  }
+
+  // Fail fast on upload misconfigurations before running any trials.
+  const { uploadRun, createR2Client, r2EnvPresent } = await import("./upload");
+  let plannedUpload = false;
+  switch (upload) {
+    case "never":
+      plannedUpload = false;
+      break;
+    case "always":
+      plannedUpload = true;
+      if (!r2EnvPresent()) {
+        throw new BenchConfigError(
+          "upload: 'always' was set but required R2 env vars are not present " +
+            "(R2_ACCOUNT_ID, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET).",
+        );
+      }
+      break;
+    case "auto":
+      plannedUpload = r2EnvPresent();
+      break;
+  }
+  if (plannedUpload && (!evalSet || !arm)) {
+    throw new BenchConfigError(
+      "Upload requires both `evalSet` and `arm` to make artifacts traceable. " +
+        "Pass both, or set upload: 'never'.",
+    );
+  }
+
+  // Arm id (run grouping) and tool-set metadata.
+  const armId = harness?.id ?? "default";
+  const armToolNames = harness ? harness.tools.map((t) => t.name) : DEFAULT_TOOL_SET;
+
+  // Run-dir resolution (resume reuses the existing dir).
+  let runId: string;
+  let runDir: string;
+  let paths: RunPaths;
+  let existingTrials: TrialResult[] = [];
+
+  if (resumeDir) {
+    paths = ensureRunDirExists(resumeDir);
+    runDir = paths.runDir;
+    const path = await import("node:path");
+    runId = path.basename(runDir);
+    existingTrials = readAllTrials(paths);
+  } else {
+    runId = makeRunId({
+      modelLabel,
+      suite,
+      taskId,
+      evalSet,
+      arm,
+    });
+    runDir = resolveRunDir({ runId, outDirOverride: outDir });
+    paths = createRunPaths(runDir);
+  }
+
+  const startedAt = new Date().toISOString();
+
+  // Resume bookkeeping: skip already-completed task ids; optionally retry errors.
+  const completedTaskIds = new Set<string>();
+  const erroredTaskIds = new Set<string>();
+  let tasks = initialTasks;
+  if (resumeDir) {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    for (const t of existingTrials) {
+      if (!keepErrors && t.error) {
+        erroredTaskIds.add(t.taskId);
+        try {
+          fs.unlinkSync(path.join(paths.trialsDir, `${t.taskId}.json`));
+        } catch {}
+      } else {
+        completedTaskIds.add(t.taskId);
+      }
+    }
+    const initialCount = tasks.length;
+    tasks = tasks.filter((t) => !completedTaskIds.has(t.id));
+    try {
+      const logMsg = `[${startedAt}] Resumed sweep. Original tasks: ${initialCount}, Already completed: ${completedTaskIds.size}, Retrying errors: ${erroredTaskIds.size}, Running now: ${tasks.length}\n`;
+      fs.appendFileSync(path.join(paths.runDir, "resume.log"), logMsg);
+    } catch {}
+  }
+
+  const startMs = Date.now();
+  const recordVideo = !noVideo;
+  const visualize = !noVisualize;
+
+  // Default concurrency.
+  let concurrency = config.concurrency ?? 0;
+  if (concurrency === 0) {
+    if (driverKind === "kernel") {
+      concurrency = 5;
+    } else {
+      const os = await import("node:os");
+      concurrency = Math.max(1, Math.floor(os.cpus().length / 2));
+    }
+  }
+
+  console.log(
+    `Running ${tasks.length} task(s) × ${replicas} replicas, model=${modelLabel}, concurrency=${concurrency}`,
+  );
+  if (resumeDir) {
+    console.log(
+      `Resuming from ${paths.runDir}: ${completedTaskIds.size} already done, ${tasks.length} remaining (${erroredTaskIds.size} errored, will retry)`,
+    );
+  } else {
+    console.log(`Run dir:   ${paths.runDir}`);
+  }
+  console.log(`Video:     ${recordVideo ? "enabled" : "disabled"}`);
+  console.log(`Visualize: ${recordVideo && visualize ? "enabled" : "disabled"}`);
+  console.log("");
+
+  let completedTasks = 0;
+  const totalTasks = tasks.length;
+  let runningTasks = 0;
+
+  if (tasks.length > 0) {
+    await runInPool(tasks, concurrency, async (task) => {
+      runningTasks++;
+
+      const trials: string[] = [];
+      const videos: string[] = [];
+
+      const logBuffer: string[] = [];
+      logBuffer.push(`=== ${task.id} ===`);
+      logBuffer.push(`  ${truncate(task.instruction, 100)}`);
+
+      for (let i = 1; i <= replicas; i++) {
+        const tag = replicas > 1 ? ` [${i}/${replicas}]` : "";
+        const result = await runTrial(task, {
+          model,
+          modelId,
+          modelLabel,
+          armId,
+          harness,
+          systemPromptId: armId,
+          toolSetId: `set:${armToolNames.join("+")}`,
+          thinking,
+          headless,
+          videosDir: recordVideo ? paths.videosDir : undefined,
+          replicaIndex: replicas > 1 ? i : undefined,
+          visualize,
+          driverKind,
+          kernelPoolId,
+        });
+
+        const trialPath = writeTrial(paths, result);
+        trials.push(trialPath);
+
+        logBuffer.push(
+          `  Trial${tag}: ${result.passed ? "PASS" : "FAIL"} steps=${result.steps} tokens=${result.tokens.in}/${result.tokens.out} time=${(result.durationMs / 1000).toFixed(1)}s`,
+        );
+        if (result.error) logBuffer.push(`    error: ${result.error.message}`);
+        logBuffer.push(`    answer: ${truncate(result.agentAnswer, 160)}`);
+        logBuffer.push(`    judge:  ${truncate(result.judge.reasoning, 160)}`);
+        if (result.videoPath) {
+          logBuffer.push(`    video:  ${result.videoPath}`);
+          videos.push(result.videoPath);
+        }
+        if (result.liveViewUrl) {
+          logBuffer.push(`    live:   ${result.liveViewUrl}`);
+        }
+      }
+
+      runningTasks--;
+      completedTasks++;
+      console.log(logBuffer.join("\n"));
+      console.log(`[${completedTasks}/${totalTasks} done | ${runningTasks} in flight]`);
+      console.log("");
+    });
+  }
+
+  // Reload all trials from disk to assemble the final summary (so resumed
+  // runs include previously-completed trials).
+  const finalTrials = readAllTrials(paths);
+  const finalRows: AggregateRow[] = [];
+  const trialsByTask = new Map<string, TrialResult[]>();
+  for (const t of finalTrials) {
+    if (!trialsByTask.has(t.taskId)) trialsByTask.set(t.taskId, []);
+    trialsByTask.get(t.taskId)!.push(t);
+  }
+
+  const path = await import("node:path");
+  for (const [taskIdInner, trialList] of trialsByTask.entries()) {
+    let passes = 0,
+      infraFails = 0,
+      agentFails = 0,
+      botBlocks = 0,
+      judgeRejects = 0;
+    let stepsSum = 0,
+      inSum = 0,
+      outSum = 0,
+      timeSum = 0;
+    const vPaths: string[] = [];
+    const tPaths: string[] = [];
+    let domain = "";
+    for (const res of trialList) {
+      if (res.passed) passes++;
+      else if (res.error) {
+        if (res.error.kind === "infrastructure-error") infraFails++;
+        else if (res.error.kind === "bot-blocked") botBlocks++;
+        else agentFails++;
+      } else {
+        judgeRejects++;
+      }
+      stepsSum += res.steps;
+      inSum += res.tokens.in;
+      outSum += res.tokens.out;
+      timeSum += res.durationMs;
+      if (res.videoPath) vPaths.push(res.videoPath);
+      tPaths.push(path.join(paths.trialsDir, `${res.taskId}.json`));
+      if (!domain && res.finalUrl) {
+        try {
+          domain = new URL(res.finalUrl).hostname.replace(/^www\./, "");
+        } catch {}
+      }
+    }
+    const count = trialList.length;
+    finalRows.push({
+      taskId: taskIdInner,
+      passed: passes,
+      total: count,
+      infrastructureFailures: infraFails,
+      agentFailures: agentFails,
+      botBlocked: botBlocks,
+      judgeRejects,
+      avgSteps: stepsSum / count,
+      avgTokensIn: inSum / count,
+      avgTokensOut: outSum / count,
+      avgDurationMs: timeSum / count,
+      domain,
+      videoPaths: vPaths,
+      trialPaths: tPaths,
+    });
+  }
+
+  console.log("Summary");
+  console.log("-------");
+  let overallPassed = 0,
+    overallTotal = 0,
+    overallInfraFails = 0,
+    overallAgentFails = 0,
+    overallBotBlocks = 0,
+    overallJudgeRejects = 0,
+    overallTokensIn = 0,
+    overallTokensOut = 0,
+    overallDurationMs = 0;
+  const failuresByDomain: Record<string, number> = {};
+  for (const r of finalRows) {
+    overallPassed += r.passed;
+    overallTotal += r.total;
+    overallInfraFails += r.infrastructureFailures;
+    overallAgentFails += r.agentFailures;
+    overallBotBlocks += r.botBlocked;
+    overallJudgeRejects += r.judgeRejects;
+    overallTokensIn += r.avgTokensIn * r.total;
+    overallTokensOut += r.avgTokensOut * r.total;
+    overallDurationMs += r.avgDurationMs * r.total;
+    if (r.total > r.passed) {
+      failuresByDomain[r.domain] = (failuresByDomain[r.domain] || 0) + (r.total - r.passed);
+    }
+    console.log(
+      `  ${r.taskId.padEnd(35)} ${r.passed}/${r.total}   steps=${r.avgSteps.toFixed(1).padStart(5)}   in=${Math.round(r.avgTokensIn).toString().padStart(6)}   out=${Math.round(r.avgTokensOut).toString().padStart(4)}   time=${(r.avgDurationMs / 1000).toFixed(1)}s`,
+    );
+  }
+  console.log("");
+  console.log(
+    `Pass rate: ${overallPassed}/${overallTotal} (${overallTotal === 0 ? "0" : ((overallPassed / overallTotal) * 100).toFixed(0)}%)`,
+  );
+  if (overallTotal > 0) {
+    console.log(`Breakdown:`);
+    console.log(`  Agent Errors:  ${((overallAgentFails / overallTotal) * 100).toFixed(1)}%`);
+    console.log(`  Infra Errors:  ${((overallInfraFails / overallTotal) * 100).toFixed(1)}%`);
+    console.log(`  Bot-blocked:   ${((overallBotBlocks / overallTotal) * 100).toFixed(1)}%`);
+    console.log(`  Judge Rejects: ${((overallJudgeRejects / overallTotal) * 100).toFixed(1)}%`);
+  }
+  console.log(
+    `Total tokens: in=${overallTokensIn.toLocaleString()}  out=${overallTokensOut.toLocaleString()}`,
+  );
+  console.log(`Total wall time: ${(overallDurationMs / 1000 / 60).toFixed(1)} min`);
+
+  // Convert recorded videos to mp4 (post-sweep batch).
+  if (recordVideo) {
+    const ffOk = await ffmpegAvailable();
+    if (!ffOk) {
+      console.log("");
+      console.log(
+        "WARNING: ffmpeg not on PATH. Skipping mp4 conversion.\n" +
+          "  Install with: brew install ffmpeg   (macOS)\n" +
+          "                apt install ffmpeg    (Debian/Ubuntu)\n" +
+          `  Raw .webm videos still saved at: ${paths.videosDir}`,
+      );
+    } else {
+      console.log("");
+      console.log(`Converting videos to mp4...`);
+      const ffStart = Date.now();
+      const convResults = await convertAllInDir(paths.videosDir, {
+        deleteSource: !keepWebm,
+        concurrency: 4,
+      });
+      const okCount = convResults.filter((r) => r.ok).length;
+      const failCount = convResults.length - okCount;
+      console.log(
+        `  ${okCount}/${convResults.length} converted in ${((Date.now() - ffStart) / 1000).toFixed(1)}s`,
+      );
+      if (failCount > 0) {
+        for (const r of convResults.filter((r) => !r.ok)) {
+          console.log(`  FAILED: ${r.source}`);
+          if (r.stderr) console.log(`    ${r.stderr.trim().split("\n").pop()}`);
+        }
+      }
+    }
+  }
+
+  // Build the harness-metadata block written into summary.json.
+  const trialPaths = finalTrials.map((t) => path.join(paths.trialsDir, `${t.taskId}.json`));
+  const crypto = await import("node:crypto");
+  const child_process = await import("node:child_process");
+  const { z } = await import("zod");
+
+  const systemPromptText = harness ? harness.systemPrompt : buildBenchSystemPrompt();
+  const systemPromptHash = crypto
+    .createHash("sha256")
+    .update(systemPromptText)
+    .digest("hex")
+    .slice(0, 16);
+
+  let gitSha: string | undefined;
+  try {
+    gitSha = child_process
+      .execSync("git rev-parse HEAD", { stdio: ["pipe", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {}
+
+  let benchVersion = "0.0.0";
+  try {
+    const pkg = JSON.parse(
+      await (await import("node:fs/promises")).readFile(
+        path.join(process.cwd(), "package.json"),
+        "utf8",
+      ),
+    );
+    benchVersion = pkg.version || "0.0.0";
+  } catch {}
+
+  const toolInstancesForMeta = harness
+    ? harness.tools
+    : DEFAULT_TOOL_SET.map((name) => BENCH_TOOL_CATALOG[name]);
+
+  const { LLM_JUDGE_VERSION, JUDGE_MODEL_ID } = await import("./judges/llm-judge");
+  const { WEBBENCH_REVISION } = await import("./tasks/webbench/revision");
+
+  const harnessMeta: NonNullable<RunSummary["harness"]> = {
+    agent: {
+      modelId,
+      systemPromptId: armId,
+      systemPromptHash,
+      systemPromptText,
+      toolSet: toolInstancesForMeta.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: z.toJSONSchema(t.parameters),
+        outputSchema: t.outputSchema ? z.toJSONSchema(t.outputSchema) : undefined,
+      })),
+      limits: {
+        contextWindow: harness?.limits?.contextWindow ?? 128000,
+        maxOutputTokens: harness?.limits?.maxOutputTokens ?? 8000,
+      },
+      thinking: thinking
+        ? { enabled: true, budget: thinking.budget }
+        : { enabled: false },
+    },
+    driver: {
+      kind: driverKind,
+      headless,
+      stealth: true,
+      visualize,
+      viewport: { width: 1280, height: 800 },
+    },
+    run: {
+      concurrency,
+      replicas,
+      timeoutMs: 15 * 60000,
+      hardTimeoutBufferMs: 30000,
+    },
+    judge: { modelId: JUDGE_MODEL_ID, version: LLM_JUDGE_VERSION },
+    suite: {
+      source: suite,
+      revision: WEBBENCH_REVISION,
+      totalTasks: preSampleCount,
+      sampleSize,
+      seed,
+    },
+    provenance: {
+      benchVersion,
+      gitSha,
+      nodeVersion: process.version,
+      platform: process.platform,
+    },
+  };
+
+  const summaryPath = writeSummary(paths, {
+    runId,
+    model: modelLabel,
+    suite,
+    taskId,
+    startedAt,
+    endedAt: new Date().toISOString(),
+    durationMs: Date.now() - startMs,
+    tasks: finalRows.length,
+    replicas,
+    passed: overallPassed,
+    passRate: overallTotal === 0 ? 0 : overallPassed / overallTotal,
+    breakdown: {
+      agentAccuracy: overallTotal === 0 ? 0 : overallPassed / overallTotal,
+      infrastructureFailureRate: overallTotal === 0 ? 0 : overallInfraFails / overallTotal,
+      botBlockedRate: overallTotal === 0 ? 0 : overallBotBlocks / overallTotal,
+      judgeRejectRate: overallTotal === 0 ? 0 : overallJudgeRejects / overallTotal,
+    },
+    failuresByDomain,
+    tokens: {
+      in: overallTokensIn,
+      out: overallTokensOut,
+      total: overallTokensIn + overallTokensOut,
+    },
+    harness: harnessMeta,
+    trialPaths,
+  });
+  console.log("");
+  console.log(`Summary: ${summaryPath}`);
+  console.log(`Trials:  ${paths.trialsDir}`);
+  if (recordVideo) {
+    console.log(`Videos:  ${paths.videosDir}`);
+  }
+
+  // Re-evaluate `auto` upload against current env (it may have flipped).
+  const shouldUpload =
+    upload === "never" ? false : upload === "always" ? true : r2EnvPresent();
+  let manifestPath: string | undefined;
+  let uploaded = false;
+  if (shouldUpload) {
+    if (!evalSet || !arm) {
+      throw new BenchConfigError(
+        "Upload requires both `evalSet` and `arm`. Either provide both, or set upload: 'never'.",
+      );
+    }
+    console.log("");
+    console.log(`Uploading to R2 (bucket=${process.env.R2_BUCKET})...`);
+    const uploadStart = Date.now();
+    try {
+      const { client, bucket } = createR2Client();
+      const manifest = await uploadRun({
+        paths,
+        runId,
+        evalSet,
+        arm,
+        deps: { s3Client: client, bucket },
+      });
+      const uploadDuration = ((Date.now() - uploadStart) / 1000).toFixed(1);
+      console.log(
+        `  ${Object.keys(manifest.trials).length} trial(s) uploaded in ${uploadDuration}s`,
+      );
+      console.log(`  Manifest: ${paths.manifestPath}`);
+      manifestPath = paths.manifestPath;
+      uploaded = true;
+    } catch (err) {
+      console.error("Upload failed:", err instanceof Error ? err.message : String(err));
+      console.error("Local artifacts preserved in:", paths.runDir);
+      throw err;
+    }
+  }
+
+  return {
+    runId,
+    runDir: paths.runDir,
+    summaryPath,
+    trialsDir: paths.trialsDir,
+    videosDir: paths.videosDir,
+    manifestPath,
+    totals: {
+      tasks: finalRows.length,
+      replicas,
+      passed: overallPassed,
+      total: overallTotal,
+      passRate: overallTotal === 0 ? 0 : overallPassed / overallTotal,
+      infrastructureFailures: overallInfraFails,
+      agentFailures: overallAgentFails,
+      botBlocked: overallBotBlocks,
+      judgeRejects: overallJudgeRejects,
+      tokensIn: overallTokensIn,
+      tokensOut: overallTokensOut,
+      durationMs: overallDurationMs,
+    },
+    failuresByDomain,
+    uploaded,
+  };
+}

--- a/packages/bench/src/cli.ts
+++ b/packages/bench/src/cli.ts
@@ -7,6 +7,12 @@
  * Per the spec's resolved decisions: this is the only entry point in v1.
  * No CI, no cron, no GitHub Action wiring — manual invocation only.
  *
+ * This file is a thin shell over `runBench()` (see `./bench.ts`): it loads
+ * env, parses argv, resolves the provider model instance + task list, then
+ * builds a `BenchConfig` and calls `runBench`. All suite orchestration lives
+ * in `bench.ts` so harness authors and integration tests can drive sweeps
+ * programmatically without spawning the CLI.
+ *
  * IMPORTANT: this file uses dynamic imports for everything that depends on
  * provider env vars. ESM static imports are hoisted above any code in the
  * module, so a top-level `loadEnv()` call followed by `import { anthropic }
@@ -16,7 +22,6 @@
  */
 
 import { loadEnv } from "./env";
-import { runInPool } from "./worker-pool";
 
 interface CliArgs {
   taskId?: string;
@@ -26,6 +31,20 @@ interface CliArgs {
   tasksFile?: string;
   modelId: string;
   modelLabel: string;
+  /**
+   * Path to a harness config file (TS/JS) describing the agent-under-test.
+   * When omitted, the trial runs the no-harness default (DEFAULT_TOOL_SET +
+   * section-stripped prompt).
+   */
+  harnessPath?: string;
+  /** Enable provider-specific thinking/reasoning (overrides harness default). */
+  thinking: boolean;
+  /** Thinking token budget (only used when `thinking` is true). */
+  thinkingBudget: number;
+  /** True when --thinking / --thinking-budget were explicitly passed. */
+  thinkingExplicit: boolean;
+  /** True when --model was explicitly passed (else harness.model may win). */
+  modelExplicit: boolean;
   headless: boolean;
   replicas: number;
   /** Disable video recording (otherwise default-on, written to .bench/runs/<id>/videos/). */
@@ -52,12 +71,22 @@ interface CliArgs {
   evalSet?: string;
   /** Arm name within the eval-set. */
   arm?: string;
+  /**
+   * If set with --driver kernel, the runner acquires browsers from this
+   * pre-existing Kernel browser pool (id or name) instead of creating a
+   * fresh browser per trial.
+   */
+  kernelPoolId?: string;
 }
 
 function parseArgs(argv: string[]): CliArgs {
   const out: CliArgs = {
     modelId: "claude-sonnet-4-5-20250929",
     modelLabel: "claude-sonnet-4-5",
+    thinking: false,
+    thinkingBudget: 4096,
+    thinkingExplicit: false,
+    modelExplicit: false,
     headless: false,
     replicas: 1,
     noVideo: false,
@@ -84,7 +113,7 @@ function parseArgs(argv: string[]): CliArgs {
           console.error(`--suite must be one of: webbench-mini, webbench, custom, all`);
           process.exit(2);
         }
-        out.suite = v as any;
+        out.suite = v as CliArgs["suite"];
         break;
       }
       case "--tasks-file":
@@ -97,6 +126,29 @@ function parseArgs(argv: string[]): CliArgs {
       case "--model":
         out.modelId = argv[++i];
         out.modelLabel = out.modelId;
+        out.modelExplicit = true;
+        break;
+      case "--harness":
+        if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+          console.error("--harness requires a file path argument");
+          process.exit(2);
+        }
+        out.harnessPath = argv[++i];
+        break;
+      case "--thinking":
+        out.thinking = true;
+        out.thinkingExplicit = true;
+        break;
+      case "--thinking-budget":
+        out.thinkingBudget = parseInt(argv[++i], 10);
+        out.thinkingExplicit = true;
+        if (isNaN(out.thinkingBudget) || out.thinkingBudget <= 0) {
+          console.error("--thinking-budget must be a positive integer");
+          process.exit(2);
+        }
+        break;
+      case "--kernel-pool":
+        out.kernelPoolId = argv[++i];
         break;
       case "--headless":
         out.headless = true;
@@ -194,6 +246,17 @@ Options:
                         gpt-5                       (OpenAI)
                         gemini-3-flash-preview      (Google)
                         gemini-2.5-flash            (Google)
+  --harness <path>    Path to a harness config file (TS/JS) describing the
+                      agent-under-test: system prompt, tools, page-state
+                      policy, subagents, and optional model/thinking defaults.
+                      When omitted, runs the no-harness default (production
+                      tool set + section-stripped prompt). Author harness
+                      files out-of-tree via defineHarness({...}).
+  --thinking          Enable provider-specific thinking/reasoning (overrides
+                      the harness default). Captures thought summaries.
+  --thinking-budget <N> Thinking token budget (default: 4096). Only used when
+                      --thinking is set. Gemini: thinkingBudget. Anthropic:
+                      adaptive. OpenAI: maps to medium effort.
   --replicas <n>      Number of times to run each task (default: 1)
   --headless          Run Chromium headless (default: headed)
   --no-video          Disable video recording (default: on)
@@ -208,6 +271,10 @@ Options:
   --out-dir <dir>     Override run output dir
                       (default: .bench/runs/<auto-id>/ at repo root)
   --driver <kind>     Browser driver to use: "local" (default) or "kernel"
+  --kernel-pool <id>  With --driver kernel, acquire browsers from this
+                      pre-existing Kernel browser pool (id or name) instead
+                      of creating a fresh browser per trial. Eliminates
+                      cold-start cost; recommended for high-concurrency runs.
   --concurrency <n>   Parallel trials (default: local=CPUs/2, kernel=5)
   --upload <mode>     R2 upload behavior. One of:
                         auto    upload iff R2_* env vars are set (default)
@@ -236,36 +303,24 @@ async function main(): Promise<void> {
 
   const args = parseArgs(process.argv.slice(2));
 
-  // Dynamic-import after loadEnv so the AI SDK providers see the keys when
-  // their default factory instances initialize.
   const [
     { anthropic },
     { google },
     { openai },
-    { runTrial },
-    { ALL_TASKS, findTask, tasksBySource },
-    { createRunPaths, resolveRunDir, makeRunId, ensureRunDirExists },
-    { writeTrial, writeSummary, readAllTrials },
-    { ffmpegAvailable, convertAllInDir },
-    { buildBenchSystemPrompt, DEFAULT_TOOL_SET, BENCH_TOOL_CATALOG },
-    { WEBBENCH_REVISION },
-    { LLM_JUDGE_VERSION, JUDGE_MODEL_ID },
+    { findTask, tasksBySource },
     { sampleTasks },
     { loadTasksFromFile },
+    { loadHarnessFromFile },
+    { runBench, BenchConfigError },
   ] = await Promise.all([
     import("@ai-sdk/anthropic"),
     import("@ai-sdk/google"),
     import("@ai-sdk/openai"),
-    import("./runner"),
     import("./tasks"),
-    import("./paths"),
-    import("./store"),
-    import("./video"),
-    import("./agent/build-agent"),
-    import("./tasks/webbench/revision"),
-    import("./judges/llm-judge"),
     import("./tasks/sample"),
     import("./tasks/from-file"),
+    import("./harness"),
+    import("./bench"),
   ]);
 
   type LanguageModel = Awaited<ReturnType<typeof anthropic>>;
@@ -315,45 +370,14 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  // Fail fast on upload misconfigurations before running any trials.
-  const { uploadRun, createR2Client, r2EnvPresent } = await import("./upload");
-  let plannedUpload = false;
-  switch (args.upload) {
-    case "never":
-      plannedUpload = false;
-      break;
-    case "always":
-      plannedUpload = true;
-      if (!r2EnvPresent()) {
-        console.error(
-          "ERROR: --upload always was specified but required R2 env vars are not set.\n" +
-            "  Set R2_ACCOUNT_ID, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET\n" +
-            "  in .env or your shell, then re-run.",
-        );
-        process.exit(2);
-      }
-      break;
-    case "auto":
-      plannedUpload = r2EnvPresent();
-      break;
-  }
-  if (plannedUpload && (!args.evalSet || !args.arm)) {
-    console.error(
-      "ERROR: upload requires both --eval-set and --arm. " +
-        "These get embedded in the run-id and manifest so the artifacts are traceable.\n" +
-        "  Either pass both flags, or use --no-upload to skip upload.",
-    );
-    process.exit(2);
-  }
-
-  // Resolve the task list. Single-task mode picks one; suite mode picks
-  // every task whose source matches; tasks-file mode reads a custom list.
-  let tasks: any[];
+  // Resolve the task list.
+  type Tsk = Awaited<ReturnType<typeof tasksBySource>>[number];
+  let resolved: Tsk[];
   if (args.tasksFile) {
     try {
-      tasks = await loadTasksFromFile(args.tasksFile, findTask);
-    } catch (e: any) {
-      console.error(e.message);
+      resolved = await loadTasksFromFile(args.tasksFile, findTask);
+    } catch (e) {
+      console.error(e instanceof Error ? e.message : String(e));
       process.exit(2);
     }
   } else if (args.taskId) {
@@ -362,529 +386,72 @@ async function main(): Promise<void> {
       console.error(`Unknown task id: ${args.taskId}`);
       process.exit(2);
     }
-    tasks = [task];
+    resolved = [task];
   } else if (args.suite === "all") {
-    tasks = await tasksBySource("custom"); // Don't run 1580 tasks on all
+    resolved = await tasksBySource("custom"); // Don't run 1580 tasks on all
   } else {
-    tasks = await tasksBySource(args.suite!);
+    resolved = await tasksBySource(args.suite!);
   }
 
-  // Apply sampling if requested
-  const preSampleCount = tasks.length;
+  const preSampleCount = resolved.length;
   if (args.sampleSize) {
-    tasks = sampleTasks(tasks, args.sampleSize, args.seed);
+    resolved = sampleTasks(resolved, args.sampleSize, args.seed);
   }
 
-  const model = resolveModel(args.modelId);
+  // Load the harness config (if provided).
+  const harness = args.harnessPath
+    ? await loadHarnessFromFile(args.harnessPath)
+    : undefined;
 
-  let runId = "";
-  let runDir = "";
-  let paths: any;
-  let existingTrials: import("./runner").TrialResult[] = [];
+  // Model resolution: explicit --model wins; else harness default; else CLI default.
+  const resolvedModelId =
+    args.modelExplicit || !harness?.model ? args.modelId : harness.model.id;
+  const resolvedModelLabel =
+    args.modelExplicit || !harness?.model ? args.modelLabel : harness.model.id;
+  const model = resolveModel(resolvedModelId);
 
-  if (args.resumeDir) {
-    paths = ensureRunDirExists(args.resumeDir);
-    runDir = paths.runDir;
-    
-    // We must use dynamic imports here because require is not defined in ESM
-    const path = await import("node:path");
-    runId = path.basename(runDir);
-    existingTrials = readAllTrials(paths);
-  } else {
-    runId = makeRunId({
-      modelLabel: args.modelLabel,
-      suite: args.suite,
-      taskId: args.taskId,
+  // Thinking resolution: explicit CLI flags win; else harness default.
+  const resolvedThinking = args.thinkingExplicit
+    ? args.thinking
+      ? { enabled: true, budget: args.thinkingBudget }
+      : undefined
+    : harness?.thinking?.enabled
+      ? { enabled: true, budget: harness.thinking.budget ?? args.thinkingBudget }
+      : undefined;
+
+  try {
+    await runBench({
+      tasks: resolved,
+      model,
+      modelId: resolvedModelId,
+      modelLabel: resolvedModelLabel,
+      harness,
+      thinking: resolvedThinking,
+      replicas: args.replicas,
+      headless: args.headless,
+      noVideo: args.noVideo,
+      noVisualize: args.noVisualize,
+      keepWebm: args.keepWebm,
+      resumeDir: args.resumeDir,
+      keepErrors: args.keepErrors,
+      outDir: args.outDir,
+      driverKind: args.driverKind,
+      kernelPoolId: args.kernelPoolId,
+      concurrency: args.concurrency,
+      upload: args.upload,
       evalSet: args.evalSet,
       arm: args.arm,
-    });
-    runDir = resolveRunDir({
-      runId,
-      outDirOverride: args.outDir,
-    });
-    paths = createRunPaths(runDir);
-  }
-
-  const startedAt = new Date().toISOString();
-  // Determine which tasks to run based on resume state
-  const completedTaskIds = new Set<string>();
-  let erroredTaskIds = new Set<string>();
-  
-  if (args.resumeDir) {
-    for (const t of existingTrials) {
-      if (!args.keepErrors && t.error) {
-        // We will retry this error. Delete the old JSON so we don't leak it if the retry crashes.
-        erroredTaskIds.add(t.taskId);
-        try {
-          const fs = await import("node:fs");
-          const path = await import("node:path");
-          fs.unlinkSync(path.join(paths.trialsDir, `${t.taskId}.json`));
-        } catch {}
-      } else {
-        completedTaskIds.add(t.taskId);
-      }
-    }
-    
-    const initialCount = tasks.length;
-    tasks = tasks.filter(t => !completedTaskIds.has(t.id));
-    
-    // Append to a resume log
-    try {
-      const fs = await import("node:fs");
-      const path = await import("node:path");
-      const logMsg = `[${startedAt}] Resumed sweep. Original tasks: ${initialCount}, Already completed: ${completedTaskIds.size}, Retrying errors: ${erroredTaskIds.size}, Running now: ${tasks.length}\n`;
-      fs.appendFileSync(path.join(paths.runDir, "resume.log"), logMsg);
-    } catch {}
-  }
-
-  const startMs = Date.now();
-  const recordVideo = !args.noVideo;
-  const visualize = !args.noVisualize;
-
-  // Determine concurrency
-  let concurrency = args.concurrency;
-  if (concurrency === 0) {
-    if (args.driverKind === "kernel") {
-      concurrency = 5; // Default free tier
-    } else {
-      const os = await import("node:os");
-      concurrency = Math.max(1, Math.floor(os.cpus().length / 2));
-    }
-  }
-
-  console.log(
-    `Running ${tasks.length} task(s) × ${args.replicas} replicas, model=${args.modelLabel}, concurrency=${concurrency}`,
-  );
-  if (args.resumeDir) {
-    console.log(
-      `Resuming from ${paths.runDir}: ${completedTaskIds.size} already done, ${tasks.length} remaining (${erroredTaskIds.size} errored, will retry)`
-    );
-  } else {
-    console.log(`Run dir:   ${paths.runDir}`);
-  }
-  console.log(`Video:     ${recordVideo ? "enabled" : "disabled"}`);
-  console.log(`Visualize: ${recordVideo && visualize ? "enabled" : "disabled"}`);
-  console.log("");
-
-  type Row = {
-    taskId: string;
-    passed: number;
-    total: number;
-    infrastructureFailures: number;
-    agentFailures: number;
-    judgeRejects: number;
-    avgSteps: number;
-    avgTokensIn: number;
-    avgTokensOut: number;
-    avgDurationMs: number;
-    domain: string;
-    videoPaths: string[];
-    trialPaths: string[];
-  };
-  const rows: Row[] = [];
-  const allTrialPaths: string[] = [];
-
-  let completedTasks = 0;
-  const totalTasks = tasks.length;
-  let runningTasks = 0;
-
-  if (tasks.length > 0) {
-    await runInPool(tasks, concurrency, async (task, index) => {
-    runningTasks++;
-    
-    let passes = 0;
-    let infraFails = 0;
-    let agentFails = 0;
-    let judgeRejects = 0;
-    let stepsSum = 0;
-    let inSum = 0;
-    let outSum = 0;
-    let timeSum = 0;
-    let domain = "";
-    try {
-      domain = new URL(task.startUrl).hostname.replace(/^www\./, "");
-    } catch {}
-    const videos: string[] = [];
-    const trials: string[] = [];
-
-    // Buffer output so parallel runs don't interleave console lines
-    const logBuffer: string[] = [];
-    logBuffer.push(`=== ${task.id} ===`);
-    logBuffer.push(`  ${truncate(task.instruction, 100)}`);
-
-    for (let i = 1; i <= args.replicas; i++) {
-      const tag = args.replicas > 1 ? ` [${i}/${args.replicas}]` : "";
-      const result = await runTrial(task, {
-        model,
-        modelId: args.modelId,
-        modelLabel: args.modelLabel,
-        headless: args.headless,
-        videosDir: recordVideo ? paths.videosDir : undefined,
-        replicaIndex: args.replicas > 1 ? i : undefined,
-        visualize,
-        driverKind: args.driverKind,
-      });
-
-      // Persist each trial immediately so a sweep that crashes mid-way still
-      // leaves the completed trials on disk.
-      const trialPath = writeTrial(paths, result);
-      trials.push(trialPath);
-      allTrialPaths.push(trialPath);
-
-      logBuffer.push(
-        `  Trial${tag}: ${result.passed ? "PASS" : "FAIL"} steps=${result.steps} tokens=${result.tokens.in}/${result.tokens.out} time=${(result.durationMs / 1000).toFixed(1)}s`,
-      );
-      if (result.error) logBuffer.push(`    error: ${result.error.message}`);
-      logBuffer.push(`    answer: ${truncate(result.agentAnswer, 160)}`);
-      logBuffer.push(`    judge:  ${truncate(result.judge.reasoning, 160)}`);
-      if (result.videoPath) {
-        logBuffer.push(`    video:  ${result.videoPath}`);
-        videos.push(result.videoPath);
-      }
-      if (result.liveViewUrl) {
-        logBuffer.push(`    live:   ${result.liveViewUrl}`);
-      }
-
-      if (result.passed) {
-        passes++;
-      } else if (result.error) {
-        if (result.error.kind === "infrastructure-error") infraFails++;
-        else agentFails++;
-      } else {
-        judgeRejects++;
-      }
-
-      stepsSum += result.steps;
-      inSum += result.tokens.in;
-      outSum += result.tokens.out;
-      timeSum += result.durationMs;
-    }
-
-    const total = args.replicas;
-    rows.push({
-      taskId: task.id,
-      passed: passes,
-      total,
-      infrastructureFailures: infraFails,
-      agentFailures: agentFails,
-      judgeRejects: judgeRejects,
-      avgSteps: stepsSum / total,
-      avgTokensIn: inSum / total,
-      avgTokensOut: outSum / total,
-      avgDurationMs: timeSum / total,
-      domain,
-      videoPaths: videos,
-      trialPaths: trials,
-    });
-    
-    runningTasks--;
-    completedTasks++;
-    
-    // Print everything for this task in one block
-    console.log(logBuffer.join("\n"));
-    console.log(`[${completedTasks}/${totalTasks} done | ${runningTasks} in flight]`);
-    console.log("");
-  });
-  }
-
-  // Reload all trials from disk to assemble the final summary (this ensures
-  // previously-completed trials from a resumed run are included).
-  const finalTrials = readAllTrials(paths);
-  
-  // Group by taskId so we can compute replica aggregations
-  const finalRows: Row[] = [];
-  const trialsByTask = new Map<string, import("./runner").TrialResult[]>();
-  for (const t of finalTrials) {
-    if (!trialsByTask.has(t.taskId)) trialsByTask.set(t.taskId, []);
-    trialsByTask.get(t.taskId)!.push(t);
-  }
-  
-  for (const [taskId, trials] of trialsByTask.entries()) {
-    let passes = 0, infraFails = 0, agentFails = 0, judgeRejects = 0;
-    let stepsSum = 0, inSum = 0, outSum = 0, timeSum = 0;
-    const vPaths: string[] = [];
-    const tPaths: string[] = [];
-    let domain = "";
-    
-    for (const res of trials) {
-      if (res.passed) passes++;
-      else if (res.error) {
-        if (res.error.kind === "infrastructure-error") infraFails++;
-        else agentFails++;
-      } else {
-        judgeRejects++;
-      }
-      
-      stepsSum += res.steps;
-      inSum += res.tokens.in;
-      outSum += res.tokens.out;
-      timeSum += res.durationMs;
-      
-      if (res.videoPath) vPaths.push(res.videoPath);
-      
-      const path = await import("node:path");
-      tPaths.push(path.join(paths.trialsDir, `${res.taskId}.json`));
-      
-      if (!domain && res.finalUrl) {
-        try { domain = new URL(res.finalUrl).hostname.replace(/^www\./, ""); } catch {}
-      }
-    }
-    
-    const count = trials.length;
-    finalRows.push({
-      taskId,
-      passed: passes,
-      total: count,
-      infrastructureFailures: infraFails,
-      agentFailures: agentFails,
-      judgeRejects: judgeRejects,
-      avgSteps: stepsSum / count,
-      avgTokensIn: inSum / count,
-      avgTokensOut: outSum / count,
-      avgDurationMs: timeSum / count,
-      domain,
-      videoPaths: vPaths,
-      trialPaths: tPaths,
-    });
-  }
-  
-  // Summary table
-  console.log("Summary");
-  console.log("-------");
-  let overallPassed = 0;
-  let overallTotal = 0;
-  let overallInfraFails = 0;
-  let overallAgentFails = 0;
-  let overallJudgeRejects = 0;
-  let overallTokensIn = 0;
-  let overallTokensOut = 0;
-  let overallDurationMs = 0;
-  
-  const failuresByDomain: Record<string, number> = {};
-
-  for (const r of finalRows) {
-    overallPassed += r.passed;
-    overallTotal += r.total;
-    overallInfraFails += r.infrastructureFailures;
-    overallAgentFails += r.agentFailures;
-    overallJudgeRejects += r.judgeRejects;
-    overallTokensIn += r.avgTokensIn * r.total;
-    overallTokensOut += r.avgTokensOut * r.total;
-    overallDurationMs += r.avgDurationMs * r.total;
-    
-    if (r.total > r.passed) {
-      failuresByDomain[r.domain] = (failuresByDomain[r.domain] || 0) + (r.total - r.passed);
-    }
-    
-    console.log(
-      `  ${r.taskId.padEnd(35)} ${r.passed}/${r.total}   steps=${r.avgSteps.toFixed(1).padStart(5)}   in=${Math.round(r.avgTokensIn).toString().padStart(6)}   out=${Math.round(r.avgTokensOut).toString().padStart(4)}   time=${(r.avgDurationMs / 1000).toFixed(1)}s`,
-    );
-  }
-  console.log("");
-  console.log(
-    `Pass rate: ${overallPassed}/${overallTotal} (${((overallPassed / overallTotal) * 100).toFixed(0)}%)`,
-  );
-  if (overallTotal > 0) {
-    console.log(`Breakdown:`);
-    console.log(`  Agent Errors:  ${((overallAgentFails / overallTotal) * 100).toFixed(1)}%`);
-    console.log(`  Infra Errors:  ${((overallInfraFails / overallTotal) * 100).toFixed(1)}%`);
-    console.log(`  Judge Rejects: ${((overallJudgeRejects / overallTotal) * 100).toFixed(1)}%`);
-  }
-  console.log(
-    `Total tokens: in=${overallTokensIn.toLocaleString()}  out=${overallTokensOut.toLocaleString()}`,
-  );
-  console.log(
-    `Total wall time: ${(overallDurationMs / 1000 / 60).toFixed(1)} min`,
-  );
-
-  // Convert recorded videos to mp4. Done as a post-sweep batch (rather
-  // than per-trial) so trial timing reflects only agent + browser, not
-  // ffmpeg. Conversions run in parallel up to a fixed cap.
-  if (recordVideo) {
-    const ffOk = await ffmpegAvailable();
-    if (!ffOk) {
-      console.log("");
-      console.log(
-        "WARNING: ffmpeg not on PATH. Skipping mp4 conversion.\n" +
-          "  Install with: brew install ffmpeg   (macOS)\n" +
-          "                apt install ffmpeg    (Debian/Ubuntu)\n" +
-          `  Raw .webm videos still saved at: ${paths.videosDir}`,
-      );
-    } else {
-      console.log("");
-      console.log(`Converting videos to mp4...`);
-      const ffStart = Date.now();
-      const convResults = await convertAllInDir(paths.videosDir, {
-        deleteSource: !args.keepWebm,
-        concurrency: 4,
-      });
-      const okCount = convResults.filter((r) => r.ok).length;
-      const failCount = convResults.length - okCount;
-      console.log(
-        `  ${okCount}/${convResults.length} converted in ${((Date.now() - ffStart) / 1000).toFixed(1)}s`,
-      );
-      if (failCount > 0) {
-        for (const r of convResults.filter((r) => !r.ok)) {
-          console.log(`  FAILED: ${r.source}`);
-          if (r.stderr) console.log(`    ${r.stderr.trim().split("\n").pop()}`);
-        }
-      }
-    }
-  }
-
-    const path = await import("node:path");
-    const trialPaths = finalTrials.map(t => path.join(paths.trialsDir, `${t.taskId}.json`));
-    
-    
-    const crypto = await import("node:crypto");
-    const child_process = await import("node:child_process");
-    const { z } = await import("zod");
-    const zodToJsonSchema = z.toJSONSchema;
-
-    const systemPromptText = buildBenchSystemPrompt();
-    const systemPromptHash = crypto.createHash("sha256").update(systemPromptText).digest("hex").slice(0, 16);
-
-    let gitSha;
-    try {
-      gitSha = child_process.execSync("git rev-parse HEAD", { stdio: ["pipe", "pipe", "ignore"] }).toString().trim();
-    } catch {}
-
-    let benchVersion = "0.0.0";
-    try {
-      const pkg = JSON.parse(await (await import("node:fs/promises")).readFile(path.join(process.cwd(), "package.json"), "utf8"));
-      benchVersion = pkg.version || "0.0.0";
-    } catch {}
-
-    const harness = {
-      agent: {
-        modelId: args.modelId,
-        systemPromptId: "default",
-        systemPromptHash,
-        systemPromptText,
-        toolSet: DEFAULT_TOOL_SET.map(name => {
-          const t = BENCH_TOOL_CATALOG[name];
-          return {
-            name: t.name,
-            description: t.description,
-            inputSchema: z.toJSONSchema(t.parameters),
-            outputSchema: t.outputSchema ? z.toJSONSchema(t.outputSchema) : undefined,
-          };
-        }),
-        limits: {
-          contextWindow: 128000,
-          maxOutputTokens: 8000
-        }
-      },
-      driver: {
-        kind: args.driverKind,
-        headless: args.headless,
-        stealth: true,
-        visualize: !args.noVisualize,
-        viewport: { width: 1280, height: 800 }
-      },
-      run: {
-        concurrency: concurrency,
-        replicas: args.replicas,
-        timeoutMs: 15 * 60000,
-        hardTimeoutBufferMs: 30000
-      },
-      judge: {
-        modelId: JUDGE_MODEL_ID,
-        version: LLM_JUDGE_VERSION
-      },
-      suite: {
-        source: args.suite,
-        revision: WEBBENCH_REVISION,
-        totalTasks: preSampleCount,
-        sampleSize: args.sampleSize,
-        seed: args.seed,
-      },
-      provenance: {
-        benchVersion,
-        gitSha,
-        nodeVersion: process.version,
-        platform: process.platform
-      }
-    };
-    
-    // Write the aggregate summary alongside the per-trial JSONs.
-    const summaryPath = writeSummary(paths, {
-      runId,
-      model: args.modelLabel,
       suite: args.suite,
       taskId: args.taskId,
-      startedAt,
-      endedAt: new Date().toISOString(),
-      durationMs: Date.now() - startMs,
-      tasks: finalRows.length,
-      replicas: args.replicas,
-      passed: overallPassed,
-      passRate: overallPassed / overallTotal,
-      breakdown: {
-        agentAccuracy: overallPassed / overallTotal,
-        infrastructureFailureRate: overallInfraFails / overallTotal,
-        judgeRejectRate: overallJudgeRejects / overallTotal,
-      },
-      failuresByDomain,
-      tokens: {
-        in: overallTokensIn,
-        out: overallTokensOut,
-        total: overallTokensIn + overallTokensOut,
-      },
-      harness,
-      trialPaths,
+      preSampleCount,
+      sampleSize: args.sampleSize,
+      seed: args.seed,
     });
-  console.log("");
-  console.log(`Summary: ${summaryPath}`);
-  console.log(`Trials:  ${paths.trialsDir}`);
-  if (recordVideo) {
-    console.log(`Videos:  ${paths.videosDir}`);
-  }
-
-  // Decide whether to upload (re-evaluate `auto` mode in case env was
-  // mutated mid-run; otherwise reuse the validated decision from earlier).
-  const shouldUpload =
-    args.upload === "never"
-      ? false
-      : args.upload === "always"
-        ? true
-        : r2EnvPresent();
-
-  if (shouldUpload) {
-    // Defense-in-depth: the early validation block above already guarded
-    // this combination, but re-evaluating `auto` against current env may
-    // flip the decision. Re-check here so we never reach `uploadRun`
-    // with missing eval-set/arm.
-    if (!args.evalSet || !args.arm) {
-      console.error(
-        "ERROR: upload requires both --eval-set and --arm. " +
-          "Either pass both flags, or use --no-upload to skip upload.",
-      );
-      process.exit(2);
-    }
-    const evalSet = args.evalSet;
-    const arm = args.arm;
-
-    console.log("");
-    console.log(`Uploading to R2 (bucket=${process.env.R2_BUCKET})...`);
-    const uploadStart = Date.now();
-    try {
-      const { client, bucket } = createR2Client();
-      const manifest = await uploadRun({
-        paths,
-        runId,
-        evalSet,
-        arm,
-        deps: { s3Client: client, bucket },
-      });
-      const uploadDuration = ((Date.now() - uploadStart) / 1000).toFixed(1);
-      console.log(`  ${Object.keys(manifest.trials).length} trial(s) uploaded in ${uploadDuration}s`);
-      console.log(`  Manifest: ${paths.manifestPath}`);
-    } catch (err) {
-      console.error("Upload failed:", err instanceof Error ? err.message : String(err));
-      console.error("Local artifacts preserved in:", paths.runDir);
-      process.exit(1);
-    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    // Config/usage errors get exit code 2 (matching the CLI's other
+    // validation paths); genuine runtime failures get exit code 1.
+    process.exit(err instanceof BenchConfigError ? 2 : 1);
   }
 }
 

--- a/packages/bench/src/drivers/kernel-driver.ts
+++ b/packages/bench/src/drivers/kernel-driver.ts
@@ -6,6 +6,22 @@ import type { BrowserTabInfo, TabId } from '@agent/driver';
 export interface KernelDriverOptions extends PlaywrightDriverOptions {
   apiKey?: string;
   stealth?: boolean;
+  /**
+   * If set, acquire a browser from this pre-existing Kernel browser pool
+   * instead of creating a fresh per-trial browser. The pool must already be
+   * created (and warmed) by the caller. Browsers are released back to the
+   * pool on `close()` instead of being deleted, eliminating cold-start cost.
+   *
+   * Use this when running many trials at high concurrency to avoid Kernel's
+   * burst-creation rate limit (which manifests as `page.goto` timeouts even
+   * when the plan-level concurrent-browser limit is not reached).
+   */
+  poolId?: string;
+  /**
+   * Max seconds to wait for `browserPools.acquire()` to return a free browser.
+   * Defaults to 120s.
+   */
+  acquireTimeoutSeconds?: number;
 }
 
 export class KernelDriver extends PlaywrightDriver {
@@ -13,6 +29,7 @@ export class KernelDriver extends PlaywrightDriver {
   private kernelSessionId: string | null = null;
   public liveViewUrl: string | null = null;
   private currentReplayId: string | null = null;
+  private poolId: string | null = null;
 
   private constructor(
     browser: Browser,
@@ -20,26 +37,81 @@ export class KernelDriver extends PlaywrightDriver {
     kernel: Kernel,
     kernelSessionId: string,
     liveViewUrl: string,
-    opts: KernelDriverOptions = {}
+    opts: KernelDriverOptions = {},
   ) {
     super(browser, context, opts.recordVideoDir);
     this.kernel = kernel;
     this.kernelSessionId = kernelSessionId;
     this.liveViewUrl = liveViewUrl;
+    this.poolId = opts.poolId ?? null;
   }
 
   static async launch(opts: KernelDriverOptions = {}): Promise<KernelDriver> {
     const kernel = new Kernel(opts.apiKey ? { apiKey: opts.apiKey } : undefined);
-    
-    // Create Kernel browser
-    const kernelBrowser = await kernel.browsers.create({
-      headless: opts.headless ?? false,
-      stealth: opts.stealth ?? true,
-    });
-    
-    // Connect Playwright over CDP
-    const browser = await chromium.connectOverCDP(kernelBrowser.cdp_ws_url);
-    const context = browser.contexts()[0] || (await browser.newContext());
+
+    let cdpWsUrl: string;
+    let sessionId: string;
+    let liveViewUrl: string;
+
+    if (opts.poolId) {
+      // Acquire from a pre-warmed browser pool. The pool's browsers were
+      // configured at pool-create time (headless/stealth/etc.), so the per-
+      // trial opts.headless / opts.stealth are advisory only — actual values
+      // come from the pool. The acquire call long-polls until a browser is
+      // available; we cap the wait via acquire_timeout_seconds.
+      const acquired = await kernel.browserPools.acquire(opts.poolId, {
+        acquire_timeout_seconds: opts.acquireTimeoutSeconds ?? 120,
+      });
+      // 204 No Content (poll timed out) returns an empty body which the SDK
+      // surfaces as a falsy / undefined-fields response — defend against it.
+      if (!acquired || !acquired.cdp_ws_url || !acquired.session_id) {
+        throw new Error(
+          `KernelDriver: browserPools.acquire returned no browser within ${opts.acquireTimeoutSeconds ?? 120}s — pool may be exhausted`,
+        );
+      }
+      cdpWsUrl = acquired.cdp_ws_url;
+      sessionId = acquired.session_id;
+      liveViewUrl = acquired.browser_live_view_url ?? "";
+    } else {
+      // Legacy path: create a fresh browser per trial.
+      const created = await kernel.browsers.create({
+        headless: opts.headless ?? false,
+        stealth: opts.stealth ?? true,
+      });
+      cdpWsUrl = created.cdp_ws_url;
+      sessionId = created.session_id;
+      liveViewUrl = created.browser_live_view_url ?? "";
+    }
+
+    // Connect Playwright over CDP.
+    const browser = await chromium.connectOverCDP(cdpWsUrl);
+
+    // Context isolation policy:
+    //   - Non-pool (fresh browser per trial): the default context is pristine,
+    //     so reuse it.
+    //   - Pool (warm browser reused across trials): the default context still
+    //     holds the PREVIOUS trial's cookies / localStorage / sessionStorage /
+    //     fingerprint state. Reusing it would leak state across trials and
+    //     break the per-trial isolation guarantee the local driver provides.
+    //     Create a FRESH BrowserContext instead — Chromium isolates cookies +
+    //     storage per BrowserContext, and `super.close()` closes this context
+    //     after each trial (so contexts don't accumulate while the pristine
+    //     default context stays untouched).
+    //
+    // NOTE: `connectOverCDP` + `newContext()` storage isolation against
+    // Kernel's REMOTE Chrome must be validated on a live pool. If the remote
+    // rejects multiple contexts or shares storage across them, fall back to
+    // explicit CDP storage clearing (Network.clearBrowserCookies +
+    // Storage.clearDataForOrigin) on acquire. Not yet exercised end-to-end.
+    const context = opts.poolId
+      ? await browser.newContext()
+      : browser.contexts()[0] || (await browser.newContext());
+    // Bump default navigation timeout from Playwright's 30s default to 90s,
+    // matching the local PlaywrightDriver. Kernel's stealth layer often auto-
+    // solves CAPTCHAs / bot challenges that take 40-60s, and the 30s default
+    // would cut the cord mid-solve and produce a spurious "page.goto Timeout"
+    // infrastructure error.
+    context.setDefaultNavigationTimeout(90_000);
     const page = context.pages()[0] || (await context.newPage());
     const cdpSession = await context.newCDPSession(page);
 
@@ -47,18 +119,22 @@ export class KernelDriver extends PlaywrightDriver {
       browser,
       context,
       kernel,
-      kernelBrowser.session_id,
-      kernelBrowser.browser_live_view_url ?? "",
-      opts
+      sessionId,
+      liveViewUrl,
+      opts,
     );
 
-    // If recording is requested, start a replay natively via Kernel
+    // If recording is requested, start a replay natively via Kernel.
+    // Replays work with both fresh browsers and pool-acquired browsers — the
+    // session_id is what matters.
     if (opts.recordVideoDir) {
       try {
-        const replay = await kernel.browsers.replays.start(kernelBrowser.session_id);
+        const replay = await kernel.browsers.replays.start(sessionId);
         driver.currentReplayId = replay.replay_id;
       } catch (err) {
-        console.warn(`KernelDriver: failed to start replay recording: ${err instanceof Error ? err.message : String(err)}`);
+        console.warn(
+          `KernelDriver: failed to start replay recording: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 
@@ -68,8 +144,22 @@ export class KernelDriver extends PlaywrightDriver {
   async close(): Promise<void> {
     await super.close();
     if (this.kernelSessionId) {
-      await this.kernel.browsers.deleteByID(this.kernelSessionId).catch(() => {});
+      const sessionId = this.kernelSessionId;
       this.kernelSessionId = null;
+      if (this.poolId) {
+        // Release back to the pool for reuse — the pool keeps the browser
+        // warm for the next acquire(). reuse: true is the default but we
+        // pass it explicitly for clarity.
+        await this.kernel.browserPools
+          .release(this.poolId, { session_id: sessionId, reuse: true })
+          .catch((err) => {
+            console.warn(
+              `KernelDriver: pool release failed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+      } else {
+        await this.kernel.browsers.deleteByID(sessionId).catch(() => {});
+      }
     }
   }
 
@@ -78,15 +168,21 @@ export class KernelDriver extends PlaywrightDriver {
       await this.close();
       return null;
     }
-    
+
+    // Claim ownership of this session and replay atomically so a concurrent
+    // caller (e.g. the hard-timeout watchdog racing the normal finally block)
+    // short-circuits above rather than double-stopping the same replay.
+    const sessionId = this.kernelSessionId;
+    const replayId = this.currentReplayId;
+    this.kernelSessionId = null;
+    this.currentReplayId = null;
+
     let savedPath: string | null = null;
-    if (this.currentReplayId && this.recordVideoDir) {
+    if (replayId && this.recordVideoDir) {
       try {
-        await this.kernel.browsers.replays.stop(this.currentReplayId, { id: this.kernelSessionId });
-        // Download the replay
-        const response = await this.kernel.browsers.replays.download(this.currentReplayId, { id: this.kernelSessionId });
+        await this.kernel.browsers.replays.stop(replayId, { id: sessionId });
+        const response = await this.kernel.browsers.replays.download(replayId, { id: sessionId });
         const fs = await import("node:fs/promises");
-        // Using response.arrayBuffer() directly since it returns a Response object
         const buffer = await response.arrayBuffer();
         await fs.writeFile(outputPath, Buffer.from(buffer));
         savedPath = outputPath;
@@ -94,8 +190,51 @@ export class KernelDriver extends PlaywrightDriver {
         console.warn(`KernelDriver: failed to stop/download replay recording: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    
-    await this.close();
+
+    // Close the Playwright browser and release/delete the Kernel session.
+    // kernelSessionId is already nulled above so close() won't double-delete.
+    await super.close();
+    if (this.poolId) {
+      await this.kernel.browserPools
+        .release(this.poolId, { session_id: sessionId, reuse: true })
+        .catch((err) => {
+          console.warn(
+            `KernelDriver: pool release failed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+    } else {
+      await this.kernel.browsers.deleteByID(sessionId).catch(() => {});
+    }
+
     return savedPath;
+  }
+
+  /**
+   * Best-effort teardown for the hard-timeout watchdog.
+   *
+   * If the normal close path already claimed the session (kernelSessionId
+   * nulled by `close()`/`closeAndSaveVideo()`), this is a no-op so we never
+   * double-release. Otherwise:
+   *   - Pooled browser: release with `reuse: false`. A trial that hit the
+   *     hard timeout may have left the browser wedged (hung navigation, stuck
+   *     dialog); returning it `reuse: true` would hand a bad browser to the
+   *     next trial. `reuse: false` tells the pool to discard and re-warm.
+   *   - Standalone browser: delete it.
+   *
+   * The previous watchdog path called `browsers.deleteByID` unconditionally,
+   * which for a pooled browser deleted the browser WITHOUT releasing the pool
+   * slot — leaking a slot (inflated acquired-count). This releases the slot.
+   */
+  async forceCleanup(): Promise<void> {
+    const sessionId = this.kernelSessionId;
+    if (!sessionId) return;
+    this.kernelSessionId = null;
+    if (this.poolId) {
+      await this.kernel.browserPools
+        .release(this.poolId, { session_id: sessionId, reuse: false })
+        .catch(() => {});
+    } else {
+      await this.kernel.browsers.deleteByID(sessionId).catch(() => {});
+    }
   }
 }

--- a/packages/bench/src/drivers/kernel-driver.ts
+++ b/packages/bench/src/drivers/kernel-driver.ts
@@ -83,62 +83,83 @@ export class KernelDriver extends PlaywrightDriver {
       liveViewUrl = created.browser_live_view_url ?? "";
     }
 
-    // Connect Playwright over CDP.
-    const browser = await chromium.connectOverCDP(cdpWsUrl);
+    // From here on the Kernel session (acquired or freshly created) is live.
+    // If Playwright connection / context / CDP setup fails before we hand back
+    // a KernelDriver, the caller has no handle to clean up — so on ANY error
+    // we must close the partial Playwright connection AND free the Kernel
+    // session (release the pool slot, or delete the standalone browser),
+    // otherwise we leak a browser / pool slot. Then rethrow so the caller still
+    // sees the failure.
+    let browser: Browser | undefined;
+    try {
+      // Connect Playwright over CDP.
+      browser = await chromium.connectOverCDP(cdpWsUrl);
 
-    // Context isolation policy:
-    //   - Non-pool (fresh browser per trial): the default context is pristine,
-    //     so reuse it.
-    //   - Pool (warm browser reused across trials): the default context still
-    //     holds the PREVIOUS trial's cookies / localStorage / sessionStorage /
-    //     fingerprint state. Reusing it would leak state across trials and
-    //     break the per-trial isolation guarantee the local driver provides.
-    //     Create a FRESH BrowserContext instead — Chromium isolates cookies +
-    //     storage per BrowserContext, and `super.close()` closes this context
-    //     after each trial (so contexts don't accumulate while the pristine
-    //     default context stays untouched).
-    //
-    // NOTE: `connectOverCDP` + `newContext()` storage isolation against
-    // Kernel's REMOTE Chrome must be validated on a live pool. If the remote
-    // rejects multiple contexts or shares storage across them, fall back to
-    // explicit CDP storage clearing (Network.clearBrowserCookies +
-    // Storage.clearDataForOrigin) on acquire. Not yet exercised end-to-end.
-    const context = opts.poolId
-      ? await browser.newContext()
-      : browser.contexts()[0] || (await browser.newContext());
-    // Bump default navigation timeout from Playwright's 30s default to 90s,
-    // matching the local PlaywrightDriver. Kernel's stealth layer often auto-
-    // solves CAPTCHAs / bot challenges that take 40-60s, and the 30s default
-    // would cut the cord mid-solve and produce a spurious "page.goto Timeout"
-    // infrastructure error.
-    context.setDefaultNavigationTimeout(90_000);
-    const page = context.pages()[0] || (await context.newPage());
-    const cdpSession = await context.newCDPSession(page);
+      // Context isolation policy:
+      //   - Non-pool (fresh browser per trial): the default context is pristine,
+      //     so reuse it.
+      //   - Pool (warm browser reused across trials): the default context still
+      //     holds the PREVIOUS trial's cookies / localStorage / sessionStorage /
+      //     fingerprint state. Reusing it would leak state across trials and
+      //     break the per-trial isolation guarantee the local driver provides.
+      //     Create a FRESH BrowserContext instead — Chromium isolates cookies +
+      //     storage per BrowserContext, and `super.close()` closes this context
+      //     after each trial (so contexts don't accumulate while the pristine
+      //     default context stays untouched).
+      //
+      // NOTE: `connectOverCDP` + `newContext()` storage isolation against
+      // Kernel's REMOTE Chrome must be validated on a live pool. If the remote
+      // rejects multiple contexts or shares storage across them, fall back to
+      // explicit CDP storage clearing (Network.clearBrowserCookies +
+      // Storage.clearDataForOrigin) on acquire. Not yet exercised end-to-end.
+      const context = opts.poolId
+        ? await browser.newContext()
+        : browser.contexts()[0] || (await browser.newContext());
+      // Bump default navigation timeout from Playwright's 30s default to 90s,
+      // matching the local PlaywrightDriver. Kernel's stealth layer often auto-
+      // solves CAPTCHAs / bot challenges that take 40-60s, and the 30s default
+      // would cut the cord mid-solve and produce a spurious "page.goto Timeout"
+      // infrastructure error.
+      context.setDefaultNavigationTimeout(90_000);
+      const page = context.pages()[0] || (await context.newPage());
+      await context.newCDPSession(page);
 
-    const driver = new KernelDriver(
-      browser,
-      context,
-      kernel,
-      sessionId,
-      liveViewUrl,
-      opts,
-    );
+      const driver = new KernelDriver(
+        browser,
+        context,
+        kernel,
+        sessionId,
+        liveViewUrl,
+        opts,
+      );
 
-    // If recording is requested, start a replay natively via Kernel.
-    // Replays work with both fresh browsers and pool-acquired browsers — the
-    // session_id is what matters.
-    if (opts.recordVideoDir) {
-      try {
-        const replay = await kernel.browsers.replays.start(sessionId);
-        driver.currentReplayId = replay.replay_id;
-      } catch (err) {
-        console.warn(
-          `KernelDriver: failed to start replay recording: ${err instanceof Error ? err.message : String(err)}`,
-        );
+      // If recording is requested, start a replay natively via Kernel.
+      // Replays work with both fresh browsers and pool-acquired browsers — the
+      // session_id is what matters.
+      if (opts.recordVideoDir) {
+        try {
+          const replay = await kernel.browsers.replays.start(sessionId);
+          driver.currentReplayId = replay.replay_id;
+        } catch (err) {
+          console.warn(
+            `KernelDriver: failed to start replay recording: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
-    }
 
-    return driver;
+      return driver;
+    } catch (err) {
+      // Best-effort teardown so a failed init doesn't strand a Kernel browser.
+      await browser?.close().catch(() => {});
+      if (opts.poolId) {
+        await kernel.browserPools
+          .release(opts.poolId, { session_id: sessionId, reuse: false })
+          .catch(() => {});
+      } else {
+        await kernel.browsers.deleteByID(sessionId).catch(() => {});
+      }
+      throw err;
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/bench/src/drivers/playwright-driver.ts
+++ b/packages/bench/src/drivers/playwright-driver.ts
@@ -88,6 +88,13 @@ export class PlaywrightDriver implements BrowserDriver {
         ? { recordVideo: { dir: opts.recordVideoDir, size: viewport } }
         : {}),
     });
+    // Bump default navigation timeout from Playwright's 30s default to 90s.
+    // Some sites (especially behind Cloudflare/PerimeterX) take 40-60s to
+    // render once Kernel's stealth layer auto-solves the bot challenge —
+    // 30s would cut the cord mid-CAPTCHA-solve, producing spurious
+    // "Failed to navigate" infrastructure errors. 90s gives Kernel enough
+    // headroom to finish the challenge before Playwright bails.
+    context.setDefaultNavigationTimeout(90_000);
     return new PlaywrightDriver(browser, context, opts.recordVideoDir);
   }
 

--- a/packages/bench/src/harness.test.ts
+++ b/packages/bench/src/harness.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the harness module — schema validation, tool-reference checks,
+ * and the unified `subagents` field that accepts either built-in slugs or
+ * custom `SubagentDef` objects.
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineHarness, BUILT_IN_SUBAGENT_SLUGS, type Harness } from "./harness";
+import type { BrowserTool } from "@agent/types";
+
+function makeTool(name: string): BrowserTool<unknown, unknown> {
+  return {
+    name,
+    description: `dummy ${name}`,
+    parameters: z.object({}),
+    execute: async () => ({}),
+  } as unknown as BrowserTool<unknown, unknown>;
+}
+
+const baseHarness = (over: Partial<Harness> = {}): Harness => ({
+  id: "test",
+  systemPrompt: "you are a test agent",
+  tools: [makeTool("readPage"), makeTool("scrollPage"), makeTool("navigate")],
+  ...over,
+});
+
+describe("defineHarness — base validation", () => {
+  it("accepts a minimal valid harness", () => {
+    expect(() => defineHarness(baseHarness())).not.toThrow();
+  });
+
+  it("rejects empty tool sets", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        tools: [],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects duplicate tool names", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        tools: [makeTool("readPage"), makeTool("readPage")],
+      }),
+    ).toThrow(/duplicate tool name/);
+  });
+
+  it("errors loudly when pageStateImageTools references a missing tool", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        pageStateImageTools: ["screenshot"], // not in the tools list
+      }),
+    ).toThrow(/pageStateImageTools.*screenshot/);
+  });
+
+  it("errors loudly when terminalToolNames references a missing tool", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        terminalToolNames: ["report"], // not in the tools list
+      }),
+    ).toThrow(/terminalToolNames.*report/);
+  });
+});
+
+describe("defineHarness — subagents (unified field)", () => {
+  it("accepts a built-in slug as a subagent entry", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        subagents: ["explore"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts both slug AND custom SubagentDef in the same array", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        tools: [makeTool("readPage"), makeTool("scrollPage")],
+        subagents: [
+          "explore",
+          {
+            slug: "form-filler",
+            description: "fills forms",
+            whenToUse: "when you encounter a form",
+            systemPrompt: "you are a form filler",
+            allowedTools: ["readPage"],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an unknown built-in slug", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        // @ts-expect-error -- intentionally invalid
+        subagents: ["nope-not-a-built-in"],
+      }),
+    ).toThrow();
+  });
+
+  it("does NOT validate built-in allowedTools against the harness tool set", () => {
+    // Built-in "explore" references readPage/snapshot/screenshot/extract/etc;
+    // most of those are absent from this minimal harness. defineHarness must
+    // still accept the entry — intersection happens at run-time, not here.
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        tools: [makeTool("readPage")], // ONLY readPage
+        subagents: ["explore"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("strictly validates custom SubagentDef allowedTools (Q25)", () => {
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        subagents: [
+          {
+            slug: "broken",
+            description: "x",
+            whenToUse: "x",
+            systemPrompt: "x",
+            allowedTools: ["does-not-exist"],
+          },
+        ],
+      }),
+    ).toThrow(/allowedTools.*does-not-exist/);
+  });
+
+  it("rejects duplicate slugs across the unified entry list", () => {
+    // A user might collide a custom slug with a built-in name.
+    expect(() =>
+      defineHarness({
+        ...baseHarness(),
+        subagents: [
+          "explore",
+          {
+            slug: "explore", // collision with the built-in
+            description: "x",
+            whenToUse: "x",
+            systemPrompt: "x",
+            allowedTools: ["readPage"],
+          },
+        ],
+      }),
+    ).toThrow(/duplicate subagent slug/);
+  });
+
+  it("exports the canonical built-in slug list", () => {
+    expect([...BUILT_IN_SUBAGENT_SLUGS].sort()).toEqual(["explore", "general"]);
+  });
+});

--- a/packages/bench/src/harness.ts
+++ b/packages/bench/src/harness.ts
@@ -1,0 +1,338 @@
+/**
+ * Harness config — the declarative contract for "what agent are we
+ * benchmarking?"
+ *
+ * A harness file (an out-of-tree config loaded by the bench CLI via
+ * `--harness <path>`) describes the agent-under-test: its system prompt,
+ * tool inventory, page-state delivery policy, optional subagents, and
+ * optional model/thinking/limit defaults.
+ *
+ * The bench package ships ZERO harnesses. An unconfigured CLI run uses the
+ * built-in `DEFAULT_TOOL_SET` + section-stripped prompt — that is "no
+ * harness," not a "baseline arm." Experiment-specific arms (SoM, etc.) live
+ * out-of-tree (in a separate harness directory) and import this module's
+ * `defineHarness` from `@openbrowse/bench`.
+ */
+
+import { z } from "zod";
+import type { BrowserTool } from "@agent/types";
+
+/**
+ * A `BrowserTool` with its input/output types erased to `any`.
+ *
+ * `Harness.tools` and `BENCH_TOOL_CATALOG` are heterogeneous tool collections,
+ * so they need a single element type that any concretely-typed tool is
+ * assignable to. `BrowserTool<unknown, unknown>` does NOT work: `TInput`
+ * appears contravariantly in `execute(input: TInput, …)` and invariantly in
+ * `parameters: z.ZodType<TInput>`, so e.g. `BrowserTool<{site: string}, …>` is
+ * not assignable to `BrowserTool<unknown, unknown>` — forcing an
+ * `as BrowserTool<unknown, unknown>` cast at every use site. Using `any` makes
+ * the type parameters bivariant, so harness authors can drop a concretely-typed
+ * tool straight into `tools: [...]` with no cast while still keeping the tool's
+ * own definition fully typed.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyBrowserTool = BrowserTool<any, any>;
+
+/**
+ * Identity helper for authoring a tool with full input/output inference.
+ *
+ * Optional sugar mirroring `defineHarness`: gives custom tools a natural home
+ * and preserves their concrete `BrowserTool<TInput, TOutput>` type (so the
+ * tool's own `execute` body is type-checked) while remaining assignable to
+ * `AnyBrowserTool` when added to a harness.
+ */
+export function defineTool<TInput, TOutput>(
+  tool: BrowserTool<TInput, TOutput>,
+): BrowserTool<TInput, TOutput> {
+  return tool;
+}
+
+/** Slugs of the subagents shipped with the openbrowse extension. */
+export const BUILT_IN_SUBAGENT_SLUGS = ["explore", "general"] as const;
+export type BuiltInSubagentSlug = (typeof BUILT_IN_SUBAGENT_SLUGS)[number];
+
+/**
+ * Static definition of a subagent the parent agent can `delegate` to.
+ *
+ * Mirrors the extension's `AgentDefinition` (apps/extension/.../subagents/
+ * types.ts) but lives here so harness authors can declare custom subagents
+ * without importing extension internals. The bench's headless subagent
+ * runner maps these onto the extension's pure `concurrency`/`types` modules.
+ */
+export interface SubagentDef {
+  /** Stable identifier; used in `delegate({slug})` / `@agent:<slug>`. */
+  slug: string;
+  /** One-line summary; surfaced in the delegate tool description. */
+  description: string;
+  /** Routing hint for the parent LLM ("Use this when ..."). */
+  whenToUse: string;
+  /** Full system prompt for the subagent (fresh-context; no parent history). */
+  systemPrompt: string;
+  /**
+   * Tool-name allowlist. The runner filters the parent's tool set down to
+   * these. `delegate` is always stripped (depth cap = 1). Every name MUST
+   * exist in the harness's `tools` — validated at load time.
+   */
+  allowedTools: string[];
+  /** Tool-name denylist applied AFTER `allowedTools`. */
+  deniedTools?: string[];
+  /** Model override (`providerId/modelId`). Defaults to the parent's model. */
+  defaultModel?: string;
+  /** Step cap forwarded to `stopWhen`. Defaults to 30. */
+  maxSteps?: number;
+}
+
+/**
+ * A subagent slot in a `Harness.subagents` array. Either:
+ *
+ *   - the slug of a shipped built-in subagent (`"explore"` | `"general"`) —
+ *     reused as-is; its `allowedTools` are intersected with the harness's
+ *     own tool names (built-ins are generic, so unavailable tools are
+ *     silently dropped rather than rejected); OR
+ *
+ *   - a `SubagentDef` describing a custom subagent — strict Q25 validation
+ *     applies (every `allowedTools` entry MUST exist in the harness's tool
+ *     set, else `defineHarness` throws).
+ */
+export type SubagentEntry = BuiltInSubagentSlug | SubagentDef;
+
+export interface Harness {
+  /** Stable id; used in run-id, summary, and manifest as the arm label. */
+  id: string;
+  /** Optional human-readable label. */
+  label?: string;
+  /** Full system prompt; passed straight to the agent (no section-stripping). */
+  systemPrompt: string;
+  /** Tool instances available to the agent. Order matters for the prompt. */
+  tools: AnyBrowserTool[];
+  /**
+   * Whether action tools hand back the fresh page state in their result.
+   * Default `true` (matches the production extension: action tools return the
+   * post-action a11y snapshot). Set `false` for vision-only experiments so
+   * the agent only perceives page state when it explicitly calls a perception
+   * tool — prevents text-state contamination of a pure-visual arm.
+   */
+  returnPageStateAfterAction?: boolean;
+  /**
+   * Field names treated as "auto-returned page state" and stripped from
+   * non-perception tool results when `returnPageStateAfterAction` is false.
+   * Default `["snapshot", "diff", "refCount"]`.
+   */
+  pageStateFields?: string[];
+  /**
+   * Tool names whose output carries page state as IMAGE data. Drives (1) the
+   * keep-only-latest-image context trim and (2) multimodal `toModelOutput`
+   * routing. Default `["screenshot"]`. Every name MUST exist in `tools`.
+   */
+  pageStateImageTools?: string[];
+  /**
+   * Tool names whose call terminates the agent loop after the call/result
+   * pair (e.g. a bot-block reporter). Default `[]`. Every name MUST exist
+   * in `tools`.
+   */
+  terminalToolNames?: string[];
+  /** Optional default thinking config; CLI `--thinking*` overrides. */
+  thinking?: { enabled: boolean; budget?: number };
+  /** Optional default model; CLI `--model` overrides. */
+  model?: { provider: "anthropic" | "google" | "openai"; id: string };
+  /** Optional tool-loop limits. */
+  limits?: { contextWindow?: number; maxOutputTokens?: number };
+  /** Subagents the parent may delegate to. Enables the `delegate` tool.
+   *  Each entry is either a built-in slug (`"explore"`/`"general"`) or a
+   *  custom `SubagentDef`. Built-ins are reused as-is with their
+   *  `allowedTools` intersected against the harness's tool set; custom
+   *  entries are validated strictly (every allowedTool must exist).
+   */
+  subagents?: SubagentEntry[];
+}
+
+/** Default fields stripped when `returnPageStateAfterAction` is false. */
+export const DEFAULT_PAGE_STATE_FIELDS = ["snapshot", "diff", "refCount"];
+/** Default image-bearing page-state tool. */
+export const DEFAULT_PAGE_STATE_IMAGE_TOOLS = ["screenshot"];
+
+const subagentDefSchema = z
+  .object({
+    slug: z.string().min(1),
+    description: z.string(),
+    whenToUse: z.string(),
+    systemPrompt: z.string().min(1),
+    allowedTools: z.array(z.string()),
+    deniedTools: z.array(z.string()).optional(),
+    defaultModel: z.string().optional(),
+    maxSteps: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const builtInSlugSchema = z.enum(BUILT_IN_SUBAGENT_SLUGS);
+const subagentEntrySchema = z.union([builtInSlugSchema, subagentDefSchema]);
+
+// `tools` are BrowserTool instances (functions/objects), not JSON — validate
+// them structurally with a passthrough custom check rather than a deep schema.
+const browserToolSchema = z.custom<AnyBrowserTool>(
+  (v) =>
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as { name?: unknown }).name === "string" &&
+    typeof (v as { execute?: unknown }).execute === "function",
+  { message: "each tool must be a BrowserTool with a string `name` and `execute` fn" },
+);
+
+const harnessSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().optional(),
+    systemPrompt: z.string().min(1),
+    tools: z.array(browserToolSchema).min(1),
+    returnPageStateAfterAction: z.boolean().optional(),
+    pageStateFields: z.array(z.string()).optional(),
+    pageStateImageTools: z.array(z.string()).optional(),
+    terminalToolNames: z.array(z.string()).optional(),
+    thinking: z
+      .object({ enabled: z.boolean(), budget: z.number().int().positive().optional() })
+      .strict()
+      .optional(),
+    model: z
+      .object({
+        provider: z.enum(["anthropic", "google", "openai"]),
+        id: z.string().min(1),
+      })
+      .strict()
+      .optional(),
+    limits: z
+      .object({
+        contextWindow: z.number().int().positive().optional(),
+        maxOutputTokens: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    subagents: z.array(subagentEntrySchema).optional(),
+  })
+  .strict();
+
+/**
+ * Cross-field validation that Zod's per-field rules can't express: tool-name
+ * references must resolve against the harness's own tool set. Errors loudly
+ * (per design decision Q25) listing every offending name.
+ */
+function validateToolReferences(h: Harness): void {
+  const toolNames = new Set(h.tools.map((t) => t.name));
+
+  // Duplicate tool names.
+  const seen = new Set<string>();
+  const dupes: string[] = [];
+  for (const t of h.tools) {
+    if (seen.has(t.name)) dupes.push(t.name);
+    seen.add(t.name);
+  }
+  if (dupes.length > 0) {
+    throw new Error(
+      `Harness "${h.id}": duplicate tool name(s): ${[...new Set(dupes)].join(", ")}`,
+    );
+  }
+
+  const checkSubset = (names: string[] | undefined, field: string) => {
+    if (!names) return;
+    const missing = names.filter((n) => !toolNames.has(n));
+    if (missing.length > 0) {
+      throw new Error(
+        `Harness "${h.id}": ${field} references tool(s) not in the harness tool set: ` +
+          `${missing.join(", ")}. Available: ${[...toolNames].join(", ")}.`,
+      );
+    }
+  };
+
+  checkSubset(h.pageStateImageTools, "pageStateImageTools");
+  checkSubset(h.terminalToolNames, "terminalToolNames");
+
+  // Subagents: unique slugs + (custom-only) allowedTools strict subset.
+  // Built-in slugs are accepted as-is; their `allowedTools` are intersected
+  // against `toolNames` at runtime (in build-agent), not validated here.
+  if (h.subagents) {
+    const slugSeen = new Set<string>();
+    const slugDupes: string[] = [];
+    const slugOf = (e: SubagentEntry): string =>
+      typeof e === "string" ? e : e.slug;
+    for (const entry of h.subagents) {
+      const slug = slugOf(entry);
+      if (slugSeen.has(slug)) slugDupes.push(slug);
+      slugSeen.add(slug);
+    }
+    if (slugDupes.length > 0) {
+      throw new Error(
+        `Harness "${h.id}": duplicate subagent slug(s): ${[...new Set(slugDupes)].join(", ")}`,
+      );
+    }
+    for (const entry of h.subagents) {
+      if (typeof entry === "string") {
+        // Built-in: zod already constrained to known slugs; allowedTools are
+        // intersected with the harness tool set at construction time. Skip.
+        continue;
+      }
+      const missing = entry.allowedTools.filter(
+        (n) => n !== "delegate" && !toolNames.has(n),
+      );
+      if (missing.length > 0) {
+        throw new Error(
+          `Harness "${h.id}": subagent "${entry.slug}" allowedTools references tool(s) ` +
+            `not in the harness tool set: ${missing.join(", ")}. ` +
+            `Available: ${[...toolNames].join(", ")}.`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate and return a harness definition. Identity at runtime (returns the
+ * same object) but enforces the schema + cross-field tool-reference rules so
+ * misconfigurations fail loudly at authoring/load time rather than mid-trial.
+ */
+export function defineHarness(h: Harness): Harness {
+  const parsed = harnessSchema.safeParse(h);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("\n");
+    throw new Error(
+      `Invalid harness "${(h as { id?: string }).id ?? "<unknown>"}":\n${issues}`,
+    );
+  }
+  // Zod strips nothing structurally for BrowserTool (custom passthrough), so
+  // the original object is the source of truth; re-run cross-field checks.
+  validateToolReferences(h);
+  return h;
+}
+
+/**
+ * Load a harness from a TS/JS module path. Resolves relative to CWD, then
+ * dynamic-imports. Accepts a `default` export or a named `harness` export.
+ * Re-runs `defineHarness` validation in case the file constructed the object
+ * directly without calling it.
+ */
+export async function loadHarnessFromFile(filePath: string): Promise<Harness> {
+  const { resolve, isAbsolute } = await import("node:path");
+  const abs = isAbsolute(filePath) ? filePath : resolve(process.cwd(), filePath);
+
+  let mod: Record<string, unknown>;
+  try {
+    mod = (await import(abs)) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `Failed to import harness file "${abs}": ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const candidate = (mod.default ?? mod.harness) as Harness | undefined;
+  if (!candidate) {
+    throw new Error(
+      `Harness file "${abs}" must export a harness as the default export ` +
+        `or a named \`harness\` export (use defineHarness({...})).`,
+    );
+  }
+
+  // Validate (idempotent if the file already called defineHarness).
+  return defineHarness(candidate);
+}

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Public API surface for `@openbrowse/bench`.
+ *
+ * Out-of-tree harness files import everything they need from this barrel —
+ * `defineHarness`, the `BrowserTool`/`ToolContext` authoring types, and the
+ * `captureViewPage` perception primitive — so they never reach into
+ * openbrowse-internal `@agent/*` paths. The bench CLI resolves this module
+ * via the `@openbrowse/bench` tsconfig path alias when it dynamic-imports a
+ * harness (spike-verified for out-of-tree resolution).
+ */
+
+// Trial + sweep orchestration
+export { runTrial, type TrialConfig, type TrialResult, type TraceEntry } from "./runner";
+export { runBench, BenchConfigError, type BenchConfig, type BenchSummary } from "./bench";
+
+// Harness contract
+export {
+  defineHarness,
+  defineTool,
+  loadHarnessFromFile,
+  DEFAULT_PAGE_STATE_FIELDS,
+  DEFAULT_PAGE_STATE_IMAGE_TOOLS,
+  BUILT_IN_SUBAGENT_SLUGS,
+  type Harness,
+  type SubagentDef,
+  type SubagentEntry,
+  type BuiltInSubagentSlug,
+  type AnyBrowserTool,
+} from "./harness";
+
+// Perception primitive for SoM-style harnesses
+export {
+  captureViewPage,
+  type CapturedView,
+  type CaptureViewOptions,
+} from "./agent/som-capture";
+
+// No-harness defaults / catalog (useful for composing custom tool sets)
+export {
+  BENCH_TOOL_CATALOG,
+  DEFAULT_TOOL_SET,
+  buildBenchSystemPrompt,
+  type BenchToolName,
+} from "./agent/build-agent";
+
+// Tool-authoring types (re-exported so harnesses avoid @agent/* directly)
+export type { BrowserTool } from "@agent/types";
+export type { ToolContext } from "@agent/driver";

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -28,17 +28,36 @@ import {
   DEFAULT_TOOL_SET,
   type BenchToolName,
 } from "./agent/build-agent";
+import type { Harness } from "./harness";
+import type { AgentDefinition } from "@agent/subagents/types";
 import { PlaywrightDriver } from "./drivers/playwright-driver";
 import { KernelDriver } from "./drivers/kernel-driver";
 import { VisualizingDriver } from "./drivers/visualizing-driver";
 import { judge, type JudgeVerdict } from "./judges";
 import { safeSegment } from "./paths";
 import { runHeadlessChatLoop } from "./agent/headless-chat";
+import { redactImageData } from "./agent/trace-redact";
 import type { TodoItem } from "../../../apps/extension/src/lib/types";
 
 import type { BenchmarkTask } from "./tasks/types";
 export interface TrialConfig {
   driverKind?: "local" | "kernel";
+  /**
+   * If set with `driverKind: "kernel"`, the trial acquires its browser from
+   * this pre-existing Kernel browser pool (by id or name) instead of
+   * creating a fresh browser. Eliminates cold-start cost so high-concurrency
+   * runs don't trip Kernel's burst-creation rate limit.
+   */
+  kernelPoolId?: string;
+  /** Bench arm / harness id, used for trial-result grouping and labelling. */
+  armId?: string;
+  /**
+   * Declarative harness describing the agent-under-test (prompt, tools,
+   * page-state policy, subagents, optional model/thinking/limit defaults).
+   * When omitted, the trial runs the no-harness default (DEFAULT_TOOL_SET +
+   * section-stripped prompt).
+   */
+  harness?: Harness;
   model: LanguageModel;
   /** Full provider ID of the model used, e.g. "google:gemini-3-pro-preview" or "gemini-3-pro-preview" */
   modelId?: string;
@@ -48,6 +67,8 @@ export interface TrialConfig {
   systemPrompt?: string;
   toolSetId?: string;
   toolNames?: BenchToolName[];
+  /** Enable provider-specific thinking/reasoning. Captures thought summaries in trace + parts. */
+  thinking?: { enabled: boolean; budget?: number };
   /** Override the runner's headless default. Defaults to headed (per spec). */
   headless?: boolean;
   /**
@@ -105,6 +126,106 @@ export interface TraceEntry {
   name: string;
   input: unknown;
   output: unknown;
+  /**
+   * For `delegate` tool calls: the nested subagent's own trace + final text +
+   * token usage. Populated by the runner from the delegate tool's raw output.
+   */
+  subagent?: {
+    slug: string;
+    finalText: string;
+    status: string;
+    trace: TraceEntry[];
+    tokens: { in: number; out: number };
+  };
+}
+
+/**
+ * Mutable progress object shared between `runTrial` and `runTrialInner`.
+ *
+ * The hard-timeout watchdog in `runTrial` reads this when it fires so the
+ * trial result reflects what the agent actually accomplished before being
+ * killed (rather than reporting `steps: 0, trace: []` as if nothing
+ * happened). The video already shows the agent making progress; the JSON
+ * trace should match.
+ */
+interface TrialProgress {
+  trace: TraceEntry[];
+  steps: number;
+  tokensIn: number;
+  tokensOut: number;
+  agentAnswer: string;
+  finalUrl: string;
+  parts: unknown[];
+}
+
+/**
+ * Resolve a harness's `subagents` array (a mix of built-in slugs and
+ * custom `SubagentDef` objects) into concrete `AgentDefinition`s the
+ * delegate tool can dispatch to.
+ *
+ * Built-in slugs (`"explore"`, `"general"`) load the shipped extension
+ * definition and **intersect** its `allowedTools` against the harness's
+ * own tool names — built-ins are generic, so unavailable tools are
+ * silently dropped (e.g. a vision-only harness without `executeOnPage`
+ * still gets a working `general` subagent that just lacks JS exec).
+ * Custom `SubagentDef`s are passed through with their (already-validated)
+ * tool list intact.
+ */
+async function resolveHarnessSubagents(
+  entries: import("./harness").SubagentEntry[],
+  harnessTools: import("@agent/types").BrowserTool<unknown, unknown>[],
+): Promise<AgentDefinition[]> {
+  if (entries.length === 0) return [];
+  const harnessToolNames = new Set(harnessTools.map((t) => t.name));
+
+  // Lazy-load the built-in registry once per resolution. Built-ins are pure
+  // type-only data (`AgentDefinition` constants) so importing them here is
+  // safe — no chatDb / chrome dependency leaks into the bench process.
+  let builtInsLoaded = false;
+  let exploreAgent: AgentDefinition | undefined;
+  let generalAgent: AgentDefinition | undefined;
+  const loadBuiltIns = async () => {
+    if (builtInsLoaded) return;
+    const [{ exploreAgent: e }, { generalAgent: g }] = await Promise.all([
+      import("@agent/subagents/built-ins/explore"),
+      import("@agent/subagents/built-ins/general"),
+    ]);
+    exploreAgent = e;
+    generalAgent = g;
+    builtInsLoaded = true;
+  };
+
+  const resolved: AgentDefinition[] = [];
+  for (const entry of entries) {
+    if (typeof entry === "string") {
+      await loadBuiltIns();
+      const builtIn =
+        entry === "explore" ? exploreAgent : entry === "general" ? generalAgent : undefined;
+      if (!builtIn) {
+        // Defensive: harness Zod schema already restricted to known slugs.
+        throw new Error(`Unknown built-in subagent slug "${entry}".`);
+      }
+      resolved.push({
+        ...builtIn,
+        // Intersect allowedTools with what this harness actually provides.
+        allowedTools: builtIn.allowedTools.filter((n) => harnessToolNames.has(n)),
+      });
+    } else {
+      resolved.push({
+        slug: entry.slug,
+        description: entry.description,
+        whenToUse: entry.whenToUse,
+        systemPrompt: entry.systemPrompt,
+        defaultIsolation: "peer",
+        allowedTools: entry.allowedTools,
+        ...(entry.deniedTools ? { deniedTools: entry.deniedTools } : {}),
+        ...(entry.defaultModel ? { defaultModel: entry.defaultModel } : {}),
+        ...(entry.maxSteps ? { maxSteps: entry.maxSteps } : {}),
+        source: "user",
+      });
+    }
+  }
+  return resolved;
 }
 
 export async function runTrial(
@@ -114,75 +235,10 @@ export async function runTrial(
   const HARD_TIMEOUT = config.timeoutMs ?? task.timeoutMs ?? 15 * 60_000;
   const HARD_BUFFER = 30_000;
 
-  // We need to keep a reference to the kernel driver if one is created
-  // so the hard timeout can clean it up.
-  let kernelDriverRef: KernelDriver | undefined;
-
-  const trialPromise = runTrialInner(task, config, (driver) => {
-    if (driver instanceof KernelDriver) {
-      kernelDriverRef = driver;
-    }
-  });
-
-  const timeoutPromise = new Promise<TrialResult>((resolve) => {
-    setTimeout(() => {
-      // If we hard timeout, fire-and-forget delete the kernel session so it doesn't leak
-      if (kernelDriverRef && (kernelDriverRef as any).kernelSessionId) {
-        try {
-          // Access the private kernel property and session ID to force a deletion
-          const kernel = (kernelDriverRef as any).kernel;
-          const sessionId = (kernelDriverRef as any).kernelSessionId;
-          if (kernel && sessionId) {
-            kernel.browsers.deleteByID(sessionId).catch(() => {});
-          }
-        } catch {}
-      }
-
-      resolve({
-        taskId: task.id,
-        modelLabel: config.modelLabel,
-        agentModelId: config.modelId,
-        systemPromptId: config.systemPromptId ?? "default",
-        toolSetId: config.toolSetId ?? `set:${(config.toolNames ?? DEFAULT_TOOL_SET).join("+")}`,
-        passed: false,
-        agentAnswer: "",
-        finalUrl: "",
-        durationMs: HARD_TIMEOUT + HARD_BUFFER,
-        steps: 0,
-        tokens: { in: 0, out: 0, total: 0 },
-        judge: { passed: false, reasoning: `Runner error: Trial exceeded hard timeout of ${HARD_TIMEOUT + HARD_BUFFER}ms` },
-        error: { kind: "infrastructure-error", message: `Trial exceeded hard timeout of ${HARD_TIMEOUT + HARD_BUFFER}ms` },
-        trace: [],
-      });
-    }, HARD_TIMEOUT + HARD_BUFFER);
-  });
-
-  return Promise.race([trialPromise, timeoutPromise]);
-}
-
-async function runTrialInner(
-  task: BenchmarkTask,
-  config: TrialConfig,
-  onDriverLaunched: (driver: PlaywrightDriver) => void,
-): Promise<TrialResult> {
-  const start = Date.now();
-  const trace: TraceEntry[] = [];
-
-  let driver: PlaywrightDriver | null = null;
-  let driverFacade: BrowserDriver | null = null;
-  let agentAnswer = "";
-  let finalUrl = "";
-  let parts: unknown[] = [];
-  let steps = 0;
-  let tokensIn = 0;
-  let tokensOut = 0;
-  let error: TrialResult["error"];
-  let videoPath: string | undefined;
-
-  // Compute the desired final video path up front (we want this in the
-  // result even if the trial errors out before finishing). The `runDir`
-  // (caller-managed) already exists; we just compute the file path within
-  // its `videos/` subdirectory.
+  // Compute the video path here so both the watchdog and `runTrialInner`'s
+  // normal finally block can refer to the same destination. Keeping this
+  // in `runTrial` scope means the watchdog can save the video without
+  // having to reach into `runTrialInner`'s locals.
   let plannedVideoPath: string | undefined;
   if (config.videosDir) {
     const safeId = safeSegment(task.id);
@@ -196,6 +252,100 @@ async function runTrialInner(
     );
   }
 
+  // We need to keep a reference to the kernel driver if one is created
+  // so the hard timeout can clean it up.
+  let kernelDriverRef: KernelDriver | undefined;
+
+  // Shared progress — `runTrialInner` writes into this as work happens, and
+  // the timeout watchdog reads from it if it has to kill the trial mid-flight.
+  const progress: TrialProgress = {
+    trace: [],
+    steps: 0,
+    tokensIn: 0,
+    tokensOut: 0,
+    agentAnswer: "",
+    finalUrl: "",
+    parts: [],
+  };
+
+  const trialPromise = runTrialInner(task, config, plannedVideoPath, (driver) => {
+    if (driver instanceof KernelDriver) {
+      kernelDriverRef = driver;
+    }
+  }, progress);
+
+  const timeoutPromise = new Promise<TrialResult>((resolve) => {
+    setTimeout(async () => {
+      // Try to stop + download the Kernel replay before cleaning up the
+      // session. `closeAndSaveVideo` is re-entrant: if the normal `finally`
+      // block in `runTrialInner` races and claims ownership first, the
+      // watchdog's call becomes a no-op (returns null immediately).
+      let savedVideoPath: string | undefined;
+      if (kernelDriverRef && plannedVideoPath) {
+        const saved = await Promise.race([
+          kernelDriverRef.closeAndSaveVideo(plannedVideoPath),
+          new Promise<null>((r) => setTimeout(() => r(null), 30_000)),
+        ]).catch(() => null);
+        if (saved) savedVideoPath = saved;
+      }
+
+      // Belt-and-suspenders: if the save timed out and the session is still
+      // alive (closeAndSaveVideo never ran or failed before nulling the id),
+      // force-clean it. For pooled browsers this releases the pool slot
+      // (reuse: false) rather than deleting the browser out from under the
+      // pool, which would leak a slot.
+      if (kernelDriverRef) {
+        await kernelDriverRef.forceCleanup().catch(() => {});
+      }
+
+      resolve({
+        taskId: task.id,
+        modelLabel: config.modelLabel,
+        agentModelId: config.modelId,
+        systemPromptId: config.systemPromptId ?? "default",
+        toolSetId: config.toolSetId ?? `set:${(config.toolNames ?? DEFAULT_TOOL_SET).join("+")}`,
+        passed: false,
+        agentAnswer: progress.agentAnswer,
+        finalUrl: progress.finalUrl,
+        durationMs: HARD_TIMEOUT + HARD_BUFFER,
+        steps: progress.steps,
+        tokens: { in: progress.tokensIn, out: progress.tokensOut, total: progress.tokensIn + progress.tokensOut },
+        judge: { passed: false, reasoning: `Runner error: Trial exceeded hard timeout of ${HARD_TIMEOUT + HARD_BUFFER}ms` },
+        error: { kind: "infrastructure-error", message: `Trial exceeded hard timeout of ${HARD_TIMEOUT + HARD_BUFFER}ms` },
+        trace: progress.trace,
+        parts: progress.parts,
+        videoPath: savedVideoPath,
+      });
+    }, HARD_TIMEOUT + HARD_BUFFER);
+  });
+
+  return Promise.race([trialPromise, timeoutPromise]);
+}
+
+async function runTrialInner(
+  task: BenchmarkTask,
+  config: TrialConfig,
+  plannedVideoPath: string | undefined,
+  onDriverLaunched: (driver: PlaywrightDriver) => void,
+  progress: TrialProgress,
+): Promise<TrialResult> {
+  const start = Date.now();
+  const trace: TraceEntry[] = progress.trace;
+
+  // Generic terminal outcome captured from any tool returning `_benchOutcome`.
+  let terminalOutcome: { kind: string; message: string } | undefined;
+
+  let driver: PlaywrightDriver | null = null;
+  let driverFacade: BrowserDriver | null = null;
+  let agentAnswer = "";
+  let finalUrl = "";
+  let parts: unknown[] = [];
+  let steps = 0;
+  let tokensIn = 0;
+  let tokensOut = 0;
+  let error: TrialResult["error"];
+  let videoPath: string | undefined;
+
   try {
     if (config.driverKind === "kernel") {
       try {
@@ -204,6 +354,7 @@ async function runTrialInner(
           apiKey: process.env.KERNEL_API_KEY,
           stealth: true,
           recordVideoDir: config.videosDir,
+          poolId: config.kernelPoolId,
         });
         onDriverLaunched(driver);
       } catch (err) {
@@ -238,7 +389,10 @@ async function runTrialInner(
     const ctx: ToolContext = {
       driver: driverFacade,
       session: {
-        conversationId: null,
+        // Stable per-trial conversation id. Non-null so the `delegate` tool
+        // (subagent dispatch) and the per-parent concurrency tracker have a
+        // key to work with. Bench trials are single-run; no chatDb row exists.
+        conversationId: "bench",
         // Bench TabIds are already stable strings (`t0`, `t1`, ...) emitted
         // by PlaywrightDriver, so we identity-map them as agent-facing
         // handles. No persistence needed — bench trials are single-run.
@@ -277,7 +431,8 @@ async function runTrialInner(
     // so bench trials see byte-for-byte the same prompt structure as
     // chrome-side, and any future legend-format change propagates here
     // automatically.
-    const baseSystemPrompt = config.systemPrompt ?? buildBenchSystemPrompt();
+    const baseSystemPrompt =
+      config.harness?.systemPrompt ?? config.systemPrompt ?? buildBenchSystemPrompt();
     const driverForLegend = driver;
     const legendEntries = await buildTabLegendEntries({
       conversationId: "bench",
@@ -291,24 +446,115 @@ async function runTrialInner(
     });
     const promptWithLegend = `${baseSystemPrompt}\n\n${renderTabLegend(legendEntries)}`;
 
+    // Resolve tool instances + page-state policy from the harness (when set),
+    // else fall back to the no-harness default tool set.
+    const harness = config.harness;
+    const harnessTools = harness?.tools;
+    const subagentDefs: AgentDefinition[] | undefined = harness?.subagents
+      ? await resolveHarnessSubagents(harness.subagents, harness.tools)
+      : undefined;
+
     const { agent, transport, getNeedsMidStreamCompaction } = buildBenchAgent(ctx, {
       model: config.model,
       systemPrompt: promptWithLegend,
-      toolNames: config.toolNames,
+      tools: harnessTools,
+      returnPageStateAfterAction: harness?.returnPageStateAfterAction,
+      pageStateFields: harness?.pageStateFields,
+      pageStateImageTools: harness?.pageStateImageTools,
+      terminalToolNames: harness?.terminalToolNames,
+      thinking: config.thinking,
+      limits: harness?.limits,
+      subagents: subagentDefs,
       onStepFinish: (step) => {
         steps += 1;
         const u = step.usage;
         if (u.inputTokens != null) tokensIn += u.inputTokens;
         if (u.outputTokens != null) tokensOut += u.outputTokens;
-        for (const tc of step.toolCalls ?? []) {
-          const matchingResult = step.toolResults?.find(
-            (r) => r.toolCallId === tc.toolCallId,
-          );
+
+        // Mirror progress to the shared TrialProgress so the hard-timeout
+        // watchdog has accurate counts if it has to fire mid-trial.
+        progress.steps = steps;
+        progress.tokensIn = tokensIn;
+        progress.tokensOut = tokensOut;
+
+        // Push reasoning text into trace[] BEFORE tool calls for this step,
+        // so reasoning shows inline with the actions it influenced. The AI SDK
+        // exposes step.reasoning as either a string (legacy) or array of
+        // reasoning parts (current). We capture full text per debug request.
+        const reasoning = (step as any).reasoning;
+        const reasoningText: string =
+          typeof reasoning === "string"
+            ? reasoning
+            : Array.isArray(reasoning)
+              ? reasoning
+                  .map((r: any) => (typeof r === "string" ? r : r?.text ?? ""))
+                  .filter((t: string) => t.length > 0)
+                  .join("\n")
+              : "";
+        if (reasoningText.length > 0) {
           trace.push({
-            name: tc.toolName,
-            input: tc.input,
-            output: matchingResult?.output ?? null,
+            name: "reasoning",
+            input: {},
+            output: { text: reasoningText },
           });
+        }
+
+        for (const tc of step.toolCalls ?? []) {
+          let output = step.toolResults?.find((r) => r.toolCallId === tc.toolCallId)?.output ?? null;
+
+          output = redactImageData(output);
+
+          // Generic terminal-outcome marker: any tool may return
+          // `_benchOutcome: { kind, message }` to tag the trial. Capture it
+          // and redact from the stored output.
+          if (
+            output &&
+            typeof output === "object" &&
+            "_benchOutcome" in (output as any)
+          ) {
+            const oc = (output as any)._benchOutcome;
+            if (oc && typeof oc === "object" && !terminalOutcome) {
+              terminalOutcome = {
+                kind: String(oc.kind ?? "agent-error"),
+                message: String(oc.message ?? oc.kind ?? "terminal outcome"),
+              };
+            }
+            const { _benchOutcome, ...rest } = output as any;
+            output = rest;
+          }
+
+          // Subagent dispatch: the bench `delegate` tool returns its nested
+          // trace + tokens in `_benchTrace` / `_benchTokens`. Lift those into
+          // a recursive `subagent` field, aggregate the subagent's tokens into
+          // the trial total, and redact the internal fields from the stored
+          // output (the model only ever saw the projected finalText).
+          const entry: TraceEntry = { name: tc.toolName, input: tc.input, output };
+          if (
+            tc.toolName === "delegate" &&
+            output &&
+            typeof output === "object" &&
+            "_benchTrace" in (output as any)
+          ) {
+            const o = output as any;
+            const subTokens = o._benchTokens ?? { in: 0, out: 0 };
+            entry.subagent = {
+              slug: (tc.input as any)?.slug ?? "<unknown>",
+              finalText: o.finalText ?? "",
+              status: o.status ?? "unknown",
+              trace: o._benchTrace ?? [],
+              tokens: subTokens,
+            };
+            // Aggregate subagent tokens into the trial total.
+            tokensIn += subTokens.in ?? 0;
+            tokensOut += subTokens.out ?? 0;
+            progress.tokensIn = tokensIn;
+            progress.tokensOut = tokensOut;
+            // Redact internal fields from the stored output.
+            const { _benchTrace, _benchTokens, ...rest } = o;
+            entry.output = rest;
+          }
+
+          trace.push(entry);
         }
       },
     });
@@ -334,7 +580,17 @@ async function runTrialInner(
         }
       );
       agentAnswer = finalText;
-      
+      progress.agentAnswer = agentAnswer;
+
+      // Generic terminal-outcome detection. A tool (e.g. an experiment's
+      // bot-block reporter) may return `_benchOutcome: { kind, message }` in
+      // its raw output to tag the trial with a specific error kind (e.g.
+      // "bot-blocked") without the bench hardcoding any experiment tool name.
+      // `terminalOutcome` is captured in onStepFinish from the raw output.
+      if (terminalOutcome && !error) {
+        error = terminalOutcome;
+      }
+
       const lastAssoc = messages[messages.length - 1];
       if (lastAssoc && lastAssoc.role === "assistant") {
         // Dedup tool calls by replacing inputs/outputs with pointers to trace
@@ -349,6 +605,7 @@ async function runTrialInner(
           }
           return p;
         });
+        progress.parts = parts;
       }
     } catch (e: any) {
       if (e.kind === "infrastructure-error") {
@@ -363,6 +620,7 @@ async function runTrialInner(
     }
 
     finalUrl = (await driver.getActiveTab().catch(() => ({ url: "error://unknown" }))).url;
+    progress.finalUrl = finalUrl;
   } catch (err: any) {
     if (err && err.kind) {
       error = err;

--- a/packages/bench/src/store.ts
+++ b/packages/bench/src/store.ts
@@ -29,6 +29,7 @@ export interface RunSummary {
   breakdown?: {
     agentAccuracy: number;
     infrastructureFailureRate: number;
+    botBlockedRate?: number;
     judgeRejectRate: number;
   };
   /** Failure rate per domain to inform infrastructure tuning and exclusions. */
@@ -51,6 +52,8 @@ export interface RunSummary {
         contextWindow: number;
         maxOutputTokens: number;
       };
+      /** Provider-specific thinking/reasoning config for this run, when enabled. */
+      thinking?: { enabled: boolean; budget?: number };
     };
     driver: {
       kind: "local" | "kernel";
@@ -63,6 +66,8 @@ export interface RunSummary {
       concurrency: number;
       replicas: number;
       timeoutMs?: number;
+      /** Extra grace period beyond `timeoutMs` before the hard-timeout watchdog fires. */
+      hardTimeoutBufferMs?: number;
     };
     judge: {
       modelId: string;

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@agent/*": ["../../apps/extension/src/lib/agent/*"]
+      "@agent/*": ["../../apps/extension/src/lib/agent/*"],
+      "@openbrowse/bench": ["./src/index.ts"]
     },
     "types": ["node"],
     "noEmit": true,


### PR DESCRIPTION
### Summary

Transforms `@openbrowse/bench` from a SoM-hardcoded harness into a general benchmarking platform: agents-under-test are described by declarative **harness config files** loaded out-of-tree, with full **headless subagent** support and **Kernel browser-pool** execution for high-concurrency runs.

### Changes

**Bench platform (`packages/bench`)**
- **Harness config contract** (`harness.ts`): `defineHarness()` / `loadHarnessFromFile()` with Zod validation that errors loudly on tool-reference mismatches. Replaces the hardcoded `--tool-set som|som-full` with `--harness <path>`.
- **Public API barrel** (`index.ts`) + `@openbrowse/bench` self-alias + `exports` map, so out-of-tree harness files import only `@openbrowse/bench` — no `@agent/*` leakage.
- **`runBench(config)` programmatic API** (`bench.ts`): suite orchestration extracted out of the CLI; `cli.ts` is now a thin shell. `BenchConfigError` preserves exit-code 2 for misconfig vs 1 for runtime failures.
- **Headless subagents** (`subagent-runner.ts`, `bench-delegate.ts`): parent + `delegate` + nested subagents run without chatDb/chrome/IndexedDB, reusing the extension's pure `concurrency` (cap 10) + `types`. Depth cap = 1, recursive trace + per-subagent token aggregation in `runner.ts`. `subagents` accepts shipped built-in slugs (`"explore"`/`"general"`) or custom defs.
- **Generalized build-agent** (`build-agent.ts`): harness-driven knobs (`returnPageStateAfterAction`, `pageStateFields`, `pageStateImageTools`, `terminalToolNames`) replace hardcoded arm logic; generic `_benchOutcome` trace marker replaces hardcoded bot-block detection. Zero experiment-specific arms ship in the package.
- **Kernel browser pools** (`kernel-driver.ts`, `scripts/{create,delete}-pool.ts`): acquire/release with a fresh `BrowserContext` per acquire for per-trial isolation; `forceCleanup()` releases the pool slot on hard-timeout instead of leaking it. Plus `--thinking`/`--thinking-budget`, 90s nav timeout, and a hard-timeout watchdog.
- **Type ergonomics**: `AnyBrowserTool` + `defineTool()` + `BENCH_TOOL_CATALOG` via `satisfies` → cast-free tool authoring and literal-union tool names (typos are now compile errors).
- Renamed `view-page-helper.ts` → `som-capture.ts` (generic perception primitive); shared `redactImageData()` trace helper.

**Extension (`apps/extension`) — internal only, default behavior unchanged**
- `keepOnlyLatestScreenshot(messages, allowlist?)` and transport `screenshotToolNames?` parameterized so headless harnesses can scope image-trimming to their own perception tools. Extension default allowlist stays `["screenshot"]`; the sole caller passes neither new option.

> Experiment-specific arms (SoM/baseline) live out-of-tree and ship as a separate change — this PR contains zero experiment arms by design.

### Testing

- `pnpm compile` ✅ (bench + extension)
- `pnpm test` ✅ — **bench 63/63**, **extension 465/465** (incl. new `harness.test.ts` (12) and `compaction.test.ts` (8))
- No-harness CLI smoke + subagent dispatch smoke (built-in `explore` + custom) ✅
- **Kernel pool live-validated**: per-trial context isolation empirically proven (pre-fix leaks cookies/localStorage across browser reuse; fix isolates), and a 2-replica pooled run passes end-to-end ✅
- Out-of-tree harness e2e (external harness → bench CLI, Gemini) ✅

Known follow-up: the Kernel `forceCleanup()` hard-timeout path is implemented but not yet runtime-exercised (only fires on a 15-min timeout).

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] Tested locally with `pnpm dev` — N/A (bench CLI + headless agent core; no extension UI change)
- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Ran `pnpm changeset` — not required: `@openbrowse/bench` is changeset-ignored and the extension changes are internal-only (no user-facing behavior change)
- [x] No unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative harness system and public bench API (runBench/runTrial).
  * Subagent delegation with headless subagent runner and depth caps.
  * CLI and scripts to create/delete browser pools.

* **Improvements**
  * Opt-in transport to keep only the latest page screenshot in message history.
  * Richer bench orchestration: thinking budgets, pool support, improved timeout/video handling.
  * Page capture with optional visual annotations and image redaction for traces.

* **Tests**
  * Added unit tests covering screenshot-pruning and harness validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbrowse-ai/openbrowse/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->