### PR TITLE
fix: subagent tabs in context card, Stripe MCP URL, sidebar sort, new-tab window

### DIFF
--- a/.changeset/agent-tabs-connector-and-sidebar.md
+++ b/.changeset/agent-tabs-connector-and-sidebar.md
@@ -1,0 +1,8 @@
+---
+"openbrowse": patch
+---
+
+Show subagent-opened tabs in the Context card with a "Subagent" badge and
+grouped cleanup, sort sidebar chats by creation time, and open new agent tabs
+in the conversation's own window instead of whatever window Chrome has focused.
+Also fixes the Stripe MCP connector endpoint (404).

--- a/apps/extension/src/entrypoints/home/components/CoworkPanel.tsx
+++ b/apps/extension/src/entrypoints/home/components/CoworkPanel.tsx
@@ -22,6 +22,7 @@ import {
   Loader2,
   ScrollText,
   Trash2,
+  Bot,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { downloadOpfsFile } from "@/lib/download";
@@ -336,6 +337,20 @@ interface ContextTab {
   id: number;
   title: string;
   favicon: string;
+  /**
+   * Conversation that owns this tab in `tab-scoping` (whose `ownedTabIds`
+   * the tab id lives in). For tabs created by the parent agent this is
+   * the parent's id; for tabs created by a subagent this is the child
+   * conversation's id. Cleanup must close tabs against their owner so
+   * the owner's `ownedTabIds` gets cleared (see `closeOwnedTabs`).
+   */
+  owningConversationId: string;
+  /**
+   * Set when this tab is owned by a subagent (i.e. owningConversationId
+   * != parent conversationId). Used to render an indicator badge in the
+   * Context card's Tabs section.
+   */
+  subagent?: { label: string };
 }
 
 function ContextCard({
@@ -363,22 +378,55 @@ function ContextCard({
       const conv = await chatDb.getConversation(conversationId);
       if (!isMounted) return;
 
-      // Tabs — fetch all owned tabs concurrently; drop any that fail
-      // (closed tab). `Promise.allSettled` preserves input order, so the
-      // resulting rows keep `ownedIds` order.
-      const ownedIds = conv?.ownedTabIds ?? [];
+      // Tabs — collect parent-owned tabs first, then any tabs owned by
+      // subagent children (peer subagents bind their tabs to the *child*
+      // conversation row in tab-scoping; incognito subagents normally
+      // auto-close their ephemeral window, but if any child tabs are
+      // still alive we surface them too). Each id is hydrated via
+      // chrome.tabs.get; closed tabs (rejected promises) drop out.
+      const children = await chatDb.listChildren(conversationId);
+      if (!isMounted) return;
+
+      type OwnedRef = {
+        tabId: number;
+        owningConversationId: string;
+        subagent?: { label: string };
+      };
+      const ownedRefs: OwnedRef[] = [];
+      for (const id of conv?.ownedTabIds ?? []) {
+        ownedRefs.push({ tabId: id, owningConversationId: conversationId });
+      }
+      for (const child of children) {
+        const label =
+          child.subagentTraceTitle ??
+          child.subagentSlug ??
+          "Subagent";
+        for (const id of child.ownedTabIds ?? []) {
+          ownedRefs.push({
+            tabId: id,
+            owningConversationId: child.id,
+            subagent: { label },
+          });
+        }
+      }
+
+      // `Promise.allSettled` preserves input order, so the resulting rows
+      // keep ownedRefs order (parent tabs first, then subagent tabs).
       const results = await Promise.allSettled(
-        ownedIds.map((id) => chrome.tabs.get(id)),
+        ownedRefs.map((r) => chrome.tabs.get(r.tabId)),
       );
       if (!isMounted) return;
       const hydrated: ContextTab[] = [];
       results.forEach((res, i) => {
         if (res.status === "fulfilled") {
           const tab = res.value;
+          const ref = ownedRefs[i];
           hydrated.push({
-            id: ownedIds[i],
+            id: ref.tabId,
             title: tab.title || tab.url || "Untitled tab",
             favicon: tab.favIconUrl ?? "",
+            owningConversationId: ref.owningConversationId,
+            subagent: ref.subagent,
           });
         }
       });
@@ -451,12 +499,23 @@ function ContextCard({
     if (isCleaningTabs || tabs.length === 0) return;
     setIsCleaningTabs(true);
     try {
-      // Background closes the tabs, clears ownership, and broadcasts
-      // AGENT_TABS_CLOSED → Undo toast (handled in useAgentChat). The poll
-      // loop will refresh `tabs` to [] on the next tick.
-      await requestCloseAgentTabs(
-        conversationId,
-        tabs.map((t) => t.id),
+      // Tabs owned by a subagent live in the *child* conversation's
+      // `ownedTabIds`; closing them against the parent id wouldn't
+      // clear the child row. Group by owning conversation id so each
+      // owner's list is cleaned up correctly. `closeOwnedTabs`
+      // (background) closes the tabs, clears ownership, and broadcasts
+      // AGENT_TABS_CLOSED → Undo toast (handled in useAgentChat). The
+      // poll loop refreshes `tabs` to [] on the next tick.
+      const byOwner = new Map<string, number[]>();
+      for (const t of tabs) {
+        const ids = byOwner.get(t.owningConversationId) ?? [];
+        ids.push(t.id);
+        byOwner.set(t.owningConversationId, ids);
+      }
+      await Promise.all(
+        Array.from(byOwner.entries()).map(([ownerId, ids]) =>
+          requestCloseAgentTabs(ownerId, ids),
+        ),
       );
     } finally {
       setIsCleaningTabs(false);
@@ -616,17 +675,37 @@ function ContextTabRow({ tab }: { tab: ContextTab }) {
     })();
   };
   return (
-    <ContextRow
-      icon={
-        tab.favicon ? (
-          <img src={tab.favicon} alt="" className="size-3.5 rounded-sm" />
-        ) : (
-          <span className="size-3.5 rounded-sm bg-muted-foreground/30" />
-        )
-      }
-      label={tab.title}
-      onClick={focusTab}
-    />
+    <li>
+      <button
+        type="button"
+        onClick={focusTab}
+        className="flex w-full items-center gap-2.5 rounded-md px-1.5 py-1.5 text-left text-sm hover:bg-muted/60 min-w-0"
+      >
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          {tab.favicon ? (
+            <img src={tab.favicon} alt="" className="size-3.5 rounded-sm" />
+          ) : (
+            <span className="size-3.5 rounded-sm bg-muted-foreground/30" />
+          )}
+        </span>
+        <span className="truncate flex-1">{tab.title}</span>
+        {tab.subagent && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                aria-label={`Used by subagent: ${tab.subagent.label}`}
+              >
+                <Bot className="size-3" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              Used by subagent: {tab.subagent.label}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </button>
+    </li>
   );
 }
 

--- a/apps/extension/src/lib/agent/__tests__/new-tab-window-targeting.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/new-tab-window-targeting.test.ts
@@ -1,0 +1,229 @@
+/**
+ * New agent-created tabs should open in the conversation's own window —
+ * where the chat and the agent's existing tabs live — not whatever window
+ * Chrome happens to have focused. This covers two layers:
+ *
+ *   1. The `navigate` tool's precedence: a static `session.targetWindowId`
+ *      (incognito subagents) wins; otherwise it falls back to the root
+ *      agent's async `session.resolveNewTabWindowId()`; otherwise it omits
+ *      `windowId` (legacy focused-window behavior).
+ *
+ *   2. `buildExtensionToolContext(...).session.resolveNewTabWindowId`:
+ *      owned-tab window → space window → undefined.
+ */
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "../../chat-db";
+import type { ToolContext } from "../driver";
+import { buildExtensionToolContext } from "../agent-transport";
+import { navigateTool } from "../tools/navigate";
+
+// ─── navigate tool: windowId precedence ─────────────────────────────────
+
+function makeDriver() {
+  const created: { url: string; opts: { active?: boolean; windowId?: number } }[] =
+    [];
+  const driver = {
+    createTab: async (
+      url: string,
+      opts: { active?: boolean; windowId?: number } = {},
+    ) => {
+      created.push({ url, opts });
+      return 999;
+    },
+    setActiveTab: async () => {},
+    waitForLoad: async () => {},
+    getActiveTabId: () => null,
+    // captureSnapshot calls into the driver; let it fail so navigate takes
+    // its caught "snapshot failed" path without us mocking CDP.
+    sendCommand: async () => {
+      throw new Error("no snapshot in test");
+    },
+  } as unknown as ToolContext["driver"];
+  return { driver, created };
+}
+
+describe("navigate — new tab windowId precedence", () => {
+  it("uses static session.targetWindowId when set (incognito subagent)", async () => {
+    const { driver, created } = makeDriver();
+    const resolveNewTabWindowId = vi.fn(async () => 7);
+    await navigateTool.execute(
+      { url: "https://example.com" },
+      {
+        driver,
+        session: {
+          conversationId: "c1",
+          targetWindowId: 42,
+          resolveNewTabWindowId,
+          getOrCreateHandle: () => "t1",
+          bindTabsToConversation: async () => {},
+        },
+      },
+    );
+    expect(created[0].opts.windowId).toBe(42);
+    // Static target short-circuits the async resolver.
+    expect(resolveNewTabWindowId).not.toHaveBeenCalled();
+  });
+
+  it("falls back to resolveNewTabWindowId for the root agent", async () => {
+    const { driver, created } = makeDriver();
+    await navigateTool.execute(
+      { url: "https://example.com" },
+      {
+        driver,
+        session: {
+          conversationId: "c1",
+          resolveNewTabWindowId: async () => 5,
+          getOrCreateHandle: () => "t1",
+          bindTabsToConversation: async () => {},
+        },
+      },
+    );
+    expect(created[0].opts.windowId).toBe(5);
+  });
+
+  it("omits windowId when neither is available (focused-window fallback)", async () => {
+    const { driver, created } = makeDriver();
+    await navigateTool.execute(
+      { url: "https://example.com" },
+      {
+        driver,
+        session: {
+          conversationId: "c1",
+          resolveNewTabWindowId: async () => undefined,
+          getOrCreateHandle: () => "t1",
+          bindTabsToConversation: async () => {},
+        },
+      },
+    );
+    expect("windowId" in created[0].opts).toBe(false);
+  });
+});
+
+// ─── buildExtensionToolContext.resolveNewTabWindowId ─────────────────────
+
+function makeChromeStub(opts: {
+  tabs?: Record<number, { windowId: number }>;
+  windows?: Set<number>;
+  spaces?: unknown[];
+}) {
+  const tabs = opts.tabs ?? {};
+  const windows = opts.windows ?? new Set<number>();
+  let store: Record<string, unknown> = {
+    spaces: opts.spaces ?? [],
+  };
+  return {
+    runtime: { id: "test", sendMessage: vi.fn(async () => undefined) },
+    tabs: {
+      get: async (id: number) => {
+        const t = tabs[id];
+        if (!t) throw new Error(`no tab ${id}`);
+        return { id, ...t };
+      },
+    },
+    windows: {
+      get: async (id: number) => {
+        if (!windows.has(id)) throw new Error(`no window ${id}`);
+        return { id };
+      },
+    },
+    storage: {
+      local: {
+        get: async (key: string) => ({ [key]: store[key] }),
+        set: async (obj: Record<string, unknown>) => {
+          store = { ...store, ...obj };
+        },
+      },
+    },
+  };
+}
+
+async function seedConv(
+  id: string,
+  opts: { ownedTabIds?: number[]; spaceId?: string | null } = {},
+) {
+  await chatDb.createConversation({
+    id,
+    title: id,
+    spaceId: opts.spaceId ?? null,
+    ownedGroupId: null,
+    ownedTabIds: opts.ownedTabIds ?? [],
+    createdAt: 0,
+    updatedAt: 0,
+  });
+}
+
+describe("buildExtensionToolContext — resolveNewTabWindowId", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    chatDb._resetForTests();
+  });
+
+  it("returns the window of the first live owned tab", async () => {
+    vi.stubGlobal(
+      "chrome",
+      makeChromeStub({ tabs: { 101: { windowId: 3 }, 102: { windowId: 9 } } }),
+    );
+    await seedConv("c1", { ownedTabIds: [101, 102] });
+    const ctx = buildExtensionToolContext("c1");
+    expect(await ctx.session?.resolveNewTabWindowId?.()).toBe(3);
+  });
+
+  it("skips dead owned tabs and uses the first live one", async () => {
+    vi.stubGlobal(
+      "chrome",
+      makeChromeStub({ tabs: { 102: { windowId: 9 } } }), // 101 is gone
+    );
+    await seedConv("c1", { ownedTabIds: [101, 102] });
+    const ctx = buildExtensionToolContext("c1");
+    expect(await ctx.session?.resolveNewTabWindowId?.()).toBe(9);
+  });
+
+  it("falls back to the space window when no owned tabs are live", async () => {
+    vi.stubGlobal(
+      "chrome",
+      makeChromeStub({
+        tabs: {},
+        windows: new Set([8]),
+        spaces: [{ id: "s1", name: "S", windowId: 8, favorites: [] }],
+      }),
+    );
+    await seedConv("c1", { ownedTabIds: [], spaceId: "s1" });
+    const ctx = buildExtensionToolContext("c1");
+    expect(await ctx.session?.resolveNewTabWindowId?.()).toBe(8);
+  });
+
+  it("returns undefined when the space window no longer exists", async () => {
+    vi.stubGlobal(
+      "chrome",
+      makeChromeStub({
+        tabs: {},
+        windows: new Set<number>(), // window 8 was closed
+        spaces: [{ id: "s1", name: "S", windowId: 8, favorites: [] }],
+      }),
+    );
+    await seedConv("c1", { ownedTabIds: [], spaceId: "s1" });
+    const ctx = buildExtensionToolContext("c1");
+    expect(await ctx.session?.resolveNewTabWindowId?.()).toBeUndefined();
+  });
+
+  it("returns undefined when there are no owned tabs and no space", async () => {
+    vi.stubGlobal("chrome", makeChromeStub({ tabs: {} }));
+    await seedConv("c1", { ownedTabIds: [], spaceId: null });
+    const ctx = buildExtensionToolContext("c1");
+    expect(await ctx.session?.resolveNewTabWindowId?.()).toBeUndefined();
+  });
+
+  it("returns undefined for a null-pinned context", async () => {
+    vi.stubGlobal("chrome", makeChromeStub({ tabs: {} }));
+    const ctx = buildExtensionToolContext(null);
+    expect(await ctx.session?.resolveNewTabWindowId?.()).toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/new-tab-window-targeting.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/new-tab-window-targeting.test.ts
@@ -99,6 +99,26 @@ describe("navigate — new tab windowId precedence", () => {
     );
     expect("windowId" in created[0].opts).toBe(false);
   });
+
+  it("swallows resolver rejection and still creates the tab", async () => {
+    const { driver, created } = makeDriver();
+    await navigateTool.execute(
+      { url: "https://example.com" },
+      {
+        driver,
+        session: {
+          conversationId: "c1",
+          resolveNewTabWindowId: async () => {
+            throw new Error("transient lookup failure");
+          },
+          getOrCreateHandle: () => "t1",
+          bindTabsToConversation: async () => {},
+        },
+      },
+    );
+    expect(created).toHaveLength(1);
+    expect("windowId" in created[0].opts).toBe(false);
+  });
 });
 
 // ─── buildExtensionToolContext.resolveNewTabWindowId ─────────────────────

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -10,6 +10,7 @@ import type {
 import { ToolLoopAgent, readUIMessageStream, stepCountIs, tool } from "ai";
 import { z } from "zod";
 import { chatDb } from "../chat-db";
+import { storage } from "../storage";
 import { getMcpRegistry } from "../mcp";
 import { sendMcpMessage } from "../mcp/messages";
 import { memoryDb } from "../memory-db";
@@ -612,6 +613,39 @@ export function buildExtensionToolContext(
           todos,
           updatedAt: Date.now(),
         });
+      },
+      resolveNewTabWindowId: async () => {
+        if (!pinnedConversationId) return undefined;
+        const conv = await chatDb.getConversation(pinnedConversationId);
+        if (!conv) return undefined;
+        // 1) Prefer the window of an existing owned tab so new tabs join
+        //    the conversation's tab group rather than splitting across
+        //    windows. Probe in order and take the first live tab.
+        for (const tabId of conv.ownedTabIds ?? []) {
+          try {
+            const tab = await chrome.tabs.get(tabId);
+            if (typeof tab.windowId === "number") return tab.windowId;
+          } catch {
+            // Tab gone; try the next owned id.
+          }
+        }
+        // 2) Otherwise fall back to the conversation's space window (the
+        //    window the chat is bound to), as long as it still exists.
+        if (conv.spaceId) {
+          const spaces = await storage.getSpaces();
+          const space = spaces.find((s) => s.id === conv.spaceId);
+          const windowId = space?.windowId;
+          if (typeof windowId === "number") {
+            try {
+              await chrome.windows.get(windowId);
+              return windowId;
+            } catch {
+              // Space's window was closed; fall through.
+            }
+          }
+        }
+        // 3) No resolvable window — caller omits windowId (focused window).
+        return undefined;
       },
     },
   };

--- a/apps/extension/src/lib/agent/driver/tool-context.ts
+++ b/apps/extension/src/lib/agent/driver/tool-context.ts
@@ -78,9 +78,25 @@ export interface ToolSession {
    * tabs land in its own window rather than the user's active window.
    *
    * Absent on `inline` and `peer` runs (and on the root agent), in which
-   * case tabs are created in the user's currently focused window.
+   * case tabs are resolved via `resolveNewTabWindowId` (root agent) or
+   * fall back to the user's currently focused window.
    */
   targetWindowId?: number;
+  /**
+   * Resolve the window new agent-created tabs should open in for the root
+   * agent. Tools that create tabs (e.g. `navigate`) call this when no
+   * static `targetWindowId` is set, so a new tab lands in the same window
+   * as the conversation (where the chat and the agent's existing tabs
+   * live) rather than whatever window Chrome happens to have focused.
+   *
+   * Returns `undefined` when no window can be resolved (no owned tabs and
+   * no live space window), in which case the caller omits `windowId` and
+   * Chrome falls back to the focused window (legacy behavior).
+   *
+   * No-op / absent in the bench harness and on subagent sessions (which
+   * use the static `targetWindowId` instead).
+   */
+  resolveNewTabWindowId?: () => Promise<number | undefined>;
 }
 
 export interface ToolContext {

--- a/apps/extension/src/lib/agent/tools/navigate.ts
+++ b/apps/extension/src/lib/agent/tools/navigate.ts
@@ -67,10 +67,15 @@ export const navigateTool: BrowserTool<Input, Output> = {
       // for the root agent we resolve it dynamically via
       // `resolveNewTabWindowId` (owned-tab window → space window). When
       // neither yields a window, `windowId` is omitted and Chrome falls
-      // back to the focused window (legacy behavior).
+      // back to the focused window (legacy behavior). The resolver runs
+      // best-effort: a rejection is swallowed to `undefined` so a transient
+      // lookup failure degrades to the focused window rather than aborting
+      // the navigation.
       const targetWindowId =
         ctx.session?.targetWindowId ??
-        (await ctx.session?.resolveNewTabWindowId?.());
+        (await Promise.resolve(ctx.session?.resolveNewTabWindowId?.()).catch(
+          () => undefined,
+        ));
       tabId = await ctx.driver.createTab(url, {
         active: false,
         ...(targetWindowId !== undefined && { windowId: targetWindowId }),

--- a/apps/extension/src/lib/agent/tools/navigate.ts
+++ b/apps/extension/src/lib/agent/tools/navigate.ts
@@ -59,11 +59,18 @@ export const navigateTool: BrowserTool<Input, Output> = {
       }
     } else {
       // No handle → create a new background tab. This is the bootstrap
-      // path used on the first action of a conversation. For subagents
-      // running with `incognito` isolation, `session.targetWindowId`
-      // is set so the new tab lands in the subagent's own incognito
-      // window rather than the user's currently focused window.
-      const targetWindowId = ctx.session?.targetWindowId;
+      // path used on the first action of a conversation. The new tab
+      // should land in the conversation's own window — where the chat
+      // and the agent's existing tabs live — not whatever window Chrome
+      // happens to have focused. For incognito subagents the runner sets
+      // a static `session.targetWindowId` (their fresh incognito window);
+      // for the root agent we resolve it dynamically via
+      // `resolveNewTabWindowId` (owned-tab window → space window). When
+      // neither yields a window, `windowId` is omitted and Chrome falls
+      // back to the focused window (legacy behavior).
+      const targetWindowId =
+        ctx.session?.targetWindowId ??
+        (await ctx.session?.resolveNewTabWindowId?.());
       tabId = await ctx.driver.createTab(url, {
         active: false,
         ...(targetWindowId !== undefined && { windowId: targetWindowId }),

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -356,7 +356,7 @@ export const chatDb = {
     } else {
       all = await db.getAll("conversations");
     }
-    return all.sort((a, b) => b.updatedAt - a.updatedAt);
+    return all.sort((a, b) => b.createdAt - a.createdAt);
   },
 
   /**

--- a/packages/connectors/src/stripe.ts
+++ b/packages/connectors/src/stripe.ts
@@ -14,7 +14,7 @@ export const definition: ConnectorDefinition = {
   icon: { light: "stripe.svg" },
   description: "Payments, subscriptions, and billing",
   category: "developer-tools",
-  url: "https://mcp.stripe.com/mcp",
+  url: "https://mcp.stripe.com",
   auth: { type: "oauth" },
   docsUrl: "https://docs.stripe.com/mcp",
   formatLabel(toolName, result): ToolResultLabel | null {


### PR DESCRIPTION
## Summary
- Context card now shows subagent-opened tabs with a "Subagent" badge; cleanup closes each against its owning conversation.
- Fix Stripe MCP 404: endpoint is `https://mcp.stripe.com` (root), not `/mcp`.
- HomeSidebar sorts chats by `createdAt` instead of `updatedAt`.
- New agent tabs open in the conversation's window (owned-tab window → space window → focused-window fallback) instead of whatever window is focused.

## Testing
- `pnpm -F openbrowse compile` → clean
- `pnpm -F openbrowse test` → 582/582 pass (+9 new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subagent-opened tabs now appear in the Context card with a "Subagent" badge and clearer tab rows (favicons and tooltips).
  * New agent tabs open in their conversation’s window instead of the currently focused Chrome window.
  * Sidebar chats now sort by creation time.

* **Improvements**
  * Tab cleanup is grouped and performed per conversation owner for more predictable behavior.

* **Bug Fixes**
  * Fixed Stripe MCP connector endpoint returning 404.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->