### PR TITLE
feat(extension): add /compact slash command

### DIFF
--- a/.changeset/compact-slash-command.md
+++ b/.changeset/compact-slash-command.md
@@ -1,0 +1,15 @@
+---
+"openbrowse": minor
+---
+
+Add a `/compact` slash command to the chat composer. Typing `/` now lists
+built-in commands (under a "Commands" group) alongside skills; selecting
+`/compact` manually compacts the conversation — summarizing the full history
+and sending only that summary to the model on the next turn, while the UI
+keeps showing every original message. Supports "compact-then-send" (`/compact
+<text>` compacts, then sends the remaining text) and surfaces a toast for every
+outcome (compacted, too short, or failure).
+
+Also fixes the compaction model resolution so it correctly handles the stored
+`provider:model` key (previously it failed to find a provider, which silently
+broke both manual and automatic compaction).

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -54,6 +54,15 @@ import {
 // once they're gone we can delete the alias and the re-export.
 type ImagePreview = Extract<Attachment, { kind: "image" }>;
 
+/**
+ * Composer placeholder shown when an AI model is configured. Defined once
+ * and used in BOTH the Placeholder extension config and the `disabled`
+ * toggle effect, so the two never drift (the toggle effect previously
+ * reset it to a stale string, dropping the "/ for skills & commands" hint).
+ */
+const COMPOSER_PLACEHOLDER =
+  "Ask anything... Type @ to mention a tab, / for skills & commands";
+
 interface ChatInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -537,7 +546,7 @@ export function ChatInput({
       }),
       NoAutoLink,
       Placeholder.configure({
-        placeholder: "Ask anything... Type @ to mention a tab, / for skills & commands",
+        placeholder: COMPOSER_PLACEHOLDER,
         showOnlyWhenEditable: false,
       }),
       Markdown,
@@ -755,7 +764,7 @@ export function ChatInput({
       if (ext.name === "placeholder") {
         (ext.options as { placeholder: string }).placeholder = disabled
           ? "Configure an AI model in settings..."
-          : "Ask anything... Type @ to mention a tab";
+          : COMPOSER_PLACEHOLDER;
       }
     });
     editor.view.dispatch(editor.state.tr);

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -1,5 +1,9 @@
 import { NoAutoLink } from "@/components/tiptap/link-extension";
 import { SkillSlash } from "@/components/tiptap/skill-slash-extension";
+import {
+  extractSlashCommands,
+  stripSlashCommandNodes,
+} from "@/components/tiptap/slash-command-extract";
 import { TabMention } from "@/components/tiptap/tab-mention-extension";
 import { Kbd } from "@/components/ui/kbd";
 import { Slider } from "@/components/ui/slider";
@@ -64,6 +68,26 @@ interface ChatInputProps {
    */
   onQueue?: (mentions: TabMentionAttrs[], attachments: Attachment[]) => void;
   onStop?: () => void;
+  /**
+   * Optional handler for built-in slash commands (e.g. `/compact`).
+   *
+   * When the submitted message contains a built-in command node, the
+   * command is stripped from the editor, `onChange` is called with the
+   * remaining text, and this handler runs *instead of* `onSubmit`. The
+   * host decides what to do — for `/compact` that means running a manual
+   * compaction and, when `hasRemaining` is true, sending the leftover
+   * text to the agent afterwards (compact-then-send).
+   *
+   * `hasRemaining` is true when, after removing the command node(s),
+   * there is still sendable content (non-whitespace text, a tab mention,
+   * or a non-command skill slash).
+   */
+  onCommand?: (payload: {
+    command: string;
+    hasRemaining: boolean;
+    mentions: TabMentionAttrs[];
+    attachments: Attachment[];
+  }) => void;
   /**
    * When true, the input is being used to edit an existing message
    * (either a sent message or a queued one). The primary button is
@@ -256,6 +280,7 @@ export function ChatInput({
   onSubmit,
   onQueue,
   onStop,
+  onCommand,
   editMode = false,
   isLoading,
   disabled,
@@ -277,6 +302,8 @@ export function ChatInput({
   onQueueRef.current = onQueue;
   const onStopRef = useRef(onStop);
   onStopRef.current = onStop;
+  const onCommandRef = useRef(onCommand);
+  onCommandRef.current = onCommand;
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
   const editModeRef = useRef(editMode);
@@ -438,9 +465,44 @@ export function ChatInput({
     if (!ed) return;
     const json = ed.getJSON();
     const mentions = extractTabMentions(json);
+
+    // Built-in slash commands (e.g. `/compact`) are intercepted here:
+    // they run a local action via `onCommand` instead of being sent to
+    // the agent as message text. We strip the command node from the
+    // editor first so any leftover text is what the host sends (the
+    // "compact-then-send" flow), and so re-submitting can't resurrect
+    // the command.
+    const commands = extractSlashCommands(json);
+    const handler = onCommandRef.current;
+    if (commands.length > 0 && handler) {
+      const { json: stripped, hasRemaining } = stripSlashCommandNodes(json);
+      // Capture the attachments before we clear them — the host may want
+      // to send them along with any remaining text.
+      const attachments = attachmentsRef.current;
+
+      if (hasRemaining) {
+        // Replace the editor content with the command-free doc. This
+        // fires onUpdate → onChange, keeping the host's `value`/`input`
+        // state in sync so a follow-up submit sends the leftover text.
+        ed.commands.setContent(stripped);
+      } else {
+        ed.commands.clearContent();
+        onChange("");
+        lastExternalValue.current = "";
+      }
+      setAttachments([]);
+
+      // Fire once per command in document order (only `compact` exists
+      // today, but keep the loop general).
+      for (const command of commands) {
+        handler({ command, hasRemaining, mentions, attachments });
+      }
+      return;
+    }
+
     onSubmitRef.current(mentions, attachmentsRef.current);
     setAttachments([]);
-  }, []);
+  }, [onChange]);
 
   const queueWithMentions = useCallback(() => {
     const handler = onQueueRef.current;
@@ -475,7 +537,7 @@ export function ChatInput({
       }),
       NoAutoLink,
       Placeholder.configure({
-        placeholder: "Ask anything... Type @ to mention a tab, / for skills",
+        placeholder: "Ask anything... Type @ to mention a tab, / for skills & commands",
         showOnlyWhenEditable: false,
       }),
       Markdown,

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -176,6 +176,7 @@ export function ChatView({
     updateSettings,
     agentSettings,
     handleSubmit,
+    compactNow,
     handleNew,
     handleRegenerate,
     handleRetry,
@@ -768,6 +769,23 @@ export function ChatView({
           onChange={setInput}
           onSubmit={isEditing ? handleEditSubmit : handleSubmit}
           onQueue={isEditing ? undefined : queueMessage}
+          onCommand={
+            isEditing
+              ? undefined
+              : async ({ command, hasRemaining, mentions, attachments }) => {
+                  if (command !== "compact") return;
+                  // Compact first; the transport prunes against the
+                  // fresh compaction state on the next send.
+                  await compactNow();
+                  // Compact-then-send: if the user typed text alongside
+                  // `/compact`, send it now. ChatInput already stripped
+                  // the command node and synced `input` to the leftover
+                  // text, so handleSubmit picks it up.
+                  if (hasRemaining) {
+                    await handleSubmit(mentions, attachments);
+                  }
+                }
+          }
           editMode={isEditing}
           onStop={stop}
           isLoading={isLoading}

--- a/apps/extension/src/components/tiptap/SkillSlashList.tsx
+++ b/apps/extension/src/components/tiptap/SkillSlashList.tsx
@@ -5,6 +5,11 @@ export interface SkillSuggestionItem {
   name: string;
   /** Frontmatter description (used for the secondary line). */
   description: string;
+  /**
+   * Whether this entry is a built-in command (local action, e.g.
+   * `/compact`) or a user skill. Defaults to "skill" when omitted.
+   */
+  kind?: "command" | "skill";
 }
 
 interface SkillSlashListProps {
@@ -46,30 +51,41 @@ export const SkillSlashList = forwardRef<SkillSlashListRef, SkillSlashListProps>
     if (items.length === 0) {
       return (
         <div className="rounded-lg border border-border bg-popover p-2 shadow-md">
-          <p className="text-xs text-muted-foreground">No matching skills</p>
+          <p className="text-xs text-muted-foreground">No matching commands or skills</p>
         </div>
       );
     }
 
     return (
       <div className="rounded-lg border border-border bg-popover py-1 shadow-md max-h-60 overflow-y-auto w-80">
-        {items.map((item, index) => (
-          <button
-            key={item.name}
-            type="button"
-            onClick={() => command(item)}
-            className={`flex w-full items-start gap-2 px-2.5 py-1.5 text-left transition-colors ${
-              index === selectedIndex ? "bg-accent text-accent-foreground" : ""
-            }`}
-          >
-            <div className="flex-1 min-w-0">
-              <p className="text-xs font-medium font-mono">/{item.name}</p>
-              <p className="text-[10px] text-muted-foreground line-clamp-2">
-                {item.description}
-              </p>
+        {items.map((item, index) => {
+          const kind = item.kind ?? "skill";
+          const prevKind = index > 0 ? items[index - 1].kind ?? "skill" : null;
+          const showHeader = kind !== prevKind;
+          return (
+            <div key={`${kind}:${item.name}`}>
+              {showHeader && (
+                <p className="px-2.5 pt-1.5 pb-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {kind === "command" ? "Commands" : "Skills"}
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={() => command(item)}
+                className={`flex w-full items-start gap-2 px-2.5 py-1.5 text-left transition-colors ${
+                  index === selectedIndex ? "bg-accent text-accent-foreground" : ""
+                }`}
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium font-mono">/{item.name}</p>
+                  <p className="text-[10px] text-muted-foreground line-clamp-2">
+                    {item.description}
+                  </p>
+                </div>
+              </button>
             </div>
-          </button>
-        ))}
+          );
+        })}
       </div>
     );
   },

--- a/apps/extension/src/components/tiptap/__tests__/slash-command-extract.test.ts
+++ b/apps/extension/src/components/tiptap/__tests__/slash-command-extract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { JSONContent } from "@tiptap/core";
+import {
+  extractSlashCommands,
+  stripSlashCommandNodes,
+} from "../slash-command-extract";
+
+/** Helper: a paragraph doc with the given inline children. */
+function doc(...inline: JSONContent[]): JSONContent {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: inline }],
+  };
+}
+
+const text = (t: string): JSONContent => ({ type: "text", text: t });
+const compactNode = (): JSONContent => ({
+  type: "skillSlash",
+  attrs: { id: "compact", label: "compact", name: "compact" },
+});
+const skillNode = (name: string): JSONContent => ({
+  type: "skillSlash",
+  attrs: { id: name, label: name, name },
+});
+const tabMention = (): JSONContent => ({
+  type: "tabMention",
+  attrs: { title: "Tab", url: "https://x.test", favicon: "" },
+});
+
+describe("extractSlashCommands", () => {
+  it("detects a built-in command node", () => {
+    expect(extractSlashCommands(doc(compactNode()))).toEqual(["compact"]);
+  });
+
+  it("ignores skill slash nodes that are not built-in commands", () => {
+    expect(extractSlashCommands(doc(skillNode("my-skill")))).toEqual([]);
+  });
+
+  it("ignores tab mentions and plain text", () => {
+    expect(
+      extractSlashCommands(doc(text("hello "), tabMention(), text(" world"))),
+    ).toEqual([]);
+  });
+
+  it("detects a command mixed with surrounding text", () => {
+    expect(
+      extractSlashCommands(doc(compactNode(), text(" then do the thing"))),
+    ).toEqual(["compact"]);
+  });
+
+  it("returns empty for an empty doc", () => {
+    expect(extractSlashCommands({ type: "doc", content: [] })).toEqual([]);
+  });
+});
+
+describe("stripSlashCommandNodes", () => {
+  it("removes built-in command nodes and reports remaining text presence", () => {
+    const result = stripSlashCommandNodes(
+      doc(compactNode(), text(" then do the thing")),
+    );
+    expect(result.hasRemaining).toBe(true);
+    // The command node is gone; text survives.
+    const inline = result.json.content?.[0]?.content ?? [];
+    expect(inline.some((n) => n.type === "skillSlash")).toBe(false);
+    expect(inline.some((n) => n.type === "text")).toBe(true);
+  });
+
+  it("reports no remaining content when only the command is present", () => {
+    const result = stripSlashCommandNodes(doc(compactNode()));
+    expect(result.hasRemaining).toBe(false);
+  });
+
+  it("treats whitespace-only remainder as no remaining content", () => {
+    const result = stripSlashCommandNodes(doc(compactNode(), text("   ")));
+    expect(result.hasRemaining).toBe(false);
+  });
+
+  it("keeps non-command skill nodes as remaining content", () => {
+    const result = stripSlashCommandNodes(
+      doc(compactNode(), text(" "), skillNode("my-skill")),
+    );
+    expect(result.hasRemaining).toBe(true);
+    const inline = result.json.content?.[0]?.content ?? [];
+    expect(inline.some((n) => n.attrs?.name === "my-skill")).toBe(true);
+    expect(inline.some((n) => n.attrs?.name === "compact")).toBe(false);
+  });
+
+  it("treats tab mentions as remaining content", () => {
+    const result = stripSlashCommandNodes(doc(compactNode(), tabMention()));
+    expect(result.hasRemaining).toBe(true);
+  });
+
+  it("leaves docs without commands untouched", () => {
+    const input = doc(text("just text"));
+    const result = stripSlashCommandNodes(input);
+    expect(result.hasRemaining).toBe(true);
+    expect(extractSlashCommands(result.json)).toEqual([]);
+  });
+});

--- a/apps/extension/src/components/tiptap/__tests__/slash-commands.test.ts
+++ b/apps/extension/src/components/tiptap/__tests__/slash-commands.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_SLASH_COMMANDS,
+  isBuiltinSlashCommand,
+  matchBuiltinCommands,
+} from "../slash-commands";
+
+describe("BUILTIN_SLASH_COMMANDS", () => {
+  it("includes the compact command", () => {
+    const compact = BUILTIN_SLASH_COMMANDS.find((c) => c.name === "compact");
+    expect(compact).toBeDefined();
+    expect(compact?.description.length).toBeGreaterThan(0);
+  });
+});
+
+describe("isBuiltinSlashCommand", () => {
+  it("returns true for a known command name", () => {
+    expect(isBuiltinSlashCommand("compact")).toBe(true);
+  });
+
+  it("is case-sensitive to the canonical name", () => {
+    // Commands are lowercase; mention names are normalised lowercase too.
+    expect(isBuiltinSlashCommand("Compact")).toBe(false);
+  });
+
+  it("returns false for unknown names", () => {
+    expect(isBuiltinSlashCommand("not-a-command")).toBe(false);
+    expect(isBuiltinSlashCommand("")).toBe(false);
+  });
+});
+
+describe("matchBuiltinCommands", () => {
+  it("returns all commands for an empty query", () => {
+    expect(matchBuiltinCommands("")).toEqual(BUILTIN_SLASH_COMMANDS);
+  });
+
+  it("filters by name prefix/substring", () => {
+    const result = matchBuiltinCommands("comp");
+    expect(result.map((c) => c.name)).toContain("compact");
+  });
+
+  it("filters by description substring", () => {
+    const result = matchBuiltinCommands("summarize");
+    expect(result.map((c) => c.name)).toContain("compact");
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchBuiltinCommands("COMPACT").map((c) => c.name)).toContain(
+      "compact",
+    );
+  });
+
+  it("returns empty for a non-matching query", () => {
+    expect(matchBuiltinCommands("zzzzz")).toEqual([]);
+  });
+});

--- a/apps/extension/src/components/tiptap/skill-slash-suggestion.tsx
+++ b/apps/extension/src/components/tiptap/skill-slash-suggestion.tsx
@@ -2,18 +2,25 @@ import { ReactRenderer } from "@tiptap/react";
 import type { SuggestionOptions } from "@tiptap/suggestion";
 import { computePosition, flip, shift, offset } from "@floating-ui/dom";
 import { getSkillsRegistry } from "@/lib/skills/registry";
+import { matchBuiltinCommands } from "./slash-commands";
 import {
   SkillSlashList,
   type SkillSlashListRef,
   type SkillSuggestionItem,
 } from "./SkillSlashList";
 
-function querySkills(query: string): SkillSuggestionItem[] {
-  const state = getSkillsRegistry().getState();
+function querySlashItems(query: string): SkillSuggestionItem[] {
   const q = query.toLowerCase();
+
+  // Built-in commands surface first, in their own "Commands" group.
+  const commands: SkillSuggestionItem[] = matchBuiltinCommands(query).map(
+    (c) => ({ name: c.name, description: c.description, kind: "command" }),
+  );
+
+  const state = getSkillsRegistry().getState();
   // Only enabled skills are surfaced as slash-command targets — disabled
   // skills won't be picked up by the agent anyway.
-  return state.skills
+  const skills: SkillSuggestionItem[] = state.skills
     .filter((s) => s.enabled !== false)
     .filter((s) => {
       if (!q) return true;
@@ -22,7 +29,9 @@ function querySkills(query: string): SkillSuggestionItem[] {
         s.description.toLowerCase().includes(q)
       );
     })
-    .map((s) => ({ name: s.name, description: s.description }));
+    .map((s) => ({ name: s.name, description: s.description, kind: "skill" }));
+
+  return [...commands, ...skills];
 }
 
 export const skillSlashSuggestion: Partial<SuggestionOptions<SkillSuggestionItem>> = {
@@ -33,7 +42,7 @@ export const skillSlashSuggestion: Partial<SuggestionOptions<SkillSuggestionItem
   allowSpaces: false,
 
   items: ({ query }) => {
-    return querySkills(query);
+    return querySlashItems(query);
   },
 
   render: () => {

--- a/apps/extension/src/components/tiptap/slash-command-extract.ts
+++ b/apps/extension/src/components/tiptap/slash-command-extract.ts
@@ -1,0 +1,94 @@
+import type { JSONContent } from "@tiptap/core";
+import { isBuiltinSlashCommand } from "./slash-commands";
+
+/**
+ * Pure JSONContent traversal helpers for built-in slash commands.
+ *
+ * Kept separate from `ChatInput.tsx` so they can be unit-tested without
+ * pulling in tiptap/react and the rest of the composer's heavy deps.
+ * Mirrors the shape of `extractTabMentions` in ChatInput.
+ *
+ * A built-in command is a `skillSlash` node whose `attrs.name` matches a
+ * registered command (see `slash-commands.ts`). Skills use the same node
+ * type, so we discriminate purely on the name.
+ */
+
+function slashNodeName(node: JSONContent): string | null {
+  if (node.type !== "skillSlash") return null;
+  const name = node.attrs?.name ?? node.attrs?.label ?? node.attrs?.id;
+  return typeof name === "string" ? name : null;
+}
+
+/**
+ * Collect the names of built-in command nodes present in the doc, in
+ * document order. Non-command skill slashes, tab mentions and text are
+ * ignored.
+ */
+export function extractSlashCommands(json: JSONContent): string[] {
+  const commands: string[] = [];
+
+  function traverse(node: JSONContent) {
+    const name = slashNodeName(node);
+    if (name && isBuiltinSlashCommand(name)) {
+      commands.push(name);
+    }
+    if (node.content) {
+      for (const child of node.content) traverse(child);
+    }
+  }
+
+  traverse(json);
+  return commands;
+}
+
+export interface StripSlashCommandsResult {
+  /** A deep copy of the doc with built-in command nodes removed. */
+  json: JSONContent;
+  /**
+   * True when, after removing built-in command nodes, the doc still has
+   * meaningful content (non-whitespace text, a tab mention, or a
+   * non-command skill slash). When false, the message was *only* the
+   * command(s) and nothing should be sent to the agent.
+   */
+  hasRemaining: boolean;
+}
+
+/**
+ * Remove built-in command nodes from the doc and report whether any
+ * sendable content remains. Does not mutate the input.
+ */
+export function stripSlashCommandNodes(
+  json: JSONContent,
+): StripSlashCommandsResult {
+  let hasRemaining = false;
+
+  function clone(node: JSONContent): JSONContent | null {
+    const name = slashNodeName(node);
+    if (name && isBuiltinSlashCommand(name)) {
+      // Drop the command node entirely.
+      return null;
+    }
+
+    // Leaf accounting: any non-whitespace text or any mention/other node
+    // counts as remaining content worth sending.
+    if (node.type === "text") {
+      if ((node.text ?? "").trim().length > 0) hasRemaining = true;
+    } else if (node.type === "tabMention" || node.type === "skillSlash") {
+      hasRemaining = true;
+    }
+
+    const next: JSONContent = { ...node };
+    if (node.content) {
+      const children: JSONContent[] = [];
+      for (const child of node.content) {
+        const c = clone(child);
+        if (c) children.push(c);
+      }
+      next.content = children;
+    }
+    return next;
+  }
+
+  const cloned = clone(json) ?? { type: json.type ?? "doc", content: [] };
+  return { json: cloned, hasRemaining };
+}

--- a/apps/extension/src/components/tiptap/slash-commands.ts
+++ b/apps/extension/src/components/tiptap/slash-commands.ts
@@ -1,0 +1,47 @@
+/**
+ * Built-in slash commands surfaced in the chat composer's "/" popup,
+ * alongside user skills. Unlike skills (which serialise to `/name` text
+ * the agent interprets), built-in commands are intercepted locally at
+ * submit time and trigger a client-side action (e.g. `/compact` runs a
+ * manual conversation compaction).
+ *
+ * A command shares the same `/name` syntax and the same `skillSlash`
+ * tiptap node as a skill; the only difference is that `ChatInput`
+ * recognises the name via `isBuiltinSlashCommand` and routes it to the
+ * host's `onCommand` handler instead of sending it as message text.
+ */
+export interface BuiltinSlashCommand {
+  /** Command name as typed after the slash, e.g. "compact". Lowercase. */
+  name: string;
+  /** Short description shown in the popup's secondary line. */
+  description: string;
+}
+
+export const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommand[] = [
+  {
+    name: "compact",
+    description: "Summarize the conversation so far to free up context",
+  },
+];
+
+const BUILTIN_NAMES = new Set(BUILTIN_SLASH_COMMANDS.map((c) => c.name));
+
+/** True when `name` is a known built-in command (exact, lowercase match). */
+export function isBuiltinSlashCommand(name: string): boolean {
+  return BUILTIN_NAMES.has(name);
+}
+
+/**
+ * Filter built-in commands for the slash popup. Matches the query against
+ * both the command name and its description, case-insensitively. An empty
+ * query returns all commands.
+ */
+export function matchBuiltinCommands(query: string): BuiltinSlashCommand[] {
+  const q = query.toLowerCase();
+  if (!q) return [...BUILTIN_SLASH_COMMANDS];
+  return BUILTIN_SLASH_COMMANDS.filter(
+    (c) =>
+      c.name.toLowerCase().includes(q) ||
+      c.description.toLowerCase().includes(q),
+  );
+}

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -325,6 +325,14 @@ export function LandingPage({
             value={input}
             onChange={setInput}
             onSubmit={handleSubmit}
+            onCommand={({ command }) => {
+              // The landing page has no active conversation, so there's
+              // nothing to compact. Acknowledge the command instead of
+              // silently sending it as text.
+              if (command === "compact") {
+                toast.info("Nothing to compact yet");
+              }
+            }}
             isLoading={false}
             disabled={!isConfigured}
             autoFocus

--- a/apps/extension/src/hooks/__tests__/heal-preserves-compaction.test.ts
+++ b/apps/extension/src/hooks/__tests__/heal-preserves-compaction.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { healPendingTools } from "../useAgentChat";
+import type { AgentUIMessage } from "@/lib/types";
+
+/**
+ * Regression test for the compact-then-send + stranded-tool bug.
+ *
+ * In the compact-then-send flow (`/compact some text`), `compactNow()`
+ * appends a compaction marker + summary to the chat, then `handleSubmit`
+ * runs its `healPendingTools` pass and `setMessages(healed)` writes the
+ * result back. If that heal pass operated on a STALE message list (the
+ * pre-compaction closure), `healed` would lack the marker/summary and
+ * `setMessages` would drop them — so the transport would ship the full
+ * un-compacted history to the model.
+ *
+ * The fix reads `messagesRef.current` (the post-compaction list) for the
+ * heal pass. This test locks in the property that makes that safe: healing
+ * a stranded tool must PRESERVE a compaction marker + summary elsewhere in
+ * the list (it only rewrites the offending tool part, nothing else).
+ */
+
+function userText(id: string, text: string): AgentUIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] } as AgentUIMessage;
+}
+
+function strandedToolAssistant(id: string): AgentUIMessage {
+  // A tool call left in a non-terminal state (input-available, no output) —
+  // this is what `healPendingTools` rewrites to output-error.
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      {
+        type: "dynamic-tool",
+        toolName: "navigate",
+        toolCallId: "call-stranded",
+        state: "input-available",
+        input: { url: "https://example.com" },
+      },
+    ],
+  } as unknown as AgentUIMessage;
+}
+
+function compactionMarker(id: string): AgentUIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [
+      {
+        type: "data-compaction",
+        data: { auto: false, tailStartMessageId: undefined },
+      },
+    ],
+  } as unknown as AgentUIMessage;
+}
+
+function summaryAssistant(id: string, text: string): AgentUIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as unknown as AgentUIMessage;
+}
+
+describe("healPendingTools — preserves compaction event", () => {
+  it("heals a stranded tool while keeping the compaction marker + summary", () => {
+    // Post-compaction layout: an earlier stranded tool, then the
+    // compaction marker + summary that compactNow() appended.
+    const messages: AgentUIMessage[] = [
+      userText("m1", "do a thing"),
+      strandedToolAssistant("m2"),
+      compactionMarker("m3"),
+      summaryAssistant("m4", "SUMMARY: did things"),
+    ];
+
+    const { healed, healedMessages } = healPendingTools(
+      messages,
+      "Superseded by new user message",
+    );
+
+    // The stranded tool was actually healed (otherwise this test proves
+    // nothing about the dangerous setMessages path).
+    expect(healedMessages.length).toBeGreaterThan(0);
+
+    // Same length — healing rewrites parts in place, never drops messages.
+    expect(healed.map((m) => m.id)).toEqual(["m1", "m2", "m3", "m4"]);
+
+    // The compaction marker survives intact.
+    const marker = healed.find((m) => m.id === "m3");
+    expect(
+      marker?.parts.some((p) => (p as { type: string }).type === "data-compaction"),
+    ).toBe(true);
+
+    // The summary survives intact.
+    const summary = healed.find((m) => m.id === "m4");
+    expect(
+      (summary?.parts.find((p) => (p as { type: string }).type === "text") as
+        | { text: string }
+        | undefined)?.text,
+    ).toContain("SUMMARY");
+
+    // The stranded tool part is now in a terminal state.
+    const toolMsg = healed.find((m) => m.id === "m2");
+    const toolPart = toolMsg?.parts[0] as { state: string };
+    expect(["output-error", "output-denied"]).toContain(toolPart.state);
+  });
+
+  it("returns the list unchanged when there are no stranded tools", () => {
+    const messages: AgentUIMessage[] = [
+      userText("m1", "hi"),
+      summaryAssistant("m2", "hello"),
+      compactionMarker("m3"),
+      summaryAssistant("m4", "SUMMARY"),
+    ];
+    const { healed, healedMessages } = healPendingTools(messages, "reason");
+    expect(healedMessages.length).toBe(0);
+    expect(healed).toBe(messages);
+  });
+});

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -16,6 +16,8 @@ import { setAgentActive, setAgentInactive } from "@/lib/active-agents";
 import {
   pruneMessages as pruneMessageParts,
   selectTail,
+  selectTailForManual,
+  resolveCompactionModel,
   buildCompactionPrompt,
   getCompactionSystemPrompt,
   prepareMessagesForSummarization,
@@ -178,7 +180,7 @@ const TERMINAL_TOOL_STATES = new Set([
   "output-denied",
 ]);
 
-function healPendingTools(
+export function healPendingTools(
   messages: AgentMessage[],
   denyReason: string,
 ): { healed: AgentMessage[]; healedMessages: AgentMessage[] } {
@@ -687,6 +689,15 @@ export function useAgentChat({
     DEFAULT_AGENT_SETTINGS,
   );
   const [input, setInput] = useState(initialInput ?? "");
+  // Mirror of `input` for callers that run after an `await` boundary,
+  // where the `input` captured in a useCallback closure may be stale
+  // (e.g. the `/compact` compact-then-send flow: ChatInput strips the
+  // command and syncs the leftover text via onChange/setInput, then the
+  // host awaits compaction before calling handleSubmit — by which point
+  // the closure's `input` predates the strip). Reading the ref inside
+  // handleSubmit guarantees we send the latest editor text.
+  const inputRef = useRef(input);
+  inputRef.current = input;
 
   const [isCompacting, setIsCompacting] = useState(false);
   // AbortController for the in-flight compaction summary call. The chat's
@@ -938,6 +949,19 @@ export function useAgentChat({
     addToolApprovalResponse,
   } = useChat<AgentMessage>({ chat });
 
+  // Mirror of `messages` for callbacks that run after an `await` boundary,
+  // where the `messages` captured in a useCallback closure may be stale.
+  // Specifically: the compact-then-send flow awaits `compactNow()` (which
+  // appends the compaction marker + summary via `setMessages`) before
+  // invoking `handleSubmit`. The `handleSubmit` instance captured in
+  // ChatView's `onCommand` closure predates that update, so its closed-over
+  // `messages` lacks the marker. Reading the ref in `handleSubmit`'s heal
+  // pass ensures we heal/append against the CURRENT chat state — otherwise
+  // a stranded-tool heal would `setMessages` a marker-less array and the
+  // transport would ship the full (un-compacted) history to the model.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
   // Wrap the chat's stop() so it also aborts any in-flight compaction
   // summarization call. Without this, clicking Stop while a summary is
   // generating would silently let the LLM call continue and write a
@@ -956,18 +980,26 @@ export function useAgentChat({
     async (
       convId: string,
       msgs: AgentMessage[],
-      opts?: { auto?: boolean; overflow?: boolean },
+      opts?: { auto?: boolean; overflow?: boolean; manual?: boolean },
     ) => {
-      if (msgs.length < MIN_MESSAGES_FOR_COMPACTION) return;
+      const manual = opts?.manual ?? false;
+      if (msgs.length < MIN_MESSAGES_FOR_COMPACTION) {
+        if (manual) toast.info("Conversation is too short to compact yet");
+        return;
+      }
 
       // Time-based debounce thrash detection. If we just compacted within
       // COMPACTION_DEBOUNCE_MS, don't compact again — covers the case
       // where the produced summary itself overflows and would otherwise
       // loop. Reads directly from the visible message list, so the UI
       // and the runtime agree on what counts.
+      //
+      // Manual `/compact` is user-initiated and can't loop, so it skips
+      // the debounce — otherwise a user who just auto-compacted would
+      // click `/compact` and see nothing happen.
       const dbMessages = await chatDb.getMessages(convId);
       const events = findCompactionEvents(dbMessages);
-      if (shouldDebounceCompaction(events)) return;
+      if (!manual && shouldDebounceCompaction(events)) return;
 
       const auto = opts?.auto ?? true;
       const overflow = opts?.overflow ?? false;
@@ -992,8 +1024,18 @@ export function useAgentChat({
         // Compute the tail boundary. The CompactionPart will anchor here so
         // the transport's filterCompactedMessages knows where to keep the
         // verbatim tail and where to drop the head.
-        const { headMessages, tailStartId } = selectTail(pruned, modelDef);
-        if (!tailStartId || headMessages.length === 0) return;
+        //
+        // Manual `/compact` summarizes the whole conversation and keeps
+        // no verbatim tail (`tailStartId === undefined`), so it gates only
+        // on having a non-empty head. Auto-compaction still requires a
+        // tail anchor (it preserves recent turns verbatim to continue).
+        const { headMessages, tailStartId } = manual
+          ? selectTailForManual(pruned)
+          : selectTail(pruned, modelDef);
+        if (manual ? headMessages.length === 0 : !tailStartId || headMessages.length === 0) {
+          if (manual) toast.info("Conversation is too short to compact yet");
+          return;
+        }
 
         // Always run summarization. We previously had a "prune-only fast
         // path" that skipped the LLM call when pruning would free enough
@@ -1023,16 +1065,24 @@ export function useAgentChat({
           agentSettingsForCompaction.agentModel;
 
         const { providers } = await import("@/registry/providers");
-        const provider = providers.find((p) =>
-          p.models.some((m) => m.id === compactionModelId),
-        );
-        if (!provider) return;
+        // Model keys are stored composite ("providerId:modelId"); resolve
+        // to a provider + bare model id. Comparing the composite key
+        // directly against the registry's bare model ids was the bug
+        // behind "no provider for compaction model" (and silent
+        // auto-compaction failures).
+        const resolved = resolveCompactionModel(compactionModelId, providers);
+        if (!resolved) {
+          if (manual) {
+            toast.error("Can't compact: no provider for the compaction model");
+          }
+          return;
+        }
 
         const config =
-          settingsForCompaction.providerConfigs[provider.id] ?? {};
-        const compactionModel = await provider.createLanguageModel(
+          settingsForCompaction.providerConfigs[resolved.provider.id] ?? {};
+        const compactionModel = await resolved.provider.createLanguageModel(
           config,
-          compactionModelId,
+          resolved.modelId,
         );
 
         const result = await generateText({
@@ -1055,6 +1105,9 @@ export function useAgentChat({
           console.warn(
             "[compaction] summary model returned empty text; skipping event",
           );
+          if (manual) {
+            toast.error("Compaction failed: the model returned no summary");
+          }
           return;
         }
 
@@ -1109,6 +1162,13 @@ export function useAgentChat({
         };
         setMessages([...msgs, compactionUiMsg, summaryUiMsg]);
 
+        // Manual `/compact` has no auto-continue, so the only signal that
+        // it worked is the new divider in the stream — confirm with a
+        // toast so the action feels acknowledged.
+        if (manual) {
+          toast.success("Conversation compacted");
+        }
+
         // Auto-continue: send a synthetic user message asking the agent
         // to resume. Manual /compact (follow-up) would skip this. The
         // wording matches OpenCode's continue prompt.
@@ -1154,6 +1214,11 @@ export function useAgentChat({
           return;
         }
         console.error("[compaction] failed:", err);
+        if (manual) {
+          toast.error(
+            `Compaction failed: ${(err as Error)?.message ?? String(err)}`,
+          );
+        }
       } finally {
         if (compactionAbortRef.current === abortController) {
           compactionAbortRef.current = null;
@@ -1163,6 +1228,41 @@ export function useAgentChat({
     },
     [sendMessage, setMessages],
   );
+
+  /**
+   * Manually compact the current conversation (the `/compact` slash
+   * command). Passes `manual: true` so `runCompaction`:
+   *   - uses `selectTailForManual` (preserve only the last user turn,
+   *     ignore the token budget) so small conversations still compact,
+   *   - skips the thrash debounce,
+   *   - surfaces user-visible toasts for every outcome (success, too
+   *     short, provider/model failure) instead of silently no-op'ing,
+   *   - does NOT auto-continue (no synthetic "Continue…" turn) — the
+   *     user controls what happens next (the composer's compact-then-send
+   *     flow may send leftover text afterwards).
+   *
+   * Resolves once compaction has finished (or was skipped), so callers
+   * can `await` it before sending a follow-up message and rely on the
+   * transport pruning against the fresh compaction state.
+   */
+  const compactNow = useCallback(async (): Promise<void> => {
+    const convId = conversationIdRef.current;
+    if (!convId) {
+      toast.info("Nothing to compact yet");
+      return;
+    }
+    if (isCompacting) {
+      toast.info("Already compacting…");
+      return;
+    }
+    if (isLoading) {
+      toast.info("Can't compact while the agent is responding");
+      return;
+    }
+    // `runCompaction({ manual: true })` owns the remaining feedback:
+    // it toasts "too short to compact" / failure / success itself.
+    await runCompaction(convId, messages, { auto: false, manual: true });
+  }, [isCompacting, isLoading, messages, runCompaction]);
 
   useEffect(() => {
     if (status === "streaming" || status === "submitted") {
@@ -1517,6 +1617,11 @@ export function useAgentChat({
       mentions: TabMentionAttrs[] = [],
       attachments: Attachment[] = [],
     ) => {
+      // Read the latest editor text via the ref, not the closure's
+      // `input` — see `inputRef` for why (compact-then-send runs this
+      // after an await boundary). Shadowing keeps the rest of the body
+      // unchanged.
+      const input = inputRef.current;
       if (!input.trim() && attachments.length === 0) return;
       if (!isConfigured) return;
 
@@ -1553,8 +1658,15 @@ export function useAgentChat({
       //   has a public API that writes them client-side, so
       //   `healPendingTools` mutates via `setMessages` and we persist
       //   the change to chatDb to survive reloads.
+      //
+      // Read `messagesRef.current` (not the closure `messages`): in the
+      // compact-then-send flow this runs after `compactNow()` appended the
+      // compaction marker + summary, and the `handleSubmit` instance held
+      // by ChatView's onCommand closure predates that. Healing against the
+      // stale closure would `setMessages` a marker-less array and drop the
+      // just-created compaction event. See `messagesRef`.
       const { healed, healedMessages } = healPendingTools(
-        messages,
+        messagesRef.current,
         "Superseded by new user message",
       );
       if (healedMessages.length > 0) {
@@ -2111,6 +2223,7 @@ export function useAgentChat({
     setAgentModel,
     setThinkingSettings,
     handleSubmit,
+    compactNow,
     handleNew,
     handleRegenerate,
     handleRetry,

--- a/apps/extension/src/lib/agent/__tests__/manual-compaction-rewrite.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/manual-compaction-rewrite.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { rewriteForLLM } from "../compacting-transport";
+import { COMPACTION_USER_PROMPT } from "../compaction";
+import type { AgentUIMessage } from "../../types";
+
+/**
+ * Regression test for the manual `/compact` model view.
+ *
+ * A user-typed `/compact` summarizes the entire conversation and keeps NO
+ * verbatim tail. Earlier, `selectTailForManual` anchored the tail at the
+ * last user message, so `rewriteForLLM` re-included that whole final
+ * exchange verbatim — the model still "remembered everything" despite the
+ * divider. With the summary-only behavior (`tailStartMessageId` undefined),
+ * the model must see only: the substituted marker prompt, the summary, and
+ * any turns that came *after* the compaction.
+ */
+
+function u(id: string, text: string): AgentUIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] } as AgentUIMessage;
+}
+function a(id: string, text: string): AgentUIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as AgentUIMessage;
+}
+function compactionMarker(id: string): AgentUIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [
+      {
+        type: "data-compaction",
+        // Manual compaction: no verbatim tail anchor.
+        data: { auto: false, tailStartMessageId: undefined },
+      },
+    ],
+  } as unknown as AgentUIMessage;
+}
+
+function text(m: AgentUIMessage): string | undefined {
+  return (m.parts.find((p) => (p as { type: string }).type === "text") as
+    | { text: string }
+    | undefined)?.text;
+}
+
+describe("rewriteForLLM — manual /compact (summary-only)", () => {
+  it("drops all pre-compaction messages from the model view", () => {
+    const pre: AgentUIMessage[] = [
+      u("m1", "write me a poem"),
+      a("m2", "poem 1"),
+      u("m3", "another poem"),
+      a("m4", "poem 2"),
+      u("m5", "what did we do so far?"),
+      a("m6", "structured summary of poems"),
+    ];
+    const marker = compactionMarker("m7");
+    const summary = a("m8", "SUMMARY: wrote two poems, greeted user");
+    const newQ = u("m9", "hi what messages did we exchange rn");
+
+    const sent = rewriteForLLM([...pre, marker, summary, newQ]);
+    const ids = sent.map((m) => m.id);
+
+    // None of the pre-compaction messages survive into the model view.
+    for (const m of pre) {
+      expect(ids).not.toContain(m.id);
+    }
+
+    // Exactly: marker (substituted), summary, the new question.
+    expect(ids).toEqual(["m7", "m8", "m9"]);
+
+    // The marker's CompactionPart is substituted with the synthetic prompt.
+    expect(text(sent[0])).toBe(COMPACTION_USER_PROMPT);
+    expect(text(sent[1])).toContain("SUMMARY");
+    expect(text(sent[2])).toBe("hi what messages did we exchange rn");
+  });
+});

--- a/apps/extension/src/lib/agent/compaction.test.ts
+++ b/apps/extension/src/lib/agent/compaction.test.ts
@@ -29,7 +29,7 @@ import {
   type PrunableMessage,
 } from "./compaction";
 import type { AgentUIMessage } from "./message-types";
-import type { ProviderDefinition } from "@/registry/providers/types";
+import type { ProviderDefinition } from "../../registry/providers/types";
 
 /** Build an assistant message wrapping a single tool-result part. */
 function toolResultMsg(

--- a/apps/extension/src/lib/agent/compaction.test.ts
+++ b/apps/extension/src/lib/agent/compaction.test.ts
@@ -24,8 +24,12 @@ import { describe, expect, it } from "vitest";
 import {
   keepOnlyLatestScreenshot,
   PAGE_SCREENSHOT_TOOLS,
+  selectTailForManual,
+  resolveCompactionModel,
+  type PrunableMessage,
 } from "./compaction";
 import type { AgentUIMessage } from "./message-types";
+import type { ProviderDefinition } from "@/registry/providers/types";
 
 /** Build an assistant message wrapping a single tool-result part. */
 function toolResultMsg(
@@ -180,5 +184,150 @@ describe("keepOnlyLatestScreenshot — custom allowlist", () => {
     // viewPage pruning still works around it.
     expect(isStripped(out[0])).toBe(true);
     expect(out[1]).toEqual(img("vp2"));
+  });
+});
+
+/**
+ * `selectTailForManual` powers the user-typed `/compact` command. Unlike
+ * `selectTail` (auto-compaction, which keeps the last 1-2 turns verbatim
+ * so the agent can continue mid-task), a manual `/compact` means "continue
+ * from the summary only" — so it summarizes the ENTIRE conversation and
+ * keeps NO verbatim tail (`tailStartId === undefined`). The UI still shows
+ * every original message; only the model view is replaced by the summary.
+ *
+ * It returns an empty head (→ caller toasts "too short") only when there
+ * are fewer than two user turns, since there's nothing worth summarizing.
+ */
+describe("selectTailForManual", () => {
+  function msg(
+    id: string,
+    role: PrunableMessage["role"],
+    text: string,
+  ): PrunableMessage {
+    return { id, role, parts: [{ type: "text", text }], createdAt: 0 };
+  }
+
+  it("summarizes the whole conversation with no verbatim tail", () => {
+    const messages: PrunableMessage[] = [
+      msg("1", "user", "first question"),
+      msg("2", "assistant", "first answer"),
+      msg("3", "user", "second question"),
+      msg("4", "assistant", "second answer"),
+    ];
+    const { headMessages, tailStartId } = selectTailForManual(messages);
+    // Empty tail → the model sees only the summary; the entire chat is
+    // the head to summarize.
+    expect(tailStartId).toBeUndefined();
+    expect(headMessages.map((m) => m.id)).toEqual(["1", "2", "3", "4"]);
+  });
+
+  it("ignores the token budget (small messages still compact fully)", () => {
+    const messages: PrunableMessage[] = [
+      msg("1", "user", "q1"),
+      msg("2", "assistant", "a1"),
+      msg("3", "user", "q2"),
+      msg("4", "assistant", "a2"),
+      msg("5", "user", "q3"),
+      msg("6", "assistant", "a3"),
+    ];
+    const { headMessages, tailStartId } = selectTailForManual(messages);
+    expect(tailStartId).toBeUndefined();
+    expect(headMessages.map((m) => m.id)).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+    ]);
+  });
+
+  it("summarizes a trailing unanswered user message too (summary-only)", () => {
+    const messages: PrunableMessage[] = [
+      msg("1", "user", "q1"),
+      msg("2", "assistant", "a1"),
+      msg("3", "user", "q2 just sent"),
+    ];
+    const { headMessages, tailStartId } = selectTailForManual(messages);
+    // Everything (including the trailing question) folds into the summary;
+    // no verbatim tail.
+    expect(tailStartId).toBeUndefined();
+    expect(headMessages.map((m) => m.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("returns an empty head when there is only one user turn", () => {
+    const messages: PrunableMessage[] = [
+      msg("1", "user", "only question"),
+      msg("2", "assistant", "only answer"),
+    ];
+    const { headMessages } = selectTailForManual(messages);
+    // Nothing worth summarizing → caller toasts "too short to compact".
+    expect(headMessages.length).toBe(0);
+  });
+
+  it("returns an empty head for an empty conversation", () => {
+    const { headMessages, tailStartId } = selectTailForManual([]);
+    expect(headMessages.length).toBe(0);
+    expect(tailStartId).toBeUndefined();
+  });
+});
+
+/**
+ * `resolveCompactionModel` maps a stored model key to a provider + bare
+ * model id. Model keys are stored as composite "providerId:modelId"
+ * strings (the format ModelPicker writes for both agentModel and
+ * compactionModel), but `ProviderDefinition.createLanguageModel` and the
+ * registry's model lists key off the BARE model id. Compaction previously
+ * compared the composite key directly against bare ids, so the lookup
+ * always failed → "no provider for compaction model" and silent
+ * auto-compaction failures. These tests lock in the split + fallback.
+ */
+describe("resolveCompactionModel", () => {
+  function provider(id: string, modelIds: string[]): ProviderDefinition {
+    return {
+      id,
+      name: id,
+      models: modelIds.map((mid) => ({ id: mid })),
+    } as unknown as ProviderDefinition;
+  }
+
+  const providers = [
+    provider("anthropic", ["claude-sonnet-4", "claude-opus-4"]),
+    provider("openai", ["gpt-5"]),
+    provider("openrouter", ["vendor:model"]),
+  ];
+
+  it("resolves a composite providerId:modelId key", () => {
+    const r = resolveCompactionModel("anthropic:claude-sonnet-4", providers);
+    expect(r?.provider.id).toBe("anthropic");
+    expect(r?.modelId).toBe("claude-sonnet-4");
+  });
+
+  it("resolves a bare model id via fallback search", () => {
+    const r = resolveCompactionModel("gpt-5", providers);
+    expect(r?.provider.id).toBe("openai");
+    expect(r?.modelId).toBe("gpt-5");
+  });
+
+  it("preserves colons in the model id portion", () => {
+    // "openrouter:vendor:model" → provider openrouter, modelId "vendor:model"
+    const r = resolveCompactionModel("openrouter:vendor:model", providers);
+    expect(r?.provider.id).toBe("openrouter");
+    expect(r?.modelId).toBe("vendor:model");
+  });
+
+  it("resolves the provider by prefix even if the model id is stale", () => {
+    // Matches the canonical agentModel resolution: when a provider prefix
+    // is present, the provider is selected by id alone.
+    const r = resolveCompactionModel("anthropic:claude-removed", providers);
+    expect(r?.provider.id).toBe("anthropic");
+    expect(r?.modelId).toBe("claude-removed");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(resolveCompactionModel("ghost-model", providers)).toBeUndefined();
+    expect(
+      resolveCompactionModel("unknown-provider:some-model", providers),
+    ).toBeUndefined();
   });
 });

--- a/apps/extension/src/lib/agent/compaction.ts
+++ b/apps/extension/src/lib/agent/compaction.ts
@@ -5,6 +5,7 @@ import type {
   CompactionPart,
   SerializedUIPart,
 } from "../types";
+import type { ProviderDefinition } from "@/registry/providers/types";
 export interface TokenLimits {
   contextWindow?: number;
   maxOutputTokens?: number;
@@ -496,6 +497,82 @@ export function selectTail(
     tailStartIndex < messages.length ? messages[tailStartIndex].id : undefined;
 
   return { headMessages, tailStartId };
+}
+
+/**
+ * Tail selection for the user-typed `/compact` command.
+ *
+ * Auto-compaction (`selectTail`) deliberately preserves the last
+ * `TAIL_TURNS` (2) user turns and up to `MAX_PRESERVE_RECENT_TOKENS` of
+ * recent context verbatim, only summarizing what spills past that budget —
+ * it fires mid-task, so the agent needs recent context to continue.
+ *
+ * A user typing `/compact` is instead saying "continue from the summary
+ * only". So this variant summarizes the ENTIRE conversation and keeps NO
+ * verbatim tail: `headMessages` is every message and `tailStartId` is
+ * `undefined`. With no tail anchor, `filterCompactedMessages` /
+ * `rewriteForLLM` fall back to dropping everything before the compaction
+ * marker, so the model sees only the marker + summary (plus any turns that
+ * come *after* the compaction). The UI still shows every original message;
+ * only the model view is replaced.
+ *
+ * Returns an empty head when the conversation has fewer than two user
+ * turns — there's nothing worth summarizing — so the caller can surface a
+ * "conversation too short to compact" message instead of producing a
+ * trivial summary.
+ */
+export function selectTailForManual(
+  messages: PrunableMessage[]
+): { headMessages: PrunableMessage[]; tailStartId: string | undefined } {
+  const userTurns = messages.reduce(
+    (n, m) => (m.role === "user" ? n + 1 : n),
+    0
+  );
+
+  // Need at least two user turns for a meaningful manual compaction.
+  if (userTurns < 2) {
+    return { headMessages: [], tailStartId: undefined };
+  }
+
+  // Summary-only: the whole conversation is the head, no verbatim tail.
+  return { headMessages: messages, tailStartId: undefined };
+}
+
+export interface ResolvedModelSelection {
+  provider: ProviderDefinition;
+  /** Bare model id (ModelDefinition.id), suitable for createLanguageModel. */
+  modelId: string;
+}
+
+/**
+ * Resolve a stored model key against the provider registry.
+ *
+ * Model keys are persisted as composite "providerId:modelId" strings (the
+ * format `ModelPicker` writes for both `agentModel` and `compactionModel`),
+ * but the registry's model lists and `createLanguageModel` key off the
+ * BARE model id. This splits the composite key and resolves the provider,
+ * mirroring the canonical agentModel resolution in `useAgentChat`:
+ *   - when a provider prefix is present, select the provider by id;
+ *   - otherwise (or as a fallback), find the provider whose model list
+ *     contains the bare id.
+ *
+ * Returns `undefined` when no provider matches. The returned `modelId` is
+ * always the bare id, ready to hand to `provider.createLanguageModel`.
+ */
+export function resolveCompactionModel(
+  rawModelKey: string,
+  providers: ProviderDefinition[]
+): ResolvedModelSelection | undefined {
+  const [providerId, ...modelIdParts] = rawModelKey.split(":");
+  const hasPrefix = modelIdParts.length > 0;
+  const modelId = hasPrefix ? modelIdParts.join(":") : rawModelKey;
+
+  const provider =
+    (hasPrefix ? providers.find((p) => p.id === providerId) : undefined) ??
+    providers.find((p) => p.models.some((m) => m.id === modelId));
+
+  if (!provider) return undefined;
+  return { provider, modelId };
 }
 
 // Summarization Prompt Builders

--- a/apps/extension/src/lib/agent/compaction.ts
+++ b/apps/extension/src/lib/agent/compaction.ts
@@ -5,7 +5,7 @@ import type {
   CompactionPart,
   SerializedUIPart,
 } from "../types";
-import type { ProviderDefinition } from "@/registry/providers/types";
+import type { ProviderDefinition } from "../../registry/providers/types";
 export interface TokenLimits {
   contextWindow?: number;
   maxOutputTokens?: number;


### PR DESCRIPTION
## Summary

Adds a built-in `/compact` command to the chat composer's `/` popup (grouped under **Commands**, alongside skills). Selecting it manually compacts the conversation — the full history is summarized and only the summary is sent to the model on the next turn, while the UI keeps showing every original message.

- **Compact-then-send:** `/compact <text>` compacts first, then sends the remaining text as a normal turn.
- **Feedback:** toasts every outcome (compacted / too short / provider or model failure) — no more silent no-ops.
- **Bug fix:** compaction model resolution now handles the stored `provider:model` key. Previously the provider lookup compared the composite key against bare model ids and failed, which silently broke **both** manual and automatic compaction.

## Behavior details

- Manual `/compact` summarizes the **entire** conversation and keeps **no verbatim tail** — the model continues from the summary only. The UI still renders all original messages (divider + collapsible summary), unchanged.
- Auto-compaction behavior is untouched (still preserves recent turns to continue mid-task).
- Landing page (no active conversation) shows a "nothing to compact yet" toast.

## Implementation notes

- `slash-commands.ts` / `slash-command-extract.ts` — pure, unit-tested registry + JSON helpers (no TipTap/React deps).
- Popup surfacing via `skill-slash-suggestion.tsx` / `SkillSlashList.tsx` (Commands vs Skills groups).
- `ChatInput` gains an `onCommand` prop + submit interception; `ChatView` wires it to a new `compactNow()` from `useAgentChat`.
- `compaction.ts` adds `selectTailForManual` (summary-only tail) and `resolveCompactionModel` (composite-key resolution).
- Closure-safety: `handleSubmit` reads the latest editor text (`inputRef`) and message list (`messagesRef`) so the compact-then-send flow (which runs after an `await`) doesn't operate on stale state and accidentally drop the compaction marker.

## Testing

- `tsc --noEmit` clean.
- **696 tests pass** (76 files), including new coverage for the slash registry/extraction, `selectTailForManual`, `resolveCompactionModel`, the summary-only model view (`rewriteForLLM`), and a regression test ensuring tool-healing preserves the compaction event.
- Production build (`wxt build`) succeeds.

## Changeset

Includes `.changeset/compact-slash-command.md` (`openbrowse`: **minor**).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a `/compact` slash command to manually compact conversations (supports `/compact <text>` to compact then send)
  * Slash menu now shows built-in commands grouped separately from skills and updated composer placeholder
  * User toasts report compaction outcomes (compacted, too short, or failure)

* **Bug Fixes**
  * Fixed compaction model/provider resolution so manual and automatic compaction reliably work
<!-- end of auto-generated comment: release notes by coderabbit.ai -->