### PR TITLE
fix(extension): hide subagent chats from chat lists

### DIFF
--- a/apps/extension/src/components/chat/ChatList.tsx
+++ b/apps/extension/src/components/chat/ChatList.tsx
@@ -39,7 +39,7 @@ export function ChatList({
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const convs = await chatDb.listConversations(spaceId);
+    const convs = await chatDb.listRootConversations(spaceId);
     setConversations(convs);
   }, [spaceId]);
 

--- a/apps/extension/src/components/chat/ChatPicker.tsx
+++ b/apps/extension/src/components/chat/ChatPicker.tsx
@@ -67,14 +67,12 @@ export function ChatPicker({
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const convs = await chatDb.listConversations(spaceId);
     // Hide subagent child conversations from the top-level picker — they
     // are reachable via "Open child →" inside the parent's tool block,
     // and as a back-link from the child view itself. Listing them at the
     // top would clutter the picker with auto-spawned rows.
-    setConversations(
-      convs.filter((c) => !c.parentConversationId),
-    );
+    const convs = await chatDb.listRootConversations(spaceId);
+    setConversations(convs);
   }, [spaceId]);
 
   useEffect(() => {

--- a/apps/extension/src/entrypoints/home/components/HomeSidebar.tsx
+++ b/apps/extension/src/entrypoints/home/components/HomeSidebar.tsx
@@ -231,7 +231,7 @@ export function HomeSidebar({
   }, [pinned]);
 
   const refresh = useCallback(async () => {
-    const convs = await chatDb.listConversations(activeSpaceId);
+    const convs = await chatDb.listRootConversations(activeSpaceId);
     setConversations(convs);
   }, [activeSpaceId]);
 

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -360,6 +360,19 @@ export const chatDb = {
   },
 
   /**
+   * Like listConversations, but excludes subagent child conversations
+   * (those with a `parentConversationId`). Subagent runs are auto-spawned
+   * and reachable from within their parent's tool block, so they should
+   * not appear as top-level chats in pickers/sidebars.
+   */
+  async listRootConversations(
+    spaceId?: string | null,
+  ): Promise<ChatDB["conversations"]["value"][]> {
+    const all = await chatDb.listConversations(spaceId);
+    return all.filter((c) => !c.parentConversationId);
+  },
+
+  /**
    * Return the immediate children of a parent conversation, ordered by
    * creation time ascending (oldest subagent run first). Used by the
    * side panel to render nested subagent runs under the parent.


### PR DESCRIPTION
## Problem

Subagent child conversations were showing up in the side panel "Chats" list (and the chat list) where they shouldn't.

Subagent runs are auto-spawned conversations that inherit the parent's `spaceId`. Because the side panel (`HomeSidebar`) and `ChatList` rendered the unfiltered `chatDb.listConversations()` result, these child rows leaked into the top-level chat lists. `ChatPicker` already filtered them out via an inline `.filter()`, but that logic was duplicated and missing from the other two consumers.

## Fix

Centralize the lineage filter in a new `chatDb.listRootConversations()` helper that excludes any conversation with a `parentConversationId`, and use it from all three consumers:

- `HomeSidebar.tsx` (the side panel in the bug report)
- `ChatList.tsx`
- `ChatPicker.tsx` (replaces the now-redundant inline filter)

Subagent runs remain reachable from within their parent's tool block, so nothing is lost — they're just no longer listed as top-level chats.

## Verification

- `pnpm compile` (`tsc --noEmit`) passes with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Conversation filtering logic moved from UI components to the database layer, ensuring consistent handling across all conversation lists and pickers. Only top-level conversations are now displayed in chat interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->