### PR TITLE
feat(scheduled-tasks): recurring background agent runs

### DIFF
--- a/.changeset/scheduled-tasks.md
+++ b/.changeset/scheduled-tasks.md
@@ -1,0 +1,9 @@
+---
+"openbrowse": minor
+---
+
+Add scheduled tasks: recurring, cron-like agent runs that execute as full
+background agent sessions (DOM + chrome.debugger, system prompt, compaction).
+Driven by a bundled `/schedule` skill and `create/list/update_scheduled_task`
+tools, with a Scheduled dashboard, create/edit dialog, status badges, and a
+per-task auto-approve toggle.

--- a/apps/extension/public/skills/schedule/SKILL.md
+++ b/apps/extension/public/skills/schedule/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: schedule
+description: Create, list, and manage scheduled tasks that run automatically on a recurring schedule or as a one-time future event. Use whenever the user wants to automate something repeatedly ("every morning", "weekdays at 8:30") or set a one-off future run ("in 20 minutes", "tomorrow at 3pm").
+---
+
+# Schedule Skill
+
+Set up and manage **scheduled tasks**: a saved prompt that OpenBrowse runs
+automatically at a time you choose, in a dedicated browser window, while
+Chrome is open. Each run lands as a conversation in your history and you get
+a notification when it finishes.
+
+You have three tools:
+
+- `create_scheduled_task` — set up a task that runs automatically, either on a
+  recurring schedule (`hourly`, `daily`, `weekdays`, `weekly`) or as a
+  one-time future event.
+- `list_scheduled_tasks` — see all existing tasks, their schedules, whether
+  they're enabled, and their last run status.
+- `update_scheduled_task` — change a task's prompt or schedule, rename it, or
+  pause/resume it (set `enabled`).
+
+## Creating a task
+
+1. **Understand what to automate.** Get a clear, self-contained instruction
+   the agent can run with no human present — it cannot ask follow-up
+   questions mid-run. Restate the task as the `prompt`.
+2. **Determine the schedule.** Map the user's words to a schedule:
+   - "every hour" → `{ kind: "hourly", minute: 0 }`
+   - "every day at 9am" → `{ kind: "daily", hour: 9, minute: 0 }`
+   - "weekdays at 8:30" → `{ kind: "weekdays", hour: 8, minute: 30 }`
+   - "every Monday at 9am" → `{ kind: "weekly", weekday: 1, hour: 9, minute: 0 }`
+     (weekday: 0=Sunday … 6=Saturday)
+   - "in 20 minutes" → `{ kind: "once", inMinutes: 20 }`
+   - "tomorrow at 3pm" → `{ kind: "once", at: "<ISO 8601 local time>" }`
+   All times are the user's local time. For relative one-time events prefer
+   `inMinutes` (you don't need to know the current time). For absolute ones
+   pass an ISO 8601 `at`.
+3. **Pick a short `name`** (e.g. `daily-briefing`) and a one-line
+   `description`. Omit `agentModel` to use the current model.
+4. **Confirm with the user** what you're about to schedule (prompt + when),
+   then call `create_scheduled_task`.
+5. **Report** the created task and when it will first run.
+
+## Listing and managing
+
+- To show what's scheduled, call `list_scheduled_tasks` and summarize each
+  task's name, schedule, enabled state, and next run.
+- To change or pause a task, call `list_scheduled_tasks` first to get its
+  `id`, then `update_scheduled_task`:
+  - Pause: `{ id, enabled: false }` · Resume: `{ id, enabled: true }`
+  - Reschedule: `{ id, schedule: { … } }`
+  - Edit the instruction: `{ id, prompt: "…" }`
+
+## Good to know
+
+- Scheduled tasks only run while Chrome is open. If Chrome is closed when a
+  task is due, that run is skipped and the next occurrence is scheduled.
+- Each run opens its own browser window and closes it when done.
+- A running scheduled task cannot itself create or modify scheduled tasks.
+- The user can also create and manage tasks visually from the **Scheduled**
+  page in the sidebar.

--- a/apps/extension/public/skills/schedule/SKILL.md
+++ b/apps/extension/public/skills/schedule/SKILL.md
@@ -6,9 +6,9 @@ description: Create, list, and manage scheduled tasks that run automatically on 
 # Schedule Skill
 
 Set up and manage **scheduled tasks**: a saved prompt that OpenBrowse runs
-automatically at a time you choose, in a dedicated browser window, while
-Chrome is open. Each run lands as a conversation in your history and you get
-a notification when it finishes.
+automatically at a time you choose. Runs execute in the background in a pinned
+home.html tab (hosted by ScheduledRunHost) while Chrome is open. Each run lands
+as a conversation in your history and you get a notification when it finishes.
 
 You have three tools:
 
@@ -56,7 +56,8 @@ You have three tools:
 
 - Scheduled tasks only run while Chrome is open. If Chrome is closed when a
   task is due, that run is skipped and the next occurrence is scheduled.
-- Each run opens its own browser window and closes it when done.
+- Each run executes in the background in a pinned home.html tab (via
+  ScheduledRunHost); it does not open a separate browser window.
 - A running scheduled task cannot itself create or modify scheduled tasks.
 - The user can also create and manage tasks visually from the **Scheduled**
   page in the sidebar.

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -32,6 +32,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAgentChat } from "@/hooks/useAgentChat";
+import { useActiveAgents } from "@/hooks/useActiveAgents";
 import { useProviders } from "@/hooks/useProviders";
 import { useConfiguredModels } from "@/hooks/useConfiguredModels";
 import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
@@ -160,12 +161,15 @@ export function ChatView({
     [],
   );
 
+  const activeAgents = useActiveAgents();
+  const isAgentActiveGlobally = conversationId ? activeAgents.has(conversationId) : false;
+
   const {
     messages,
     input,
     setInput,
-    isLoading,
-    isStreaming,
+    isLoading: hookIsLoading,
+    isStreaming: hookIsStreaming,
     isCompacting,
     isConfigured,
     settings,
@@ -190,53 +194,34 @@ export function ChatView({
     clearQueue,
     setQueueEditing,
   } = useAgentChat({
-    conversationId,
-    spaceId,
+    conversationId: conversationId ?? null,
+    spaceId: spaceId ?? null,
     onNewConversation,
     initialInput,
     getSharedTabId,
   });
 
-  // Global Option+Space popup: persist unsent draft text across dismiss/reopen
-  // cycles using chrome.storage.session. Hydrate once on mount; debounce-write
-  // on subsequent changes. Storage is cleared automatically when the input is
-  // emptied (e.g. after a successful send).
-  const draftHydratedRef = useRef(false);
+  // Seed the composer from an external "seed-chat-input" event (e.g. the
+  // per-chat "Schedule" action inserting "/schedule "). Scoped to the active
+  // conversation so only the visible chat responds. Bumps a focus nonce so
+  // ChatInput refocuses on the seeded text.
+  const [seedNonce, setSeedNonce] = useState(0);
   useEffect(() => {
-    if (!isGlobalChat) return;
-    if (draftHydratedRef.current) return;
-    chrome.storage.session
-      .get("globalChatDraft")
-      .then((stored) => {
-        const v = stored.globalChatDraft;
-        if (typeof v === "string" && v.length > 0) setInput(v);
-      })
-      .catch((err) => {
-        console.warn("[global-chat] failed to hydrate draft:", err);
-      })
-      .finally(() => {
-        draftHydratedRef.current = true;
-      });
-  }, [isGlobalChat, setInput]);
+    function onSeed(e: Event) {
+      const detail = (e as CustomEvent).detail as
+        | { conversationId: string | null; text: string }
+        | undefined;
+      if (!detail) return;
+      if ((detail.conversationId ?? null) !== (conversationId ?? null)) return;
+      setInput(detail.text);
+      setSeedNonce((n) => n + 1);
+    }
+    window.addEventListener("seed-chat-input", onSeed);
+    return () => window.removeEventListener("seed-chat-input", onSeed);
+  }, [conversationId, setInput]);
 
-  useEffect(() => {
-    if (!isGlobalChat) return;
-    if (!draftHydratedRef.current) return; // skip until hydration ran
-    const timer = setTimeout(() => {
-      if (input && input.length > 0) {
-        chrome.storage.session
-          .set({ globalChatDraft: input })
-          .catch((err) => {
-            console.warn("[global-chat] failed to persist draft:", err);
-          });
-      } else {
-        chrome.storage.session.remove("globalChatDraft").catch((err) => {
-          console.warn("[global-chat] failed to clear draft:", err);
-        });
-      }
-    }, 200);
-    return () => clearTimeout(timer);
-  }, [isGlobalChat, input]);
+  const isLoading = hookIsLoading || isAgentActiveGlobally;
+  const isStreaming = hookIsStreaming || isAgentActiveGlobally;
 
   const { providers } = useProviders();
 
@@ -810,7 +795,7 @@ export function ChatView({
               })?.capabilities
           }
           autoFocus
-          focusTrigger={`${conversationId ?? "new"}-${editing?.id ?? ""}`}
+          focusTrigger={`${conversationId ?? "new"}-${editing?.id ?? ""}-${seedNonce}`}
         />
       </div>
     </div>

--- a/apps/extension/src/components/chat/ModelPicker.tsx
+++ b/apps/extension/src/components/chat/ModelPicker.tsx
@@ -15,7 +15,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Star } from "lucide-react";
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode, type RefObject } from "react";
 
 export interface ModelOption {
   id: string;
@@ -85,6 +85,15 @@ interface ModelPickerProps {
   /** Controlled open state (e.g. driven by a keyboard shortcut). */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Container for the combobox popup's portal. Defaults to document.body.
+   * Pass the enclosing dialog's content element when rendering inside a
+   * modal Radix Dialog so the popup mounts within the dialog's focus trap
+   * (otherwise the Dialog treats combobox clicks as "outside" and dismisses
+   * the popup / steals focus from its search input).
+   */
+  portalContainer?: HTMLElement | RefObject<HTMLElement | null> | null;
 
   disabled?: boolean;
 }
@@ -166,6 +175,7 @@ export function ModelPicker({
   footerExtra,
   open: controlledOpen,
   onOpenChange,
+  portalContainer,
   disabled = false,
 }: ModelPickerProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
@@ -426,6 +436,7 @@ export function ModelPicker({
       <ComboboxContent
         side={trigger === "chat" ? "top" : "bottom"}
         sideOffset={4}
+        container={portalContainer}
         className="w-[320px] border border-border shadow-lg"
       >
           <ComboboxInput placeholder="Select a model..." showTrigger={false} />

--- a/apps/extension/src/components/chat/ToolCallBlock.tsx
+++ b/apps/extension/src/components/chat/ToolCallBlock.tsx
@@ -26,6 +26,11 @@ import { SnapshotResult } from "./tool-results/snapshot";
 import { WebFetchResult } from "./tool-results/web-fetch";
 import { MemoryResult } from "./tool-results/memory";
 import { SelectTabResult } from "./tool-results/select-tab";
+import {
+  CreateScheduledTaskResult,
+  ListScheduledTasksResult,
+  UpdateScheduledTaskResult,
+} from "./tool-results/scheduled-task";
 
 import { getToolPreview } from "./tool-previews";
 
@@ -77,6 +82,15 @@ const BUILTIN_RESULT_RENDERERS: Record<string, ResultRenderer> = {
     />
   ),
   webFetch: ({ args, result }) => <WebFetchResult args={args} result={result} />,
+  create_scheduled_task: ({ args, result }) => (
+    <CreateScheduledTaskResult args={args} result={result} />
+  ),
+  list_scheduled_tasks: ({ args, result }) => (
+    <ListScheduledTasksResult args={args} result={result} />
+  ),
+  update_scheduled_task: ({ args, result }) => (
+    <UpdateScheduledTaskResult args={args} result={result} />
+  ),
 };
 
 interface ToolCallBlockProps {
@@ -123,6 +137,20 @@ const TOOL_LABELS: Record<string, { pending: string; done: string }> = {
   skill: { pending: "Loading skill...", done: "Loaded skill" },
   create_skill: { pending: "Creating skill...", done: "Created skill" },
   install_skill: { pending: "Installing skill...", done: "Installed skill" },
+
+  // Scheduled task tools
+  create_scheduled_task: {
+    pending: "Scheduling task...",
+    done: "Scheduled task",
+  },
+  list_scheduled_tasks: {
+    pending: "Listing scheduled tasks...",
+    done: "Listed scheduled tasks",
+  },
+  update_scheduled_task: {
+    pending: "Updating scheduled task...",
+    done: "Updated scheduled task",
+  },
 
   // (No `delegate` entry — `delegate` bypasses the outer ToolCallBlock
   // wrapper entirely; SubagentTrace renders the whole UI itself.)
@@ -220,6 +248,49 @@ export function closeTabsLabels(
   return fallback;
 }
 
+/**
+ * Refine the create/update scheduled-task labels with the task name so the
+ * collapsed row shows what's being scheduled (e.g. "Scheduling
+ * 'daily-briefing'..." / "Scheduled 'daily-briefing'") instead of the
+ * generic label.
+ */
+export function scheduledTaskLabels(
+  toolName: string,
+  args: Record<string, unknown>,
+  fallback: { pending: string; done: string },
+): { pending: string; done: string } {
+  const name = typeof args.name === "string" ? args.name.trim() : "";
+  if (toolName === "create_scheduled_task") {
+    if (name) {
+      return {
+        pending: `Scheduling “${name}”...`,
+        done: `Scheduled “${name}”`,
+      };
+    }
+    return fallback;
+  }
+  if (toolName === "update_scheduled_task") {
+    // Distinguish pause/resume from a general edit when possible.
+    if (typeof args.enabled === "boolean") {
+      const verbing = args.enabled ? "Resuming" : "Pausing";
+      const verbed = args.enabled ? "Resumed" : "Paused";
+      const label = name ? `“${name}”` : "scheduled task";
+      return {
+        pending: `${verbing} ${label}...`,
+        done: `${verbed} ${label}`,
+      };
+    }
+    if (name) {
+      return {
+        pending: `Updating “${name}”...`,
+        done: `Updated “${name}”`,
+      };
+    }
+    return fallback;
+  }
+  return fallback;
+}
+
 export function ToolCallBlock({
   toolName,
   toolCallId,
@@ -251,7 +322,10 @@ export function ToolCallBlock({
       ? webFetchLabels(args, labels)
       : toolName === "closeTabs"
         ? closeTabsLabels(args, labels)
-        : labels;
+        : toolName === "create_scheduled_task" ||
+            toolName === "update_scheduled_task"
+          ? scheduledTaskLabels(toolName, args, labels)
+          : labels;
 
   const showTabBadge = TAB_TOOLS.has(toolName);
 

--- a/apps/extension/src/components/chat/__tests__/scheduled-task-labels.test.ts
+++ b/apps/extension/src/components/chat/__tests__/scheduled-task-labels.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { scheduledTaskLabels } from "../ToolCallBlock";
+
+const createFallback = {
+  pending: "Scheduling task...",
+  done: "Scheduled task",
+};
+const updateFallback = {
+  pending: "Updating scheduled task...",
+  done: "Updated scheduled task",
+};
+
+describe("scheduledTaskLabels", () => {
+  it("create: includes the task name", () => {
+    expect(
+      scheduledTaskLabels(
+        "create_scheduled_task",
+        { name: "daily-briefing" },
+        createFallback,
+      ),
+    ).toEqual({
+      pending: "Scheduling “daily-briefing”...",
+      done: "Scheduled “daily-briefing”",
+    });
+  });
+
+  it("create: falls back without a name", () => {
+    expect(
+      scheduledTaskLabels("create_scheduled_task", {}, createFallback),
+    ).toBe(createFallback);
+  });
+
+  it("update: pause (enabled=false)", () => {
+    expect(
+      scheduledTaskLabels(
+        "update_scheduled_task",
+        { name: "brief", enabled: false },
+        updateFallback,
+      ),
+    ).toEqual({ pending: "Pausing “brief”...", done: "Paused “brief”" });
+  });
+
+  it("update: resume (enabled=true) without a name", () => {
+    expect(
+      scheduledTaskLabels(
+        "update_scheduled_task",
+        { enabled: true },
+        updateFallback,
+      ),
+    ).toEqual({
+      pending: "Resuming scheduled task...",
+      done: "Resumed scheduled task",
+    });
+  });
+
+  it("update: general edit shows the name", () => {
+    expect(
+      scheduledTaskLabels(
+        "update_scheduled_task",
+        { name: "brief", prompt: "new" },
+        updateFallback,
+      ),
+    ).toEqual({ pending: "Updating “brief”...", done: "Updated “brief”" });
+  });
+
+  it("update: falls back with no name and no enabled", () => {
+    expect(
+      scheduledTaskLabels("update_scheduled_task", { id: "x" }, updateFallback),
+    ).toBe(updateFallback);
+  });
+
+  it("falls back for unrelated tool names", () => {
+    expect(scheduledTaskLabels("list_scheduled_tasks", {}, createFallback)).toBe(
+      createFallback,
+    );
+  });
+});

--- a/apps/extension/src/components/chat/tool-results/scheduled-task.tsx
+++ b/apps/extension/src/components/chat/tool-results/scheduled-task.tsx
@@ -1,0 +1,150 @@
+import { Clock, CheckCircle2, XCircle, List } from "lucide-react";
+
+function formatRunTime(epoch: number | null | undefined): string {
+  if (epoch == null) return "—";
+  return new Date(epoch).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function Shell({
+  icon,
+  header,
+  children,
+}: {
+  icon: React.ReactNode;
+  header: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="ml-3 mt-1 mb-1 rounded-md border border-border overflow-hidden text-xs">
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-muted/50 border-b border-border text-muted-foreground">
+        {icon}
+        <span className="truncate">{header}</span>
+      </div>
+      {children && (
+        <div className="px-3 py-2 bg-background/50">{children}</div>
+      )}
+    </div>
+  );
+}
+
+interface RProps {
+  args: Record<string, unknown>;
+  result: unknown;
+}
+
+export function CreateScheduledTaskResult({ args, result }: RProps) {
+  const r = result as
+    | { created: true; id: string; nextRunAt: number | null }
+    | { created: false; reason: string }
+    | undefined;
+  const name = typeof args.name === "string" ? args.name : "task";
+
+  if (r && r.created === false) {
+    return (
+      <Shell
+        icon={<XCircle className="size-3 shrink-0 text-destructive" />}
+        header={`Couldn't schedule “${name}”`}
+      >
+        <span className="text-muted-foreground">{r.reason}</span>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell
+      icon={<CheckCircle2 className="size-3 shrink-0 text-emerald-500" />}
+      header={`Scheduled “${name}”`}
+    >
+      <div className="flex items-center gap-1.5 text-muted-foreground">
+        <Clock className="size-3 shrink-0" />
+        <span>Next run: {formatRunTime(r?.created ? r.nextRunAt : null)}</span>
+      </div>
+    </Shell>
+  );
+}
+
+export function UpdateScheduledTaskResult({ args, result }: RProps) {
+  const r = result as
+    | { updated: true }
+    | { updated: false; reason: string }
+    | undefined;
+  const name = typeof args.name === "string" ? args.name : null;
+  const enabled =
+    typeof args.enabled === "boolean" ? args.enabled : undefined;
+
+  if (r && r.updated === false) {
+    return (
+      <Shell
+        icon={<XCircle className="size-3 shrink-0 text-destructive" />}
+        header="Couldn't update scheduled task"
+      >
+        <span className="text-muted-foreground">{r.reason}</span>
+      </Shell>
+    );
+  }
+
+  let header = name ? `Updated “${name}”` : "Updated scheduled task";
+  if (enabled === false) header = name ? `Paused “${name}”` : "Paused scheduled task";
+  if (enabled === true) header = name ? `Resumed “${name}”` : "Resumed scheduled task";
+
+  return (
+    <Shell
+      icon={<CheckCircle2 className="size-3 shrink-0 text-emerald-500" />}
+      header={header}
+    />
+  );
+}
+
+interface TaskSummary {
+  id: string;
+  name: string;
+  description: string;
+  schedule: string;
+  enabled: boolean;
+  nextRunAt: number | null;
+  lastRunStatus: string | null;
+}
+
+export function ListScheduledTasksResult({ result }: RProps) {
+  const r = result as { tasks?: TaskSummary[] } | undefined;
+  const tasks = r?.tasks ?? [];
+
+  return (
+    <Shell
+      icon={<List className="size-3 shrink-0" />}
+      header={
+        tasks.length === 0
+          ? "No scheduled tasks"
+          : `${tasks.length} scheduled ${tasks.length === 1 ? "task" : "tasks"}`
+      }
+    >
+      {tasks.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {tasks.map((t) => (
+            <li key={t.id} className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-1.5">
+                <span className="font-medium text-foreground">{t.name}</span>
+                {!t.enabled && (
+                  <span className="rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+                    Paused
+                  </span>
+                )}
+              </div>
+              <span className="text-muted-foreground">
+                {t.schedule}
+                {t.enabled && ` · next ${formatRunTime(t.nextRunAt)}`}
+                {t.lastRunStatus && ` · last: ${t.lastRunStatus}`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Shell>
+  );
+}

--- a/apps/extension/src/entrypoints/background/__tests__/scheduler.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/scheduler.test.ts
@@ -1,0 +1,115 @@
+// src/entrypoints/background/__tests__/scheduler.test.ts
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "@/lib/chat-db";
+import { taskDb } from "@/lib/schedule/task-db";
+import {
+  registerScheduler,
+  rescheduleAll,
+  runDueTasks,
+  SCHEDULER_ALARM,
+} from "../scheduler";
+
+beforeEach(() => {
+  indexedDB = new IDBFactory();
+  chatDb._resetForTests();
+});
+
+describe("runDueTasks", () => {
+  it("runs only enabled tasks whose nextRunAt <= now and not already running", async () => {
+    const due = await taskDb.create({
+      name: "due",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 0, minute: 0 },
+      enabled: true,
+      needsBrowser: false,
+    });
+    const future = await taskDb.create({
+      name: "future",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 0, minute: 0 },
+      enabled: true,
+      needsBrowser: false,
+    });
+    const disabled = await taskDb.create({
+      name: "off",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 0, minute: 0 },
+      enabled: false,
+      needsBrowser: false,
+    });
+
+    // Force nextRunAt: due in the past, future in the future.
+    await taskDb.update(due.id, { nextRunAt: 100 });
+    await taskDb.update(future.id, { nextRunAt: 10_000 });
+    await taskDb.update(disabled.id, { nextRunAt: 100 });
+
+    const ran: string[] = [];
+    await runDueTasks(1_000, async (id) => {
+      ran.push(id);
+    });
+
+    expect(ran).toEqual([due.id]);
+  });
+
+  it("does not dispatch a task already marked running", async () => {
+    const t = await taskDb.create({
+      name: "r",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 0, minute: 0 },
+      enabled: true,
+      needsBrowser: false,
+    });
+    await taskDb.update(t.id, { nextRunAt: 100, lastRunStatus: "running" });
+
+    const ran: string[] = [];
+    await runDueTasks(1_000, async (id) => ran.push(id) as unknown as void);
+    expect(ran).toEqual([]);
+  });
+});
+
+describe("rescheduleAll (skip missed runs on startup)", () => {
+  it("recomputes nextRunAt forward, never firing a missed run immediately", async () => {
+    const t = await taskDb.create({
+      name: "t",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 9, minute: 0 },
+      enabled: true,
+      needsBrowser: false,
+    });
+    // Simulate a stale nextRunAt from when Chrome was last open.
+    await taskDb.update(t.id, { nextRunAt: 1 });
+
+    await rescheduleAll(Date.now());
+
+    const after = await taskDb.get(t.id);
+    expect(after!.nextRunAt!).toBeGreaterThan(Date.now()); // forward, not 1
+  });
+});
+
+describe("registerScheduler", () => {
+  it("creates the tick alarm and an onAlarm listener", () => {
+    const create = vi.fn();
+    const addListener = vi.fn();
+    vi.stubGlobal("chrome", {
+      alarms: { create, onAlarm: { addListener }, clear: vi.fn() },
+    });
+    registerScheduler();
+    expect(create).toHaveBeenCalledWith(
+      SCHEDULER_ALARM,
+      expect.objectContaining({ periodInMinutes: 1 }),
+    );
+    expect(addListener).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -3,6 +3,7 @@ import type { TidyState, SortResult, ModelStatus } from "@/lib/types";
 import { markUserOpenedSidePanel, markUserClosedSidePanel, isUserOpenedSidePanel } from "./tab-scoping";
 import { openHomePage } from "./messages";
 import { registerModelsDevRefresh } from "./models-dev-refresh";
+import { registerScheduler } from "./scheduler";
 import { chatDb } from "@/lib/chat-db";
 import { finalizeAllRunningChildrenAtStartup } from "@/lib/agent/subagents/heal-orphan-children";
 
@@ -26,6 +27,7 @@ function getTidyState(data: Record<string, unknown>, key: string): TidyState {
 export default defineBackground({
   main() {
     registerModelsDevRefresh();
+    registerScheduler();
 
     // Defensive cleanup for orphaned subagent runs that survived an
     // MV3 service-worker death. Any conversation row with
@@ -789,6 +791,35 @@ export default defineBackground({
           const { storage } = await import("@/lib/storage");
           await storage.clearAutoTidyNotification();
           sendResponse({ ok: true });
+        })();
+        return true;
+      }
+
+      if (message.type === "SCHEDULER_RUN_NOW") {
+        (async () => {
+          try {
+            const { taskDb } = await import("@/lib/schedule/task-db");
+            // Respect the running guard: don't start a second concurrent run
+            // of the same task (e.g. double-click, or a tick already running it).
+            const existing = await taskDb.get(message.taskId);
+            if (!existing || existing.lastRunStatus === "running") {
+              sendResponse({ ok: true, skipped: true });
+              return;
+            }
+            const { runScheduledTask, createHomeHostDeps } =
+              await import("@/lib/agent/scheduled-run");
+            const hostDeps = createHomeHostDeps();
+            await runScheduledTask(message.taskId, {
+              ...hostDeps,
+              notify: (payload) =>
+                chrome.runtime
+                  ?.sendMessage?.({ type: "AGENT_NOTIFY", payload })
+                  ?.catch?.(() => {}),
+            });
+            sendResponse({ ok: true });
+          } catch (err) {
+            sendResponse({ ok: false, error: String(err) });
+          }
         })();
         return true;
       }

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -806,11 +806,10 @@ export default defineBackground({
               sendResponse({ ok: true, skipped: true });
               return;
             }
-            const { runScheduledTask, createHomeHostDeps } =
+            const { runScheduledTask, getHomeHostDeps } =
               await import("@/lib/agent/scheduled-run");
-            const hostDeps = createHomeHostDeps();
             await runScheduledTask(message.taskId, {
-              ...hostDeps,
+              ...getHomeHostDeps(),
               notify: (payload) =>
                 chrome.runtime
                   ?.sendMessage?.({ type: "AGENT_NOTIFY", payload })

--- a/apps/extension/src/entrypoints/background/scheduler.ts
+++ b/apps/extension/src/entrypoints/background/scheduler.ts
@@ -52,12 +52,11 @@ export async function rescheduleAll(now: number): Promise<void> {
 
 /** Default production run: host the run in a home page and await its result. */
 async function runOneProduction(taskId: string): Promise<void> {
-  const { runScheduledTask, createHomeHostDeps } = await import(
+  const { runScheduledTask, getHomeHostDeps } = await import(
     "@/lib/agent/scheduled-run"
   );
-  const hostDeps = createHomeHostDeps();
   await runScheduledTask(taskId, {
-    ...hostDeps,
+    ...getHomeHostDeps(),
     notify: (payload) => {
       chrome.runtime
         ?.sendMessage?.({ type: "AGENT_NOTIFY", payload })

--- a/apps/extension/src/entrypoints/background/scheduler.ts
+++ b/apps/extension/src/entrypoints/background/scheduler.ts
@@ -1,0 +1,83 @@
+// src/entrypoints/background/scheduler.ts
+import { taskDb } from "@/lib/schedule/task-db";
+import { computeNextRun } from "@/lib/schedule/next-run";
+
+export const SCHEDULER_ALARM = "scheduler-tick";
+const PERIOD_MINUTES = 1;
+
+/**
+ * Read all tasks and dispatch any that are due: enabled, with a numeric
+ * nextRunAt <= now, and not already running. `runOne` performs the actual
+ * run (injected so tests don't spin up a real agent loop).
+ */
+export async function runDueTasks(
+  now: number,
+  runOne: (taskId: string) => Promise<void>,
+): Promise<void> {
+  const tasks = await taskDb.list();
+  for (const t of tasks) {
+    if (!t.enabled) continue;
+    if (t.lastRunStatus === "running") continue;
+    if (typeof t.nextRunAt !== "number") continue;
+    if (t.nextRunAt > now) continue;
+    try {
+      await runOne(t.id);
+    } catch (err) {
+      console.warn(`[scheduler] task ${t.id} run failed:`, err);
+    }
+  }
+}
+
+/**
+ * On startup, recompute nextRunAt for every task from `now`. Missed runs are
+ * skipped: a task whose time passed while Chrome was closed gets its NEXT
+ * future occurrence, not an immediate fire.
+ */
+export async function rescheduleAll(now: number): Promise<void> {
+  const tasks = await taskDb.list();
+  for (const t of tasks) {
+    const next = computeNextRun(t.schedule, now);
+    if (next !== t.nextRunAt) {
+      await taskDb.update(t.id, { nextRunAt: next });
+    }
+    // Clear any stale "running" left by an SW teardown mid-run.
+    if (t.lastRunStatus === "running") {
+      await taskDb.update(t.id, {
+        lastRunStatus: "error",
+        lastRunError: "interrupted",
+      });
+    }
+  }
+}
+
+/** Default production run: host the run in a home page and await its result. */
+async function runOneProduction(taskId: string): Promise<void> {
+  const { runScheduledTask, createHomeHostDeps } = await import(
+    "@/lib/agent/scheduled-run"
+  );
+  const hostDeps = createHomeHostDeps();
+  await runScheduledTask(taskId, {
+    ...hostDeps,
+    notify: (payload) => {
+      chrome.runtime
+        ?.sendMessage?.({ type: "AGENT_NOTIFY", payload })
+        ?.catch?.(() => {});
+    },
+  });
+}
+
+export function registerScheduler(): void {
+  chrome.alarms.create(SCHEDULER_ALARM, { periodInMinutes: PERIOD_MINUTES });
+
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name !== SCHEDULER_ALARM) return;
+    void runDueTasks(Date.now(), runOneProduction).catch((err) => {
+      console.warn("[scheduler] tick failed:", err);
+    });
+  });
+
+  // Opportunistic startup reschedule (skip missed runs).
+  void rescheduleAll(Date.now()).catch((err) => {
+    console.warn("[scheduler] startup reschedule failed:", err);
+  });
+}

--- a/apps/extension/src/entrypoints/home/App.tsx
+++ b/apps/extension/src/entrypoints/home/App.tsx
@@ -44,11 +44,14 @@ import {
   PanelRight,
   Pencil,
   Trash2,
+  Clock,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HomeSidebar } from "./components/HomeSidebar";
 import { LandingPage } from "./components/LandingPage";
 import { RightRail } from "./components/RightRail";
+import { ScheduledView } from "./components/ScheduledView";
+import { ScheduledRunHost } from "./components/ScheduledRunHost";
 
 export default function App() {
   useTheme();
@@ -81,6 +84,9 @@ export default function App() {
   const [showOverlay, setShowOverlay] = useState(false);
   const [overlayAction, setOverlayAction] = useState<string | null>(null);
   const overlayIframeRef = useRef<HTMLIFrameElement>(null);
+
+  const [view, setView] = useState<"chat" | "scheduled">("chat");
+  const scheduleModels = useScheduleModels();
 
   const [conversationTitle, setConversationTitle] = useState<string | null>(
     null,
@@ -370,6 +376,7 @@ export default function App() {
   }, [deleteTarget, activeConversationId]);
 
   const handleNewConversation = useCallback((id: string) => {
+    setView("chat");
     if (id) {
       setActiveConversationId(id);
     } else {
@@ -378,7 +385,43 @@ export default function App() {
   }, []);
 
   const handleSelectConversation = useCallback((id: string) => {
+    setView("chat");
     setActiveConversationId(id);
+  }, []);
+
+  const handleOpenScheduled = useCallback(() => setView("scheduled"), []);
+
+  // Per-chat "Schedule": open the conversation (if not already active) and
+  // seed its composer with "/schedule " so the schedule skill is invoked.
+  // The slash token auto-forms a skill mention at start-of-line.
+  const handleScheduleConversation = useCallback(
+    (conv: { id: string; title: string }) => {
+      setView("chat");
+      setActiveConversationId(conv.id);
+      // Defer so ChatView for this conversation is mounted/listening.
+      setTimeout(() => {
+        window.dispatchEvent(
+          new CustomEvent("seed-chat-input", {
+            detail: { conversationId: conv.id, text: "/schedule " },
+          }),
+        );
+      }, 50);
+    },
+    [],
+  );
+
+  // "Create with agent" from the Scheduled view: open a fresh chat and seed
+  // it with "/schedule " so the user can describe the task conversationally.
+  const handleCreateScheduleWithAgent = useCallback(() => {
+    setView("chat");
+    setActiveConversationId(null);
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("seed-chat-input", {
+          detail: { conversationId: null, text: "/schedule " },
+        }),
+      );
+    }, 50);
   }, []);
 
   const handleSelectFile = useCallback((file: string | null) => {
@@ -395,13 +438,18 @@ export default function App() {
 
   return (
     <div className="flex h-screen bg-[var(--background)]">
+      <ScheduledRunHost />
       <HomeSidebar
         spaces={spaces}
         activeSpaceId={activeSpaceId}
-        activeConversationId={activeConversationId}
+        activeConversationId={view === "scheduled" ? null : activeConversationId}
+        scheduledActive={view === "scheduled"}
         onSelectConversation={handleSelectConversation}
         onNewConversation={() => handleNewConversation("")}
-        onGoHome={() => setActiveConversationId(null)}
+        onGoHome={() => {
+          setView("chat");
+          setActiveConversationId(null);
+        }}
         onOpenOverlay={() => setShowOverlay(true)}
         onNewSpace={() => {
           setOverlayAction("new-space");
@@ -413,9 +461,20 @@ export default function App() {
         }}
         onRenameConversation={handleRenameConversation}
         onDeleteConversation={handleDeleteConversation}
+        onOpenScheduled={handleOpenScheduled}
+        onScheduleConversation={handleScheduleConversation}
       />
 
-      {activeConversationId ? (
+      {view === "scheduled" ? (
+        <ScheduledView
+          models={scheduleModels}
+          onOpenConversation={(id) => {
+            setView("chat");
+            handleSelectConversation(id);
+          }}
+          onCreateWithAgent={handleCreateScheduleWithAgent}
+        />
+      ) : activeConversationId ? (
         <FileSelectionContext.Provider value={handleSelectFile}>
         <RightRail
           conversationId={activeConversationId}
@@ -443,6 +502,18 @@ export default function App() {
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => {
+                          if (!activeConversationId) return;
+                          void handleScheduleConversation({
+                            id: activeConversationId,
+                            title: conversationTitle ?? "New conversation",
+                          });
+                        }}
+                      >
+                        <Clock className="size-3.5" />
+                        Schedule
+                      </DropdownMenuItem>
                       <DropdownMenuItem onClick={handleRenameChat}>
                         <Pencil className="size-3.5" />
                         Rename
@@ -606,4 +677,22 @@ export default function App() {
       </AlertDialog>
     </div>
   );
+}
+
+/**
+ * Available model strings ("<provider>:<model>") for the schedule dialog:
+ * the user's favorite models plus the currently-selected agent model.
+ */
+function useScheduleModels(): string[] {
+  const [models, setModels] = useState<string[]>([]);
+  useEffect(() => {
+    void (async () => {
+      const s = await storage.getSettings();
+      const a = await storage.getAgentSettings();
+      const list = new Set<string>(s.favoriteModels ?? []);
+      if (a.agentModel) list.add(a.agentModel);
+      setModels([...list]);
+    })();
+  }, []);
+  return models;
 }

--- a/apps/extension/src/entrypoints/home/components/CreateScheduledTaskDialog.tsx
+++ b/apps/extension/src/entrypoints/home/components/CreateScheduledTaskDialog.tsx
@@ -1,0 +1,330 @@
+// src/entrypoints/home/components/CreateScheduledTaskDialog.tsx
+import { useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ModelPicker } from "@/components/chat/ModelPicker";
+import { useConfiguredModels } from "@/hooks/useConfiguredModels";
+import { storage } from "@/lib/storage";
+import { DEFAULT_SETTINGS } from "@/lib/constants";
+import type { Settings } from "@/lib/types";
+import { taskDb } from "@/lib/schedule/task-db";
+import type { Schedule, ScheduleKind, ScheduledTask } from "@/lib/schedule/types";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** When set, the dialog edits this task; otherwise creates a new one. */
+  editing?: ScheduledTask | null;
+  /** Prefill values (e.g. from a conversation's "Schedule" action). */
+  prefill?: {
+    name?: string;
+    prompt?: string;
+    agentModel?: string;
+    sourceConversationId?: string;
+  } | null;
+  /** Available model strings ("<provider>:<model>") for the picker. */
+  models: string[];
+  onSaved?: () => void;
+}
+
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+export function CreateScheduledTaskDialog({
+  open,
+  onOpenChange,
+  editing,
+  prefill,
+  models,
+  onSaved,
+}: Props) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [agentModel, setAgentModel] = useState("");
+  const [kind, setKind] = useState<ScheduleKind>("daily");
+  const [hour, setHour] = useState(9);
+  const [minute, setMinute] = useState(0);
+  const [weekday, setWeekday] = useState(1);
+  const [onceAt, setOnceAt] = useState(""); // datetime-local string
+  const [autoApprove, setAutoApprove] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
+  const providerModels = useConfiguredModels(settings);
+  const formRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    void storage.getSettings().then(setSettings);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      setName(editing.name);
+      setDescription(editing.description);
+      setPrompt(editing.prompt);
+      setAgentModel(editing.agentModel);
+      setKind(editing.schedule.kind);
+      if ("hour" in editing.schedule) setHour(editing.schedule.hour);
+      if ("minute" in editing.schedule) setMinute(editing.schedule.minute);
+      if (editing.schedule.kind === "weekly")
+        setWeekday(editing.schedule.weekday);
+      if (editing.schedule.kind === "once")
+        setOnceAt(toLocalInput(editing.schedule.at));
+      setAutoApprove(editing.autoApprove ?? false);
+    } else {
+      setName(prefill?.name ?? "");
+      setDescription("");
+      setPrompt(prefill?.prompt ?? "");
+      setAgentModel(prefill?.agentModel ?? models[0] ?? "");
+      setKind("daily");
+      setHour(9);
+      setMinute(0);
+      setWeekday(1);
+      setOnceAt("");
+      setAutoApprove(false);
+    }
+  }, [open, editing, prefill, models]);
+
+  function buildSchedule(): Schedule {
+    switch (kind) {
+      case "manual":
+        return { kind: "manual" };
+      case "hourly":
+        return { kind: "hourly", minute };
+      case "daily":
+        return { kind: "daily", hour, minute };
+      case "weekdays":
+        return { kind: "weekdays", hour, minute };
+      case "weekly":
+        return { kind: "weekly", weekday, hour, minute };
+      case "once":
+        return {
+          kind: "once",
+          at: onceAt ? new Date(onceAt).getTime() : Date.now(),
+        };
+    }
+  }
+
+  async function handleSave() {
+    if (!name.trim() || !prompt.trim() || !agentModel) return;
+    setSaving(true);
+    try {
+      const schedule = buildSchedule();
+      if (editing) {
+        await taskDb.update(editing.id, {
+          name: name.trim(),
+          description: description.trim(),
+          prompt: prompt.trim(),
+          agentModel,
+          schedule,
+          autoApprove,
+        });
+      } else {
+        await taskDb.create({
+          name: name.trim(),
+          description: description.trim(),
+          prompt: prompt.trim(),
+          agentModel,
+          schedule,
+          enabled: true,
+          needsBrowser: true,
+          autoApprove,
+          sourceConversationId: prefill?.sourceConversationId,
+        });
+      }
+      onSaved?.();
+      onOpenChange(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-lg max-h-[85vh] overflow-y-auto"
+        onKeyDown={(e) => {
+          if (e.metaKey && e.key === "Enter" && !saving) {
+            e.preventDefault();
+            void handleSave();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {editing ? "Edit scheduled task" : "Create scheduled task"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div ref={formRef} className="flex flex-col gap-3">
+          <label className="text-sm font-medium">Name</label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="daily-briefing"
+          />
+
+          <label className="text-sm font-medium">Description</label>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What this task does"
+          />
+
+          <label className="text-sm font-medium">Prompt</label>
+          <Textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            rows={4}
+            placeholder="Instructions for the agent…"
+          />
+
+          <label className="text-sm font-medium">Model</label>
+          <ModelPicker
+            trigger="settings"
+            providerModels={providerModels}
+            value={agentModel || undefined}
+            onValueChange={setAgentModel}
+            placeholder="Select a model"
+            portalContainer={formRef}
+          />
+
+          <label className="text-sm font-medium">Frequency</label>
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={kind}
+              onValueChange={(v) => setKind(v as ScheduleKind)}
+            >
+              <SelectTrigger className="w-36">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="manual">Manual</SelectItem>
+                <SelectItem value="hourly">Hourly</SelectItem>
+                <SelectItem value="daily">Daily</SelectItem>
+                <SelectItem value="weekdays">Weekdays</SelectItem>
+                <SelectItem value="weekly">Weekly</SelectItem>
+                <SelectItem value="once">Once</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {(kind === "daily" || kind === "weekdays" || kind === "weekly") && (
+              <input
+                type="time"
+                className="h-9 rounded-md border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                value={`${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`}
+                onChange={(e) => {
+                  const [h, m] = e.target.value.split(":").map(Number);
+                  setHour(h);
+                  setMinute(m);
+                }}
+              />
+            )}
+
+            {kind === "hourly" && (
+              <input
+                type="number"
+                min={0}
+                max={59}
+                className="h-9 w-20 rounded-md border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                value={minute}
+                onChange={(e) => setMinute(Number(e.target.value))}
+              />
+            )}
+
+            {kind === "weekly" && (
+              <Select
+                value={String(weekday)}
+                onValueChange={(v) => setWeekday(Number(v))}
+              >
+                <SelectTrigger className="w-36">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {WEEKDAYS.map((d, i) => (
+                    <SelectItem key={d} value={String(i)}>
+                      {d}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+
+            {kind === "once" && (
+              <input
+                type="datetime-local"
+                className="h-9 rounded-md border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                value={onceAt}
+                onChange={(e) => setOnceAt(e.target.value)}
+              />
+            )}
+          </div>
+
+          <div className="flex items-start justify-between gap-3 rounded-lg border p-3">
+            <div className="min-w-0">
+              <label className="text-sm font-medium">Auto-approve tool actions</label>
+              <p className="text-xs text-muted-foreground">
+                Lets the scheduled run use tools that normally ask for
+                confirmation (it runs with no one watching). Off by default.
+              </p>
+            </div>
+            <Switch
+              checked={autoApprove}
+              onCheckedChange={setAutoApprove}
+              className="mt-0.5 shrink-0"
+            />
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Scheduled tasks only run while Chrome is open.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+            <Kbd className="ml-1.5">
+              <span>⌘</span>
+              <span>↵</span>
+            </Kbd>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function toLocalInput(epoch: number): string {
+  const d = new Date(epoch);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/apps/extension/src/entrypoints/home/components/CreateScheduledTaskDialog.tsx
+++ b/apps/extension/src/entrypoints/home/components/CreateScheduledTaskDialog.tsx
@@ -73,6 +73,7 @@ export function CreateScheduledTaskDialog({
   const [onceAt, setOnceAt] = useState(""); // datetime-local string
   const [autoApprove, setAutoApprove] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const providerModels = useConfiguredModels(settings);
   const formRef = useRef<HTMLDivElement>(null);
@@ -84,6 +85,7 @@ export function CreateScheduledTaskDialog({
 
   useEffect(() => {
     if (!open) return;
+    setError(null);
     if (editing) {
       setName(editing.name);
       setDescription(editing.description);
@@ -123,19 +125,36 @@ export function CreateScheduledTaskDialog({
         return { kind: "weekdays", hour, minute };
       case "weekly":
         return { kind: "weekly", weekday, hour, minute };
-      case "once":
-        return {
-          kind: "once",
-          at: onceAt ? new Date(onceAt).getTime() : Date.now(),
-        };
+      case "once": {
+        // Require an explicit future datetime — never fall back to Date.now(),
+        // which would fire the run immediately on save.
+        if (!onceAt) {
+          throw new Error("Pick a date and time for the one-time run.");
+        }
+        const at = new Date(onceAt).getTime();
+        if (Number.isNaN(at)) {
+          throw new Error("That date and time isn't valid.");
+        }
+        if (at <= Date.now()) {
+          throw new Error("Pick a date and time in the future.");
+        }
+        return { kind: "once", at };
+      }
     }
   }
 
   async function handleSave() {
     if (!name.trim() || !prompt.trim() || !agentModel) return;
+    setError(null);
+    let schedule: Schedule;
+    try {
+      schedule = buildSchedule();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return;
+    }
     setSaving(true);
     try {
-      const schedule = buildSchedule();
       if (editing) {
         await taskDb.update(editing.id, {
           name: name.trim(),
@@ -307,6 +326,11 @@ export function CreateScheduledTaskDialog({
         </div>
 
         <DialogFooter>
+          {error && (
+            <p className="mr-auto self-center text-xs text-destructive">
+              {error}
+            </p>
+          )}
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>

--- a/apps/extension/src/entrypoints/home/components/HomeSidebar.tsx
+++ b/apps/extension/src/entrypoints/home/components/HomeSidebar.tsx
@@ -18,6 +18,7 @@ import {
   Search,
   Settings,
   Trash2,
+  Clock,
 } from "lucide-react";
 import { Popover } from "radix-ui";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -35,6 +36,10 @@ interface HomeSidebarProps {
   onConfigureSpace: () => void;
   onRenameConversation: (conv: { id: string; title: string }) => void;
   onDeleteConversation: (conv: { id: string; title: string }) => void;
+  onOpenScheduled: () => void;
+  onScheduleConversation: (conv: { id: string; title: string }) => void;
+  /** True when the Scheduled view is the active main pane. */
+  scheduledActive?: boolean;
 }
 
 interface ConversationItem {
@@ -214,6 +219,9 @@ export function HomeSidebar({
   onConfigureSpace,
   onRenameConversation,
   onDeleteConversation,
+  onOpenScheduled,
+  onScheduleConversation,
+  scheduledActive,
 }: HomeSidebarProps) {
   const [pinned, setPinned] = useState(() => {
     const stored = localStorage.getItem("openbrowse-sidebar-pinned");
@@ -231,8 +239,22 @@ export function HomeSidebar({
   }, [pinned]);
 
   const refresh = useCallback(async () => {
-    const convs = await chatDb.listRootConversations(activeSpaceId);
-    setConversations(convs);
+    // Normal chats: space-scoped roots (subagent children excluded upstream).
+    const roots = await chatDb.listRootConversations(activeSpaceId);
+    // Scheduled-task runs are global (spaceId null) and have a
+    // parentConversationId, so listRootConversations omits them. Fetch the
+    // full list and surface the per-run conversations regardless of space.
+    const all = await chatDb.listConversations();
+    const scheduledRuns = all.filter(
+      (c) => c.subagentSlug === "scheduled" && !!c.parentConversationId,
+    );
+    const seen = new Set(roots.map((c) => c.id));
+    const merged = [...roots];
+    for (const run of scheduledRuns) {
+      if (!seen.has(run.id)) merged.push(run);
+    }
+    merged.sort((a, b) => b.createdAt - a.createdAt);
+    setConversations(merged);
   }, [activeSpaceId]);
 
   useEffect(() => {
@@ -430,6 +452,18 @@ export function HomeSidebar({
             <span className="flex-1 text-left">Search tabs</span>
             <Kbd>⌥K</Kbd>
           </button>
+          <button
+            type="button"
+            onClick={onOpenScheduled}
+            className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors ${
+              scheduledActive
+                ? "bg-sidebar-accent text-sidebar-foreground"
+                : "hover:bg-sidebar-accent"
+            }`}
+          >
+            <Clock className="size-3.5 shrink-0" />
+            <span className="flex-1 text-left">Scheduled</span>
+          </button>
         </div>
 
         {/* Chats */}
@@ -470,6 +504,15 @@ export function HomeSidebar({
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="right" align="start" sideOffset={4}>
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onScheduleConversation(conv);
+                    }}
+                  >
+                    <Clock className="size-3.5" />
+                    Schedule
+                  </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={(e) => {
                       e.stopPropagation();

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -50,6 +50,21 @@ export function LandingPage({
 }: LandingPageProps) {
   const recentTabs = useRecentTabs(space?.windowId ?? null);
   const [input, setInput] = useState(initialInput ?? "");
+
+  // Seed the composer from a "seed-chat-input" event targeting a new chat
+  // (conversationId === null) — used by the Scheduled view's "Create with
+  // agent" action to insert "/schedule ".
+  useEffect(() => {
+    function onSeed(e: Event) {
+      const detail = (e as CustomEvent).detail as
+        | { conversationId: string | null; text: string }
+        | undefined;
+      if (!detail || detail.conversationId != null) return;
+      setInput(detail.text);
+    }
+    window.addEventListener("seed-chat-input", onSeed);
+    return () => window.removeEventListener("seed-chat-input", onSeed);
+  }, []);
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [agentSettings, setAgentSettings] = useState<AgentSettings>(DEFAULT_AGENT_SETTINGS);
 

--- a/apps/extension/src/entrypoints/home/components/ScheduledRunHost.tsx
+++ b/apps/extension/src/entrypoints/home/components/ScheduledRunHost.tsx
@@ -1,0 +1,262 @@
+// src/entrypoints/home/components/ScheduledRunHost.tsx
+//
+// Hosts scheduled-task agent runs as BACKGROUND chats inside the home app —
+// the only realm with both a DOM and chrome.debugger/tabs/scripting. A run
+// does NOT need to be the focused conversation: the per-conversation `Chat`
+// (cached in chatInstances) runs independently of what's displayed, exactly
+// like any other background agent chat in OpenBrowse.
+//
+// The service worker, when a task fires, ensures a home page exists, records
+// the pending run in chrome.storage.session, and broadcasts SCHEDULER_HOST_RUN.
+// This host claims each run (first-writer-wins, so multiple open home pages
+// don't double-run it) and mounts a hidden ScheduledRunInstance to drive it.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAgentChat } from "@/hooks/useAgentChat";
+import { taskDb } from "@/lib/schedule/task-db";
+import {
+  extractTextContent,
+  serializeParts,
+} from "@/lib/agent/serialize-parts";
+
+const PENDING_RUNS_KEY = "scheduled-pending-runs";
+const CLAIM_KEY_PREFIX = "scheduled-run-claim:";
+
+interface PendingRun {
+  childConversationId: string;
+  taskId: string;
+}
+
+/** Read the set of pending runs the SW has queued. */
+async function readPendingRuns(): Promise<PendingRun[]> {
+  try {
+    const r = await chrome.storage.session.get(PENDING_RUNS_KEY);
+    const list = r[PENDING_RUNS_KEY];
+    return Array.isArray(list) ? (list as PendingRun[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Try to claim a run for THIS page. First-writer-wins via a session-storage
+ * flag keyed by childConversationId. Returns true if we won the claim.
+ */
+async function claimRun(childConversationId: string): Promise<boolean> {
+  const key = `${CLAIM_KEY_PREFIX}${childConversationId}`;
+  try {
+    const existing = await chrome.storage.session.get(key);
+    if (existing[key]) return false;
+    // Best-effort claim. There's an unavoidable tiny TOCTOU window across
+    // pages, but the SW running-guard + dedupe make double-run benign-rare.
+    await chrome.storage.session.set({ [key]: Date.now() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function releaseRunRecord(childConversationId: string): Promise<void> {
+  try {
+    const key = `${CLAIM_KEY_PREFIX}${childConversationId}`;
+    await chrome.storage.session.remove(key);
+    const pending = await readPendingRuns();
+    const next = pending.filter(
+      (p) => p.childConversationId !== childConversationId,
+    );
+    await chrome.storage.session.set({ [PENDING_RUNS_KEY]: next });
+  } catch {
+    // ignore
+  }
+}
+
+export function ScheduledRunHost() {
+  // Runs this page has claimed and is hosting.
+  const [hosted, setHosted] = useState<PendingRun[]>([]);
+  const hostedIdsRef = useRef<Set<string>>(new Set());
+
+  const tryHost = useCallback(async (run: PendingRun) => {
+    if (hostedIdsRef.current.has(run.childConversationId)) return;
+    const won = await claimRun(run.childConversationId);
+    if (!won) return;
+    hostedIdsRef.current.add(run.childConversationId);
+    setHosted((prev) => [...prev, run]);
+  }, []);
+
+  // On mount: scan storage for runs queued before this page loaded.
+  useEffect(() => {
+    void readPendingRuns().then((runs) => {
+      for (const run of runs) void tryHost(run);
+    });
+  }, [tryHost]);
+
+  // Live: pick up runs requested while this page is open.
+  useEffect(() => {
+    function onMessage(msg: unknown) {
+      if (typeof msg !== "object" || msg === null) return;
+      const m = msg as {
+        type?: string;
+        childConversationId?: string;
+        taskId?: string;
+      };
+      if (
+        m.type === "SCHEDULER_HOST_RUN" &&
+        m.childConversationId &&
+        m.taskId
+      ) {
+        void tryHost({
+          childConversationId: m.childConversationId,
+          taskId: m.taskId,
+        });
+      }
+    }
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [tryHost]);
+
+  const handleFinished = useCallback((childConversationId: string) => {
+    void releaseRunRecord(childConversationId);
+    hostedIdsRef.current.delete(childConversationId);
+    setHosted((prev) =>
+      prev.filter((r) => r.childConversationId !== childConversationId),
+    );
+  }, []);
+
+  return (
+    <>
+      {hosted.map((run) => (
+        <ScheduledRunInstance
+          key={run.childConversationId}
+          taskId={run.taskId}
+          childConversationId={run.childConversationId}
+          onFinished={handleFinished}
+        />
+      ))}
+    </>
+  );
+}
+
+interface InstanceProps {
+  taskId: string;
+  childConversationId: string;
+  onFinished: (childConversationId: string) => void;
+}
+
+/**
+ * Drives ONE scheduled run as a background chat via the real useAgentChat
+ * path. Renders nothing. Auto-sends the task prompt once and posts
+ * SCHEDULED_RUN_DONE when the run reaches a terminal state.
+ */
+function ScheduledRunInstance({
+  taskId,
+  childConversationId,
+  onFinished,
+}: InstanceProps) {
+  const [prompt, setPrompt] = useState<string | null>(null);
+  const [autoApprove, setAutoApprove] = useState(false);
+  const [model, setModel] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void taskDb.get(taskId).then((task) => {
+      if (cancelled) return;
+      if (!task) {
+        reportDone(childConversationId, "error", "", "Task not found.");
+        onFinished(childConversationId);
+        return;
+      }
+      setPrompt(task.prompt);
+      setAutoApprove(task.autoApprove ?? false);
+      setModel(task.agentModel);
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [taskId, childConversationId, onFinished]);
+
+  const {
+    input,
+    setInput,
+    handleSubmit,
+    isLoading,
+    messages,
+    isConfigured,
+    isReady,
+  } = useAgentChat({
+    conversationId: childConversationId,
+    spaceId: null,
+    onNewConversation: () => {},
+    headless: { autoApprove },
+    // Force the task's model for THIS run only — never persist it to the
+    // user's global agent settings (which setAgentModel would do).
+    modelOverride: model,
+  });
+
+  // Auto-send the prompt exactly once, but only after the chat transport has
+  // finished building (`isReady`). The transport is constructed asynchronously;
+  // sending before it exists falls through to the AI SDK's default `api/chat`
+  // endpoint (ERR_FILE_NOT_FOUND in the extension), failing the run instantly.
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    if (!loaded || !prompt || !isConfigured || !isReady) return;
+    if (input !== prompt) {
+      setInput(prompt);
+      return;
+    }
+    startedRef.current = true;
+    void handleSubmit();
+  }, [loaded, prompt, isConfigured, isReady, input, setInput, handleSubmit, childConversationId]);
+
+  // Terminal detection: only report done after a REAL run cycle — i.e. once
+  // we've observed isLoading become true (the run actually started) and then
+  // false. Without the `hasStreamed` gate, the effect fires immediately after
+  // handleSubmit (before isLoading flips true) and falsely reports done.
+  const hasStreamedRef = useRef(false);
+  const reportedRef = useRef(false);
+  useEffect(() => {
+    if (!startedRef.current || reportedRef.current) return;
+    if (isLoading) {
+      hasStreamedRef.current = true;
+      return;
+    }
+    if (!hasStreamedRef.current) return; // not started streaming yet
+    reportedRef.current = true;
+    const lastAssistant = [...messages]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    const finalText = lastAssistant
+      ? extractTextContent(serializeParts(lastAssistant.parts)).trim()
+      : "";
+    reportDone(
+      childConversationId,
+      finalText.length > 0 ? "success" : "error",
+      finalText,
+      finalText.length > 0
+        ? undefined
+        : "Run ended without a final summary (possible stall).",
+    );
+    onFinished(childConversationId);
+  }, [isLoading, messages, childConversationId, onFinished]);
+
+  return null;
+}
+
+function reportDone(
+  childConversationId: string,
+  status: "success" | "error",
+  finalText: string,
+  errorMessage?: string,
+): void {
+  chrome.runtime
+    ?.sendMessage?.({
+      type: "SCHEDULED_RUN_DONE",
+      childConversationId,
+      status,
+      finalText,
+      errorMessage,
+    })
+    ?.catch?.(() => {});
+}

--- a/apps/extension/src/entrypoints/home/components/ScheduledRunHost.tsx
+++ b/apps/extension/src/entrypoints/home/components/ScheduledRunHost.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAgentChat } from "@/hooks/useAgentChat";
 import { taskDb } from "@/lib/schedule/task-db";
+import { clearHeadlessRunPolicy } from "@/lib/agent/agent-transport";
 import {
   extractTextContent,
   serializeParts,
@@ -56,18 +57,40 @@ async function claimRun(childConversationId: string): Promise<boolean> {
   }
 }
 
+// Serialize all mutations of PENDING_RUNS_KEY through a single promise chain.
+// releaseRunRecord does a read-modify-write on session storage; two runs
+// finishing near-simultaneously could otherwise interleave and reinsert a
+// just-removed run. Chaining makes each read-modify-write atomic within the
+// page.
+let pendingRunsLock: Promise<void> = Promise.resolve();
+
+function serializePendingRunsOp(op: () => Promise<void>): Promise<void> {
+  const run = pendingRunsLock.then(op, op);
+  pendingRunsLock = run.then(
+    () => {},
+    () => {},
+  );
+  return run;
+}
+
 async function releaseRunRecord(childConversationId: string): Promise<void> {
+  const key = `${CLAIM_KEY_PREFIX}${childConversationId}`;
   try {
-    const key = `${CLAIM_KEY_PREFIX}${childConversationId}`;
     await chrome.storage.session.remove(key);
-    const pending = await readPendingRuns();
-    const next = pending.filter(
-      (p) => p.childConversationId !== childConversationId,
-    );
-    await chrome.storage.session.set({ [PENDING_RUNS_KEY]: next });
   } catch {
     // ignore
   }
+  await serializePendingRunsOp(async () => {
+    try {
+      const pending = await readPendingRuns();
+      const next = pending.filter(
+        (p) => p.childConversationId !== childConversationId,
+      );
+      await chrome.storage.session.set({ [PENDING_RUNS_KEY]: next });
+    } catch {
+      // ignore
+    }
+  });
 }
 
 export function ScheduledRunHost() {
@@ -116,6 +139,10 @@ export function ScheduledRunHost() {
 
   const handleFinished = useCallback((childConversationId: string) => {
     void releaseRunRecord(childConversationId);
+    // Drop the per-conversation headless policy registered by the transport
+    // so the (module-global, home-realm) policy map doesn't grow unbounded
+    // across runs. Safe: sched-run conversation ids are single-use.
+    clearHeadlessRunPolicy(childConversationId);
     hostedIdsRef.current.delete(childConversationId);
     setHosted((prev) =>
       prev.filter((r) => r.childConversationId !== childConversationId),
@@ -159,18 +186,32 @@ function ScheduledRunInstance({
 
   useEffect(() => {
     let cancelled = false;
-    void taskDb.get(taskId).then((task) => {
-      if (cancelled) return;
-      if (!task) {
-        reportDone(childConversationId, "error", "", "Task not found.");
+    void taskDb
+      .get(taskId)
+      .then((task) => {
+        if (cancelled) return;
+        if (!task) {
+          reportDone(childConversationId, "error", "", "Task not found.");
+          onFinished(childConversationId);
+          return;
+        }
+        setPrompt(task.prompt);
+        setAutoApprove(task.autoApprove ?? false);
+        setModel(task.agentModel);
+        setLoaded(true);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // taskDb.get rejected (e.g. IDB unavailable). Don't leave the run
+        // claimed and silently stuck — report failure and release it.
+        reportDone(
+          childConversationId,
+          "error",
+          "",
+          `Task retrieval failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
         onFinished(childConversationId);
-        return;
-      }
-      setPrompt(task.prompt);
-      setAutoApprove(task.autoApprove ?? false);
-      setModel(task.agentModel);
-      setLoaded(true);
-    });
+      });
     return () => {
       cancelled = true;
     };

--- a/apps/extension/src/entrypoints/home/components/ScheduledView.tsx
+++ b/apps/extension/src/entrypoints/home/components/ScheduledView.tsx
@@ -1,0 +1,360 @@
+// src/entrypoints/home/components/ScheduledView.tsx
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { taskDb } from "@/lib/schedule/task-db";
+import { chatDb } from "@/lib/chat-db";
+import { formatSchedule, formatRelativeTime } from "@/lib/schedule/format";
+import type { ScheduledTask } from "@/lib/schedule/types";
+import { CreateScheduledTaskDialog } from "./CreateScheduledTaskDialog";
+import { cn } from "@/lib/utils";
+import {
+  Clock,
+  Play,
+  Pencil,
+  Trash2,
+  ChevronDown,
+  Sparkles,
+  SlidersHorizontal,
+  Search,
+  Info,
+  MoreVertical,
+  ExternalLink,
+} from "lucide-react";
+
+interface Props {
+  /** Available model strings for the create/edit dialog. */
+  models: string[];
+  /** Open a conversation (e.g. when clicking a run). */
+  onOpenConversation: (conversationId: string) => void;
+  /** Start a new chat and seed it with the /schedule slash command. */
+  onCreateWithAgent: () => void;
+}
+
+export function ScheduledView({
+  models,
+  onOpenConversation,
+  onCreateWithAgent,
+}: Props) {
+  const [tasks, setTasks] = useState<ScheduledTask[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<ScheduledTask | null>(null);
+  const [query, setQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const refresh = useCallback(() => {
+    void taskDb.list().then((t) => setTasks(t as ScheduledTask[]));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    return taskDb.subscribe(refresh);
+  }, [refresh]);
+
+  // "/" focuses the search input when the user isn't already typing in a
+  // field. (Escape-to-clear is handled on the input's own onKeyDown.)
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      const typing =
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable);
+      if (e.key === "/" && !typing) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return tasks;
+    return tasks.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        t.prompt.toLowerCase().includes(q),
+    );
+  }, [tasks, query]);
+
+  async function toggle(task: ScheduledTask, enabled: boolean) {
+    await taskDb.update(task.id, { enabled });
+  }
+
+  function runNow(task: ScheduledTask) {
+    chrome.runtime
+      ?.sendMessage?.({ type: "SCHEDULER_RUN_NOW", taskId: task.id })
+      ?.catch?.(() => {});
+  }
+
+  // Open the last run's conversation only if it still exists and has
+  // messages. A run row can be missing (deleted) or empty (the run failed
+  // before persisting anything), in which case navigating would land on a
+  // blank chat — so we no-op instead.
+  async function openLastRun(task: ScheduledTask) {
+    const id = task.lastRunConversationId;
+    if (!id) return;
+    const conv = await chatDb.getConversation(id);
+    if (!conv) return;
+    const messages = await chatDb.getMessages(id);
+    if (messages.length === 0) return;
+    onOpenConversation(id);
+  }
+
+  async function remove(task: ScheduledTask) {
+    await taskDb.remove(task.id);
+  }
+
+  function openManualCreate() {
+    setEditing(null);
+    setDialogOpen(true);
+  }
+
+  return (
+    <div className="flex h-full min-w-0 flex-1 flex-col overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-xl font-semibold">Scheduled tasks</h1>
+            <p className="text-sm text-muted-foreground">
+              Run tasks on a schedule or whenever you need them. Type{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-[0.8em]">
+                /schedule
+              </code>{" "}
+              in any chat to set one up.
+            </p>
+            <p
+              className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground"
+              title="Scheduled tasks run in the background only while Chrome is open. If Chrome is closed when a task is due, that run is skipped and the next occurrence runs at its scheduled time."
+            >
+              <Info className="size-3.5 shrink-0" />
+              Runs only while Chrome is open; missed runs are skipped.
+            </p>
+          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button className="shrink-0 gap-1.5">
+                New task
+                <ChevronDown className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-48">
+              <DropdownMenuItem onClick={onCreateWithAgent}>
+                <Sparkles className="size-3.5 shrink-0" />
+                <span className="whitespace-nowrap">Create with agent</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={openManualCreate}>
+                <SlidersHorizontal className="size-3.5 shrink-0" />
+                <span className="whitespace-nowrap">Set up manually</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* Search */}
+        {tasks.length > 0 && (
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              ref={searchRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onFocus={() => setSearchFocused(true)}
+              onBlur={() => setSearchFocused(false)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" && query) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setQuery("");
+                  searchRef.current?.blur();
+                }
+              }}
+              placeholder="Search tasks…"
+              className="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent pl-8 pr-10 py-1 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+            />
+            {query ? (
+              <Kbd className="absolute right-2.5 top-1/2 -translate-y-1/2">
+                esc
+              </Kbd>
+            ) : !searchFocused ? (
+              <Kbd className="absolute right-2.5 top-1/2 -translate-y-1/2">
+                /
+              </Kbd>
+            ) : null}
+          </div>
+        )}
+
+        {/* List / empty state */}
+        {tasks.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+            <Clock className="size-10" />
+            <p>Create your first scheduled task</p>
+          </div>
+        ) : filtered.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No tasks match “{query}”.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {filtered.map((task) => (
+              <li
+                key={task.id}
+                className="flex items-center justify-between gap-3 rounded-lg border p-3"
+              >
+                <div
+                  className={cn(
+                    "min-w-0 flex-1",
+                    !task.enabled && "opacity-60",
+                  )}
+                >
+                  <span className="font-medium">{task.name}</span>
+                  <p className="truncate text-sm text-muted-foreground">
+                    {task.description || task.prompt}
+                  </p>
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <span>{formatSchedule(task.schedule)}</span>
+                    {!task.enabled ? (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>Paused</span>
+                      </>
+                    ) : (
+                      typeof task.nextRunAt === "number" && (
+                        <>
+                          <span aria-hidden>·</span>
+                          <span title={new Date(task.nextRunAt).toLocaleString()}>
+                            Next run {formatRelativeTime(task.nextRunAt)}
+                          </span>
+                        </>
+                      )
+                    )}
+                    {task.enabled && task.lastRunStatus && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <RunStatusBadge
+                          status={task.lastRunStatus}
+                          error={task.lastRunError}
+                        />
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <Switch
+                          checked={task.enabled}
+                          onCheckedChange={(v) => toggle(task, v)}
+                        />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {task.enabled ? "Pause" : "Resume"}
+                    </TooltipContent>
+                  </Tooltip>
+
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon">
+                        <MoreVertical className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => runNow(task)}>
+                        <Play className="size-3.5" />
+                        Run now
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setEditing(task);
+                          setDialogOpen(true);
+                        }}
+                      >
+                        <Pencil className="size-3.5" />
+                        Edit
+                      </DropdownMenuItem>
+                      {task.lastRunConversationId &&
+                        (task.lastRunStatus === "success" ||
+                          task.lastRunStatus === "error") && (
+                          <DropdownMenuItem
+                            onClick={() => openLastRun(task)}
+                          >
+                            <ExternalLink className="size-3.5" />
+                            View last run
+                          </DropdownMenuItem>
+                        )}
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => remove(task)}
+                      >
+                        <Trash2 className="size-3.5" />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <CreateScheduledTaskDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        editing={editing}
+        models={models}
+      />
+    </div>
+  );
+}
+
+function RunStatusBadge({
+  status,
+  error,
+}: {
+  status: NonNullable<ScheduledTask["lastRunStatus"]>;
+  error?: string;
+}) {
+  const config = {
+    success: { label: "Last run succeeded", dot: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-400" },
+    error: { label: "Last run failed", dot: "bg-destructive", text: "text-destructive" },
+    running: { label: "Running…", dot: "bg-amber-500", text: "text-amber-600 dark:text-amber-400" },
+  }[status];
+
+  return (
+    <span
+      className={cn("inline-flex items-center gap-1", config.text)}
+      title={status === "error" && error ? error : undefined}
+    >
+      <span
+        className={cn(
+          "size-1.5 rounded-full",
+          config.dot,
+          status === "running" && "animate-pulse",
+        )}
+      />
+      {config.label}
+    </span>
+  );
+}

--- a/apps/extension/src/entrypoints/home/components/ScheduledView.tsx
+++ b/apps/extension/src/entrypoints/home/components/ScheduledView.tsx
@@ -265,6 +265,7 @@ export function ScheduledView({
                         <Switch
                           checked={task.enabled}
                           onCheckedChange={(v) => toggle(task, v)}
+                          aria-label={`${task.enabled ? "Pause" : "Resume"} ${task.name}`}
                         />
                       </span>
                     </TooltipTrigger>
@@ -275,7 +276,11 @@ export function ScheduledView({
 
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Open actions for ${task.name}`}
+                      >
                         <MoreVertical className="size-4" />
                       </Button>
                     </DropdownMenuTrigger>

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -102,6 +102,21 @@ interface UseAgentChatOptions {
    * null when the user has dismissed the pill or no eligible tab is active.
    */
   getSharedTabId?: () => number | null;
+  /**
+   * When set, this chat is a headless scheduled run: the transport is built
+   * with the headless policy (auto-approve / approval-tool filtering) so the
+   * run completes with no human present.
+   */
+  headless?: { autoApprove: boolean };
+  /**
+   * Forces the agent model for this chat instance only, WITHOUT persisting to
+   * the global agent settings. Used by background scheduled runs so a task's
+   * configured model doesn't overwrite the user's globally-selected model (and
+   * doesn't get broadcast to other open chat instances via the agent-settings
+   * storage listener). When set, this value also survives the async
+   * getAgentSettings() hydration.
+   */
+  modelOverride?: string | null;
 }
 
 function generateId() {
@@ -664,6 +679,8 @@ export function useAgentChat({
   onNewConversation,
   initialInput,
   getSharedTabId,
+  headless,
+  modelOverride,
 }: UseAgentChatOptions) {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [agentSettings, setAgentSettings] = useState<AgentSettings>(
@@ -712,7 +729,11 @@ export function useAgentChat({
 
   useEffect(() => {
     storage.getSettings().then(setSettings);
-    storage.getAgentSettings().then(setAgentSettings);
+    storage.getAgentSettings().then((loaded) =>
+      setAgentSettings(
+        modelOverride ? { ...loaded, agentModel: modelOverride } : loaded,
+      ),
+    );
     const listener = (
       changes: Record<string, chrome.storage.StorageChange>,
       area: string,
@@ -720,12 +741,18 @@ export function useAgentChat({
       if (area === "local") {
         if (changes.settings) storage.getSettings().then(setSettings);
         if (changes["agent-settings"])
-          storage.getAgentSettings().then(setAgentSettings);
+          storage.getAgentSettings().then((loaded) =>
+            setAgentSettings(
+              modelOverride
+                ? { ...loaded, agentModel: modelOverride }
+                : loaded,
+            ),
+          );
       }
     };
     chrome.storage.onChanged.addListener(listener);
     return () => chrome.storage.onChanged.removeListener(listener);
-  }, []);
+  }, [modelOverride]);
 
   /**
    * Hydrate the per-conversation queue and keep it in sync with both
@@ -882,11 +909,12 @@ export function useAgentChat({
         agentSettings.thinkingEnabled
           ? { enabled: true, config: agentSettings.thinkingConfig }
           : undefined,
+        headless,
       );
       if (!cancelled) setTransport(t);
     })();
     return () => { cancelled = true; };
-  }, [settings, agentSettings.agentModel, agentSettings.thinkingEnabled, agentSettings.thinkingConfig, spaceId, mcpVersion]);
+  }, [settings, agentSettings.agentModel, agentSettings.thinkingEnabled, agentSettings.thinkingConfig, spaceId, mcpVersion, headless?.autoApprove]);
 
   // Get or create a Chat instance for the current conversation
   const origin: "sidepanel" | "home" = window.location.pathname.includes("home")
@@ -2069,6 +2097,13 @@ export function useAgentChat({
     isStreaming,
     isCompacting,
     isConfigured,
+    // True once the chat transport has finished building. The transport is
+    // constructed asynchronously (createAgentTransport), so on first render it
+    // is null and the underlying Chat has no transport — sending then would
+    // fall through to the AI SDK's default `api/chat` endpoint (ERR_FILE_NOT_FOUND
+    // in the extension). Headless/background runs auto-send and must wait for
+    // this before calling handleSubmit.
+    isReady: transport !== null,
     hasVisionSupport,
     settings,
     updateSettings,

--- a/apps/extension/src/lib/active-agents.race.test.ts
+++ b/apps/extension/src/lib/active-agents.race.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Reproduces the hypothesized concurrent read-modify-write race in
+// active-agents.ts. A realistic chrome.storage.local backend resolves get/set
+// asynchronously (microtask), so two overlapping mutations can read the same
+// snapshot and the later set() clobbers the earlier one.
+
+function makeAsyncStorage() {
+  const data: Record<string, unknown> = {};
+  return {
+    store: data,
+    local: {
+      get: vi.fn((key: string) =>
+        // Resolve on a microtask, mimicking real async storage. This is what
+        // creates the interleaving window between two callers.
+        Promise.resolve().then(() => ({ [key]: data[key] })),
+      ),
+      set: vi.fn((obj: Record<string, unknown>) =>
+        Promise.resolve().then(() => {
+          Object.assign(data, obj);
+        }),
+      ),
+      remove: vi.fn(() => Promise.resolve()),
+    },
+    onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+  };
+}
+
+describe("active-agents concurrent mutation race", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("keeps both ids when two setAgentActive calls overlap", async () => {
+    const storage = makeAsyncStorage();
+    vi.stubGlobal("chrome", { storage });
+
+    const { setAgentActive, getActiveAgents } = await import("./active-agents");
+
+    // Fire two activations "simultaneously" (no await between) — exactly the
+    // scenario when the visible chat and the hidden scheduled run both flip to
+    // streaming at about the same time.
+    await Promise.all([setAgentActive("chat-A"), setAgentActive("sched-run-1")]);
+
+    const result = await getActiveAgents();
+    expect(result).toContain("chat-A");
+    expect(result).toContain("sched-run-1");
+  });
+
+  it("keeps the run id when an unrelated chat goes inactive concurrently", async () => {
+    const storage = makeAsyncStorage();
+    storage.store["active-agents"] = ["chat-A"];
+    vi.stubGlobal("chrome", { storage });
+
+    const { setAgentActive, setAgentInactive, getActiveAgents } = await import(
+      "./active-agents"
+    );
+
+    // The visible chat finishes (clears its id) at the same instant the
+    // background scheduled run starts (sets its id). The run id must survive.
+    await Promise.all([
+      setAgentInactive("chat-A"),
+      setAgentActive("sched-run-1"),
+    ]);
+
+    const result = await getActiveAgents();
+    expect(result).toContain("sched-run-1");
+  });
+});

--- a/apps/extension/src/lib/active-agents.ts
+++ b/apps/extension/src/lib/active-agents.ts
@@ -5,16 +5,41 @@ export async function getActiveAgents(): Promise<string[]> {
   return (result[STORAGE_KEYS.ACTIVE_AGENTS] as string[]) ?? [];
 }
 
-export async function setAgentActive(conversationId: string): Promise<void> {
-  const agents = await getActiveAgents();
-  if (!agents.includes(conversationId)) {
-    agents.push(conversationId);
-    await chrome.storage.local.set({ [STORAGE_KEYS.ACTIVE_AGENTS]: agents });
-  }
+// `setAgentActive` / `setAgentInactive` are read-modify-write against
+// chrome.storage.local. Multiple `useAgentChat` instances live in one page
+// (the visible chat plus any hidden background scheduled-run hosts), and their
+// status effects can fire near-simultaneously. Without serialization, two
+// overlapping mutations read the same snapshot and the later `set` clobbers
+// the earlier one — silently dropping a conversation id from the active list,
+// so its sidebar "running" dot never appears (or vanishes early). Chaining all
+// mutations onto a single promise queue makes each read-modify-write atomic
+// within the page.
+let mutationQueue: Promise<void> = Promise.resolve();
+
+function enqueueMutation(mutate: () => Promise<void>): Promise<void> {
+  const run = mutationQueue.then(mutate, mutate);
+  // Keep the queue alive even if a mutation rejects.
+  mutationQueue = run.then(
+    () => {},
+    () => {},
+  );
+  return run;
 }
 
-export async function setAgentInactive(conversationId: string): Promise<void> {
-  const agents = await getActiveAgents();
-  const updated = agents.filter((id) => id !== conversationId);
-  await chrome.storage.local.set({ [STORAGE_KEYS.ACTIVE_AGENTS]: updated });
+export function setAgentActive(conversationId: string): Promise<void> {
+  return enqueueMutation(async () => {
+    const agents = await getActiveAgents();
+    if (!agents.includes(conversationId)) {
+      agents.push(conversationId);
+      await chrome.storage.local.set({ [STORAGE_KEYS.ACTIVE_AGENTS]: agents });
+    }
+  });
+}
+
+export function setAgentInactive(conversationId: string): Promise<void> {
+  return enqueueMutation(async () => {
+    const agents = await getActiveAgents();
+    const updated = agents.filter((id) => id !== conversationId);
+    await chrome.storage.local.set({ [STORAGE_KEYS.ACTIVE_AGENTS]: updated });
+  });
 }

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -43,12 +43,14 @@ import {
 import {
   clickElementTool,
   closeTabsTool,
+  createScheduledTaskTool,
   createSkillTool,
   deleteMemoryTool,
   executeCodeTool,
   executeOnPageTool,
   extractTool,
   installSkillTool,
+  listScheduledTasksTool,
   listTabsTool,
   navigateTool,
   readPageTool,
@@ -62,6 +64,7 @@ import {
   todoWriteTool,
   typeInElementTool,
   updateMemoryTool,
+  updateScheduledTaskTool,
 } from "./tools";
 import { createDelegateTool } from "./tools/delegate";
 import { createFsTools } from "./tools/fs";
@@ -355,6 +358,28 @@ let lastIndicatorTabId: number | null = null;
 
 let agentConversationId: string | null = null;
 
+/**
+ * Per-conversation policy for HEADLESS runs (scheduled tasks). When a policy
+ * is present for the active conversation, `toSDKTool`'s approval gate honors
+ * `autoApprove` instead of prompting a (non-existent) human. Set by the
+ * offscreen scheduled-run host around a run; cleared in its `finally`.
+ */
+interface HeadlessRunPolicy {
+  autoApprove: boolean;
+}
+const headlessRunPolicies = new Map<string, HeadlessRunPolicy>();
+
+export function setHeadlessRunPolicy(
+  conversationId: string,
+  policy: HeadlessRunPolicy,
+): void {
+  headlessRunPolicies.set(conversationId, policy);
+}
+
+export function clearHeadlessRunPolicy(conversationId: string): void {
+  headlessRunPolicies.delete(conversationId);
+}
+
 let lastTotalTokens = 0;
 let currentModelDef: ModelDefinition | undefined;
 
@@ -551,6 +576,64 @@ const extensionDriver = new ExtensionDriver();
  * The bench harness builds its own minimal context with `session` left
  * undefined.
  */
+/**
+ * Build the browser tool set for a conversation. Extracted from
+ * `createAgentTransport` so the headless scheduled-run loop can reuse the
+ * exact same tool wrappers. `fsTools`/`pythonTool` are conversation-scoped,
+ * so they are created here from `conversationId`. The tools resolve their
+ * `ToolContext` at call time from the SDK's `experimental_context` (or the
+ * module-level `agentConversationId` fallback), so this function does not
+ * take a context argument.
+ */
+export function createBrowserToolSet(
+  conversationId: string | null,
+): Record<string, ToolSet[string]> {
+  const fsTools = createFsTools(conversationId);
+  const pythonTool = createPythonTool(conversationId);
+  return {
+    snapshot: toSDKTool(snapshotTool, "snapshot"),
+    readPage: toSDKTool(readPageTool, "readPage"),
+    screenshot: toSDKTool(screenshotTool, "screenshot"),
+    listTabs: toSDKTool(listTabsTool, "listTabs"),
+    navigate: toSDKTool(navigateTool, "navigate"),
+    clickElement: toSDKTool(clickElementTool, "clickElement"),
+    typeInElement: toSDKTool(typeInElementTool, "typeInElement"),
+    scrollPage: toSDKTool(scrollPageTool, "scrollPage"),
+    selectTab: toSDKTool(selectTabTool, "selectTab"),
+    closeTabs: toSDKTool(closeTabsTool, "closeTabs"),
+    saveMemory: toSDKTool(saveMemoryTool, "saveMemory"),
+    updateMemory: toSDKTool(updateMemoryTool, "updateMemory"),
+    recallMemory: toSDKTool(recallMemoryTool, "recallMemory"),
+    deleteMemory: toSDKTool(deleteMemoryTool, "deleteMemory"),
+    executeCode: toSDKTool(executeCodeTool, "executeCode"),
+    executeOnPage: toSDKTool(executeOnPageTool, "executeOnPage"),
+    executePython: toSDKTool(pythonTool, "executePython"),
+    extract: toSDKTool(extractTool, "extract"),
+    todoWrite: toSDKTool(todoWriteTool, "todoWrite"),
+    skill: toSDKTool(skillTool, "skill"),
+    install_skill: toSDKTool(installSkillTool, "install_skill"),
+    create_skill: toSDKTool(createSkillTool, "create_skill"),
+    create_scheduled_task: toSDKTool(
+      createScheduledTaskTool,
+      "create_scheduled_task",
+    ),
+    list_scheduled_tasks: toSDKTool(
+      listScheduledTasksTool,
+      "list_scheduled_tasks",
+    ),
+    update_scheduled_task: toSDKTool(
+      updateScheduledTaskTool,
+      "update_scheduled_task",
+    ),
+    Read: toSDKTool(fsTools.readTool, "Read"),
+    Write: toSDKTool(fsTools.writeTool, "Write"),
+    Edit: toSDKTool(fsTools.editTool, "Edit"),
+    Glob: toSDKTool(fsTools.globTool, "Glob"),
+    Grep: toSDKTool(fsTools.grepTool, "Grep"),
+    LS: toSDKTool(fsTools.lsTool, "LS"),
+  };
+}
+
 export function buildExtensionToolContext(
   pinnedConversationId: string | null,
 ): ToolContext {
@@ -747,6 +830,33 @@ export function toSDKTool<TInput, TOutput>(
           }
         : approvalRequired;
 
+  /**
+   * Wrap the resolved `needsApproval` so that during a HEADLESS scheduled
+   * run with `autoApprove`, approval-gated tools execute without prompting
+   * (there's no human to approve). When the policy is absent or
+   * `autoApprove` is false, the original behavior applies. (Approval-gated
+   * tools are omitted entirely from non-auto-approve headless runs at the
+   * tool-set level, so this branch only matters for auto-approve.)
+   */
+  const needsApprovalWithHeadless =
+    approvalRequired && typeof needsApproval !== "boolean"
+      ? async (input: unknown, opts: unknown) => {
+          const cid = agentConversationId;
+          const policy = cid ? headlessRunPolicies.get(cid) : undefined;
+          if (policy?.autoApprove) return false;
+          return (
+            needsApproval as (i: unknown, o: unknown) => Promise<boolean>
+          )(input, opts);
+        }
+      : approvalRequired
+        ? async () => {
+            const cid = agentConversationId;
+            const policy = cid ? headlessRunPolicies.get(cid) : undefined;
+            if (policy?.autoApprove) return false;
+            return true;
+          }
+        : needsApproval;
+
   const execute = async (
     input: TInput,
     options: {
@@ -925,7 +1035,7 @@ export function toSDKTool<TInput, TOutput>(
       : undefined,
     strict: true,
     execute,
-    needsApproval,
+    needsApproval: needsApprovalWithHeadless,
     ...(onInputAvailable && { onInputAvailable }),
     ...(toModelOutput && { toModelOutput }),
   } as ToolSet[string];
@@ -1023,6 +1133,10 @@ export async function createAgentTransport(
     enabled: boolean;
     config?: import("../types").ThinkingConfig;
   },
+  headless?: {
+    /** Auto-approve approval-gated tools (no human present). */
+    autoApprove: boolean;
+  },
 ): Promise<ChatTransport<AgentUIMessage> | null> {
   if (!agentModel) return null;
 
@@ -1058,6 +1172,16 @@ export async function createAgentTransport(
   // (1M window) or Claude Sonnet 4.5 (200K window).
   const modelDef = provider.models.find((m) => m.id === actualModelId);
   setCurrentModelDef(modelDef);
+
+  // Headless (scheduled) run: register the per-conversation policy so the
+  // tool wrapper's approval gate auto-approves (or the tool set excludes
+  // approval-gated tools) for this conversation. Keyed by conversationId so
+  // it doesn't affect interactive chats in the same realm.
+  if (headless && conversationId) {
+    setHeadlessRunPolicy(conversationId, {
+      autoApprove: headless.autoApprove,
+    });
+  }
 
   // Resolve the evaluator model once at transport build time. When
   // settings.completionCheck.evaluatorModel is unset (the recommended
@@ -1106,39 +1230,7 @@ export async function createAgentTransport(
     }
   }
 
-  const fsTools = createFsTools(conversationId);
-  const pythonTool = createPythonTool(conversationId);
-
-  const browserTools: Record<string, ToolSet[string]> = {
-    snapshot: toSDKTool(snapshotTool, "snapshot"),
-    readPage: toSDKTool(readPageTool, "readPage"),
-    screenshot: toSDKTool(screenshotTool, "screenshot"),
-    listTabs: toSDKTool(listTabsTool, "listTabs"),
-    navigate: toSDKTool(navigateTool, "navigate"),
-    clickElement: toSDKTool(clickElementTool, "clickElement"),
-    typeInElement: toSDKTool(typeInElementTool, "typeInElement"),
-    scrollPage: toSDKTool(scrollPageTool, "scrollPage"),
-    selectTab: toSDKTool(selectTabTool, "selectTab"),
-    closeTabs: toSDKTool(closeTabsTool, "closeTabs"),
-    saveMemory: toSDKTool(saveMemoryTool, "saveMemory"),
-    updateMemory: toSDKTool(updateMemoryTool, "updateMemory"),
-    recallMemory: toSDKTool(recallMemoryTool, "recallMemory"),
-    deleteMemory: toSDKTool(deleteMemoryTool, "deleteMemory"),
-    executeCode: toSDKTool(executeCodeTool, "executeCode"),
-    executeOnPage: toSDKTool(executeOnPageTool, "executeOnPage"),
-    executePython: toSDKTool(pythonTool, "executePython"),
-    extract: toSDKTool(extractTool, "extract"),
-    todoWrite: toSDKTool(todoWriteTool, "todoWrite"),
-    skill: toSDKTool(skillTool, "skill"),
-    install_skill: toSDKTool(installSkillTool, "install_skill"),
-    create_skill: toSDKTool(createSkillTool, "create_skill"),
-    Read: toSDKTool(fsTools.readTool, "Read"),
-    Write: toSDKTool(fsTools.writeTool, "Write"),
-    Edit: toSDKTool(fsTools.editTool, "Edit"),
-    Glob: toSDKTool(fsTools.globTool, "Glob"),
-    Grep: toSDKTool(fsTools.grepTool, "Grep"),
-    LS: toSDKTool(fsTools.lsTool, "LS"),
-  };
+  const browserTools = createBrowserToolSet(conversationId);
 
   // The completion-check evaluator runs WITHOUT tools by default.
   //
@@ -1498,7 +1590,38 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
     runAgentLoop: runSubagentAgentLoop,
   });
 
-  const tools = { ...parentTools, delegate: toSDKTool(delegateTool, "delegate") };
+  const tools = (() => {
+    const base = {
+      ...parentTools,
+      delegate: toSDKTool(delegateTool, "delegate"),
+    };
+    if (!headless) return base;
+    // Headless (scheduled) run: never spawn subagents. When not
+    // auto-approving, also drop approval-gated tools (no human to approve).
+    const HEADLESS_DROP = new Set<string>(["delegate"]);
+    if (!headless.autoApprove) {
+      for (const k of [
+        "closeTabs",
+        "executeOnPage",
+        "executePython",
+        "updateMemory",
+        "install_skill",
+        "create_skill",
+      ]) {
+        HEADLESS_DROP.add(k);
+      }
+    }
+    // Scheduled runs must never create/modify scheduled tasks (no recursion).
+    HEADLESS_DROP.add("create_scheduled_task");
+    HEADLESS_DROP.add("list_scheduled_tasks");
+    HEADLESS_DROP.add("update_scheduled_task");
+    const filtered: Record<string, ToolSet[string]> = {};
+    for (const [name, sdkTool] of Object.entries(base)) {
+      if (HEADLESS_DROP.has(name)) continue;
+      filtered[name] = sdkTool;
+    }
+    return filtered;
+  })();
 
   // Per-stream "needs mid-stream compaction" signal. Set by `onStepFinish`
   // when token usage crosses the threshold; read by `stopWhen` to break

--- a/apps/extension/src/lib/agent/driver/browser-driver.ts
+++ b/apps/extension/src/lib/agent/driver/browser-driver.ts
@@ -75,7 +75,7 @@ export interface BrowserDriver {
    * (chrome://, chrome-extension://, devtools://) so the agent never
    * accidentally targets its own UI.
    */
-  listTabs(): Promise<BrowserTabInfo[]>;
+  listTabs(targetWindowId?: number): Promise<BrowserTabInfo[]>;
 
   /**
    * Navigate an existing tab to a new URL. Returns once the navigation has

--- a/apps/extension/src/lib/agent/driver/extension-driver.ts
+++ b/apps/extension/src/lib/agent/driver/extension-driver.ts
@@ -75,10 +75,11 @@ export class ExtensionDriver implements BrowserDriver {
     return getTargetTabId();
   }
 
-  async listTabs(): Promise<BrowserTabInfo[]> {
-    const window = await chrome.windows.getCurrent();
-    if (!window.id) return [];
-    const tabs = await chrome.tabs.query({ windowId: window.id });
+  async listTabs(targetWindowId?: number): Promise<BrowserTabInfo[]> {
+    const windowId =
+      targetWindowId ?? (await chrome.windows.getCurrent()).id;
+    if (windowId == null) return [];
+    const tabs = await chrome.tabs.query({ windowId });
     return tabs
       .filter((t) => !isInternalUrl(t.url))
       .map(toBrowserTabInfo);

--- a/apps/extension/src/lib/agent/scheduled-run.test.ts
+++ b/apps/extension/src/lib/agent/scheduled-run.test.ts
@@ -1,0 +1,120 @@
+// src/lib/agent/scheduled-run.test.ts
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { chatDb } from "@/lib/chat-db";
+import { taskDb } from "@/lib/schedule/task-db";
+import { runScheduledTask } from "./scheduled-run";
+
+beforeEach(() => {
+  indexedDB = new IDBFactory();
+  chatDb._resetForTests();
+});
+
+async function seedTask(over: Record<string, unknown> = {}) {
+  return taskDb.create({
+    name: "t",
+    description: "d",
+    prompt: "do the thing",
+    agentModel: "openai:gpt-4o",
+    schedule: { kind: "daily", hour: 9, minute: 0 },
+    enabled: true,
+    needsBrowser: true,
+    ...over,
+  });
+}
+
+describe("runScheduledTask", () => {
+  it("hosts the run, awaits its result, finalizes the child + bookkeeping + notifies", async () => {
+    const task = await seedTask();
+    const hosted: string[] = [];
+    const notified: any[] = [];
+
+    const result = await runScheduledTask(task.id, {
+      hostRun: async ({ childConversationId }) => {
+        hosted.push(childConversationId);
+      },
+      awaitResult: async () => ({ finalText: "All set.", status: "success" }),
+      notify: (p) => notified.push(p),
+      now: () => 1_000_000,
+    });
+
+    expect(result.status).toBe("success");
+    expect(hosted).toHaveLength(1);
+    expect(notified).toHaveLength(1);
+    expect(notified[0].kind).toBe("complete");
+
+    const after = await taskDb.get(task.id);
+    expect(after?.lastRunStatus).toBe("success");
+    expect(after?.lastRunAt).toBe(1_000_000);
+    expect(after?.lastRunConversationId).toBeTruthy();
+    expect(after?.nextRunAt).toBeTypeOf("number");
+    expect(after?.taskConversationId).toBeTruthy();
+
+    const children = await chatDb.listChildren(after!.taskConversationId!);
+    expect(children).toHaveLength(1);
+    expect(children[0].subagentStatus).toBe("completed");
+  });
+
+  it("records error status when the host/await throws", async () => {
+    const task = await seedTask();
+    const result = await runScheduledTask(task.id, {
+      hostRun: async () => {},
+      awaitResult: async () => {
+        throw new Error("boom");
+      },
+      notify: () => {},
+      now: () => 2_000_000,
+    });
+    expect(result.status).toBe("error");
+    const after = await taskDb.get(task.id);
+    expect(after?.lastRunStatus).toBe("error");
+    expect(after?.lastRunError).toContain("boom");
+  });
+
+  it("records error status when the run reports failure", async () => {
+    const task = await seedTask();
+    await runScheduledTask(task.id, {
+      hostRun: async () => {},
+      awaitResult: async () => ({
+        finalText: "",
+        status: "error",
+        errorMessage: "stalled",
+      }),
+      notify: () => {},
+      now: () => 4_000_000,
+    });
+    const after = await taskDb.get(task.id);
+    expect(after?.lastRunStatus).toBe("error");
+    expect(after?.lastRunError).toBe("stalled");
+  });
+
+  it("skips a task already marked running (no double-fire)", async () => {
+    const task = await seedTask();
+    await taskDb.update(task.id, { lastRunStatus: "running" });
+    let hostCalls = 0;
+
+    const result = await runScheduledTask(task.id, {
+      hostRun: async () => {
+        hostCalls += 1;
+      },
+      awaitResult: async () => ({ finalText: "x", status: "success" }),
+      notify: () => {},
+      now: () => 5_000_000,
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(hostCalls).toBe(0);
+  });
+
+  it("recomputes nextRunAt (manual stays null)", async () => {
+    const task = await seedTask({ schedule: { kind: "manual" } });
+    await runScheduledTask(task.id, {
+      hostRun: async () => {},
+      awaitResult: async () => ({ finalText: "ok", status: "success" }),
+      notify: () => {},
+      now: () => 3_000_000,
+    });
+    const after = await taskDb.get(task.id);
+    expect(after?.nextRunAt).toBeNull();
+  });
+});

--- a/apps/extension/src/lib/agent/scheduled-run.test.ts
+++ b/apps/extension/src/lib/agent/scheduled-run.test.ts
@@ -117,4 +117,78 @@ describe("runScheduledTask", () => {
     const after = await taskDb.get(task.id);
     expect(after?.nextRunAt).toBeNull();
   });
+
+  it("registers the result waiter BEFORE broadcasting hostRun", async () => {
+    // Simulate a home page that posts SCHEDULED_RUN_DONE synchronously during
+    // hostRun: awaitResult must already be pending so the result isn't lost.
+    const task = await seedTask();
+    let awaitResultCalled = false;
+    let hostRunCalled = false;
+
+    const result = await runScheduledTask(task.id, {
+      awaitResult: async () => {
+        awaitResultCalled = true;
+        return { finalText: "fast", status: "success" };
+      },
+      hostRun: async () => {
+        hostRunCalled = true;
+        // By the time hostRun runs, awaitResult must already have been invoked.
+        expect(awaitResultCalled).toBe(true);
+      },
+      notify: () => {},
+      now: () => 6_000_000,
+    });
+
+    expect(hostRunCalled).toBe(true);
+    expect(result.status).toBe("success");
+  });
+
+  it("marks the task failed if conversation setup throws (not left running)", async () => {
+    const task = await seedTask();
+    // Force createConversation to fail by closing the DB out from under it is
+    // hard; instead, pre-create the child id collision is also hard. Simplest:
+    // stub chatDb.createConversation to throw for this test.
+    const orig = chatDb.createConversation;
+    (chatDb as any).createConversation = async () => {
+      throw new Error("db write failed");
+    };
+    try {
+      const result = await runScheduledTask(task.id, {
+        hostRun: async () => {},
+        awaitResult: async () => ({ finalText: "x", status: "success" }),
+        notify: () => {},
+        now: () => 7_000_000,
+      });
+      expect(result.status).toBe("error");
+      const after = await taskDb.get(task.id);
+      expect(after?.lastRunStatus).toBe("error");
+      expect(after?.lastRunError).toContain("db write failed");
+      // Crucially, not stuck as "running".
+      expect(after?.lastRunStatus).not.toBe("running");
+    } finally {
+      (chatDb as any).createConversation = orig;
+    }
+  });
+
+  it("claimRun is atomic: only one of two concurrent runs proceeds", async () => {
+    const task = await seedTask();
+    let hostCalls = 0;
+    const deps = {
+      hostRun: async () => {
+        hostCalls += 1;
+      },
+      awaitResult: async () => ({ finalText: "x", status: "success" as const }),
+      notify: () => {},
+      now: () => 8_000_000,
+    };
+
+    const [a, b] = await Promise.all([
+      runScheduledTask(task.id, deps),
+      runScheduledTask(task.id, deps),
+    ]);
+
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual(["skipped", "success"]);
+    expect(hostCalls).toBe(1);
+  });
 });

--- a/apps/extension/src/lib/agent/scheduled-run.ts
+++ b/apps/extension/src/lib/agent/scheduled-run.ts
@@ -52,50 +52,71 @@ export async function runScheduledTask(
   deps: RunScheduledTaskDeps,
 ): Promise<RunScheduledTaskResult> {
   const now = deps.now ?? Date.now;
+
+  // Atomically claim the task: sets lastRunStatus="running" only if it isn't
+  // already running, in one IDB transaction. This closes the TOCTOU gap where
+  // an alarm tick and a "run now" request both pass a separate get() guard and
+  // then double-fire the same task.
+  const claimed = await taskDb.claimRun(taskId);
+  if (!claimed) return { status: "skipped" };
+
   const task = await taskDb.get(taskId);
+  // Defensive: claimRun returned true, so the row existed a moment ago.
   if (!task) return { status: "skipped" };
 
-  // Guard against starting a second concurrent run of the same task.
-  if (task.lastRunStatus === "running") return { status: "skipped" };
+  // Pre-host setup: create the parent + per-run conversations. If any of this
+  // throws, the task would otherwise stay stuck as "running" until the next
+  // SW startup reschedule — so mark it failed here and bail.
+  let childConversationId: string;
+  try {
+    // Ensure a parent "task" conversation exists to own this run's transcript.
+    let taskConversationId = task.taskConversationId;
+    if (!taskConversationId) {
+      taskConversationId = `task-conv-${taskId}`;
+      await chatDb.createConversation({
+        id: taskConversationId,
+        title: task.name,
+        spaceId: null,
+        parentConversationId: null,
+        subagentSlug: "scheduled",
+        subagentStatus: null,
+        createdAt: now(),
+        updatedAt: now(),
+      });
+      await taskDb.update(taskId, { taskConversationId });
+    }
 
-  // Mark running so a concurrent tick won't double-fire this task.
-  await taskDb.update(taskId, { lastRunStatus: "running" });
-
-  // Ensure a parent "task" conversation exists to own this run's transcript.
-  let taskConversationId = task.taskConversationId;
-  if (!taskConversationId) {
-    taskConversationId = `task-conv-${taskId}`;
+    // Create the child (per-run) conversation.
+    childConversationId = `sched-run-${taskId}-${now()}`;
     await chatDb.createConversation({
-      id: taskConversationId,
-      title: task.name,
+      id: childConversationId,
+      title: `${task.name} — ${new Date(now()).toLocaleString()}`,
       spaceId: null,
-      parentConversationId: null,
+      parentConversationId: taskConversationId,
       subagentSlug: "scheduled",
-      subagentStatus: null,
+      subagentStatus: "running",
       createdAt: now(),
       updatedAt: now(),
     });
-    await taskDb.update(taskId, { taskConversationId });
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    await taskDb.update(taskId, {
+      lastRunStatus: "error",
+      lastRunError: errorMessage,
+      lastRunAt: now(),
+      nextRunAt: computeNextRun(task.schedule, now()),
+    });
+    return { status: "error" };
   }
-
-  // Create the child (per-run) conversation.
-  const childConversationId = `sched-run-${taskId}-${now()}`;
-  await chatDb.createConversation({
-    id: childConversationId,
-    title: `${task.name} — ${new Date(now()).toLocaleString()}`,
-    spaceId: null,
-    parentConversationId: taskConversationId,
-    subagentSlug: "scheduled",
-    subagentStatus: "running",
-    createdAt: now(),
-    updatedAt: now(),
-  });
 
   let result: ScheduledLoopResult;
   try {
-    // Hand the run to a home page (ensure one exists), then await its result.
+    // Register the result waiter BEFORE broadcasting the host request, so a
+    // home page that runs and posts SCHEDULED_RUN_DONE immediately can't beat
+    // the waiter registration (which would strand the run until timeout).
+    const resultPromise = deps.awaitResult({ taskId, childConversationId });
     await deps.hostRun({ taskId, childConversationId });
-    result = await deps.awaitResult({ taskId, childConversationId });
+    result = await resultPromise;
   } catch (err) {
     result = {
       finalText: "",
@@ -226,6 +247,27 @@ export function createHomeHostDeps(
       });
     },
   };
+}
+
+/**
+ * Lazily-initialized singleton of the production host deps. `createHomeHostDeps`
+ * attaches a `chrome.runtime.onMessage` listener (on first `hostRun`) that lives
+ * for the SW's lifetime; creating a fresh deps object per tick / per "run now"
+ * would accumulate one listener per invocation. Callers must reuse this single
+ * instance so exactly one listener exists.
+ */
+let homeHostDepsSingleton:
+  | Pick<RunScheduledTaskDeps, "hostRun" | "awaitResult">
+  | null = null;
+
+export function getHomeHostDeps(): Pick<
+  RunScheduledTaskDeps,
+  "hostRun" | "awaitResult"
+> {
+  if (!homeHostDepsSingleton) {
+    homeHostDepsSingleton = createHomeHostDeps();
+  }
+  return homeHostDepsSingleton;
 }
 
 /**

--- a/apps/extension/src/lib/agent/scheduled-run.ts
+++ b/apps/extension/src/lib/agent/scheduled-run.ts
@@ -1,0 +1,251 @@
+// src/lib/agent/scheduled-run.ts
+import { chatDb } from "@/lib/chat-db";
+import { taskDb } from "@/lib/schedule/task-db";
+import { computeNextRun } from "@/lib/schedule/next-run";
+
+/** Outcome of the run, surfaced by the home-page host via SCHEDULED_RUN_DONE. */
+export interface ScheduledLoopResult {
+  finalText: string;
+  status: "success" | "error";
+  errorMessage?: string;
+}
+
+/** Args identifying the run to host + await. */
+export interface ScheduledLoopArgs {
+  taskId: string;
+  childConversationId: string;
+}
+
+export interface NotifyPayload {
+  kind: "complete";
+  conversationId: string;
+  snippet: string;
+  origin: "home";
+}
+
+export interface RunScheduledTaskDeps {
+  /**
+   * Ensure a home page exists to host the run, record the pending run, and
+   * broadcast the host request. The agent itself runs in that home page (the
+   * only realm with DOM + chrome.debugger/tabs/scripting).
+   */
+  hostRun: (args: ScheduledLoopArgs) => Promise<void>;
+  /** Await the home page's SCHEDULED_RUN_DONE for this run (with timeout). */
+  awaitResult: (args: ScheduledLoopArgs) => Promise<ScheduledLoopResult>;
+  notify: (payload: NotifyPayload) => void;
+  now?: () => number;
+}
+
+export interface RunScheduledTaskResult {
+  status: "success" | "error" | "skipped";
+  childConversationId?: string;
+}
+
+/**
+ * Orchestrate one scheduled task: ensure a home page hosts the run, await its
+ * result, then update bookkeeping + notify. The agent runs as a background
+ * chat in the home page; its work tabs are isolated via the normal tab-group
+ * machinery. Returns "skipped" when the task is gone or already running.
+ */
+export async function runScheduledTask(
+  taskId: string,
+  deps: RunScheduledTaskDeps,
+): Promise<RunScheduledTaskResult> {
+  const now = deps.now ?? Date.now;
+  const task = await taskDb.get(taskId);
+  if (!task) return { status: "skipped" };
+
+  // Guard against starting a second concurrent run of the same task.
+  if (task.lastRunStatus === "running") return { status: "skipped" };
+
+  // Mark running so a concurrent tick won't double-fire this task.
+  await taskDb.update(taskId, { lastRunStatus: "running" });
+
+  // Ensure a parent "task" conversation exists to own this run's transcript.
+  let taskConversationId = task.taskConversationId;
+  if (!taskConversationId) {
+    taskConversationId = `task-conv-${taskId}`;
+    await chatDb.createConversation({
+      id: taskConversationId,
+      title: task.name,
+      spaceId: null,
+      parentConversationId: null,
+      subagentSlug: "scheduled",
+      subagentStatus: null,
+      createdAt: now(),
+      updatedAt: now(),
+    });
+    await taskDb.update(taskId, { taskConversationId });
+  }
+
+  // Create the child (per-run) conversation.
+  const childConversationId = `sched-run-${taskId}-${now()}`;
+  await chatDb.createConversation({
+    id: childConversationId,
+    title: `${task.name} — ${new Date(now()).toLocaleString()}`,
+    spaceId: null,
+    parentConversationId: taskConversationId,
+    subagentSlug: "scheduled",
+    subagentStatus: "running",
+    createdAt: now(),
+    updatedAt: now(),
+  });
+
+  let result: ScheduledLoopResult;
+  try {
+    // Hand the run to a home page (ensure one exists), then await its result.
+    await deps.hostRun({ taskId, childConversationId });
+    result = await deps.awaitResult({ taskId, childConversationId });
+  } catch (err) {
+    result = {
+      finalText: "",
+      status: "error",
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // Finalize child conversation status.
+  await chatDb.updateConversation(childConversationId, {
+    subagentStatus: result.status === "success" ? "completed" : "failed",
+    subagentFinalText: result.finalText,
+  });
+
+  // Update task bookkeeping + recompute next run.
+  await taskDb.update(taskId, {
+    lastRunAt: now(),
+    lastRunStatus: result.status,
+    lastRunConversationId: childConversationId,
+    lastRunError: result.status === "error" ? result.errorMessage : undefined,
+    nextRunAt: computeNextRun(task.schedule, now()),
+  });
+
+  // Notify.
+  const snippet =
+    result.status === "success"
+      ? result.finalText.slice(0, 120) || `${task.name} finished`
+      : `${task.name} failed: ${result.errorMessage ?? "unknown error"}`;
+  deps.notify({
+    kind: "complete",
+    conversationId: childConversationId,
+    snippet,
+    origin: "home",
+  });
+
+  return { status: result.status, childConversationId };
+}
+
+const PENDING_RUNS_KEY = "scheduled-pending-runs";
+
+interface PendingRun {
+  childConversationId: string;
+  taskId: string;
+}
+
+/**
+ * Production deps: host the run in a home page and await its result.
+ *
+ *  - `hostRun`: ensure a home page exists (reuse an existing one, else open a
+ *    pinned UNFOCUSED home tab in the current window), record the pending run
+ *    in session storage (so a freshly-opened page can late-join), broadcast
+ *    SCHEDULER_HOST_RUN, and start listening for the result.
+ *  - `awaitResult`: resolve when the hosting page posts SCHEDULED_RUN_DONE for
+ *    this run (or on timeout).
+ *
+ * The agent runs as a background chat in the home page; its work tabs are
+ * isolated by the normal tab-group machinery (no dedicated window).
+ */
+export function createHomeHostDeps(
+  timeoutMs = 10 * 60_000,
+): Pick<RunScheduledTaskDeps, "hostRun" | "awaitResult"> {
+  const waiters = new Map<
+    string,
+    { resolve: (r: ScheduledLoopResult) => void; timer: ReturnType<typeof setTimeout> }
+  >();
+  let listenerAttached = false;
+
+  function onMessage(msg: unknown): void {
+    if (typeof msg !== "object" || msg === null) return;
+    const m = msg as {
+      type?: string;
+      childConversationId?: string;
+      status?: "success" | "error";
+      finalText?: string;
+      errorMessage?: string;
+    };
+    if (m.type !== "SCHEDULED_RUN_DONE" || !m.childConversationId) return;
+    const waiter = waiters.get(m.childConversationId);
+    if (!waiter) return;
+    clearTimeout(waiter.timer);
+    waiters.delete(m.childConversationId);
+    waiter.resolve({
+      status: m.status === "success" ? "success" : "error",
+      finalText: m.finalText ?? "",
+      errorMessage: m.errorMessage,
+    });
+  }
+
+  return {
+    async hostRun({ taskId, childConversationId }) {
+      if (!listenerAttached) {
+        chrome.runtime.onMessage.addListener(onMessage);
+        listenerAttached = true;
+      }
+      // Record the pending run so a home page opened after this broadcast can
+      // late-join (scans session storage on mount).
+      try {
+        const r = await chrome.storage.session.get(PENDING_RUNS_KEY);
+        const list: PendingRun[] = Array.isArray(r[PENDING_RUNS_KEY])
+          ? (r[PENDING_RUNS_KEY] as PendingRun[])
+          : [];
+        if (!list.some((p) => p.childConversationId === childConversationId)) {
+          list.push({ childConversationId, taskId });
+          await chrome.storage.session.set({ [PENDING_RUNS_KEY]: list });
+        }
+      } catch {
+        // session storage unavailable; live broadcast still covers open pages
+      }
+
+      await ensureHomePage();
+
+      chrome.runtime
+        ?.sendMessage?.({ type: "SCHEDULER_HOST_RUN", childConversationId, taskId })
+        ?.catch?.(() => {});
+    },
+
+    awaitResult({ childConversationId }) {
+      return new Promise<ScheduledLoopResult>((resolve) => {
+        const timer = setTimeout(() => {
+          waiters.delete(childConversationId);
+          resolve({
+            status: "error",
+            finalText: "",
+            errorMessage: `Scheduled run timed out after ${Math.round(timeoutMs / 60000)} min.`,
+          });
+        }, timeoutMs);
+        waiters.set(childConversationId, { resolve, timer });
+      });
+    },
+  };
+}
+
+/**
+ * Ensure at least one home.html page exists to host runs. Reuses an existing
+ * one if present; otherwise opens a pinned, UNFOCUSED home tab in the current
+ * window so it doesn't interrupt the user.
+ */
+async function ensureHomePage(): Promise<void> {
+  const homeUrl = chrome.runtime.getURL("/home.html");
+  try {
+    const existing = await chrome.tabs.query({ url: `${homeUrl}*` });
+    if (existing.length > 0) return;
+  } catch {
+    // fall through to open one
+  }
+  try {
+    await chrome.tabs.create({ url: homeUrl, pinned: true, active: false });
+  } catch (err) {
+    console.warn("[scheduler] failed to open home page for run:", err);
+  }
+}
+
+

--- a/apps/extension/src/lib/agent/tools/__tests__/scheduled-task-tools.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/scheduled-task-tools.test.ts
@@ -48,6 +48,16 @@ describe("resolveScheduleInput", () => {
       resolveScheduleInput({ kind: "once", at: "not-a-date" }),
     ).toThrow();
   });
+
+  it("once: rejects ambiguous input (both at and inMinutes)", () => {
+    expect(() =>
+      resolveScheduleInput({
+        kind: "once",
+        at: "2030-01-01T00:00:00Z",
+        inMinutes: 20,
+      }),
+    ).toThrow(/exactly one of 'at' or 'inMinutes'/);
+  });
 });
 
 describe("create_scheduled_task", () => {

--- a/apps/extension/src/lib/agent/tools/__tests__/scheduled-task-tools.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/scheduled-task-tools.test.ts
@@ -1,0 +1,192 @@
+// src/lib/agent/tools/__tests__/scheduled-task-tools.test.ts
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "@/lib/chat-db";
+import { taskDb } from "@/lib/schedule/task-db";
+import {
+  createScheduledTaskTool,
+  resolveScheduleInput,
+} from "../create-scheduled-task";
+import { listScheduledTasksTool } from "../list-scheduled-tasks";
+import { updateScheduledTaskTool } from "../update-scheduled-task";
+import { storage } from "@/lib/storage";
+
+// Tools don't read ctx; pass a minimal stand-in.
+const ctx = {} as never;
+
+beforeEach(() => {
+  indexedDB = new IDBFactory();
+  chatDb._resetForTests();
+  vi.restoreAllMocks();
+});
+
+describe("resolveScheduleInput", () => {
+  it("passes recurring schedules through unchanged", () => {
+    expect(
+      resolveScheduleInput({ kind: "daily", hour: 9, minute: 0 }),
+    ).toEqual({ kind: "daily", hour: 9, minute: 0 });
+  });
+
+  it("once: computes absolute time from inMinutes", () => {
+    const now = 1_000_000;
+    const out = resolveScheduleInput({ kind: "once", inMinutes: 20 }, now);
+    expect(out).toEqual({ kind: "once", at: now + 20 * 60_000 });
+  });
+
+  it("once: parses an absolute ISO 'at'", () => {
+    const iso = "2026-06-03T15:00:00.000Z";
+    const out = resolveScheduleInput({ kind: "once", at: iso });
+    expect(out).toEqual({ kind: "once", at: new Date(iso).getTime() });
+  });
+
+  it("once: throws when neither at nor inMinutes given", () => {
+    expect(() => resolveScheduleInput({ kind: "once" })).toThrow();
+  });
+
+  it("once: throws on an invalid at", () => {
+    expect(() =>
+      resolveScheduleInput({ kind: "once", at: "not-a-date" }),
+    ).toThrow();
+  });
+});
+
+describe("create_scheduled_task", () => {
+  it("creates a recurring task with an explicit model", async () => {
+    const res = await createScheduledTaskTool.execute(
+      {
+        name: "brief",
+        description: "morning digest",
+        prompt: "Summarize AI news",
+        agentModel: "openai:gpt-4o",
+        schedule: { kind: "daily", hour: 9, minute: 0 },
+      },
+      ctx,
+    );
+    expect(res.created).toBe(true);
+    if (!res.created) throw new Error("expected created");
+    const row = await taskDb.get(res.id);
+    expect(row?.name).toBe("brief");
+    expect(row?.agentModel).toBe("openai:gpt-4o");
+    expect(row?.schedule).toEqual({ kind: "daily", hour: 9, minute: 0 });
+    expect(row?.enabled).toBe(true);
+    expect(row?.needsBrowser).toBe(true);
+    expect(row?.autoApprove).toBe(false);
+    expect(res.nextRunAt).toBeTypeOf("number");
+  });
+
+  it("sets autoApprove when requested", async () => {
+    const res = await createScheduledTaskTool.execute(
+      {
+        name: "t",
+        prompt: "p",
+        agentModel: "openai:gpt-4o",
+        schedule: { kind: "daily", hour: 9, minute: 0 },
+        autoApprove: true,
+      },
+      ctx,
+    );
+    expect(res.created).toBe(true);
+    if (!res.created) throw new Error("expected created");
+    expect((await taskDb.get(res.id))?.autoApprove).toBe(true);
+  });
+
+  it("defaults to the current agent model when omitted", async () => {
+    vi.spyOn(storage, "getAgentSettings").mockResolvedValue({
+      agentModel: "anthropic:claude-sonnet-4-6",
+    });
+    const res = await createScheduledTaskTool.execute(
+      {
+        name: "t",
+        prompt: "do",
+        schedule: { kind: "once", inMinutes: 30 },
+      },
+      ctx,
+    );
+    expect(res.created).toBe(true);
+    if (!res.created) throw new Error("expected created");
+    const row = await taskDb.get(res.id);
+    expect(row?.agentModel).toBe("anthropic:claude-sonnet-4-6");
+    expect(row?.schedule.kind).toBe("once");
+  });
+
+  it("fails when no model is available", async () => {
+    vi.spyOn(storage, "getAgentSettings").mockResolvedValue({
+      agentModel: "",
+    });
+    const res = await createScheduledTaskTool.execute(
+      { name: "t", prompt: "do", schedule: { kind: "daily", hour: 9, minute: 0 } },
+      ctx,
+    );
+    expect(res.created).toBe(false);
+  });
+});
+
+describe("list_scheduled_tasks", () => {
+  it("returns task summaries with formatted schedules", async () => {
+    await taskDb.create({
+      name: "a",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 9, minute: 0 },
+      enabled: true,
+      needsBrowser: true,
+    });
+    const res = await listScheduledTasksTool.execute({}, ctx);
+    expect(res.tasks).toHaveLength(1);
+    expect(res.tasks[0].name).toBe("a");
+    expect(res.tasks[0].schedule).toBe("Daily at 09:00");
+    expect(res.tasks[0].enabled).toBe(true);
+  });
+});
+
+describe("update_scheduled_task", () => {
+  it("pauses (enabled=false) and resumes a task", async () => {
+    const t = await taskDb.create({
+      name: "t",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 9, minute: 0 },
+      enabled: true,
+      needsBrowser: true,
+    });
+    const paused = await updateScheduledTaskTool.execute(
+      { id: t.id, enabled: false },
+      ctx,
+    );
+    expect(paused.updated).toBe(true);
+    expect((await taskDb.get(t.id))?.enabled).toBe(false);
+
+    await updateScheduledTaskTool.execute({ id: t.id, enabled: true }, ctx);
+    expect((await taskDb.get(t.id))?.enabled).toBe(true);
+  });
+
+  it("updates schedule and recomputes nextRunAt", async () => {
+    const t = await taskDb.create({
+      name: "t",
+      description: "",
+      prompt: "p",
+      agentModel: "openai:gpt-4o",
+      schedule: { kind: "daily", hour: 9, minute: 0 },
+      enabled: true,
+      needsBrowser: true,
+    });
+    const before = (await taskDb.get(t.id))?.nextRunAt;
+    await updateScheduledTaskTool.execute(
+      { id: t.id, schedule: { kind: "hourly", minute: 30 } },
+      ctx,
+    );
+    const after = await taskDb.get(t.id);
+    expect(after?.schedule.kind).toBe("hourly");
+    expect(after?.nextRunAt).not.toBe(before);
+  });
+
+  it("fails for an unknown id", async () => {
+    const res = await updateScheduledTaskTool.execute(
+      { id: "nope", enabled: false },
+      ctx,
+    );
+    expect(res.updated).toBe(false);
+  });
+});

--- a/apps/extension/src/lib/agent/tools/create-scheduled-task.ts
+++ b/apps/extension/src/lib/agent/tools/create-scheduled-task.ts
@@ -56,6 +56,11 @@ export function resolveScheduleInput(
   now: number = Date.now(),
 ): Schedule {
   if (input.kind === "once") {
+    if (typeof input.inMinutes === "number" && input.at) {
+      throw new Error(
+        "once schedule requires exactly one of 'at' or 'inMinutes', not both",
+      );
+    }
     let at: number;
     if (typeof input.inMinutes === "number") {
       at = now + input.inMinutes * 60_000;

--- a/apps/extension/src/lib/agent/tools/create-scheduled-task.ts
+++ b/apps/extension/src/lib/agent/tools/create-scheduled-task.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import type { BrowserTool } from "../types";
+import { taskDb } from "@/lib/schedule/task-db";
+import type { Schedule } from "@/lib/schedule/types";
+import { storage } from "@/lib/storage";
+
+/**
+ * Tool-facing schedule spec. Recurring kinds mirror the `Schedule` union.
+ * For one-time events the agent may pass EITHER an absolute ISO timestamp
+ * (`at`, e.g. "tomorrow 3pm" resolved by the model) OR a relative
+ * `inMinutes` (e.g. "in 20 minutes") — the tool computes the absolute time
+ * so the model doesn't need to know the wall clock.
+ */
+export const scheduleInputSchema = z.union([
+  z.object({ kind: z.literal("hourly"), minute: z.number().int().min(0).max(59) }),
+  z.object({
+    kind: z.literal("daily"),
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  }),
+  z.object({
+    kind: z.literal("weekdays"),
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  }),
+  z.object({
+    kind: z.literal("weekly"),
+    weekday: z
+      .number()
+      .int()
+      .min(0)
+      .max(6)
+      .describe("0=Sunday, 1=Monday, … 6=Saturday"),
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  }),
+  z.object({
+    kind: z.literal("once"),
+    at: z
+      .string()
+      .optional()
+      .describe("Absolute time, ISO 8601 (e.g. '2026-06-03T15:00'). Use for 'tomorrow at 3pm'."),
+    inMinutes: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Relative offset in minutes from now. Use for 'in 20 minutes'."),
+  }),
+]);
+
+export type ScheduleInput = z.infer<typeof scheduleInputSchema>;
+
+/** Resolve the tool-facing schedule spec into a concrete `Schedule`. */
+export function resolveScheduleInput(
+  input: ScheduleInput,
+  now: number = Date.now(),
+): Schedule {
+  if (input.kind === "once") {
+    let at: number;
+    if (typeof input.inMinutes === "number") {
+      at = now + input.inMinutes * 60_000;
+    } else if (input.at) {
+      const parsed = new Date(input.at).getTime();
+      if (Number.isNaN(parsed)) {
+        throw new Error(`Invalid 'at' timestamp: ${input.at}`);
+      }
+      at = parsed;
+    } else {
+      throw new Error("once schedule requires either 'at' or 'inMinutes'");
+    }
+    return { kind: "once", at };
+  }
+  return input;
+}
+
+const parameters = z.object({
+  name: z.string().describe("Short name for the task (e.g. 'daily-briefing')."),
+  description: z
+    .string()
+    .optional()
+    .describe("One-line summary of what the task does."),
+  prompt: z
+    .string()
+    .describe("The instruction the agent runs each time the task fires."),
+  agentModel: z
+    .string()
+    .optional()
+    .describe(
+      "Model as '<providerId>:<modelId>'. Omit to use the current agent model.",
+    ),
+  schedule: scheduleInputSchema,
+  autoApprove: z
+    .boolean()
+    .optional()
+    .describe(
+      "Auto-approve tool actions that normally need confirmation (the task runs headless with no human). Default false.",
+    ),
+});
+
+type Input = z.infer<typeof parameters>;
+type Output =
+  | { created: true; id: string; nextRunAt: number | null }
+  | { created: false; reason: string };
+
+export const createScheduledTaskTool: BrowserTool<Input, Output> = {
+  name: "create_scheduled_task",
+  description:
+    "Create a scheduled task that runs automatically — either on a recurring schedule (hourly/daily/weekdays/weekly) or as a one-time future event. Gather the prompt and the schedule from the user first. Scheduled tasks run in a dedicated browser window while Chrome is open.",
+  parameters,
+  execute: async (input) => {
+    const { name, description, prompt, agentModel, schedule, autoApprove } =
+      parameters.parse(input);
+    try {
+      let model = agentModel;
+      if (!model) {
+        const agentSettings = await storage.getAgentSettings();
+        model = agentSettings.agentModel;
+      }
+      if (!model) {
+        return {
+          created: false,
+          reason:
+            "No model specified and no current agent model is configured. Ask the user to pick a model.",
+        };
+      }
+      const resolved = resolveScheduleInput(schedule);
+      const task = await taskDb.create({
+        name,
+        description: description ?? "",
+        prompt,
+        agentModel: model,
+        schedule: resolved,
+        enabled: true,
+        needsBrowser: true,
+        autoApprove: autoApprove ?? false,
+      });
+      return { created: true, id: task.id, nextRunAt: task.nextRunAt ?? null };
+    } catch (e) {
+      return { created: false, reason: (e as Error).message };
+    }
+  },
+};

--- a/apps/extension/src/lib/agent/tools/index.ts
+++ b/apps/extension/src/lib/agent/tools/index.ts
@@ -20,3 +20,6 @@ export { skillTool } from "./skill";
 export { installSkillTool } from "./install-skill";
 export { createSkillTool } from "./create-skill";
 export { closeTabsTool } from "./close-tabs";
+export { createScheduledTaskTool } from "./create-scheduled-task";
+export { listScheduledTasksTool } from "./list-scheduled-tasks";
+export { updateScheduledTaskTool } from "./update-scheduled-task";

--- a/apps/extension/src/lib/agent/tools/list-scheduled-tasks.ts
+++ b/apps/extension/src/lib/agent/tools/list-scheduled-tasks.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import type { BrowserTool } from "../types";
+import { taskDb } from "@/lib/schedule/task-db";
+import { formatSchedule } from "@/lib/schedule/format";
+
+const parameters = z.object({});
+
+type Input = z.infer<typeof parameters>;
+interface TaskSummary {
+  id: string;
+  name: string;
+  description: string;
+  schedule: string;
+  enabled: boolean;
+  nextRunAt: number | null;
+  lastRunStatus: string | null;
+}
+type Output = { tasks: TaskSummary[] };
+
+export const listScheduledTasksTool: BrowserTool<Input, Output> = {
+  name: "list_scheduled_tasks",
+  description:
+    "List all scheduled tasks with their schedules, whether they're enabled, when they next run, and their last run status.",
+  parameters,
+  execute: async () => {
+    const tasks = await taskDb.list();
+    return {
+      tasks: tasks.map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        schedule: formatSchedule(t.schedule),
+        enabled: t.enabled,
+        nextRunAt: t.nextRunAt ?? null,
+        lastRunStatus: t.lastRunStatus ?? null,
+      })),
+    };
+  },
+};

--- a/apps/extension/src/lib/agent/tools/list-tabs.ts
+++ b/apps/extension/src/lib/agent/tools/list-tabs.ts
@@ -21,7 +21,7 @@ export const listTabsTool: BrowserTool<Input, Output> = {
   parameters,
   outputSchema,
   execute: async (_input, ctx) => {
-    const tabs = await ctx.driver.listTabs();
+    const tabs = await ctx.driver.listTabs(ctx.session?.targetWindowId);
     return tabs.map((t) => ({
       tab: handleForTab(ctx, t.id),
       url: t.url,

--- a/apps/extension/src/lib/agent/tools/update-scheduled-task.ts
+++ b/apps/extension/src/lib/agent/tools/update-scheduled-task.ts
@@ -35,8 +35,12 @@ export const updateScheduledTaskTool: BrowserTool<Input, Output> = {
     "Modify an existing scheduled task: change its prompt or schedule, rename it, or pause/resume it (set enabled). Use list_scheduled_tasks first to get the task id.",
   parameters,
   execute: async (input) => {
+    const parsed = parameters.safeParse(input);
+    if (!parsed.success) {
+      return { updated: false, reason: parsed.error.message };
+    }
     const { id, name, description, prompt, schedule, enabled, autoApprove } =
-      parameters.parse(input);
+      parsed.data;
     try {
       const existing = await taskDb.get(id);
       if (!existing) {

--- a/apps/extension/src/lib/agent/tools/update-scheduled-task.ts
+++ b/apps/extension/src/lib/agent/tools/update-scheduled-task.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { BrowserTool } from "../types";
+import { taskDb } from "@/lib/schedule/task-db";
+import type { ScheduledTaskRow } from "@/lib/chat-db";
+import {
+  resolveScheduleInput,
+  type ScheduleInput,
+} from "./create-scheduled-task";
+import { scheduleInputSchema } from "./create-scheduled-task";
+
+const parameters = z.object({
+  id: z.string().describe("The id of the scheduled task to update."),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  prompt: z.string().optional().describe("New instruction for the task."),
+  schedule: scheduleInputSchema.optional().describe("New schedule."),
+  enabled: z
+    .boolean()
+    .optional()
+    .describe("Set false to pause the task, true to resume it."),
+  autoApprove: z
+    .boolean()
+    .optional()
+    .describe(
+      "Auto-approve tool actions that normally need confirmation during the headless run.",
+    ),
+});
+
+type Input = z.infer<typeof parameters>;
+type Output = { updated: true } | { updated: false; reason: string };
+
+export const updateScheduledTaskTool: BrowserTool<Input, Output> = {
+  name: "update_scheduled_task",
+  description:
+    "Modify an existing scheduled task: change its prompt or schedule, rename it, or pause/resume it (set enabled). Use list_scheduled_tasks first to get the task id.",
+  parameters,
+  execute: async (input) => {
+    const { id, name, description, prompt, schedule, enabled, autoApprove } =
+      parameters.parse(input);
+    try {
+      const existing = await taskDb.get(id);
+      if (!existing) {
+        return { updated: false, reason: `No scheduled task with id ${id}.` };
+      }
+      const patch: Partial<ScheduledTaskRow> = {};
+      if (name !== undefined) patch.name = name;
+      if (description !== undefined) patch.description = description;
+      if (prompt !== undefined) patch.prompt = prompt;
+      if (enabled !== undefined) patch.enabled = enabled;
+      if (autoApprove !== undefined) patch.autoApprove = autoApprove;
+      if (schedule !== undefined) {
+        patch.schedule = resolveScheduleInput(schedule as ScheduleInput);
+        // nextRunAt is recomputed by taskDb.update when schedule changes.
+      }
+      await taskDb.update(id, patch);
+      return { updated: true };
+    } catch (e) {
+      return { updated: false, reason: (e as Error).message };
+    }
+  },
+};

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -84,7 +84,35 @@ interface ChatDB extends DBSchema {
       "by-conversation": string;
     };
   };
+  scheduledTasks: {
+    key: string;
+    value: {
+      id: string;
+      name: string;
+      description: string;
+      prompt: string;
+      agentModel: string;
+      schedule: import("./schedule/types").Schedule;
+      enabled: boolean;
+      needsBrowser: boolean;
+      autoApprove: boolean;
+      sourceConversationId?: string;
+      taskConversationId?: string;
+      createdAt: number;
+      updatedAt: number;
+      lastRunAt?: number;
+      lastRunStatus?: import("./schedule/types").ScheduledRunStatus;
+      lastRunConversationId?: string;
+      lastRunError?: string;
+      nextRunAt?: number | null;
+    };
+    indexes: {
+      "by-next-run": number;
+    };
+  };
 }
+
+export type ScheduledTaskRow = ChatDB["scheduledTasks"]["value"];
 
 let dbPromise: Promise<IDBPDatabase<ChatDB>> | null = null;
 
@@ -155,7 +183,8 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
     //      blanket "running" sweep).
     // v13: adds `lastCompletionApproved` + `taskCompletedAt` on
     //      conversations for agent tab-cleanup. Optional; no backfill.
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 13, {
+    // v14: adds the scheduledTasks object store.
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 14, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -338,6 +367,17 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
         if (oldVersion < 13) {
           // Completion marker fields are optional and default to undefined;
           // no backfill needed. New writes set them via updateConversation.
+        }
+
+        if (oldVersion < 14) {
+          // New store for scheduled tasks. Fresh store; no data backfill.
+          const taskStore = db.createObjectStore("scheduledTasks", {
+            keyPath: "id",
+          });
+          // Index on nextRunAt is informational; the scheduler reads all
+          // enabled tasks each tick and filters in memory (task counts are
+          // small). The index is kept for future range queries.
+          taskStore.createIndex("by-next-run", "nextRunAt");
         }
       },
     });
@@ -639,3 +679,12 @@ export const chatDb = {
     dbPromise = null;
   },
 };
+
+/**
+ * Shared accessor for the `openbrowse-chat` IndexedDB connection. Exposed so
+ * sibling stores (e.g. scheduled tasks) reuse the same versioned connection
+ * instead of opening a second DB. Returns the typed idb database.
+ */
+export function getChatDbConnection() {
+  return getDb();
+}

--- a/apps/extension/src/lib/schedule/format.test.ts
+++ b/apps/extension/src/lib/schedule/format.test.ts
@@ -1,0 +1,69 @@
+// src/lib/schedule/format.test.ts
+import { describe, expect, it } from "vitest";
+import { formatSchedule, formatRelativeTime } from "./format";
+
+describe("formatSchedule", () => {
+  it("manual", () => {
+    expect(formatSchedule({ kind: "manual" })).toBe("Manual");
+  });
+  it("hourly", () => {
+    expect(formatSchedule({ kind: "hourly", minute: 0 })).toBe(
+      "Hourly at :00",
+    );
+    expect(formatSchedule({ kind: "hourly", minute: 5 })).toBe(
+      "Hourly at :05",
+    );
+  });
+  it("daily", () => {
+    expect(formatSchedule({ kind: "daily", hour: 9, minute: 0 })).toBe(
+      "Daily at 09:00",
+    );
+  });
+  it("weekdays", () => {
+    expect(formatSchedule({ kind: "weekdays", hour: 8, minute: 30 })).toBe(
+      "Weekdays at 08:30",
+    );
+  });
+  it("weekly", () => {
+    expect(
+      formatSchedule({ kind: "weekly", weekday: 1, hour: 9, minute: 0 }),
+    ).toBe("Weekly on Monday at 09:00");
+  });
+  it("once", () => {
+    // Just assert it starts with "Once on" — exact date string is locale-dependent.
+    const out = formatSchedule({ kind: "once", at: Date.now() });
+    expect(out.startsWith("Once on ")).toBe(true);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  const now = 1_000_000_000_000;
+  const min = 60_000;
+  const hr = 60 * min;
+  const day = 24 * hr;
+
+  it("'soon' for under a minute away", () => {
+    expect(formatRelativeTime(now + 30_000, now)).toBe("soon");
+    expect(formatRelativeTime(now + min - 1, now)).toBe("soon");
+  });
+
+  it("minutes", () => {
+    expect(formatRelativeTime(now + 5 * min, now)).toBe("in 5 minutes");
+    expect(formatRelativeTime(now + 1 * min, now)).toBe("in 1 minute");
+  });
+
+  it("hours", () => {
+    expect(formatRelativeTime(now + 3 * hr, now)).toBe("in 3 hours");
+    expect(formatRelativeTime(now + 1 * hr, now)).toBe("in 1 hour");
+  });
+
+  it("days", () => {
+    expect(formatRelativeTime(now + 2 * day, now)).toBe("in 2 days");
+    expect(formatRelativeTime(now + 1 * day, now)).toBe("in 1 day");
+  });
+
+  it("past times read as 'soon' (never negative)", () => {
+    expect(formatRelativeTime(now - 5 * min, now)).toBe("soon");
+  });
+});
+

--- a/apps/extension/src/lib/schedule/format.ts
+++ b/apps/extension/src/lib/schedule/format.ts
@@ -1,0 +1,52 @@
+// src/lib/schedule/format.ts
+import type { Schedule } from "./types";
+
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function hhmm(hour: number, minute: number): string {
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+export function formatSchedule(schedule: Schedule): string {
+  switch (schedule.kind) {
+    case "manual":
+      return "Manual";
+    case "hourly":
+      return `Hourly at :${String(schedule.minute).padStart(2, "0")}`;
+    case "daily":
+      return `Daily at ${hhmm(schedule.hour, schedule.minute)}`;
+    case "weekdays":
+      return `Weekdays at ${hhmm(schedule.hour, schedule.minute)}`;
+    case "weekly":
+      return `Weekly on ${WEEKDAYS[schedule.weekday]} at ${hhmm(schedule.hour, schedule.minute)}`;
+    case "once":
+      return `Once on ${new Date(schedule.at).toLocaleString()}`;
+  }
+}
+
+/**
+ * Human-readable relative time for a future timestamp, e.g. "in 3 hours",
+ * "in 5 minutes", "in 2 days". Returns "soon" for anything under a minute
+ * away or already in the past (we never render a negative/"ago" value for a
+ * next-run time).
+ */
+export function formatRelativeTime(epoch: number, now: number = Date.now()): string {
+  const diffMs = epoch - now;
+  if (diffMs < 60_000) return "soon";
+
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 60) return rtf.format(minutes, "minute");
+  const hours = Math.round(diffMs / 3_600_000);
+  if (hours < 24) return rtf.format(hours, "hour");
+  const days = Math.round(diffMs / 86_400_000);
+  return rtf.format(days, "day");
+}

--- a/apps/extension/src/lib/schedule/next-run.test.ts
+++ b/apps/extension/src/lib/schedule/next-run.test.ts
@@ -1,0 +1,99 @@
+// src/lib/schedule/next-run.test.ts
+import { describe, expect, it } from "vitest";
+import { computeNextRun } from "./next-run";
+
+// Helper: local Date → epoch ms. Tests run in the host TZ; we assert
+// relationships (strictly-after, correct wall-clock fields) rather than
+// hard-coded UTC values so they pass in any timezone.
+function at(y: number, mo: number, d: number, h: number, mi: number): number {
+  return new Date(y, mo, d, h, mi, 0, 0).getTime();
+}
+
+describe("computeNextRun", () => {
+  it("returns null for manual", () => {
+    expect(computeNextRun({ kind: "manual" }, at(2026, 0, 1, 9, 0))).toBeNull();
+  });
+
+  it("returns future 'once' as-is", () => {
+    const future = at(2026, 0, 2, 9, 0);
+    expect(
+      computeNextRun({ kind: "once", at: future }, at(2026, 0, 1, 9, 0)),
+    ).toBe(future);
+  });
+
+  it("returns null for past 'once'", () => {
+    const past = at(2026, 0, 1, 8, 0);
+    expect(
+      computeNextRun({ kind: "once", at: past }, at(2026, 0, 1, 9, 0)),
+    ).toBeNull();
+  });
+
+  it("hourly: next occurrence of the given minute, strictly after now", () => {
+    const now = at(2026, 0, 1, 9, 30);
+    const next = computeNextRun({ kind: "hourly", minute: 15 }, now)!;
+    const d = new Date(next);
+    expect(d.getMinutes()).toBe(15);
+    expect(next).toBeGreaterThan(now);
+    expect(next - now).toBeLessThanOrEqual(60 * 60 * 1000);
+  });
+
+  it("hourly: when now is before the minute this hour, uses this hour", () => {
+    const now = at(2026, 0, 1, 9, 10);
+    const next = computeNextRun({ kind: "hourly", minute: 15 }, now)!;
+    expect(next).toBe(at(2026, 0, 1, 9, 15));
+  });
+
+  it("daily: same day if time is later", () => {
+    const now = at(2026, 0, 1, 7, 0);
+    const next = computeNextRun({ kind: "daily", hour: 9, minute: 0 }, now)!;
+    expect(next).toBe(at(2026, 0, 1, 9, 0));
+  });
+
+  it("daily: next day if time already passed", () => {
+    const now = at(2026, 0, 1, 9, 1);
+    const next = computeNextRun({ kind: "daily", hour: 9, minute: 0 }, now)!;
+    expect(next).toBe(at(2026, 0, 2, 9, 0));
+  });
+
+  it("daily: exactly at the minute rolls to next day (strictly after)", () => {
+    const now = at(2026, 0, 1, 9, 0);
+    const next = computeNextRun({ kind: "daily", hour: 9, minute: 0 }, now)!;
+    expect(next).toBe(at(2026, 0, 2, 9, 0));
+  });
+
+  it("weekdays: skips weekend", () => {
+    // 2026-01-03 is a Saturday; 2026-01-04 Sunday; next weekday is Mon 01-05.
+    const sat = at(2026, 0, 3, 7, 0);
+    const next = computeNextRun({ kind: "weekdays", hour: 9, minute: 0 }, sat)!;
+    expect(next).toBe(at(2026, 0, 5, 9, 0));
+  });
+
+  it("weekly: next matching weekday", () => {
+    // 2026-01-01 is a Thursday (weekday 4). Target Monday (1).
+    const thu = at(2026, 0, 1, 9, 0);
+    const next = computeNextRun(
+      { kind: "weekly", weekday: 1, hour: 9, minute: 0 },
+      thu,
+    )!;
+    expect(new Date(next).getDay()).toBe(1);
+    expect(next).toBe(at(2026, 0, 5, 9, 0));
+  });
+
+  it("weekly: same weekday but later today uses today", () => {
+    const thu = at(2026, 0, 1, 7, 0); // Thursday, weekday 4
+    const next = computeNextRun(
+      { kind: "weekly", weekday: 4, hour: 9, minute: 0 },
+      thu,
+    )!;
+    expect(next).toBe(at(2026, 0, 1, 9, 0));
+  });
+
+  it("weekly: same weekday already passed rolls 7 days", () => {
+    const thu = at(2026, 0, 1, 9, 1); // Thursday, weekday 4, past 09:00
+    const next = computeNextRun(
+      { kind: "weekly", weekday: 4, hour: 9, minute: 0 },
+      thu,
+    )!;
+    expect(next).toBe(at(2026, 0, 8, 9, 0));
+  });
+});

--- a/apps/extension/src/lib/schedule/next-run.ts
+++ b/apps/extension/src/lib/schedule/next-run.ts
@@ -1,0 +1,67 @@
+// src/lib/schedule/next-run.ts
+import type { Schedule } from "./types";
+
+/**
+ * Compute the next fire time (absolute epoch ms) for a schedule, strictly
+ * after `now`. All recurring kinds are evaluated in the host's LOCAL
+ * timezone. Returns null for `manual` and for a `once` already in the past.
+ */
+export function computeNextRun(schedule: Schedule, now: number): number | null {
+  switch (schedule.kind) {
+    case "manual":
+      return null;
+    case "once":
+      return schedule.at > now ? schedule.at : null;
+    case "hourly": {
+      const d = new Date(now);
+      d.setSeconds(0, 0);
+      d.setMinutes(schedule.minute);
+      if (d.getTime() <= now) d.setTime(d.getTime() + 60 * 60 * 1000);
+      return d.getTime();
+    }
+    case "daily": {
+      return nextDailyMatch(now, schedule.hour, schedule.minute, () => true);
+    }
+    case "weekdays": {
+      return nextDailyMatch(
+        now,
+        schedule.hour,
+        schedule.minute,
+        (day) => day >= 1 && day <= 5,
+      );
+    }
+    case "weekly": {
+      return nextDailyMatch(
+        now,
+        schedule.hour,
+        schedule.minute,
+        (day) => day === schedule.weekday,
+      );
+    }
+  }
+}
+
+/**
+ * Find the next local-time instant at hour:minute on a day matching
+ * `dayAllowed(weekday)`, strictly after `now`. Scans up to 8 days ahead
+ * (covers weekly + weekdays).
+ */
+function nextDailyMatch(
+  now: number,
+  hour: number,
+  minute: number,
+  dayAllowed: (weekday: number) => boolean,
+): number {
+  const base = new Date(now);
+  base.setSeconds(0, 0);
+  for (let offset = 0; offset <= 8; offset++) {
+    const d = new Date(base);
+    d.setDate(base.getDate() + offset);
+    d.setHours(hour, minute, 0, 0);
+    if (d.getTime() > now && dayAllowed(d.getDay())) {
+      return d.getTime();
+    }
+  }
+  // Unreachable for valid inputs (a matching day always occurs within 8 days).
+  throw new Error("computeNextRun: no match within 8 days");
+}

--- a/apps/extension/src/lib/schedule/task-db.test.ts
+++ b/apps/extension/src/lib/schedule/task-db.test.ts
@@ -1,0 +1,79 @@
+// src/lib/schedule/task-db.test.ts
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { taskDb } from "./task-db";
+
+beforeEach(() => {
+  indexedDB = new IDBFactory();
+  // chat-db caches its connection promise; reset it so each test gets a
+  // fresh DB. _resetForTests clears the cached promise.
+  return import("@/lib/chat-db").then((m) => m.chatDb._resetForTests());
+});
+
+function makeTask(over: Partial<Parameters<typeof taskDb.create>[0]> = {}) {
+  return {
+    name: "daily-brief",
+    description: "Morning digest",
+    prompt: "Summarize AI news",
+    agentModel: "openai:gpt-4o",
+    schedule: { kind: "daily" as const, hour: 9, minute: 0 },
+    enabled: true,
+    needsBrowser: true,
+    ...over,
+  };
+}
+
+describe("taskDb", () => {
+  it("creates a task with id/timestamps and computed nextRunAt", async () => {
+    const task = await taskDb.create(makeTask());
+    expect(task.id).toBeTruthy();
+    expect(task.createdAt).toBeGreaterThan(0);
+    expect(task.updatedAt).toBe(task.createdAt);
+    expect(task.nextRunAt).toBeTypeOf("number");
+
+    const fetched = await taskDb.get(task.id);
+    expect(fetched?.name).toBe("daily-brief");
+  });
+
+  it("lists tasks", async () => {
+    await taskDb.create(makeTask({ name: "a" }));
+    await taskDb.create(makeTask({ name: "b" }));
+    const all = await taskDb.list();
+    expect(all.map((t) => t.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("updates a task and recomputes nextRunAt when schedule changes", async () => {
+    const task = await taskDb.create(makeTask());
+    const before = task.nextRunAt;
+    await taskDb.update(task.id, {
+      schedule: { kind: "hourly", minute: 30 },
+    });
+    const after = await taskDb.get(task.id);
+    expect(after?.schedule.kind).toBe("hourly");
+    expect(after?.nextRunAt).not.toBe(before);
+    expect(after!.updatedAt).toBeGreaterThanOrEqual(task.updatedAt);
+  });
+
+  it("manual schedule yields null nextRunAt", async () => {
+    const task = await taskDb.create(makeTask({ schedule: { kind: "manual" } }));
+    expect(task.nextRunAt).toBeNull();
+  });
+
+  it("removes a task", async () => {
+    const task = await taskDb.create(makeTask());
+    await taskDb.remove(task.id);
+    expect(await taskDb.get(task.id)).toBeUndefined();
+  });
+
+  it("notifies subscribers on create/update/remove", async () => {
+    const fn = vi.fn();
+    const unsub = taskDb.subscribe(fn);
+    const task = await taskDb.create(makeTask());
+    await taskDb.update(task.id, { enabled: false });
+    await taskDb.remove(task.id);
+    expect(fn).toHaveBeenCalledTimes(3);
+    unsub();
+    await taskDb.create(makeTask());
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/extension/src/lib/schedule/task-db.ts
+++ b/apps/extension/src/lib/schedule/task-db.ts
@@ -1,0 +1,102 @@
+// src/lib/schedule/task-db.ts
+import { getChatDbConnection, type ScheduledTaskRow } from "@/lib/chat-db";
+import { computeNextRun } from "./next-run";
+import type { ScheduledTask } from "./types";
+
+export type CreateScheduledTaskInput = Omit<
+  ScheduledTask,
+  | "id"
+  | "createdAt"
+  | "updatedAt"
+  | "nextRunAt"
+  | "lastRunAt"
+  | "lastRunStatus"
+  | "lastRunConversationId"
+  | "lastRunError"
+  | "taskConversationId"
+  | "autoApprove"
+> &
+  Partial<
+    Pick<ScheduledTask, "taskConversationId" | "sourceConversationId" | "autoApprove">
+  >;
+
+type TaskChangeListener = () => void;
+const listeners = new Set<TaskChangeListener>();
+
+function emit(): void {
+  for (const fn of listeners) {
+    try {
+      fn();
+    } catch (err) {
+      console.warn("[task-db] listener threw:", err);
+    }
+  }
+}
+
+function newId(): string {
+  return `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export const taskDb = {
+  async create(input: CreateScheduledTaskInput): Promise<ScheduledTaskRow> {
+    const now = Date.now();
+    const row: ScheduledTaskRow = {
+      ...input,
+      autoApprove: input.autoApprove ?? false,
+      id: newId(),
+      createdAt: now,
+      updatedAt: now,
+      nextRunAt: computeNextRun(input.schedule, now),
+    };
+    const db = await getChatDbConnection();
+    await db.put("scheduledTasks", row);
+    emit();
+    return row;
+  },
+
+  async get(id: string): Promise<ScheduledTaskRow | undefined> {
+    const db = await getChatDbConnection();
+    return db.get("scheduledTasks", id);
+  },
+
+  async list(): Promise<ScheduledTaskRow[]> {
+    const db = await getChatDbConnection();
+    const all = await db.getAll("scheduledTasks");
+    return all.sort((a, b) => b.createdAt - a.createdAt);
+  },
+
+  /**
+   * Shallow-merge update. If `schedule` is part of the patch, `nextRunAt`
+   * is recomputed from the new schedule (unless the caller explicitly set
+   * `nextRunAt` in the same patch).
+   */
+  async update(
+    id: string,
+    patch: Partial<ScheduledTaskRow>,
+  ): Promise<void> {
+    const db = await getChatDbConnection();
+    const existing = await db.get("scheduledTasks", id);
+    if (!existing) return;
+    const merged: ScheduledTaskRow = {
+      ...existing,
+      ...patch,
+      updatedAt: Date.now(),
+    };
+    if (patch.schedule !== undefined && patch.nextRunAt === undefined) {
+      merged.nextRunAt = computeNextRun(merged.schedule, Date.now());
+    }
+    await db.put("scheduledTasks", merged);
+    emit();
+  },
+
+  async remove(id: string): Promise<void> {
+    const db = await getChatDbConnection();
+    await db.delete("scheduledTasks", id);
+    emit();
+  },
+
+  subscribe(listener: TaskChangeListener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};

--- a/apps/extension/src/lib/schedule/task-db.ts
+++ b/apps/extension/src/lib/schedule/task-db.ts
@@ -70,10 +70,7 @@ export const taskDb = {
    * is recomputed from the new schedule (unless the caller explicitly set
    * `nextRunAt` in the same patch).
    */
-  async update(
-    id: string,
-    patch: Partial<ScheduledTaskRow>,
-  ): Promise<void> {
+  async update(id: string, patch: Partial<ScheduledTaskRow>): Promise<void> {
     const db = await getChatDbConnection();
     const existing = await db.get("scheduledTasks", id);
     if (!existing) return;
@@ -87,6 +84,32 @@ export const taskDb = {
     }
     await db.put("scheduledTasks", merged);
     emit();
+  },
+
+  /**
+   * Atomically claim a task for a run: within a single IDB transaction, set
+   * `lastRunStatus = "running"` only if it isn't already "running". Returns
+   * true if this caller won the claim (and should proceed with the run),
+   * false if the task is missing or already running. This closes the
+   * check-then-update (TOCTOU) gap between a `get` and a later `update` when
+   * an alarm tick and a "run now" request race for the same task.
+   */
+  async claimRun(id: string): Promise<boolean> {
+    const db = await getChatDbConnection();
+    const tx = db.transaction("scheduledTasks", "readwrite");
+    const existing = await tx.store.get(id);
+    if (!existing || existing.lastRunStatus === "running") {
+      await tx.done;
+      return false;
+    }
+    await tx.store.put({
+      ...existing,
+      lastRunStatus: "running",
+      updatedAt: Date.now(),
+    });
+    await tx.done;
+    emit();
+    return true;
   },
 
   async remove(id: string): Promise<void> {

--- a/apps/extension/src/lib/schedule/types.ts
+++ b/apps/extension/src/lib/schedule/types.ts
@@ -22,7 +22,11 @@ export interface ScheduledTask {
   agentModel: string;
   schedule: Schedule;
   enabled: boolean;
-  /** When true, the run opens a dedicated browser window. Default true. */
+  /**
+   * Reserved flag for tasks that require browser/DOM access during the run.
+   * Runs always execute in the background in a pinned home.html tab (via
+   * ScheduledRunHost); no separate browser window is opened. Default true.
+   */
   needsBrowser: boolean;
   /**
    * When true, the headless run auto-approves tool actions that normally

--- a/apps/extension/src/lib/schedule/types.ts
+++ b/apps/extension/src/lib/schedule/types.ts
@@ -1,0 +1,47 @@
+// src/lib/schedule/types.ts
+
+/** Discriminated recurrence rule. All clock fields are LOCAL time. */
+export type Schedule =
+  | { kind: "manual" }
+  | { kind: "once"; at: number } // absolute epoch ms
+  | { kind: "hourly"; minute: number } // 0-59
+  | { kind: "daily"; hour: number; minute: number } // hour 0-23
+  | { kind: "weekdays"; hour: number; minute: number } // Mon-Fri
+  | { kind: "weekly"; weekday: number; hour: number; minute: number }; // weekday 0=Sun..6=Sat
+
+export type ScheduleKind = Schedule["kind"];
+
+export type ScheduledRunStatus = "success" | "error" | "running";
+
+export interface ScheduledTask {
+  id: string;
+  name: string;
+  description: string;
+  prompt: string;
+  /** "<providerId>:<modelId>" — same format as AgentSettings.agentModel. */
+  agentModel: string;
+  schedule: Schedule;
+  enabled: boolean;
+  /** When true, the run opens a dedicated browser window. Default true. */
+  needsBrowser: boolean;
+  /**
+   * When true, the headless run auto-approves tool actions that normally
+   * require human confirmation (the task runs with no human present).
+   * When false (default), approval-gated tools are omitted from the run.
+   */
+  autoApprove: boolean;
+  /** Set when the task was created from an existing conversation. */
+  sourceConversationId?: string;
+  /** Parent "task" conversation that owns this task's runs (lazy-created). */
+  taskConversationId?: string;
+  createdAt: number;
+  updatedAt: number;
+
+  // Runtime bookkeeping (persisted; the SW is torn down between alarms).
+  lastRunAt?: number;
+  lastRunStatus?: ScheduledRunStatus;
+  lastRunConversationId?: string;
+  lastRunError?: string;
+  /** Absolute epoch ms of the next fire; null when manual or consumed once. */
+  nextRunAt?: number | null;
+}


### PR DESCRIPTION
## Summary
Recurring, cron-like agent runs that execute as full background agent sessions
(DOM + chrome.debugger, system prompt, compaction). Driven by a bundled
`/schedule` skill and agent tools, not just a UI dialog.

## Includes
- `scheduledTasks` IDB store (chat-db v14), `Schedule` types, `computeNextRun`
- SW scheduler via `chrome.alarms`; runs hosted as background chats in a pinned
  `home.html` tab (`ScheduledRunHost`) with first-writer-wins claim
- Tools: `create/list/update_scheduled_task` + `public/skills/schedule/SKILL.md`
- UI: Scheduled sidebar/dashboard, create/edit dialog, status badges,
  per-task `autoApprove`

## Fixes
- Background run instant-fail (`api/chat` ERR_FILE_NOT_FOUND): added `isReady`
  gate so auto-send waits for the async transport
- Scheduled run overwrote user's global model: non-persisting `modelOverride`
- Sidebar running-dot race: serialized `active-agents` mutations (tested)
- `ModelPicker` focus trap inside Radix dialog

## Testing
`tsc` clean; 630/630 tests pass (incl. scheduler, next-run, format, task-db,
tools, active-agents race). Manual: Run now executes in background, dot
appears/clears, global model unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled Tasks: create/manage recurring or one‑time automated tasks (hourly/daily/weekly/once) with model selection and auto‑approve option.
  * Schedule Dashboard: dedicated view to list, search, run now, edit, pause/resume, and delete tasks; per‑task status badges and next/last run info.
  * Chat integrations: quick “Schedule” action and seeded schedule prompts from the chat UI.

* **Bug Fixes / Reliability**
  * Missed runs are skipped and next occurrences rescheduled to avoid duplicate firings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->