### PR TITLE
chore(release): add changeset for #80 + #82

### DIFF
--- a/.changeset/agent-tab-cleanup-and-writing-skills.md
+++ b/.changeset/agent-tab-cleanup-and-writing-skills.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": minor
+---
+
+Agent can now clean up the tabs it opened: a `closeTabs` tool closes the conversation's tab group (or specific tabs you opened) with a reversible Undo toast, plus manual control over the workspace Context card. Adds a bundled `writing-skills` skill that guides the agent through authoring a new skill and installing it via `create_skill`. Also fixes `closeTabs` being rejected by the Anthropic API (its tool input schema now serializes to a top-level object), which previously broke agent turns on Anthropic models.


### PR DESCRIPTION
## Why

Two PRs already merged to `main` shipped user-facing changes to the `openbrowse` extension but **did not include a changeset**, so the next release would version/changelog them incorrectly:

- **#80** `feat(agent)`: agent tab cleanup with reversible undo + manual Context card control
- **#82** `feat(skills)`: bundled `writing-skills` skill + fix for `closeTabs` being rejected by the Anthropic API

## What

Adds a single **minor** changeset for `openbrowse` covering both (bumps `0.4.3` → `0.5.0` on the next release).

Skipped: `111a2ea` (models.dev snapshot refresh) and `723f7eb` (docs-only landing fix) — consistent with prior practice (snapshot refreshes aren't versioned; `openbrowse-docs` is in the changeset `ignore` list).

Validated with `pnpm changeset status` → `openbrowse` bumped at minor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to close conversation tabs with Undo support for easy recovery
  * Introduced bundled skill creation and installation flow for building custom skills
  * Enhanced workspace Context card with additional manual controls

* **Bug Fixes**
  * Resolved issue preventing tab closing functionality from working properly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->