### PR TITLE
feat(extension): add context usage indicator to chat header

### DIFF
--- a/.changeset/context-usage-indicator.md
+++ b/.changeset/context-usage-indicator.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": minor
+---
+
+Add a context-usage indicator to the chat header: a circular progress ring that shows tokens, usage %, and cost on hover, and a detailed breakdown (provider/model, context limit, token split, total cost, timestamps) on click.

--- a/apps/extension/src/components/chat/ContextUsage.tsx
+++ b/apps/extension/src/components/chat/ContextUsage.tsx
@@ -188,22 +188,29 @@ export function ContextUsage({ conversationId }: { conversationId: string }) {
   useEffect(() => {
     let mounted = true;
     async function refresh() {
-      const [conv, messages] = await Promise.all([
-        chatDb.getConversation(conversationId),
-        chatDb.getMessages(conversationId),
-      ]);
-      if (!mounted) return;
-      if (!conv?.usage) {
-        setSnapshot(null);
-        return;
+      try {
+        const [conv, messageCount] = await Promise.all([
+          chatDb.getConversation(conversationId),
+          chatDb.getMessageCount(conversationId),
+        ]);
+        if (!mounted) return;
+        if (!conv?.usage) {
+          setSnapshot(null);
+          return;
+        }
+        setSnapshot({
+          usage: conv.usage,
+          title: conv.title,
+          createdAt: conv.createdAt,
+          updatedAt: conv.updatedAt,
+          messageCount,
+        });
+      } catch (err) {
+        // Transient DB error: keep the last-good snapshot rather than
+        // blanking the indicator, and don't let the rejection bubble out
+        // of the interval. The next tick retries.
+        console.error("[context-usage] failed to read usage:", err);
       }
-      setSnapshot({
-        usage: conv.usage,
-        title: conv.title,
-        createdAt: conv.createdAt,
-        updatedAt: conv.updatedAt,
-        messageCount: messages.length,
-      });
     }
     refresh();
     const interval = setInterval(refresh, 1000);

--- a/apps/extension/src/components/chat/ContextUsage.tsx
+++ b/apps/extension/src/components/chat/ContextUsage.tsx
@@ -1,0 +1,299 @@
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { chatDb } from "@/lib/chat-db";
+import type { ConversationUsage } from "@/lib/types";
+import { getProvider } from "@/registry/providers";
+import { useEffect, useState } from "react";
+
+const tokenFmt = new Intl.NumberFormat(undefined);
+const costFmt = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+const dateFmt = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+/** Grouped exact token count, e.g. 53731 -> "53,731". */
+export function formatTokens(tokens: number): string {
+  return tokenFmt.format(tokens);
+}
+
+/** Grouped exact count (e.g. message counts). Alias of the same number format. */
+export function formatCount(count: number): string {
+  return tokenFmt.format(count);
+}
+
+/** Whole-number percent of context window used, clamped to 0–100; 0 when window is unknown. */
+export function usagePercentValue(
+  totalTokens: number,
+  contextWindow: number,
+): number {
+  if (!contextWindow || contextWindow <= 0) return 0;
+  // totalTokens (input+output of the latest step) can exceed the input-only
+  // contextWindow when output is large; clamp the ceiling at 100.
+  return Math.min(100, Math.round((totalTokens / contextWindow) * 100));
+}
+
+/** Whole-number percent of context window used (clamped to 100); 0% when window is unknown. */
+export function formatUsagePercent(
+  totalTokens: number,
+  contextWindow: number,
+): string {
+  return `${usagePercentValue(totalTokens, contextWindow)}%`;
+}
+
+/**
+ * USD currency, e.g. 73.48 -> "$73.48". A positive cost that would round
+ * to "$0.00" at cent precision is shown as "<$0.01" so a real (tiny) spend
+ * never reads as free.
+ */
+export function formatCost(costUsd: number): string {
+  if (costUsd > 0 && costUsd < 0.005) return "<$0.01";
+  return costFmt.format(costUsd);
+}
+
+/** Localized date+time, e.g. "May 26, 2026, 6:23 PM". Empty string for falsy input. */
+export function formatDateTime(ms: number): string {
+  if (!ms) return "";
+  return dateFmt.format(new Date(ms));
+}
+
+/**
+ * Resolve human-readable provider and model display names from the
+ * persisted qualified model id ("provider:model"). Falls back to the raw
+ * segments when the id can't be matched against the registry (e.g. a model
+ * that was removed from the catalog), so the popover never shows blanks.
+ */
+export function resolveModelNames(modelId: string): {
+  providerName: string;
+  modelName: string;
+} {
+  if (!modelId) return { providerName: "—", modelName: "—" };
+  const [providerId, ...rest] = modelId.split(":");
+  const actualModelId = rest.length > 0 ? rest.join(":") : modelId;
+  const provider = rest.length > 0 ? getProvider(providerId) : undefined;
+  const model = provider?.models.find((m) => m.id === actualModelId);
+  return {
+    providerName: provider?.name ?? providerId,
+    modelName: model?.name ?? actualModelId,
+  };
+}
+
+/**
+ * Resolve a combined provider + model label across every model used in the
+ * conversation. Falls back to the single latest `modelId` when the list is
+ * empty (snapshots written before `modelIds` existed). Distinct provider
+ * names are joined with ", "; model names are joined with ", " in first-seen
+ * order, so a multi-model conversation reads e.g. "Claude Opus 4.8, GPT-4".
+ */
+export function resolveModelsLabel(
+  modelIds: string[] | undefined,
+  latestModelId: string,
+): { providerLabel: string; modelLabel: string } {
+  const ids =
+    modelIds && modelIds.length > 0
+      ? modelIds
+      : latestModelId
+        ? [latestModelId]
+        : [];
+  if (ids.length === 0) return { providerLabel: "—", modelLabel: "—" };
+
+  const resolved = ids.map(resolveModelNames);
+  const providers: string[] = [];
+  for (const r of resolved) {
+    if (!providers.includes(r.providerName)) providers.push(r.providerName);
+  }
+  return {
+    providerLabel: providers.join(", "),
+    modelLabel: resolved.map((r) => r.modelName).join(", "),
+  };
+}
+
+/**
+ * Circular progress ring (no label). The arc fills proportionally to
+ * `percent` (0–100), starting at the top. Uses `currentColor` so it
+ * inherits the trigger button's theme color.
+ */
+function ContextRing({ percent }: { percent: number }) {
+  const radius = 9;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - Math.min(100, Math.max(0, percent)) / 100);
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-4 -rotate-90"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r={radius}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        className="opacity-20"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r={radius}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+      />
+    </svg>
+  );
+}
+
+/** One label/value cell in the detail grid. */
+function DetailCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-medium break-words">{value}</div>
+    </div>
+  );
+}
+
+/** Snapshot of the conversation fields the indicator displays. */
+interface ConvSnapshot {
+  usage: ConversationUsage;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messageCount: number;
+}
+
+/**
+ * Header context-usage indicator. Polls the conversation row every 1s
+ * (mirroring CoworkPanel's ContextCard). The ring trigger shows a compact
+ * Tokens / Usage% / Cost tooltip on hover and opens a detailed popover on
+ * click. Renders nothing until usage exists.
+ */
+export function ContextUsage({ conversationId }: { conversationId: string }) {
+  const [snapshot, setSnapshot] = useState<ConvSnapshot | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    async function refresh() {
+      const [conv, messages] = await Promise.all([
+        chatDb.getConversation(conversationId),
+        chatDb.getMessages(conversationId),
+      ]);
+      if (!mounted) return;
+      if (!conv?.usage) {
+        setSnapshot(null);
+        return;
+      }
+      setSnapshot({
+        usage: conv.usage,
+        title: conv.title,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+        messageCount: messages.length,
+      });
+    }
+    refresh();
+    const interval = setInterval(refresh, 1000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [conversationId]);
+
+  if (!snapshot) return null;
+
+  const { usage, title, createdAt, updatedAt, messageCount } = snapshot;
+  const showCost = usage.costUsd > 0;
+  const { providerLabel, modelLabel } = resolveModelsLabel(
+    usage.modelIds,
+    usage.modelId,
+  );
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Context usage"
+            >
+              <ContextRing
+                percent={usagePercentValue(usage.totalTokens, usage.contextWindow)}
+              />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent align="end">
+          <dl className="space-y-1">
+            <div className="flex items-center justify-between gap-4">
+              <dd className="order-1 font-medium">
+                {formatTokens(usage.totalTokens)}
+              </dd>
+              <dt className="order-2 opacity-70">Tokens</dt>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dd className="order-1 font-medium">
+                {formatUsagePercent(usage.totalTokens, usage.contextWindow)}
+              </dd>
+              <dt className="order-2 opacity-70">Usage</dt>
+            </div>
+            {showCost && (
+              <div className="flex items-center justify-between gap-4">
+                <dd className="order-1 font-medium">
+                  {formatCost(usage.costUsd)}
+                </dd>
+                <dt className="order-2 opacity-70">Cost</dt>
+              </div>
+            )}
+          </dl>
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent align="end" className="w-80 p-3">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-3 text-xs">
+          <DetailCell label="Session" value={title || "Untitled"} />
+          <DetailCell label="Messages" value={formatCount(messageCount)} />
+          <DetailCell label="Provider" value={providerLabel} />
+          <DetailCell label="Model" value={modelLabel} />
+          <DetailCell
+            label="Context Limit"
+            value={formatTokens(usage.contextWindow)}
+          />
+          <DetailCell
+            label="Total Tokens"
+            value={formatTokens(usage.totalTokens)}
+          />
+          <DetailCell
+            label="Usage"
+            value={formatUsagePercent(usage.totalTokens, usage.contextWindow)}
+          />
+          <DetailCell
+            label="Input Tokens"
+            value={formatTokens(usage.inputTokens)}
+          />
+          <DetailCell
+            label="Output Tokens"
+            value={formatTokens(usage.outputTokens)}
+          />
+          <DetailCell label="Total Cost" value={formatCost(usage.costUsd)} />
+          <DetailCell label="Session Created" value={formatDateTime(createdAt)} />
+          <DetailCell label="Last Activity" value={formatDateTime(updatedAt)} />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/extension/src/components/chat/__tests__/context-usage.test.ts
+++ b/apps/extension/src/components/chat/__tests__/context-usage.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTokens,
+  formatCount,
+  formatUsagePercent,
+  formatCost,
+  formatDateTime,
+  resolveModelNames,
+  resolveModelsLabel,
+  usagePercentValue,
+} from "../ContextUsage";
+
+describe("ContextUsage formatters", () => {
+  it("formats token counts with grouping", () => {
+    expect(formatTokens(53_731)).toBe("53,731");
+    expect(formatTokens(0)).toBe("0");
+    expect(formatTokens(842)).toBe("842");
+  });
+
+  it("formats usage percent, guarding divide-by-zero", () => {
+    expect(formatUsagePercent(10_000, 200_000)).toBe("5%");
+    expect(formatUsagePercent(0, 200_000)).toBe("0%");
+    expect(formatUsagePercent(1_000, 0)).toBe("0%");
+    // rounds to nearest integer
+    expect(formatUsagePercent(7_500, 200_000)).toBe("4%");
+    // clamps the display ceiling at 100% when total exceeds the window
+    expect(formatUsagePercent(250_000, 200_000)).toBe("100%");
+  });
+
+  it("computes the numeric usage percent for the ring", () => {
+    expect(usagePercentValue(10_000, 200_000)).toBe(5);
+    expect(usagePercentValue(0, 200_000)).toBe(0);
+    expect(usagePercentValue(1_000, 0)).toBe(0);
+    // rounds to nearest integer
+    expect(usagePercentValue(7_500, 200_000)).toBe(4);
+    // clamps the ceiling at 100
+    expect(usagePercentValue(250_000, 200_000)).toBe(100);
+  });
+
+  it("formats counts with grouping", () => {
+    expect(formatCount(2)).toBe("2");
+    expect(formatCount(1_234)).toBe("1,234");
+  });
+
+  it("formats cost as USD currency", () => {
+    expect(formatCost(73.48)).toBe("$73.48");
+    expect(formatCost(0)).toBe("$0.00");
+    expect(formatCost(1.5)).toBe("$1.50");
+    // A positive sub-cent cost never reads as free.
+    expect(formatCost(0.0003)).toBe("<$0.01");
+    expect(formatCost(0.004)).toBe("<$0.01");
+    // At/above half a cent it rounds normally.
+    expect(formatCost(0.005)).toBe("$0.01");
+  });
+
+  it("formats a date+time, returning empty string for falsy input", () => {
+    expect(formatDateTime(0)).toBe("");
+    // A real timestamp produces a non-empty localized string containing the year.
+    const formatted = formatDateTime(Date.UTC(2026, 4, 26, 18, 23));
+    expect(formatted).not.toBe("");
+    expect(formatted).toContain("2026");
+  });
+
+  it("resolves model names, falling back to raw segments", () => {
+    // Empty id → placeholder dashes.
+    expect(resolveModelNames("")).toEqual({
+      providerName: "—",
+      modelName: "—",
+    });
+    // Unknown qualified id → raw provider + model segments preserved.
+    expect(resolveModelNames("madeup:some-model-x")).toEqual({
+      providerName: "madeup",
+      modelName: "some-model-x",
+    });
+    // Model id containing extra colons is rejoined for the model segment.
+    expect(resolveModelNames("madeup:a:b:c")).toEqual({
+      providerName: "madeup",
+      modelName: "a:b:c",
+    });
+    // Bare id with no provider segment → used as the model name.
+    expect(resolveModelNames("bare-model")).toEqual({
+      providerName: "bare-model",
+      modelName: "bare-model",
+    });
+  });
+
+  it("resolves a combined label across all models used", () => {
+    // Empty list + no latest → placeholder dashes.
+    expect(resolveModelsLabel([], "")).toEqual({
+      providerLabel: "—",
+      modelLabel: "—",
+    });
+    // Empty list falls back to the single latest model id.
+    expect(resolveModelsLabel(undefined, "p1:model-a")).toEqual({
+      providerLabel: "p1",
+      modelLabel: "model-a",
+    });
+    // Multiple models across distinct providers — joined in order.
+    expect(
+      resolveModelsLabel(["p1:model-a", "p2:model-b"], "p2:model-b"),
+    ).toEqual({
+      providerLabel: "p1, p2",
+      modelLabel: "model-a, model-b",
+    });
+    // Two models from the SAME provider — provider listed once, both models shown.
+    expect(
+      resolveModelsLabel(["p1:model-a", "p1:model-b"], "p1:model-b"),
+    ).toEqual({
+      providerLabel: "p1",
+      modelLabel: "model-a, model-b",
+    });
+  });
+});

--- a/apps/extension/src/components/chat/__tests__/context-usage.test.ts
+++ b/apps/extension/src/components/chat/__tests__/context-usage.test.ts
@@ -10,11 +10,20 @@ import {
   usagePercentValue,
 } from "../ContextUsage";
 
+// Compute expected strings with the SAME runtime locale formatters the
+// component uses, so number/currency assertions are stable regardless of the
+// CI locale.
+const numFmt = new Intl.NumberFormat(undefined);
+const usdFmt = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+
 describe("ContextUsage formatters", () => {
   it("formats token counts with grouping", () => {
-    expect(formatTokens(53_731)).toBe("53,731");
-    expect(formatTokens(0)).toBe("0");
-    expect(formatTokens(842)).toBe("842");
+    expect(formatTokens(53_731)).toBe(numFmt.format(53_731));
+    expect(formatTokens(0)).toBe(numFmt.format(0));
+    expect(formatTokens(842)).toBe(numFmt.format(842));
   });
 
   it("formats usage percent, guarding divide-by-zero", () => {
@@ -38,19 +47,19 @@ describe("ContextUsage formatters", () => {
   });
 
   it("formats counts with grouping", () => {
-    expect(formatCount(2)).toBe("2");
-    expect(formatCount(1_234)).toBe("1,234");
+    expect(formatCount(2)).toBe(numFmt.format(2));
+    expect(formatCount(1_234)).toBe(numFmt.format(1_234));
   });
 
   it("formats cost as USD currency", () => {
-    expect(formatCost(73.48)).toBe("$73.48");
-    expect(formatCost(0)).toBe("$0.00");
-    expect(formatCost(1.5)).toBe("$1.50");
-    // A positive sub-cent cost never reads as free.
+    expect(formatCost(73.48)).toBe(usdFmt.format(73.48));
+    expect(formatCost(0)).toBe(usdFmt.format(0));
+    expect(formatCost(1.5)).toBe(usdFmt.format(1.5));
+    // A positive sub-cent cost never reads as free (our own sentinel string).
     expect(formatCost(0.0003)).toBe("<$0.01");
     expect(formatCost(0.004)).toBe("<$0.01");
     // At/above half a cent it rounds normally.
-    expect(formatCost(0.005)).toBe("$0.01");
+    expect(formatCost(0.005)).toBe(usdFmt.format(0.005));
   });
 
   it("formats a date+time, returning empty string for falsy input", () => {

--- a/apps/extension/src/entrypoints/home/App.tsx
+++ b/apps/extension/src/entrypoints/home/App.tsx
@@ -1,5 +1,6 @@
 import { formatMessageAsMarkdown } from "@/lib/format-markdown";
 import { ChatView } from "@/components/chat/ChatView";
+import { ContextUsage } from "@/components/chat/ContextUsage";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,7 +41,7 @@ import { storage } from "@/lib/storage";
 import type { Space } from "@/lib/types";
 import {
   Download,
-  MoreVertical,
+  Ellipsis,
   PanelRight,
   Pencil,
   Trash2,
@@ -433,13 +434,14 @@ export default function App() {
                   {conversationTitle ?? "New conversation"}
                 </span>
                 <div className="flex items-center gap-1">
+                  <ContextUsage conversationId={activeConversationId} />
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <button
                         type="button"
                         className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
                       >
-                        <MoreVertical className="size-4" />
+                        <Ellipsis className="size-4" />
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">

--- a/apps/extension/src/lib/agent/__tests__/usage-snapshot.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/usage-snapshot.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { nextUsageSnapshot } from "../usage-snapshot";
+import type { ModelDefinition } from "@/registry/providers/types";
+
+const model: ModelDefinition = {
+  id: "claude-x",
+  name: "Claude X",
+  capabilities: ["chat"],
+  contextWindow: 200_000,
+  pricing: { inputPer1M: 3, outputPer1M: 15 },
+};
+
+const modelNoPricing: ModelDefinition = {
+  id: "local-x",
+  name: "Local X",
+  capabilities: ["chat"],
+  contextWindow: 8_192,
+};
+
+describe("nextUsageSnapshot", () => {
+  it("computes totals and cost from the first step", () => {
+    const next = nextUsageSnapshot(
+      undefined,
+      { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      model,
+      "anthropic:claude-x",
+      123,
+    );
+    expect(next.inputTokens).toBe(1_000_000);
+    expect(next.outputTokens).toBe(1_000_000);
+    expect(next.totalTokens).toBe(2_000_000);
+    // 1M input * $3 + 1M output * $15 = $18
+    expect(next.costUsd).toBeCloseTo(18, 6);
+    expect(next.contextWindow).toBe(200_000);
+    expect(next.modelId).toBe("anthropic:claude-x");
+    expect(next.updatedAt).toBe(123);
+  });
+
+  it("overwrites totalTokens but accumulates cost across steps", () => {
+    const first = nextUsageSnapshot(
+      undefined,
+      { inputTokens: 1_000_000, outputTokens: 0 },
+      model,
+      "anthropic:claude-x",
+      1,
+    );
+    // first cost = 1M * $3 = $3
+    expect(first.costUsd).toBeCloseTo(3, 6);
+
+    const second = nextUsageSnapshot(
+      first,
+      { inputTokens: 2_000_000, outputTokens: 1_000_000 },
+      model,
+      "anthropic:claude-x",
+      2,
+    );
+    // totalTokens overwrites: 2M + 1M = 3M (NOT added to the prior 1M)
+    expect(second.totalTokens).toBe(3_000_000);
+    // cost accumulates: $3 + (2M*$3 + 1M*$15) = $3 + $21 = $24
+    expect(second.costUsd).toBeCloseTo(24, 6);
+  });
+
+  it("treats missing token fields as zero", () => {
+    const next = nextUsageSnapshot(
+      undefined,
+      { inputTokens: undefined, outputTokens: undefined },
+      model,
+      "anthropic:claude-x",
+      5,
+    );
+    expect(next.inputTokens).toBe(0);
+    expect(next.outputTokens).toBe(0);
+    expect(next.totalTokens).toBe(0);
+    expect(next.costUsd).toBe(0);
+  });
+
+  it("adds zero cost when the model has no pricing", () => {
+    const first = nextUsageSnapshot(
+      undefined,
+      { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      modelNoPricing,
+      "local:local-x",
+      1,
+    );
+    expect(first.costUsd).toBe(0);
+    const second = nextUsageSnapshot(
+      first,
+      { inputTokens: 1_000_000, outputTokens: 0 },
+      modelNoPricing,
+      "local:local-x",
+      2,
+    );
+    expect(second.costUsd).toBe(0);
+    expect(second.totalTokens).toBe(1_000_000);
+  });
+
+  it("falls back to 0 contextWindow when the model omits it", () => {
+    const next = nextUsageSnapshot(
+      undefined,
+      { inputTokens: 10, outputTokens: 10 },
+      { id: "m", name: "M", capabilities: ["chat"] },
+      "p:m",
+      1,
+    );
+    expect(next.contextWindow).toBe(0);
+  });
+
+  it("accumulates distinct model ids in first-seen order", () => {
+    const first = nextUsageSnapshot(
+      undefined,
+      { inputTokens: 10, outputTokens: 10 },
+      model,
+      "anthropic:claude-x",
+      1,
+    );
+    expect(first.modelIds).toEqual(["anthropic:claude-x"]);
+
+    // Same model again — no duplicate.
+    const second = nextUsageSnapshot(
+      first,
+      { inputTokens: 10, outputTokens: 10 },
+      model,
+      "anthropic:claude-x",
+      2,
+    );
+    expect(second.modelIds).toEqual(["anthropic:claude-x"]);
+
+    // New model — appended after the first.
+    const third = nextUsageSnapshot(
+      second,
+      { inputTokens: 10, outputTokens: 10 },
+      model,
+      "openai:gpt-x",
+      3,
+    );
+    expect(third.modelIds).toEqual(["anthropic:claude-x", "openai:gpt-x"]);
+    expect(third.modelId).toBe("openai:gpt-x");
+  });
+
+  it("never adds an empty model id to the list", () => {
+    const next = nextUsageSnapshot(
+      undefined,
+      { inputTokens: 10, outputTokens: 10 },
+      model,
+      "",
+      1,
+    );
+    expect(next.modelIds).toEqual([]);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/usage-snapshot.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/usage-snapshot.test.ts
@@ -147,4 +147,37 @@ describe("nextUsageSnapshot", () => {
     );
     expect(next.modelIds).toEqual([]);
   });
+
+  it("carries a legacy prev.modelId into modelIds when the list is absent", () => {
+    // Simulate a snapshot written before `modelIds` existed: it has a
+    // single `modelId` but no `modelIds` array.
+    const legacy = {
+      inputTokens: 10,
+      outputTokens: 10,
+      totalTokens: 20,
+      costUsd: 1,
+      contextWindow: 200_000,
+      modelId: "anthropic:claude-x",
+      updatedAt: 1,
+    };
+    const next = nextUsageSnapshot(
+      legacy,
+      { inputTokens: 10, outputTokens: 10 },
+      model,
+      "openai:gpt-x",
+      2,
+    );
+    // The legacy model is preserved first, then the new one appended.
+    expect(next.modelIds).toEqual(["anthropic:claude-x", "openai:gpt-x"]);
+
+    // When the legacy model matches the current one, no duplicate.
+    const same = nextUsageSnapshot(
+      legacy,
+      { inputTokens: 10, outputTokens: 10 },
+      model,
+      "anthropic:claude-x",
+      3,
+    );
+    expect(same.modelIds).toEqual(["anthropic:claude-x"]);
+  });
 });

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -1102,6 +1102,11 @@ export async function createAgentTransport(
 
   if (!provider) return null;
 
+  // Normalized "<providerId>:<modelId>" key. `agentModel` may be a legacy
+  // flat id (no provider segment); this always yields a qualified key so the
+  // persisted ConversationUsage.modelId is consistent and resolvable.
+  const qualifiedModelId = `${provider.id}:${actualModelId}`;
+
   const config = settings.providerConfigs[provider.id] ?? {};
   const requiredFields = provider.configSchema?.filter((f) => f.required) ?? [];
   if (!requiredFields.every((f) => !!config[f.key])) return null;
@@ -1670,7 +1675,7 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
       void recordUsageForStep(agentConversationId, {
         inputTokens: usage.inputTokens,
         outputTokens: usage.outputTokens,
-      }, modelDef, agentModel);
+      }, modelDef, qualifiedModelId);
     },
     stopWhen: () => needsMidStreamCompaction,
   });

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -18,6 +18,7 @@ import type { AgentUIMessage, Settings } from "../types";
 import { shouldCompact } from "./compaction";
 import { CompactingChatTransport } from "./compacting-transport";
 import { scanToolUsage, mergeDistinct } from "./tool-usage";
+import { nextUsageSnapshot, type StepUsage } from "./usage-snapshot";
 import { ExtensionDriver } from "./driver/extension-driver";
 import type { ToolContext } from "./driver";
 import type {
@@ -1012,6 +1013,65 @@ async function recordToolUsageForStep(
   }
 }
 
+/**
+ * Persist a token/cost usage snapshot onto the conversation row at
+ * step-finish time, so the header Context popover can read it live.
+ *
+ * Serialized through the same per-conversation `usageWriteQueues` chain as
+ * `recordToolUsageForStep` so the read-modify-write (needed to accumulate
+ * `costUsd`) can't race other usage writes for the same conversation.
+ * Best-effort; failures are swallowed and never disrupt the agent loop.
+ *
+ * `modelId` is the fully-qualified user-facing model key (provider:model,
+ * e.g. "anthropic:claude-x") and `model` is its `ModelDefinition` (for
+ * contextWindow + pricing). Both are passed by the caller from the
+ * transport's closure — NOT read from the module-global `currentModelDef`,
+ * which races across concurrent transports (e.g. a side-panel run and a
+ * popup run on different models), mirroring the evaluator-model pinning
+ * below.
+ */
+async function recordUsageForStep(
+  conversationId: string | null,
+  step: StepUsage,
+  model: ModelDefinition | undefined,
+  modelId: string,
+): Promise<void> {
+  if (!conversationId) return;
+  // Nothing to record if the provider reported no tokens this step.
+  if (step.inputTokens == null && step.outputTokens == null) return;
+
+  const cid = conversationId;
+  const persist = async (): Promise<void> => {
+    try {
+      const conv = await chatDb.getConversation(cid);
+      if (!conv) return;
+      const usage = nextUsageSnapshot(
+        conv.usage,
+        step,
+        model,
+        modelId,
+        Date.now(),
+      );
+      // Like recordToolUsageForStep, we intentionally do NOT bump
+      // `updatedAt` on the row — usage churn shouldn't reorder the sidebar.
+      await chatDb.updateConversation(cid, { usage });
+    } catch {
+      // Best-effort; recording usage must never disrupt the agent loop.
+    }
+  };
+
+  const prev = usageWriteQueues.get(cid) ?? Promise.resolve();
+  const next = prev.then(persist);
+  usageWriteQueues.set(cid, next);
+  try {
+    await next;
+  } finally {
+    if (usageWriteQueues.get(cid) === next) {
+      usageWriteQueues.delete(cid);
+    }
+  }
+}
+
 
 export async function createAgentTransport(
   settings: Settings,
@@ -1605,6 +1665,12 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
       // the Context card surfaces them live (mirrors how todoWrite persists
       // todos mid-turn, instead of waiting for end-of-turn message persistence).
       void recordToolUsageForStep(agentConversationId, stepResult.toolCalls);
+      // Persist the token/cost usage snapshot for the header Context popover.
+      // Fire-and-forget; serialized per-conversation alongside tool usage.
+      void recordUsageForStep(agentConversationId, {
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+      }, modelDef, agentModel);
     },
     stopWhen: () => needsMidStreamCompaction,
   });

--- a/apps/extension/src/lib/agent/usage-snapshot.ts
+++ b/apps/extension/src/lib/agent/usage-snapshot.ts
@@ -1,0 +1,63 @@
+import type { ModelDefinition } from "@/registry/providers/types";
+import type { ConversationUsage } from "../types";
+
+/**
+ * A finished step's token usage, as reported by the AI SDK's
+ * `onStepFinish` callback (`stepResult.usage`). Both fields may be
+ * undefined for providers that don't report them.
+ */
+export interface StepUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+/**
+ * Compute the next conversation usage snapshot from the previous snapshot
+ * and a finished step.
+ *
+ * - `inputTokens`/`outputTokens`/`totalTokens` OVERWRITE — they reflect the
+ *   current context occupancy (the SDK reports the full growing context as
+ *   the step's input each call), so the latest step is the source of truth.
+ * - `costUsd` ACCUMULATES — each step's spend is added to the running total.
+ *   Missing pricing contributes 0.
+ * - `modelIds` ACCUMULATES — the latest `modelId` is appended (deduped,
+ *   first-seen order) so the UI knows every model that contributed to the
+ *   cumulative cost across a multi-model conversation.
+ *
+ * `modelId` is the fully-qualified `provider:model` key (e.g.
+ * "anthropic:claude-x"), which is distinct from `model.id` ("claude-x").
+ * Pass the qualified key, not `model?.id`.
+ */
+export function nextUsageSnapshot(
+  prev: ConversationUsage | undefined,
+  step: StepUsage,
+  model: ModelDefinition | undefined,
+  modelId: string,
+  now: number,
+): ConversationUsage {
+  const inputTokens = step.inputTokens ?? 0;
+  const outputTokens = step.outputTokens ?? 0;
+  const totalTokens = inputTokens + outputTokens;
+
+  const pricing = model?.pricing;
+  const stepCost = pricing
+    ? (inputTokens / 1_000_000) * pricing.inputPer1M +
+      (outputTokens / 1_000_000) * pricing.outputPer1M
+    : 0;
+
+  // Append this step's model to the distinct first-seen list. Skip empty
+  // ids so a missing key never pollutes the list.
+  const modelIds = [...(prev?.modelIds ?? [])];
+  if (modelId && !modelIds.includes(modelId)) modelIds.push(modelId);
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    costUsd: (prev?.costUsd ?? 0) + stepCost,
+    contextWindow: model?.contextWindow ?? 0,
+    modelId,
+    modelIds,
+    updatedAt: now,
+  };
+}

--- a/apps/extension/src/lib/agent/usage-snapshot.ts
+++ b/apps/extension/src/lib/agent/usage-snapshot.ts
@@ -45,9 +45,14 @@ export function nextUsageSnapshot(
       (outputTokens / 1_000_000) * pricing.outputPer1M
     : 0;
 
-  // Append this step's model to the distinct first-seen list. Skip empty
-  // ids so a missing key never pollutes the list.
+  // Build the distinct first-seen model list. Seed from a prior list, then
+  // fold in `prev.modelId` so a legacy snapshot (written before `modelIds`
+  // existed) doesn't lose its single attributed model, then append this
+  // step's model. Skip empty ids and dedupe throughout.
   const modelIds = [...(prev?.modelIds ?? [])];
+  if (prev?.modelId && !modelIds.includes(prev.modelId)) {
+    modelIds.push(prev.modelId);
+  }
   if (modelId && !modelIds.includes(modelId)) modelIds.push(modelId);
 
   return {

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -554,6 +554,16 @@ export const chatDb = {
     return msgs.sort((a, b) => a.createdAt - b.createdAt);
   },
 
+  /**
+   * Cheap message count for a conversation via the `by-conversation` index,
+   * without deserializing every message row (unlike `getMessages`). Used by
+   * the header Context indicator's poll.
+   */
+  async getMessageCount(conversationId: string): Promise<number> {
+    const db = await getDb();
+    return db.countFromIndex("messages", "by-conversation", conversationId);
+  },
+
   async saveMessage(msg: ChatDB["messages"]["value"]): Promise<void> {
     const db = await getDb();
     await db.put("messages", msg);

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -1,7 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 import { queueDb } from "./queue-db";
 import type { IsolationProfile, SubagentStatus } from "./agent/subagents/types";
-import type { SerializedUIPart, TodoItem } from "./types";
+import type { ConversationUsage, SerializedUIPart, TodoItem } from "./types";
 import { OPFS } from "./vfs/opfs";
 
 /**
@@ -57,6 +57,11 @@ interface ChatDB extends DBSchema {
       // on rows created before v13 and on conversations never completed.
       lastCompletionApproved?: boolean;
       taskCompletedAt?: number;
+      // Token/cost usage snapshot for the header Context popover. Optional;
+      // undefined on rows created before this field existed. No migration
+      // needed (keyPath store stores whole objects). Mirrors `Conversation`
+      // in lib/types.ts.
+      usage?: ConversationUsage;
     };
     indexes: {
       "by-updated": number;

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -150,6 +150,46 @@ export interface Conversation {
   lastCompletionApproved?: boolean;
   /** Timestamp (ms) of the most recent `approved` CompletionCheck verdict. */
   taskCompletedAt?: number;
+  /**
+   * Token/cost usage snapshot for the conversation, written live at
+   * step-finish time by the agent transport. Drives the header Context
+   * popover. Optional; undefined on rows created before this field existed
+   * and on conversations that have never run a step.
+   */
+  usage?: ConversationUsage;
+}
+
+/**
+ * Token/cost usage snapshot persisted on a conversation row.
+ *
+ * `totalTokens` is the CURRENT context occupancy (latest step's
+ * input + output, overwritten each step) — it shrinks after compaction.
+ * `costUsd` is CUMULATIVE spend across every step in the conversation.
+ * The two intentionally differ in scope.
+ */
+export interface ConversationUsage {
+  /** Latest step's input tokens (current context input). */
+  inputTokens: number;
+  /** Latest step's output tokens. */
+  outputTokens: number;
+  /** inputTokens + outputTokens — the current context size. */
+  totalTokens: number;
+  /** Cumulative USD spent across all steps in this conversation. */
+  costUsd: number;
+  /** Snapshot of the model's context window at write time. */
+  contextWindow: number;
+  /** Model id used for the latest step (e.g. "anthropic:claude-..."). */
+  modelId: string;
+  /**
+   * All distinct model ids used across the conversation, in first-seen
+   * order (qualified "provider:model" keys). Lets the UI surface that
+   * multiple models contributed to the cumulative cost. Always includes
+   * the latest `modelId`. Optional for snapshots written before this field
+   * existed.
+   */
+  modelIds?: string[];
+  /** ms timestamp of the most recent usage write. */
+  updatedAt: number;
 }
 
 export interface TodoItem {


### PR DESCRIPTION
### Summary

Adds a context-usage indicator to the chat header: a circular progress ring that shows Tokens/Usage%/Cost on hover and a detailed breakdown on click.

### Changes

- Persist a `ConversationUsage` snapshot per conversation (tokens, cumulative cost, context window, models used); no DB migration (additive optional field).
- Write it from the agent transport's `onStepFinish`; new `ContextUsage` component polls the row (~1s) and renders the ring + tooltip + popover.
- Header: indicator rendered left of the chat menu; menu icon switched to a horizontal ellipsis.

Note: Usage % reflects the current context size (shrinks after compaction); Cost is cumulative across all models used.

### Testing

- `pnpm compile` passes
- `pnpm test`: 598/598 passing (new `usage-snapshot` + `ContextUsage` tests)

### Checklist

- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Added changeset
- [x] Tested locally with `pnpm dev`
- [x] No unrelated changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a context-usage indicator in the chat header showing token consumption and context-window percentage. Hover shows tokens/percent/cost; click opens details with provider/model labels, token breakdown, cost, and timestamps.
* **Tests**
  * Added unit tests covering formatting, percent/clamping behavior, cost/date formatting, and model-label resolution.
* **Chores**
  * Persisted per-step usage snapshots and added a cheap message-count API to support the feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->