### PR TITLE
perf(extension): memoize chat message list to fix input lag

### DIFF
--- a/.changeset/chat-message-memoization.md
+++ b/.changeset/chat-message-memoization.md
@@ -1,0 +1,7 @@
+---
+"openbrowse": patch
+---
+
+Fix chat input lag in long conversations. The message list is now memoized and
+extracted from the input's render path, so typing no longer re-renders every
+message (markdown + syntax highlighting) on each keystroke.

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -12,6 +12,7 @@ import { ToolCallBlock } from "./ToolCallBlock";
 import { ToolApprovalBlock } from "./ToolApprovalBlock";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 import { capturedToolOrigins, allowToolOnSite, setCloseTabsAlwaysAllowed } from "@/lib/agent/agent-transport";
+import { memo } from "react";
 import "@/components/chat/tool-previews";
 
 /**
@@ -111,7 +112,7 @@ interface AssistantMessageProps {
   dimmed?: boolean;
 }
 
-export function AssistantMessage({ message, isStreaming = false, onRegenerate, onToolApproval, dimmed }: AssistantMessageProps) {
+function AssistantMessageImpl({ message, isStreaming = false, onRegenerate, onToolApproval, dimmed }: AssistantMessageProps) {
   return (
     <div className={`group/message flex flex-col items-start gap-1 ${dimmed ? "opacity-40" : ""}`}>
       <div className="w-full text-sm text-foreground">
@@ -266,3 +267,5 @@ export function AssistantMessage({ message, isStreaming = false, onRegenerate, o
     </div>
   );
 }
+
+export const AssistantMessage = memo(AssistantMessageImpl);

--- a/apps/extension/src/components/chat/ChatMessage.tsx
+++ b/apps/extension/src/components/chat/ChatMessage.tsx
@@ -1,26 +1,68 @@
 import type { AgentUIMessage } from "@/lib/types";
+import { memo, useCallback } from "react";
 import { AssistantMessage } from "./AssistantMessage";
 import { UserMessage } from "./UserMessage";
 
 interface ChatMessageProps {
   message: AgentUIMessage;
   isStreaming?: boolean;
-  onRegenerate?: () => void;
+  /**
+   * Stable, id-taking callbacks. The list passes a single stable function
+   * identity for all rows; this component binds `message.id` internally so
+   * the per-row closure only changes when this row actually re-renders.
+   * Combined with `React.memo`, this keeps settled rows from re-rendering
+   * when unrelated parent state (e.g. the chat input value) changes.
+   */
+  onRegenerate?: (id: string) => void;
+  onEdit?: (id: string) => void;
+  /**
+   * Capability flags gate whether the regenerate/edit affordances render.
+   * Passing booleans (instead of toggling the callback to `undefined`)
+   * keeps the callback identity stable across load/edit transitions.
+   */
+  canRegenerate?: boolean;
+  canEdit?: boolean;
   onToolApproval?: (opts: { id: string; approved: boolean }) => void;
-  onEdit?: () => void;
   dimmed?: boolean;
 }
 
-export function ChatMessage({ message, isStreaming, onRegenerate, onToolApproval, onEdit, dimmed }: ChatMessageProps) {
+function ChatMessageImpl({
+  message,
+  isStreaming,
+  onRegenerate,
+  onEdit,
+  canRegenerate,
+  canEdit,
+  onToolApproval,
+  dimmed,
+}: ChatMessageProps) {
+  const handleRegenerate = useCallback(() => {
+    onRegenerate?.(message.id);
+  }, [onRegenerate, message.id]);
+
+  const handleEdit = useCallback(() => {
+    onEdit?.(message.id);
+  }, [onEdit, message.id]);
+
   if (message.role === "system") return null;
-  if (message.role === "user") return <UserMessage message={message} onEdit={onEdit} dimmed={dimmed} />;
+  if (message.role === "user") {
+    return (
+      <UserMessage
+        message={message}
+        onEdit={canEdit && onEdit ? handleEdit : undefined}
+        dimmed={dimmed}
+      />
+    );
+  }
   return (
     <AssistantMessage
       message={message}
       isStreaming={isStreaming}
-      onRegenerate={onRegenerate}
+      onRegenerate={canRegenerate && onRegenerate ? handleRegenerate : undefined}
       onToolApproval={onToolApproval}
       dimmed={dimmed}
     />
   );
 }
+
+export const ChatMessage = memo(ChatMessageImpl);

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -3,9 +3,7 @@ import {
   type TabMentionAttrs,
   type Attachment,
 } from "./ChatInput";
-import { ChatMessage } from "./ChatMessage";
-import { CompactionDivider } from "./CompactionDivider";
-import { ExpandableText } from "./tool-results/expandable-text";
+import { MessageList } from "./MessageList";
 import {
   Conversation,
   ConversationContent,
@@ -41,16 +39,13 @@ import { openSettingsTab } from "@/lib/open-settings";
 import { cn } from "@/lib/utils";
 import { classifyFile } from "@/lib/vfs/file-classify";
 import {
-  AlertCircle,
   ArrowLeft,
-  ArrowRight,
   ArrowUp,
   FileText,
   HelpCircle,
   Link,
   MessageSquarePlus,
   Pencil,
-  RefreshCw,
   Settings2,
   Sparkles,
   X,
@@ -307,6 +302,15 @@ export function ChatView({
   >(null);
   const [preEditInput, setPreEditInput] = useState("");
 
+  // Mirror the latest input/messages into refs so the per-message
+  // callbacks (startEdit) can read them without listing them as deps.
+  // Keeping startEdit's identity stable across keystrokes is what lets
+  // the memoized <MessageList> skip re-rendering while the user types.
+  const inputRef = useRef(input);
+  inputRef.current = input;
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
   useEffect(() => {
     if (!isPopupMode) return;
     if (originUrl == null || originWindowId == null) return;
@@ -411,18 +415,18 @@ export function ChatView({
 
   const startEdit = useCallback(
     (messageId: string) => {
-      const msg = messages.find((m) => m.id === messageId);
+      const msg = messagesRef.current.find((m) => m.id === messageId);
       if (!msg) return;
       const text = msg.parts
         .filter((p) => p.type === "text")
         .map((p) => (p as { text: string }).text)
         .join("")
         .split("\n\n-----\n\n<Mentioned tabs>")[0];
-      setPreEditInput(input);
+      setPreEditInput(inputRef.current);
       setEditing({ kind: "sent", id: messageId });
       setInput(text);
     },
-    [messages, input, setInput],
+    [setInput],
   );
 
   const startEditQueued = useCallback(
@@ -586,81 +590,21 @@ export function ChatView({
                 </div>
               </div>
             )}
-            {messages.map((message, i) => {
-              // Compaction-user message: replace the bubble with a
-              // CompactionDivider. The next assistant message in the
-              // stream is the summary; we render its text inside the
-              // divider's expand panel.
-              const compactionPart = message.parts.find(
-                (p) => p.type === "data-compaction",
-              );
-              if (message.role === "user" && compactionPart) {
-                const next = messages[i + 1];
-                const summaryText =
-                  next?.role === "assistant"
-                    ? next.parts
-                        .filter((p) => p.type === "text")
-                        .map((p) => p.text)
-                        .join("\n")
-                        .trim()
-                    : "";
-                return (
-                  <CompactionDivider
-                    key={message.id}
-                    summary={summaryText}
-                    hiddenCount={i}
-                    auto={compactionPart.data.auto}
-                    overflow={compactionPart.data.overflow}
-                  />
-                );
-              }
-
-              // Assistant summary message: hide from the main chat. Its
-              // content is shown via the divider's expand toggle. We
-              // detect it structurally — the previous message is a
-              // compaction-user.
-              const prev = messages[i - 1];
-              const prevIsCompactionUser =
-                prev?.role === "user" &&
-                prev.parts.some((p) => p.type === "data-compaction");
-              if (message.role === "assistant" && prevIsCompactionUser) {
-                return null;
-              }
-
-              const isLastAssistant =
-                message.role === "assistant" &&
-                isStreaming &&
-                !messages.slice(i + 1).some((m) => m.role === "assistant");
-              const isDimmed = editingIndex !== -1 && i >= editingIndex;
-              return (
-                 <ChatMessage
-                  key={message.id}
-                  message={message}
-                  isStreaming={isLastAssistant}
-                  dimmed={isDimmed}
-                  onRegenerate={
-                    message.role === "assistant" &&
-                    !isLoading &&
-                    !isEditing
-                      ? () => handleRegenerate(message.id)
-                      : undefined
-                  }
-                  onToolApproval={addToolApprovalResponse}
-                  onEdit={
-                    message.role === "user" && !isLoading && !isEditing
-                      ? () => startEdit(message.id)
-                      : undefined
-                  }
-                />
-              );
-            })}
-            {showThinking && <ThinkingIndicator />}
-            {error && (
-              <ErrorMessage
+            {(messages.length > 0 || showThinking || error) && (
+              <MessageList
+                messages={messages}
+                isStreaming={isStreaming}
+                isLoading={isLoading}
+                isEditing={isEditing}
+                editingIndex={editingIndex}
+                showThinking={showThinking}
                 error={error}
+                onRegenerate={handleRegenerate}
+                onEdit={startEdit}
+                onToolApproval={addToolApprovalResponse}
                 onRetry={handleRetry}
                 onContinue={handleContinue}
-                onDismiss={clearError}
+                onDismissError={clearError}
               />
             )}
           </div>
@@ -873,81 +817,3 @@ export function ChatView({
   );
 }
 
-function ThinkingIndicator() {
-  return (
-    <div className="flex justify-start">
-      <div className="rounded-lg px-3 py-2 bg-muted">
-        <div className="flex items-center gap-1">
-          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse" />
-          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse [animation-delay:150ms]" />
-          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse [animation-delay:300ms]" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ErrorMessage({
-  error,
-  onRetry,
-  onContinue,
-  onDismiss,
-}: {
-  error: Error;
-  onRetry: () => void;
-  onContinue: () => void;
-  onDismiss: () => void;
-}) {
-  return (
-    <div className="flex justify-start">
-      <div className="max-w-[85%] rounded-lg px-3 py-2 text-sm border border-destructive/30 bg-destructive/5">
-        <div className="flex items-start gap-2">
-          <AlertCircle className="size-3.5 text-destructive shrink-0 mt-0.5" />
-          <div className="min-w-0">
-            <p className="text-xs text-destructive font-medium">
-              Something went wrong
-            </p>
-            {/*
-              * Provider SDK errors can carry full request payloads,
-              * stack traces, or upstream HTML responses — easily
-              * dozens of visual lines. Clamp to ~10 visual lines with
-              * an inline expand toggle. `font-sans` overrides
-              * ExpandableText's <pre> default so the banner keeps the
-              * surrounding chat font; `text-muted-foreground` and
-              * `break-words` reproduce the previous styling.
-              */}
-            <ExpandableText
-              text={error.message}
-              className="text-xs text-muted-foreground mt-0.5 break-words font-sans"
-            />
-            <div className="flex items-center gap-2 mt-1.5">
-              <button
-                type="button"
-                onClick={onRetry}
-                className="flex items-center gap-1 text-xs text-primary hover:underline"
-              >
-                <RefreshCw className="size-3" />
-                Retry
-              </button>
-              <button
-                type="button"
-                onClick={onContinue}
-                className="flex items-center gap-1 text-xs text-primary hover:underline"
-              >
-                <ArrowRight className="size-3" />
-                Continue
-              </button>
-              <button
-                type="button"
-                onClick={onDismiss}
-                className="text-xs text-muted-foreground hover:text-foreground"
-              >
-                Dismiss
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/apps/extension/src/components/chat/MessageList.tsx
+++ b/apps/extension/src/components/chat/MessageList.tsx
@@ -1,0 +1,209 @@
+import { memo } from "react";
+import type { AgentUIMessage } from "@/lib/types";
+import { ChatMessage } from "./ChatMessage";
+import { CompactionDivider } from "./CompactionDivider";
+import { ExpandableText } from "./tool-results/expandable-text";
+import {
+  AlertCircle,
+  ArrowRight,
+  RefreshCw,
+} from "lucide-react";
+
+interface MessageListProps {
+  messages: AgentUIMessage[];
+  isStreaming: boolean;
+  isLoading: boolean;
+  isEditing: boolean;
+  /** Index of the message being edited (sent edits), or -1. Rows at and
+   *  below this index are dimmed. */
+  editingIndex: number;
+  showThinking: boolean;
+  error: Error | null | undefined;
+  /** Stable, id-taking callbacks (see ChatMessage). */
+  onRegenerate: (id: string) => void;
+  onEdit: (id: string) => void;
+  onToolApproval: (opts: { id: string; approved: boolean }) => void;
+  onRetry: () => void;
+  onContinue: () => void;
+  onDismissError: () => void;
+}
+
+/**
+ * Renders the transcript. Extracted from ChatView and memoized so that
+ * unrelated ChatView state changes — most importantly every keystroke in
+ * the chat input — do not re-render the (potentially large, markdown- and
+ * syntax-highlight-heavy) message list. The component intentionally takes
+ * NO `input`/draft state; its props only change on genuine transcript or
+ * load/edit/stream transitions.
+ */
+function MessageListImpl({
+  messages,
+  isStreaming,
+  isLoading,
+  isEditing,
+  editingIndex,
+  showThinking,
+  error,
+  onRegenerate,
+  onEdit,
+  onToolApproval,
+  onRetry,
+  onContinue,
+  onDismissError,
+}: MessageListProps) {
+  const canAct = !isLoading && !isEditing;
+  return (
+    <>
+      {messages.map((message, i) => {
+        // Compaction-user message: replace the bubble with a
+        // CompactionDivider. The next assistant message in the
+        // stream is the summary; we render its text inside the
+        // divider's expand panel.
+        const compactionPart = message.parts.find(
+          (p) => p.type === "data-compaction",
+        );
+        if (message.role === "user" && compactionPart) {
+          const next = messages[i + 1];
+          const summaryText =
+            next?.role === "assistant"
+              ? next.parts
+                  .filter((p) => p.type === "text")
+                  .map((p) => p.text)
+                  .join("\n")
+                  .trim()
+              : "";
+          return (
+            <CompactionDivider
+              key={message.id}
+              summary={summaryText}
+              hiddenCount={i}
+              auto={compactionPart.data.auto}
+              overflow={compactionPart.data.overflow}
+            />
+          );
+        }
+
+        // Assistant summary message: hide from the main chat. Its
+        // content is shown via the divider's expand toggle. We
+        // detect it structurally — the previous message is a
+        // compaction-user.
+        const prev = messages[i - 1];
+        const prevIsCompactionUser =
+          prev?.role === "user" &&
+          prev.parts.some((p) => p.type === "data-compaction");
+        if (message.role === "assistant" && prevIsCompactionUser) {
+          return null;
+        }
+
+        const isLastAssistant =
+          message.role === "assistant" &&
+          isStreaming &&
+          !messages.slice(i + 1).some((m) => m.role === "assistant");
+        const isDimmed = editingIndex !== -1 && i >= editingIndex;
+        return (
+          <ChatMessage
+            key={message.id}
+            message={message}
+            isStreaming={isLastAssistant}
+            dimmed={isDimmed}
+            onRegenerate={onRegenerate}
+            canRegenerate={message.role === "assistant" && canAct}
+            onToolApproval={onToolApproval}
+            onEdit={onEdit}
+            canEdit={message.role === "user" && canAct}
+          />
+        );
+      })}
+      {showThinking && <ThinkingIndicator />}
+      {error && (
+        <ErrorMessage
+          error={error}
+          onRetry={onRetry}
+          onContinue={onContinue}
+          onDismiss={onDismissError}
+        />
+      )}
+    </>
+  );
+}
+
+export const MessageList = memo(MessageListImpl);
+
+function ThinkingIndicator() {
+  return (
+    <div className="flex justify-start">
+      <div className="rounded-lg px-3 py-2 bg-muted">
+        <div className="flex items-center gap-1">
+          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse" />
+          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse [animation-delay:150ms]" />
+          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse [animation-delay:300ms]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ErrorMessage({
+  error,
+  onRetry,
+  onContinue,
+  onDismiss,
+}: {
+  error: Error;
+  onRetry: () => void;
+  onContinue: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] rounded-lg px-3 py-2 text-sm border border-destructive/30 bg-destructive/5">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="size-3.5 text-destructive shrink-0 mt-0.5" />
+          <div className="min-w-0">
+            <p className="text-xs text-destructive font-medium">
+              Something went wrong
+            </p>
+            {/*
+              * Provider SDK errors can carry full request payloads,
+              * stack traces, or upstream HTML responses — easily
+              * dozens of visual lines. Clamp to ~10 visual lines with
+              * an inline expand toggle. `font-sans` overrides
+              * ExpandableText's <pre> default so the banner keeps the
+              * surrounding chat font; `text-muted-foreground` and
+              * `break-words` reproduce the previous styling.
+              */}
+            <ExpandableText
+              text={error.message}
+              className="text-xs text-muted-foreground mt-0.5 break-words font-sans"
+            />
+            <div className="flex items-center gap-2 mt-1.5">
+              <button
+                type="button"
+                onClick={onRetry}
+                className="flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <RefreshCw className="size-3" />
+                Retry
+              </button>
+              <button
+                type="button"
+                onClick={onContinue}
+                className="flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <ArrowRight className="size-3" />
+                Continue
+              </button>
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/extension/src/components/chat/UserMessage.tsx
+++ b/apps/extension/src/components/chat/UserMessage.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 import { Check, Copy, Pencil } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, memo } from "react";
 import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
 import { classifyFile } from "@/lib/vfs/file-classify";
 import { getTypeBadge } from "@/lib/chat/attachment-meta";
@@ -19,7 +19,7 @@ interface UserMessageProps {
   dimmed?: boolean;
 }
 
-export function UserMessage({ message, onEdit, dimmed }: UserMessageProps) {
+function UserMessageImpl({ message, onEdit, dimmed }: UserMessageProps) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const onSelectFile = useFileSelection();
@@ -173,3 +173,5 @@ export function UserMessage({ message, onEdit, dimmed }: UserMessageProps) {
     </div>
   );
 }
+
+export const UserMessage = memo(UserMessageImpl);


### PR DESCRIPTION
## Problem

Typing in the chat input lags in long conversations. Input state lives in `useAgentChat` and is consumed by `ChatView`, which renders the whole transcript inline via `messages.map(...)`. Every keystroke triggers `setInput` → `ChatView` re-render → re-runs the map → re-renders **every** message. Each assistant message runs Streamdown + Shiki syntax highlighting, so cost scales with message count.

## Fix

Stop re-rendering the transcript on keystrokes:

- **`MessageList` (new, `React.memo`)** — extracts the `messages.map(...)` block (plus thinking/error rows) out of `ChatView`. It takes **no input/draft state**, so keystroke-driven `ChatView` re-renders skip the whole subtree.
- **`ChatMessage` / `AssistantMessage` / `UserMessage`** — wrapped in `React.memo` so settled messages don't re-render.
- **Stable callbacks** — pass id-based `onRegenerate(id)`/`onEdit(id)` + `canRegenerate`/`canEdit` booleans instead of per-row inline closures; `startEdit` reads `input`/`messages` from refs so its identity stays stable across keystrokes.

Render logic moved verbatim — same compaction-divider handling, dimming, and regenerate/edit gating (`!isLoading && !isEditing`).

## Verification

- `tsc --noEmit` clean
- 583/583 extension tests pass

Virtualization was intentionally deferred; revisit only if lag persists at extreme message counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat input lag in long conversations by optimizing message list rendering to prevent unnecessary re-renders when typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->