### PR TITLE
feat(skills): bundled writing-skills skill + fix closeTabs Anthropic schema

### DIFF
--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -18,12 +18,14 @@ OpenBrowse implements the open [**agentskills.io**](https://agentskills.io) stan
 
 ## Bundled skills
 
-OpenBrowse ships with two skills out of the box:
+OpenBrowse ships with three skills out of the box:
 
 | Skill | What it does |
 | --- | --- |
 | `python-env` | Pyodide runtime reference for `executePython` — pre-built package list, browser-env substitutions (e.g. `pdftoppm` → `get_pixmap`, no `subprocess`), `pyfetch` idioms, common pitfalls (top-level `return`, latin-1 PDF unicode errors). The agent loads this whenever it's about to write non-trivial Python. |
 | `find-skills` | Search the [skills.sh](https://skills.sh) registry for additional skills and install them via `install_skill`. |
+| `writing-skills` | Author a new skill for the user. Activates whenever the user asks to "make a skill", "turn this into a skill", or "save this workflow as a skill" — drafts a well-formed `SKILL.md` and installs it via `create_skill`. |
+
 ## Invoking skills in chat
 
 Type `/` in the side panel input to open the slash-command picker. It lists every enabled skill with its trigger description; selecting one prepends a hint that nudges the agent to load that skill via the `skill` tool before continuing.
@@ -92,3 +94,5 @@ description: Use whenever the user asks to convert a CSV to a markdown table.
 ```
 
 Larger skills can include supporting files alongside `SKILL.md` — reference docs, scripts, templates. The agent can read any of them with the `Read` tool using the skill's path (e.g. `Read({ file_path: "/skills/<name>/references/<file>" })`).
+
+You don't have to write skills by hand. Ask the agent to author one for you — _"make a skill that converts CSVs to markdown tables"_ — and the bundled `writing-skills` skill will draft a well-formed `SKILL.md`, walk you through the trigger and scope, and install it via `create_skill` once you approve.

--- a/apps/extension/public/skills/writing-skills/SKILL.md
+++ b/apps/extension/public/skills/writing-skills/SKILL.md
@@ -92,7 +92,7 @@ A skill written for OpenBrowse runs inside a browser-based agent. Reference real
 
 If your skill body would exceed ~200 lines, split long material into reference files and reference them by path. The agent reads them on demand:
 
-```
+```text
 my-skill/
 ├── SKILL.md
 └── references/
@@ -156,7 +156,7 @@ User: "Save this as a skill — whenever I paste a CSV, convert it to a markdown
 
 Draft you'd present:
 
-```md
+````md
 ---
 name: csv-to-markdown
 description: Use whenever the user pastes CSV data and asks for it as a markdown table, or asks to "convert this CSV", "render this as a table", or "tabulate this data".
@@ -177,6 +177,6 @@ description: Use whenever the user pastes CSV data and asks for it as a markdown
 Edge cases:
 - If the CSV has no header row, ask the user before parsing.
 - If parsing fails, show the error and the first 10 lines so the user can correct it.
-```
+````
 
 Then call `create_skill` with that name, description, and body.

--- a/apps/extension/public/skills/writing-skills/SKILL.md
+++ b/apps/extension/public/skills/writing-skills/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: writing-skills
+description: Use whenever the user asks to create, write, author, or save a skill — for example "make a skill for X", "turn this workflow into a skill", "save this as a reusable skill", or "write me a skill that…". Guides authoring a well-formed SKILL.md for OpenBrowse and installing it via the create_skill tool.
+---
+
+# `writing-skills` Skill: Authoring Skills for OpenBrowse
+
+Use this skill whenever the user wants to capture a workflow as a reusable skill. Your job is to draft a clean, well-scoped `SKILL.md`, confirm it with the user, then persist it via the `create_skill` tool.
+
+## 1. What a skill is in OpenBrowse
+
+A skill is a folder under `/skills/<name>/` in the user's local workspace, containing:
+
+- **`SKILL.md`** — required. YAML frontmatter (`name`, `description`) plus a markdown body of instructions.
+- **Optional reference files** — long examples, style guides, or templates. The agent reads them on demand via `Read({ file_path: "/skills/<name>/<path>" })`.
+
+Skills are loaded **on demand**: only each skill's `name` and `description` live in the system prompt. The body is fetched (via the `skill` tool) only when a request matches the description. Two design implications:
+
+- The `description` is the **trigger**, not a summary. Write it as plain English: when should this skill activate?
+- One skill = one clear purpose. Don't bundle unrelated workflows into a single skill — split them.
+
+## 2. Authoring workflow
+
+Walk through these steps with the user. Don't skip the confirmation.
+
+1. **Clarify the trigger and scope.** Ask: when should this skill fire? What does success look like? What is explicitly out of scope?
+2. **Pick a name.** Lowercase-hyphen, matches `^[a-z0-9-]+$`, ≤ 64 characters. Prefer short, specific names (`csv-to-markdown`, not `data-tools`).
+3. **Draft the description.** Plain English, ≤ 1024 characters. Lead with "Use when…" or "Use whenever the user asks to…". Mention concrete trigger phrases the user might say. This is the only thing the model sees until the skill loads — make it earn its activation.
+4. **Draft the body.** Imperative voice, numbered steps, concrete tool calls. Keep it tight; push long material into reference files (see §5).
+5. **Show the draft to the user.** Render the full `SKILL.md` (frontmatter + body) in the chat and ask for changes before installing.
+6. **Install.** Once confirmed, call `create_skill({ name, description, body })`. The user will see an approval prompt; once approved, the skill is immediately available in this and future conversations.
+
+## 3. Frontmatter rules
+
+```md
+---
+name: my-skill
+description: Use whenever the user asks to convert a CSV to a markdown table.
+---
+```
+
+| Field | Required | Constraint |
+| --- | --- | --- |
+| `name` | yes | matches `^[a-z0-9-]+$`, ≤ 64 chars |
+| `description` | yes | ≤ 1024 chars; plain English; this is the trigger |
+
+You may include extra keys (`author`, `version`, etc.) — they're stored as metadata but not used for trigger matching.
+
+### Description: good vs. bad
+
+- **Bad:** `"A skill for working with CSVs."` (Summary, not a trigger.)
+- **Bad:** `"CSV utilities"` (Too short; agent has nothing to match against.)
+- **Good:** `"Use whenever the user asks to convert a CSV to a markdown table, render a CSV inline, or summarize the columns of a CSV file."`
+
+The good version names the **user actions** that should trigger the skill. The agent matches user intent against this string in the system prompt.
+
+## 4. Writing a good body
+
+- **Imperative voice.** "Parse the CSV with pandas," not "The agent should parse…".
+- **Numbered steps.** Make the workflow scannable.
+- **Concrete tool calls.** Reference real OpenBrowse tools (see §5). Show example invocations where useful.
+- **Keep it tight.** A SKILL.md body is loaded into the conversation every time the skill activates — token cost matters. Aim for ≤ 200 lines for most skills.
+- **No filler.** Skip "this skill is great because…" preambles. Get to the workflow.
+- **Decision tables for variants.** When a step has multiple branches (e.g. "if the CSV has headers… otherwise…"), a small table beats prose.
+
+## 5. OpenBrowse-runtime awareness
+
+A skill written for OpenBrowse runs inside a browser-based agent. Reference real tools, not Linux-shell idioms.
+
+**Common tools your skill body can reference:**
+
+| Need | Tool |
+| --- | --- |
+| Open or navigate a tab | `navigate({ url })` |
+| Read the current page's accessibility tree | `readPage({ tab })` or `snapshot({ tab })` |
+| Run JS in the page context | `executeOnPage({ tab, code })` |
+| Run JS in an isolated worker (no tab needed) | `executeCode({ code })` |
+| Run Python in the user's browser (Pyodide) | `executePython({ code, allow_network? })` |
+| Read / write / edit / search files in the workspace | `Read`, `Write`, `Edit`, `Glob`, `Grep`, `LS` |
+| Read a file bundled with this skill | `Read({ file_path: "/skills/<name>/<path>" })` |
+| Install another skill from a URL/repo | `install_skill({ source })` |
+
+**Things that don't exist in OpenBrowse:**
+
+- No shell, no `subprocess`, no `bash`. There is no way to spawn an OS process.
+- No native binaries. `ffmpeg`, `pdftoppm`, `git`, `soffice` etc. are unavailable. Find a pure-Python or pure-JS alternative.
+- Bundled scripts (`scripts/foo.sh`, `scripts/foo.py`) cannot be **executed** — they can only be **read** as reference text via `Read`. If your skill needs computation, use `executeCode` / `executePython` directly.
+
+**Don't restate `python-env`.** If your skill writes Python, just say so — the agent will load the bundled `python-env` skill automatically for the Pyodide runtime details (pre-built packages, `micropip`, `pyfetch`, common pitfalls). Restating that material wastes tokens and goes stale.
+
+## 6. Reference files (optional)
+
+If your skill body would exceed ~200 lines, split long material into reference files and reference them by path. The agent reads them on demand:
+
+```
+my-skill/
+├── SKILL.md
+└── references/
+    └── style-guide.md
+```
+
+In your SKILL.md body, point to them like this:
+
+> For the full style guide, read `Read({ file_path: "/skills/my-skill/references/style-guide.md" })`.
+
+Pass them to `create_skill` via the optional `references` array:
+
+```json
+{
+  "name": "my-skill",
+  "description": "...",
+  "body": "...",
+  "references": [
+    { "path": "references/style-guide.md", "content": "..." }
+  ]
+}
+```
+
+Most skills don't need this. Start with a single `SKILL.md` and only split when it grows.
+
+## 7. Installing the skill
+
+Once the user has approved the draft, call:
+
+```json
+{
+  "name": "my-skill",
+  "description": "Use whenever the user asks to ...",
+  "body": "# my-skill\n\n1. ...\n2. ...\n"
+}
+```
+
+`create_skill` requires user approval. After approval:
+
+- The skill is written to `/skills/my-skill/` in the workspace.
+- It's added to the registry with `source: "local-draft"`.
+- Its `name: description` is injected into future system prompts so it can self-trigger.
+
+If the user wants an **existing** community skill instead of a brand-new one, don't author it — point them at the `find-skills` skill (searches the [skills.sh](https://skills.sh) registry) and let it call `install_skill` directly.
+
+## 8. Quality checklist
+
+Before calling `create_skill`, verify the draft:
+
+- [ ] **Single responsibility.** One clear purpose. If you find yourself writing "and also…", split it.
+- [ ] **Trigger-style description.** Starts with "Use when…" or names concrete user phrases. ≤ 1024 chars.
+- [ ] **Self-contained.** A fresh agent can complete the workflow from this body alone (or with the listed reference files).
+- [ ] **No duplication of bundled skills.** Don't restate `python-env`; don't reimplement `find-skills`.
+- [ ] **Real tool names.** Every tool referenced exists in OpenBrowse (see §5).
+- [ ] **Tight.** Body ≤ ~200 lines; long material lives in references.
+- [ ] **User-confirmed.** You showed the draft to the user and they approved it.
+
+## 9. Worked example
+
+User: "Save this as a skill — whenever I paste a CSV, convert it to a markdown table."
+
+Draft you'd present:
+
+```md
+---
+name: csv-to-markdown
+description: Use whenever the user pastes CSV data and asks for it as a markdown table, or asks to "convert this CSV", "render this as a table", or "tabulate this data".
+---
+
+# `csv-to-markdown` Skill
+
+1. Identify the CSV content in the user's message. Strip any surrounding code fences.
+2. Parse it with `executePython`:
+   ```python
+   import pandas as pd, io
+   df = pd.read_csv(io.StringIO(__input))
+   df.to_markdown(index=False)
+   ```
+   Pass the CSV text as the tool's `input` (available as `__input`).
+3. Return the markdown table inline in your reply.
+
+Edge cases:
+- If the CSV has no header row, ask the user before parsing.
+- If parsing fails, show the error and the first 10 lines so the user can correct it.
+```
+
+Then call `create_skill` with that name, description, and body.

--- a/apps/extension/src/lib/agent/tools/__tests__/close-tabs.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/close-tabs.test.ts
@@ -107,4 +107,18 @@ describe("closeTabs tool", () => {
   it("declares approval required", () => {
     expect(closeTabsTool.approval?.required).toBe(true);
   });
+
+  it("target:'tabs' with no handles returns an error and sends nothing", async () => {
+    const res = await closeTabsTool.execute({ target: "tabs" }, ctx());
+    expect(res.closed).toBe(0);
+    expect(res.error).toMatch(/non-empty 'handles'/);
+    expect(sent.length).toBe(0);
+  });
+
+  it("target:'tabs' with empty handles array returns an error and sends nothing", async () => {
+    const res = await closeTabsTool.execute({ target: "tabs", handles: [] }, ctx());
+    expect(res.closed).toBe(0);
+    expect(res.error).toMatch(/non-empty 'handles'/);
+    expect(sent.length).toBe(0);
+  });
 });

--- a/apps/extension/src/lib/agent/tools/__tests__/tool-input-schema.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/tool-input-schema.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Guard test: every browser tool's `parameters` Zod schema must serialize to
+ * a JSON Schema with a top-level `"type": "object"`.
+ *
+ * Anthropic's Messages API requires `tools[].input_schema.type === "object"`.
+ * Schemas that serialize to top-level `{ oneOf: ... }` or `{ anyOf: ... }`
+ * (e.g. `z.discriminatedUnion`, `z.union`) — or to non-object roots
+ * (e.g. bare `z.string()`, `z.array(...)`) — are rejected with:
+ *
+ *   tools.<i>.custom.input_schema.type: Field required
+ *
+ * This regression test enumerates every tool registered into the
+ * `browserTools` map in `agent-transport.ts` and asserts the converted
+ * schema is a top-level object. Update the list below whenever a new tool
+ * is registered.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { clickElementTool } from "../click-element";
+import { closeTabsTool } from "../close-tabs";
+import { createSkillTool } from "../create-skill";
+import { deleteMemoryTool } from "../delete-memory";
+import { executeCodeTool } from "../execute-code";
+import { executeOnPageTool } from "../execute-on-page";
+import { createPythonTool } from "../execute-python";
+import { extractTool } from "../extract";
+import { createFsTools } from "../fs";
+import { installSkillTool } from "../install-skill";
+import { listTabsTool } from "../list-tabs";
+import { navigateTool } from "../navigate";
+import { readPageTool } from "../read-page";
+import { recallMemoryTool } from "../recall-memory";
+import { saveMemoryTool } from "../save-memory";
+import { screenshotTool } from "../screenshot";
+import { scrollPageTool } from "../scroll-page";
+import { selectTabTool } from "../select-tab";
+import { skillTool } from "../skill";
+import { snapshotTool } from "../snapshot";
+import { todoWriteTool } from "../todowrite";
+import { typeInElementTool } from "../type-in-element";
+import { updateMemoryTool } from "../update-memory";
+
+const fsTools = createFsTools(null);
+const pythonTool = createPythonTool(null);
+
+// Mirrors `browserTools` in agent-transport.ts. Add new tools here when
+// they're registered there.
+const allTools = [
+  ["snapshot", snapshotTool],
+  ["readPage", readPageTool],
+  ["screenshot", screenshotTool],
+  ["listTabs", listTabsTool],
+  ["navigate", navigateTool],
+  ["clickElement", clickElementTool],
+  ["typeInElement", typeInElementTool],
+  ["scrollPage", scrollPageTool],
+  ["selectTab", selectTabTool],
+  ["closeTabs", closeTabsTool],
+  ["saveMemory", saveMemoryTool],
+  ["updateMemory", updateMemoryTool],
+  ["recallMemory", recallMemoryTool],
+  ["deleteMemory", deleteMemoryTool],
+  ["executeCode", executeCodeTool],
+  ["executeOnPage", executeOnPageTool],
+  ["executePython", pythonTool],
+  ["extract", extractTool],
+  ["todoWrite", todoWriteTool],
+  ["skill", skillTool],
+  ["install_skill", installSkillTool],
+  ["create_skill", createSkillTool],
+  ["Read", fsTools.readTool],
+  ["Write", fsTools.writeTool],
+  ["Edit", fsTools.editTool],
+  ["Glob", fsTools.globTool],
+  ["Grep", fsTools.grepTool],
+  ["LS", fsTools.lsTool],
+] as const;
+
+describe("tool input schemas (Anthropic compatibility)", () => {
+  it.each(allTools)(
+    "%s parameters serialize to a top-level object schema",
+    (_name, tool) => {
+      const json = z.toJSONSchema(tool.parameters) as Record<string, unknown>;
+      expect(json.type).toBe("object");
+      // Sanity: object schemas have a `properties` map (even if empty).
+      expect(json).toHaveProperty("properties");
+      // Reject top-level union shapes that lack `type`.
+      expect(json).not.toHaveProperty("oneOf");
+      expect(json).not.toHaveProperty("anyOf");
+    },
+  );
+});

--- a/apps/extension/src/lib/agent/tools/close-tabs.ts
+++ b/apps/extension/src/lib/agent/tools/close-tabs.ts
@@ -2,26 +2,20 @@ import { z } from "zod";
 import { chatDb } from "../../chat-db";
 import type { BrowserTool } from "../types";
 
-const parameters = z
-  .discriminatedUnion("target", [
-    z
-      .object({
-        target: z.literal("group"),
-      })
-      .strict(),
-    z
-      .object({
-        target: z.literal("tabs"),
-        handles: z
-          .array(z.string())
-          .min(1)
-          .describe("Tab handles to close (e.g. ['t1','t3']). From the tab legend or listTabs."),
-      })
-      .strict(),
-  ])
-  .describe(
-    "What to close: the whole conversation's tab group, or a specific set of tab handles.",
-  );
+const parameters = z.object({
+  target: z
+    .enum(["group", "tabs"])
+    .describe(
+      "What to close: 'group' closes the whole conversation's tab group (use when the task is fully complete); 'tabs' closes a specific set of tab handles.",
+    ),
+  handles: z
+    .array(z.string())
+    .min(1)
+    .optional()
+    .describe(
+      "Required when target is 'tabs'. Tab handles to close (e.g. ['t1','t3']) from the tab legend or listTabs. Ignored when target is 'group'.",
+    ),
+});
 
 type Input = z.infer<typeof parameters>;
 
@@ -59,6 +53,13 @@ export const closeTabsTool: BrowserTool<Input, Output> = {
       const conv = await chatDb.getConversation(cid);
       tabIds = conv?.ownedTabIds ?? [];
     } else {
+      // input.target === "tabs"
+      if (!input.handles || input.handles.length === 0) {
+        return {
+          closed: 0,
+          error: "target 'tabs' requires a non-empty 'handles' array.",
+        };
+      }
       tabIds = [];
       for (const handle of input.handles) {
         const id = ctx.session?.resolveHandle?.(handle);

--- a/apps/extension/src/lib/agent/tools/create-skill.ts
+++ b/apps/extension/src/lib/agent/tools/create-skill.ts
@@ -21,7 +21,7 @@ type Output =
 
 export const createSkillTool: BrowserTool<Input, Output> = {
   name: "create_skill",
-  description: "Creates and installs a new skill directly into the browser's local skill registry. Use this when the user asks you to author a new skill for them, or after you have drafted a new skill using the skill-creator.",
+  description: "Creates and installs a new skill directly into the browser's local skill registry. Use this when the user asks you to author a new skill for them, or after you have drafted a new skill using the writing-skills skill.",
   parameters,
   approval: { required: true },
   execute: async ({ name, description, body, references }) => {


### PR DESCRIPTION
## What

- **New bundled `writing-skills` skill** — a third default skill that activates whenever a user asks to create/write/author/save a skill. It guides the agent through authoring a well-formed `SKILL.md` for OpenBrowse's runtime and persisting it via `create_skill`. The build's walk-skills hook + `bootstrapBundledSkills` pick up the new `public/skills/writing-skills/` folder automatically — no plumbing changes.
- **Fix: `closeTabs` rejected by the Anthropic API.** Its `parameters` used `z.discriminatedUnion`, which serializes to top-level `{ oneOf: [...] }` with no `"type"`. Anthropic requires every tool's `input_schema` root to be `{ "type": "object" }`, so every agent turn including `closeTabs` failed before any tool ran (`tools.9.custom.input_schema.type: Field required`). Replaced with a flat `z.object({ target, handles? })` + a runtime guard for the `target:'tabs'` / non-empty `handles` rule.

## Tests

- New guard test asserts **every** browser tool's `parameters` serializes to a top-level object schema — prevents this class of regression for current and future tools.
- Added `closeTabs` cases for missing/empty `handles`.
- Docs: `skills.mdx` bundled count + table row + cross-link.

`tsc` clean · 570/570 tests pass · `pnpm -F openbrowse build` succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "writing-skills" as a bundled skill; the agent can draft and install skills on request.

* **Documentation**
  * Expanded skill-authoring guidance and added comprehensive writing-skills workflow docs; updated create-skill wording.

* **Bug Fixes**
  * Tab-closing now validates inputs and returns a clear error when attempting to close tabs without handles.

* **Tests**
  * Added tests for tool input validation and JSON schema compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->