### PR TITLE
fix: route agent notification clicks to the originating tab/window

### DIFF
--- a/.changeset/notification-routing-fix.md
+++ b/.changeset/notification-routing-fix.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": patch
+---
+
+Fix agent completion/approval notification clicks to open the conversation in the tab and window where the agent actually ran, instead of the last-active window (which sometimes spawned a new window).

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -96,7 +96,19 @@ export default defineBackground({
     // Serializes Option+Space toggles so rapid presses can't race and spawn
     // orphan popups (or attempt to remove a window twice).
     let globalChatToggleInFlight: Promise<void> | null = null;
-    const pendingNotifications = new Map<string, { conversationId: string; origin: "sidepanel" | "home" }>();
+    const pendingNotifications = new Map<
+      string,
+      {
+        conversationId: string;
+        origin: "sidepanel" | "home";
+        // The tab/window the agent actually ran in (captured from the
+        // AGENT_NOTIFY message sender). This is the authoritative routing
+        // target — far more reliable than re-deriving it from the
+        // conversation's spaceId, which can be unanchored or stale.
+        senderTabId: number | null;
+        senderWindowId: number | null;
+      }
+    >();
 
     // windowId → active tabId. Maintained synchronously off chrome.tabs events
     // so chrome.sidePanel.open({tabId}) can be called inline from a user
@@ -814,7 +826,12 @@ export default defineBackground({
               console.log("[BG] notification created:", id);
             }
           });
-          pendingNotifications.set(notificationId, { conversationId, origin });
+          pendingNotifications.set(notificationId, {
+            conversationId,
+            origin,
+            senderTabId: sender.tab?.id ?? null,
+            senderWindowId: sender.tab?.windowId ?? null,
+          });
           import("./tab-scoping").then(({ clearToastDismissalForConversation }) => {
             clearToastDismissalForConversation(conversationId).catch(() => {});
           });
@@ -2182,20 +2199,128 @@ export default defineBackground({
       if (!info) return;
       pendingNotifications.delete(notificationId);
       chrome.notifications.clear(notificationId);
+      const { conversationId, senderTabId, senderWindowId } = info;
+
+      const { chatDb } = await import("@/lib/chat-db");
+      const { storage } = await import("@/lib/storage");
+      const conv = await chatDb.getConversation(conversationId).catch(() => null);
+      const spaceId = conv?.spaceId ?? null;
+
+      // Is the originating tab still live? That tab/window is the
+      // authoritative routing target — the agent literally ran in it.
+      const senderTab =
+        senderTabId != null
+          ? await chrome.tabs.get(senderTabId).catch(() => null)
+          : null;
+
+      // Resolve the *live* window for the conversation's space, used only as a
+      // fallback when the originating tab is gone. Finds the live window by
+      // its `home.html?space=<id>` anchor first (authoritative; survives stale
+      // windowId caches and avoids spuriously recreating a window), then
+      // owned-tab window, then last-focused. Only when the space's window is
+      // genuinely closed do we recreate it.
+      async function resolveFallbackWindowId(): Promise<number | undefined> {
+        if (spaceId) {
+          const { spaceIdFromUrl } = await import("./spaces");
+          const wins = await chrome.windows
+            .getAll({ populate: true, windowTypes: ["normal"] })
+            .catch(() => [] as chrome.windows.Window[]);
+          for (const w of wins) {
+            if (w.id == null) continue;
+            if (w.tabs?.some((t) => spaceIdFromUrl(t.url) === spaceId)) {
+              return w.id;
+            }
+          }
+          // No live anchored window — recreate the space's window.
+          const space = (await storage.getSpaces()).find(
+            (s) => s.id === spaceId,
+          );
+          if (space) {
+            const { focusOrCreateWindow } = await import("./spaces");
+            await focusOrCreateWindow(space).catch(() => {});
+            const live = (await storage.getSpaces()).find(
+              (s) => s.id === spaceId,
+            );
+            if (live?.windowId != null) return live.windowId;
+          }
+        }
+        try {
+          const { getTabsForConversation } = await import("./tab-scoping");
+          for (const tabId of getTabsForConversation(conversationId)) {
+            const tab = await chrome.tabs.get(tabId).catch(() => null);
+            if (tab?.windowId != null) return tab.windowId;
+          }
+        } catch {}
+        return (
+          lastFocusedWindowId ??
+          (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id ??
+          undefined
+        );
+      }
+
       if (info.origin === "sidepanel") {
-        const windowId = lastFocusedWindowId ?? (await chrome.windows.getLastFocused({ windowTypes: ["normal"] })).id;
-        if (windowId) {
+        const windowId =
+          senderTab?.windowId ?? senderWindowId ?? (await resolveFallbackWindowId());
+        if (windowId != null) {
           const tabId = activeTabByWindow.get(windowId);
           if (tabId != null) openSidePanelOnTab(tabId);
+          chrome.windows.update(windowId, { focused: true }).catch(() => {});
+          // The side panel matches on windowId; deliver immediately and again
+          // after a beat so a freshly-mounted panel still receives it.
+          const focusMsg = {
+            type: "FOCUS_CONVERSATION",
+            windowId,
+            conversationId,
+          };
+          chrome.runtime.sendMessage(focusMsg).catch(() => {});
+          setTimeout(() => {
+            chrome.runtime.sendMessage(focusMsg).catch(() => {});
+          }, 400);
         }
       } else {
-        const homeUrl = chrome.runtime.getURL("/home.html");
-        const [existing] = await chrome.tabs.query({ url: homeUrl + "*" });
-        if (existing?.id) {
-          chrome.tabs.update(existing.id, { active: true });
-          if (existing.windowId) chrome.windows.update(existing.windowId, { focused: true });
+        const homeBase = chrome.runtime.getURL("/home.html");
+
+        // Prefer the exact home tab the agent ran in (still live). This is
+        // the most reliable target — no anchor/space guessing, no new window.
+        let target: chrome.tabs.Tab | null = senderTab ?? null;
+
+        if (!target) {
+          // Originating tab is gone. Fall back to space-based resolution,
+          // which finds the live anchored window (recreating only if closed).
+          const { spaceIdFromUrl } = await import("./spaces");
+          const fallbackWindowId = await resolveFallbackWindowId();
+          const matches = await chrome.tabs.query({ url: homeBase + "*" });
+          target =
+            (spaceId
+              ? matches.find((t) => spaceIdFromUrl(t.url) === spaceId)
+              : undefined) ??
+            matches.find((t) => t.windowId === fallbackWindowId) ??
+            matches[0] ??
+            null;
+        }
+
+        if (target?.id != null) {
+          // Rewrite only the hash to the target conversation, preserving the
+          // existing query (e.g. ?space=<id>). The home tab listens for
+          // hashchange and switches conversations accordingly.
+          let nextUrl = homeBase + `#${conversationId}`;
+          if (target.url) {
+            try {
+              const u = new URL(target.url);
+              u.hash = `#${conversationId}`;
+              nextUrl = u.toString();
+            } catch {}
+          }
+          chrome.tabs.update(target.id, { active: true, url: nextUrl });
+          if (target.windowId)
+            chrome.windows.update(target.windowId, { focused: true });
         } else {
-          chrome.tabs.create({ url: homeUrl });
+          // No home tab exists anywhere — open one anchored to the space.
+          const url =
+            (spaceId
+              ? `${homeBase}?space=${encodeURIComponent(spaceId)}`
+              : homeBase) + `#${conversationId}`;
+          chrome.tabs.create({ url });
         }
       }
     });

--- a/apps/extension/src/entrypoints/background/tab-scoping.ts
+++ b/apps/extension/src/entrypoints/background/tab-scoping.ts
@@ -121,6 +121,19 @@ export function getConversationForTab(tabId: number): string | null {
   return tabOwnership.get(tabId) ?? null;
 }
 
+/**
+ * Reverse lookup: all tabIds currently owned by a conversation. Used to
+ * resolve which browser window a conversation lives in (e.g. routing a
+ * notification click to the correct space's side panel).
+ */
+export function getTabsForConversation(conversationId: string): number[] {
+  const tabIds: number[] = [];
+  for (const [tabId, cid] of tabOwnership) {
+    if (cid === conversationId) tabIds.push(tabId);
+  }
+  return tabIds;
+}
+
 export function getConversationForGroup(groupId: number): string | null {
   return groupOwnership.get(groupId) ?? null;
 }


### PR DESCRIPTION
## Problem
Clicking an agent completion / approval notification didn't take you to the conversation's actual space — it routed to the last-active window, and in some cases spawned a brand-new empty window. The handler stored the `conversationId` but never used it to locate the right tab/window.

## Fix
Route by the **tab/window the agent actually ran in**, captured from the `AGENT_NOTIFY` message sender:

- `AGENT_NOTIFY` now records `senderTabId` / `senderWindowId` in `pendingNotifications`.
- **Home origin:** activate the originating home tab, set its hash to the conversation, and focus its window — no anchor guessing, no new window.
- **Sidepanel origin:** focus the originating window, open the side panel there, and send `FOCUS_CONVERSATION`.
- **Fallback** (only when the originating tab is gone): resolve the space's live window via its `home.html?space=<id>` anchor first (avoids stale `windowId` caches that previously triggered spurious window creation), then owned-tab window, then last-focused — recreating the window only if it's genuinely closed.

Added `getTabsForConversation` helper in `tab-scoping.ts` for the owned-tab fallback.

## Testing
- `pnpm compile` clean
- `pnpm test`: 570/570 pass
- Manually verified: clicking a notification with home.html open in multiple windows lands on the correct window + conversation, no new window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification routing so agent completion and approval notifications open conversations in the correct window or tab where the agent originally ran, with intelligent fallback routing when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->