### PR TITLE
fix(extension): reduce completion-check false rejections and latency

### DIFF
--- a/.changeset/completion-check-tuning.md
+++ b/.changeset/completion-check-tuning.md
@@ -1,0 +1,9 @@
+---
+"openbrowse": patch
+---
+
+Tune the completion check to reduce false rejections and latency: the
+evaluator now runs as a single fast pass (no tool calls), accepts a
+reasonable interpretation of ambiguous requests instead of looping the
+agent, and no longer rejects page-grounded facts based on its own stale
+knowledge (e.g. "that batch doesn't exist yet").

--- a/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/completion-check.test.ts
@@ -620,6 +620,45 @@ describe("buildEvaluatorSystemPrompt", () => {
     expect(p).toMatch(/should/);
     expect(p).toMatch(/needs to/);
   });
+
+  it("instructs not to reject reasonable interpretations of ambiguous requests", () => {
+    const p = buildEvaluatorSystemPrompt({ hasTools: false });
+    // Dedicated guidance section exists.
+    expect(p).toContain("## Ambiguous requests");
+    // Establishes that a best-effort reading of a vague request is
+    // acceptable and must not be rejected for completeness/handoff.
+    expect(p.toLowerCase()).toContain("unclear referent");
+    expect(p).toMatch(/do NOT reject/i);
+    expect(p).toContain("`completeness`");
+    expect(p).toContain("`noPrematureHandoff`");
+    // Reinforces the "verify what was claimed, don't litigate
+    // interpretation" framing.
+    expect(p.toLowerCase()).toContain("interpretation");
+  });
+
+  it("forbids rejecting on the evaluator's own world knowledge / hallucinated facts", () => {
+    const p = buildEvaluatorSystemPrompt({ hasTools: false });
+    // Dedicated time-sensitive section exists.
+    expect(p).toContain("## Current and time-sensitive facts");
+    // Names the failure mode explicitly so the model can't rationalize it.
+    expect(p.toLowerCase()).toContain("knowledge cutoff");
+    expect(p.toLowerCase()).toContain("in the future");
+    expect(p.toLowerCase()).toContain(`doesn't exist`);
+    // The trace/page outranks the evaluator's memory.
+    expect(p.toLowerCase()).toContain("source of truth");
+    expect(p.toLowerCase()).toContain("the observation wins");
+    // Unfamiliarity is not fabrication.
+    expect(p.toLowerCase()).toContain("unfamiliarity is not evidence of fabrication");
+  });
+
+  it("frames evidenceGrounding as contradicted-or-absent, not 'unverifiable by the evaluator'", () => {
+    const p = buildEvaluatorSystemPrompt({ hasTools: false });
+    // The dimension description now keys off the trace, not belief.
+    expect(p).toMatch(/CONTRADICTED by the tool-call trace/);
+    // Both the no-tools guidance and the dimension forbid belief-based rejects.
+    const noTools = buildEvaluatorSystemPrompt({ hasTools: false });
+    expect(noTools.toLowerCase()).toContain("never reject a claim on the basis of your own knowledge");
+  });
 });
 
 describe("buildEvaluatorUserPrompt", () => {

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -1106,32 +1106,23 @@ export async function createAgentTransport(
     LS: toSDKTool(fsTools.lsTool, "LS"),
   };
 
-  // Read-only subset for the completion-check evaluator. The evaluator
-  // may call these to ground factual claims (e.g. verify a price the
-  // executor cited actually appears on the page) before deciding the
-  // verdict. Excluded:
-  //  - clickElement, typeInElement, navigate, scrollPage, selectTab —
-  //    page-state mutations.
-  //  - executeOnPage, executeCode — arbitrary side effects.
-  //  - todoWrite — plan ownership belongs to the executor.
-  //  - saveMemory/updateMemory/deleteMemory — write-mode memory ops.
-  //  - install_skill/create_skill — config mutation.
-  //  - Write, Edit — filesystem mutations.
-  //  - MCP tools — out of scope for Phase 5; many are write-mode.
-  // The evaluator's system prompt explicitly tells it the tools are
-  // read-only and that it should call them sparingly.
-  const evaluatorReadOnlyTools: Record<string, ToolSet[string]> = {
-    snapshot: browserTools.snapshot,
-    readPage: browserTools.readPage,
-    screenshot: browserTools.screenshot,
-    listTabs: browserTools.listTabs,
-    extract: browserTools.extract,
-    recallMemory: browserTools.recallMemory,
-    Read: browserTools.Read,
-    Glob: browserTools.Glob,
-    Grep: browserTools.Grep,
-    LS: browserTools.LS,
-  };
+  // The completion-check evaluator runs WITHOUT tools by default.
+  //
+  // Earlier we handed it a read-only browser/filesystem subset so it
+  // could make its own verification calls to ground factual claims.
+  // In practice that turned every gate into a multi-step agentic loop
+  // (`generateText` + `stepCountIs`, plus an occasional second-stage
+  // commit), which dominated end-of-turn latency. The tool-call trace
+  // already includes the captured output of every tool the executor
+  // ran this turn, so the evaluator can ground the vast majority of
+  // claims from context alone. Dropping tools routes the evaluator
+  // down its single-shot `generateObject` path (one round-trip) and
+  // cuts the perceived "Refining answer" delay dramatically.
+  //
+  // The evaluator still SUPPORTS tools (see completion-check/evaluator.ts);
+  // we simply don't wire any here. To re-enable grounded verification,
+  // pass a read-only tool subset as `evaluatorTools` in
+  // `buildCompletionCheckInput` below.
 
   const mcpTools = getMcpRegistry().toSDKTools();
 
@@ -1655,10 +1646,11 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
         // Threaded once at transport build; null means "fall back to
         // the executor's current model" inside the evaluator.
         evaluatorModel: evaluatorLanguageModel,
-        // Read-only tool subset for grounded verification. The
-        // evaluator's `allowTools` flips on automatically when this is
-        // non-empty; the system prompt branches accordingly.
-        evaluatorTools: evaluatorReadOnlyTools as unknown as import("ai").ToolSet,
+        // Intentionally no `evaluatorTools`: the evaluator runs as a
+        // single-shot `generateObject` against the conversation context
+        // and tool-call trace. See the comment at the
+        // `evaluatorReadOnlyTools` removal above for the latency
+        // rationale and how to re-enable grounded verification.
       };
     },
     onCompletionCheckApproved: (cid, now) => {

--- a/apps/extension/src/lib/agent/completion-check/prompt.ts
+++ b/apps/extension/src/lib/agent/completion-check/prompt.ts
@@ -26,13 +26,13 @@ import type { ConcernDimension, ToolCallTraceEntry } from "./types";
 
 const DIMENSION_DESCRIPTIONS: Record<ConcernDimension, string> = {
   completeness:
-    "The drafted response does not fulfill the original user request end-to-end. Examples: claimed 'top 3' but listed 2; promised a summary but described one item; promised a price comparison but only quoted one source.",
+    "The drafted response does not fulfill the original user request end-to-end. Examples: claimed 'top 3' but listed 2; promised a summary but described one item; promised a price comparison but only quoted one source. Judge completeness against a reasonable reading of the request: if the request was ambiguous or underspecified, a sensible best-effort interpretation that the executor actually fulfilled counts as complete — do not flag merely because a different interpretation was possible.",
   planClosure:
     "The conversation has open todos (status 'pending' or 'in_progress') that contradict the claim of completion. The executor either should have closed them, explicitly cancelled them, or should not be claiming completion yet.",
   evidenceGrounding:
-    "A specific factual claim in the drafted response (price, count, page text, URL, product name, date, etc.) is not supported by any tool observation in this turn. The fact may be invented or carried from stale context. Do not flag claims that are clearly opinions or general background; only flag claims that purport to describe specific observations.",
+    "A specific factual claim in the drafted response is CONTRADICTED by the tool-call trace, OR is a specific observable (price, count, page text, URL, product name, date, etc.) that should have a supporting trace observation but has none. Do NOT flag a claim merely because you are unfamiliar with it, think it implausible, or believe it false based on your own knowledge — unfamiliarity is not evidence of fabrication. If the trace shows the executor observed the claim (e.g. read it off a page it visited), the claim is grounded; do not flag it. Do not flag claims that are clearly opinions or general background.",
   noPrematureHandoff:
-    "The drafted response punts work back to the user that was within the original scope. Phrases like 'you can now do X yourself', 'I'll let you handle the rest', or stopping after partial fulfillment when the user asked for full completion. Not a flag for legitimate clarifying questions about genuinely ambiguous requirements.",
+    "The drafted response punts work back to the user that was within the original scope. Phrases like 'you can now do X yourself', 'I'll let you handle the rest', or stopping after partial fulfillment when the user asked for full completion. Not a flag for legitimate clarifying questions about genuinely ambiguous requirements, and not a flag when the executor reasonably interpreted an ambiguous request, completed it, and merely offered to adjust the interpretation afterwards.",
   surfaceAccuracy:
     "The drafted response describes the page state but a verification tool call (snapshot/extract/readPage) shows the page disagrees. Only raise this concern if you actually performed a verification call this turn and observed a mismatch.",
 };
@@ -58,11 +58,17 @@ export function buildEvaluatorSystemPrompt({
 
   const toolGuidance = hasTools
     ? `\n## Tools\n\nYou have access to a read-only subset of the browser agent's tools (page-state inspection: snapshot, readPage, screenshot, extract, listTabs; filesystem read: Read, Glob, Grep, LS; recallMemory). The tool-call trace in your input already includes the captured output of every tool the executor ran this turn — judge most factual claims from those outputs directly. Only call a tool yourself when a specific claim genuinely cannot be checked from the trace (e.g. the executor never inspected the relevant element). Don't re-verify what the trace already shows. You have a generous research budget but reserve your final response to commit a structured verdict; do not start a new tool call once you have enough evidence to decide.`
-    : `\n## Tools\n\nYou have no tools available in this run. Evaluate strictly from the conversation context, the executor's drafted response, and the tool-call trace included in your input — including the captured tool outputs. If a factual claim cannot be verified from the trace, raise an \`evidenceGrounding\` concern rather than approving by default.`;
+    : `\n## Tools\n\nYou have no tools available in this run. Evaluate strictly from the conversation context, the executor's drafted response, and the tool-call trace included in your input — including the captured tool outputs. Raise an \`evidenceGrounding\` concern only when a specific claim is CONTRADICTED by the trace, or when it is a specific observable the executor should have captured but the trace shows none. A claim that is simply outside the trace's scope — and not something the executor was obligated to capture — is not grounds for rejection; in particular, never reject a claim on the basis of your own knowledge, your unfamiliarity with it, or a belief that it is false or impossible. When unsure, prefer to approve rather than assert the claim is wrong.`;
 
   return `You are a skeptical reviewer for an AI browser agent's work. Your job is to verify, before the user sees it, that the agent has actually completed the task it claims to have completed.
 
 Default to skepticism. LLM-generated work is biased to look complete; your job is to push back when it isn't. A response can look polished and still be wrong on substance. When in doubt, raise a concern — the executor will get one more chance to address it before the user sees the response.
+
+Your skepticism is about whether the executor DID THE WORK — not about whether the world matches your memory. You have a knowledge cutoff; the executor reads live pages and current data. You do NOT. A hallucinated rejection is worse than no review at all: it corrupts a correct answer and wastes the user's time. Therefore:
+
+- NEVER introduce a "fact" of your own as grounds for rejection. In particular, never reject because you believe a claim is false, implausible, "doesn't exist", "isn't real", or "is in the future" based on your own training knowledge.
+- The tool-call trace is your source of truth, not your memory. When your prior conflicts with what the executor observed in the trace, the observation wins.
+- Unfamiliarity is not evidence of fabrication. If you have never heard of something, that is a fact about you, not about the executor's work.
 
 ## Your decision
 
@@ -136,6 +142,45 @@ Bad \`userSummary\` examples (DO NOT EMIT):
 - Hypotheticals or recommendations the executor explicitly framed as "you might also consider…".
 - Genuine clarifying questions about ambiguous requirements (those are not premature handoffs).
 - Already-completed todos. Only \`pending\`/\`in_progress\` items count toward planClosure.
+
+## Ambiguous requests
+
+The user's request itself may be ambiguous, underspecified, or contain
+an unclear referent (e.g. "do this", "schedule that", "make it daily"
+with no obvious antecedent). When the executor resolved the ambiguity by
+choosing a plausible interpretation and then fulfilled THAT
+interpretation, the task is complete. Approve it.
+
+- Do NOT reject merely because the request was vague or a referent was
+  unclear. Picking a reasonable reading of an ambiguous request and
+  delivering it is correct behavior, not a gap.
+- Do NOT raise \`completeness\` or \`noPrematureHandoff\` simply because a
+  different interpretation was possible, or because you personally would
+  have read the request differently.
+- An evaluator's job is to verify the executor did what it CLAIMED to do
+  and what a reasonable reading of the request asked for — not to
+  litigate which of several valid interpretations is best.
+- Only flag interpretation when the executor's reading is clearly
+  implausible (contradicts explicit details the user gave) or when the
+  executor claimed to do one thing but actually did another.
+
+## Current and time-sensitive facts
+
+Your training knowledge has a cutoff date. The world has moved on since
+then; the executor reads live pages and sees the CURRENT state of the
+world. This is the single most common way an evaluator produces a false
+rejection, so be strict with yourself here:
+
+- NEVER reject because something appears to be "in the future", "doesn't
+  exist yet", "isn't real", or "can't be verified" relative to what you
+  remember. The current date is later than your cutoff, and dates,
+  "latest"/"current" cohorts, batches, versions, releases, prices,
+  rosters, and company details change constantly.
+- If the executor cites such a fact and the trace shows it read a
+  relevant page, treat the fact as grounded — even if it contradicts
+  what you remember or seems impossible from your vantage point.
+- The live page is authoritative. Your memory is not. When they
+  disagree, defer to the page.
 
 If everything checks out, approve cleanly with empty concerns. Don't manufacture problems to look diligent.
 ${toolGuidance}`;


### PR DESCRIPTION
## Summary

The completion check ("Refining answer" pill) had three problems that made it slow and prone to incorrectly rejecting good answers. A hallucinating verifier is worse than no verifier, so these focus on precision and speed.

## Changes

**1. Latency — single-shot evaluation.** The evaluator was always wired with a read-only tool subset, turning every check into a multi-step `generateText` loop (plus an occasional second-stage commit). It now runs as one `generateObject` call against the conversation context and the captured tool-call trace. Tool support is retained in the evaluator and re-enableable in one line.

**2. Ambiguous requests.** Requests like "do this every morning at 9am" (unclear referent) were rejected for "no clear antecedent," looping the agent to redo the same work. The evaluator now treats a reasonable best-effort interpretation of an ambiguous request as complete.

**3. Hallucinated factual rejections.** The evaluator rejected a correct, page-grounded answer by asserting a "Winter 2026 YC batch doesn't exist yet" — its own stale prior, not anything in the trace. The prompt now forbids rejecting on the evaluator's own world knowledge: the live trace is the source of truth, `evidenceGrounding` is reframed as "contradicted-by or absent-from the trace," and a dedicated time-sensitive-facts section prohibits "doesn't exist / is in the future" rejections.

## Files
- `apps/extension/src/lib/agent/agent-transport.ts` — stop wiring evaluator tools
- `apps/extension/src/lib/agent/completion-check/prompt.ts` — ambiguity + anti-hallucination guidance
- `apps/extension/src/lib/agent/__tests__/completion-check.test.ts` — new prompt assertions
- `.changeset/completion-check-tuning.md` — patch changeset

## Verification
- `pnpm compile` — clean
- `pnpm test` — 573 extension + 63 bench tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved evaluator accuracy by reducing false rejections based on outdated or unverifiable information
- Enhanced handling of ambiguous requests to better accept reasonable interpretations

**Refactor**
- Optimized evaluator performance with streamlined single-pass evaluation

**Tests**
- Added comprehensive test coverage for evaluator behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->