### PR TITLE
feat(extension): single-host agent runs with live cross-tab mirror

### DIFF
--- a/.changeset/single-host-agent-run-mirror.md
+++ b/.changeset/single-host-agent-run-mirror.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": patch
+---
+
+Prevent multiple tabs from auto-restarting the same agent run and mirror live agent progress across tabs. Disables message-load auto-resume, adds an atomic per-conversation ownership lock so only one context drives a run, and streams full-message snapshots to other open tabs as read-only viewers (with approval/stop forwarded to the owner).

--- a/.changeset/single-host-agent-run-mirror.md
+++ b/.changeset/single-host-agent-run-mirror.md
@@ -2,4 +2,12 @@
 "openbrowse": patch
 ---
 
-Prevent multiple tabs from auto-restarting the same agent run and mirror live agent progress across tabs. Disables message-load auto-resume, adds an atomic per-conversation ownership lock so only one context drives a run, and streams full-message snapshots to other open tabs as read-only viewers (with approval/stop forwarded to the owner).
+Prevent multiple open tabs from auto-restarting the same agent run, and
+mirror live agent progress across tabs.
+
+- Disable message-load auto-resume (it made every open context restart
+  the same run).
+- Add an atomic per-conversation ownership lock so only one context
+  drives a run.
+- Stream full-message snapshots to other tabs as read-only viewers;
+  approvals and stop are forwarded to the owner.

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -182,7 +182,8 @@ export function ChatView({
     handleRetry,
     handleContinue,
     confirmEdit,
-    addToolApprovalResponse,
+    approveToolCall,
+    isViewer,
     setAgentModel,
     setThinkingSettings,
     stop,
@@ -223,6 +224,24 @@ export function ChatView({
 
   const isLoading = hookIsLoading || isAgentActiveGlobally;
   const isStreaming = hookIsStreaming || isAgentActiveGlobally;
+
+  // Viewer-aware stop. In a viewer tab there is no live local loop to
+  // abort — the run is driven by the host. Forward a stop request via
+  // the existing AGENT_STOP broadcast, which the host's listener honors.
+  // (New messages typed in a viewer already route to the queue because
+  // `isLoading` is true, so ChatInput queues instead of submitting; the
+  // host drains the queue. So only stop needs special handling here.)
+  const handleStop = useCallback(() => {
+    if (isViewer) {
+      try {
+        chrome.runtime?.sendMessage?.({ type: "AGENT_STOP" })?.catch?.(() => {});
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    stop();
+  }, [isViewer, stop]);
 
   const { providers } = useProviders();
 
@@ -587,7 +606,7 @@ export function ChatView({
                 error={error}
                 onRegenerate={handleRegenerate}
                 onEdit={startEdit}
-                onToolApproval={addToolApprovalResponse}
+                onToolApproval={approveToolCall}
                 onRetry={handleRetry}
                 onContinue={handleContinue}
                 onDismissError={clearError}
@@ -787,7 +806,7 @@ export function ChatView({
                 }
           }
           editMode={isEditing}
-          onStop={stop}
+          onStop={handleStop}
           isLoading={isLoading}
           disabled={!isConfigured}
           providerModels={providerModels}

--- a/apps/extension/src/entrypoints/home/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/home/components/LandingPage.tsx
@@ -14,6 +14,7 @@ import { SpaceHeader } from "./SpaceHeader";
 import { TabCard } from "./TabCard";
 import { useRecentTabs } from "@/hooks/useRecentTabs";
 import { chatDb } from "@/lib/chat-db";
+import { markPendingFirstTurn } from "@/lib/agent/pending-first-turn";
 import { storage } from "@/lib/storage";
 import { DEFAULT_SETTINGS, DEFAULT_AGENT_SETTINGS } from "@/lib/constants";
 import { useProviders } from "@/hooks/useProviders";
@@ -284,6 +285,12 @@ export function LandingPage({
       }
 
       setInput("");
+      // Mark the new conversation as needing its first turn dispatched.
+      // LandingPage doesn't sendMessage directly — the side panel / chat
+      // view mounts on `onNewConversation`, reloads from chatDb, and the
+      // message-load effect dispatches the first turn, gated on this
+      // marker (so it's a scoped first-turn dispatch, not auto-resume).
+      await markPendingFirstTurn(convId);
       onNewConversation(convId);
     },
     [

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -14,6 +14,24 @@ import { setTargetTabId } from "@/lib/agent/active-tab";
 import { healPendingTools } from "@/lib/agent/heal-pending-tools";
 import { bindSharedTab } from "@/lib/agent/bind-shared-tab";
 import { setAgentActive, setAgentInactive } from "@/lib/active-agents";
+import { runOwnership, HEARTBEAT_MS, STALE_OWNER_MS } from "@/lib/agent/run-ownership";
+import {
+  markPendingFirstTurn,
+  hasPendingFirstTurn,
+  clearPendingFirstTurn,
+} from "@/lib/agent/pending-first-turn";
+import {
+  broadcastStreamParts,
+  broadcastStreamDone,
+  isStreamPartsMessage,
+  isStreamDoneMessage,
+  applyStreamSnapshot,
+  SeqGuard,
+} from "@/lib/agent/stream-mirror";
+import {
+  RUNTIME_MESSAGES,
+  STREAM_MIRROR_THROTTLE_MS,
+} from "@/lib/constants";
 import {
   pruneMessages as pruneMessageParts,
   selectTail,
@@ -495,6 +513,33 @@ export function useAgentChat({
   const compactionAbortRef = useRef<AbortController | null>(null);
   const conversationIdRef = useRef(conversationId);
   conversationIdRef.current = conversationId;
+
+  /**
+   * Stable per-mount identity for the run-ownership lock. Exactly one
+   * context may own (drive) a conversation's agent loop at a time; this
+   * token is how `run-ownership` distinguishes "me" from sibling tabs.
+   * Minted once per hook mount and never changes.
+   */
+  const ownerTokenRef = useRef<string>(generateId());
+
+  /**
+   * True when a *different* live context currently owns this
+   * conversation's run — i.e. this context is a read-only "viewer" that
+   * mirrors the host's stream and routes actions (send/approve/stop) to
+   * the owner rather than driving the loop locally.
+   */
+  const [isViewer, setIsViewer] = useState(false);
+  const isViewerRef = useRef(false);
+  isViewerRef.current = isViewer;
+
+  // Monotonic sequence for outgoing stream snapshots (host side) and a
+  // guard that drops stale/out-of-order frames (viewer side).
+  const streamSeqRef = useRef(0);
+  const seqGuardRef = useRef(new SeqGuard());
+  // Wall-clock of the last mirror signal (frame or done) this context
+  // received as a viewer. Used by the viewer watchdog to detect a host
+  // that died mid-stream (no STREAM_DONE will ever arrive).
+  const lastMirrorActivityRef = useRef(0);
 
   /**
    * Per-conversation FIFO queue of un-sent user messages. Items here
@@ -1056,11 +1101,49 @@ export function useAgentChat({
   useEffect(() => {
     if (status === "streaming" || status === "submitted") {
       wasStreamingRef.current = true;
-      if (conversationId) setAgentActive(conversationId);
+      if (conversationId) {
+        setAgentActive(conversationId);
+        // Claim ownership the moment this context starts driving a run.
+        // If a different live context already owns it, we lost the race:
+        // stop our local loop and fall back to viewer mode (mirror the
+        // owner's stream instead of duplicating the work).
+        const cid = conversationId;
+        const token = ownerTokenRef.current;
+        void runOwnership.claimOwnership(cid, token).then((won) => {
+          if (conversationIdRef.current !== cid) return;
+          if (won) {
+            setIsViewer(false);
+          } else {
+            setIsViewer(true);
+            stop();
+          }
+        });
+      }
     } else if (wasStreamingRef.current) {
       wasStreamingRef.current = false;
       resetAgentIndicator();
-      if (conversationId) setAgentInactive(conversationId);
+      if (conversationId) {
+        setAgentInactive(conversationId);
+        // Terminal state for this context's run: emit one final snapshot
+        // (the throttled broadcaster may have skipped the last partial
+        // when status flipped out of "streaming"), then release ownership
+        // and tell viewers to re-read the authoritative transcript.
+        const cid = conversationId;
+        if (!isViewer) {
+          const lastMsg = messages[messages.length - 1];
+          if (lastMsg && lastMsg.role === "assistant") {
+            streamSeqRef.current += 1;
+            broadcastStreamParts({
+              conversationId: cid,
+              messageId: lastMsg.id,
+              parts: serializeParts(lastMsg.parts),
+              seq: streamSeqRef.current,
+            });
+          }
+        }
+        void runOwnership.releaseOwnership(cid, ownerTokenRef.current);
+        broadcastStreamDone(cid);
+      }
 
       // Check if compaction is needed after response completes. This
       // covers both true inter-turn compaction and mid-stream compaction
@@ -1072,7 +1155,174 @@ export function useAgentChat({
         runCompaction(conversationId, messages, { auto: true });
       }
     }
-  }, [status, conversationId, messages, runCompaction]);
+  }, [status, conversationId, messages, runCompaction, stop, isViewer]);
+
+  // Heartbeat: while this context owns a streaming run, renew the
+  // ownership claim periodically so sibling tabs don't reap it as stale.
+  // If renewal fails (we lost ownership, e.g. after a stale reap), stop
+  // the local loop and become a viewer.
+  useEffect(() => {
+    if (!conversationId) return;
+    if (status !== "streaming" && status !== "submitted") return;
+    if (isViewer) return;
+    const cid = conversationId;
+    const token = ownerTokenRef.current;
+    const interval = setInterval(() => {
+      void runOwnership.renewOwnership(cid, token).then((stillMine) => {
+        if (conversationIdRef.current !== cid) return;
+        if (!stillMine) {
+          setIsViewer(true);
+          stop();
+        }
+      });
+    }, HEARTBEAT_MS);
+    return () => clearInterval(interval);
+  }, [status, conversationId, isViewer, stop]);
+
+  // Host broadcaster: while this context owns a streaming run, broadcast
+  // throttled full-message snapshots of the in-flight assistant message
+  // so viewer tabs can mirror progress live. Full snapshots (not deltas)
+  // self-heal dropped frames and instantly catch up late joiners.
+  const lastBroadcastRef = useRef(0);
+  useEffect(() => {
+    if (!conversationId) return;
+    if (isViewer) return;
+    if (status !== "streaming") return;
+    const lastMsg = messages[messages.length - 1];
+    if (!lastMsg || lastMsg.role !== "assistant") return;
+
+    const now = Date.now();
+    const elapsed = now - lastBroadcastRef.current;
+    const cid = conversationId;
+    const emit = () => {
+      lastBroadcastRef.current = Date.now();
+      streamSeqRef.current += 1;
+      broadcastStreamParts({
+        conversationId: cid,
+        messageId: lastMsg.id,
+        parts: serializeParts(lastMsg.parts),
+        seq: streamSeqRef.current,
+      });
+    };
+    if (elapsed >= STREAM_MIRROR_THROTTLE_MS) {
+      emit();
+      return;
+    }
+    // Trailing edge: ensure the final partial state for this render
+    // lands even if updates stop arriving before the next interval.
+    const t = setTimeout(emit, STREAM_MIRROR_THROTTLE_MS - elapsed);
+    return () => clearTimeout(t);
+  }, [messages, status, isViewer, conversationId]);
+
+  // Viewer receiver: in a non-owner context, apply mirrored snapshots
+  // from the host into the local message list and converge on the
+  // authoritative transcript when the turn finishes.
+  useEffect(() => {
+    if (!conversationId) return;
+    const cid = conversationId;
+    const guard = seqGuardRef.current;
+
+    const onMessage = (msg: unknown) => {
+      if (isStreamPartsMessage(msg) && msg.conversationId === cid) {
+        // Receiving a frame means another context is the host: we're a
+        // viewer for the duration of this run.
+        lastMirrorActivityRef.current = Date.now();
+        if (!isViewerRef.current) setIsViewer(true);
+        if (!guard.shouldApply(msg.messageId, msg.seq)) return;
+        const snapshot = dbMessageToUIMessage({
+          id: msg.messageId,
+          role: "assistant",
+          parts: msg.parts,
+        });
+        setMessages((prev) => applyStreamSnapshot(prev, snapshot));
+        return;
+      }
+      if (isStreamDoneMessage(msg) && msg.conversationId === cid) {
+        // Host finished the turn. Re-read the persisted transcript so we
+        // converge on the authoritative state (covers any dropped frame)
+        // and drop viewer mode.
+        lastMirrorActivityRef.current = Date.now();
+        guard.reset();
+        void chatDb.getMessages(cid).then((dbMsgs) => {
+          if (conversationIdRef.current !== cid) return;
+          // Only adopt the DB transcript if it actually has content. An
+          // errored/empty turn may not have persisted the in-flight
+          // assistant message (onFinish skips empty turns), and the host's
+          // self-heal can delete a trailing empty assistant row — in
+          // either case we must NOT blow away what the viewer already
+          // mirrored down to an empty list. Keep the mirrored messages if
+          // the DB has nothing.
+          if (dbMsgs.length > 0) {
+            setMessages(dbMsgs.map(dbMessageToUIMessage));
+          }
+          setIsViewer(false);
+        });
+      }
+    };
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [conversationId, setMessages]);
+
+  // Viewer watchdog: if this context is mirroring a host (isViewer) but
+  // the host dies mid-stream, no STREAM_DONE will ever arrive and the
+  // viewer would stay stuck read-only forever. Periodically check: if no
+  // mirror activity for a while AND the ownership claim is gone/stale,
+  // exit viewer mode and converge on whatever the host last persisted.
+  // This realizes the "host death -> run stops; user manually continues"
+  // behavior on the viewer side (auto-resume stays disabled).
+  useEffect(() => {
+    if (!conversationId) return;
+    if (!isViewer) return;
+    const cid = conversationId;
+    const interval = setInterval(() => {
+      const idle = Date.now() - lastMirrorActivityRef.current;
+      if (idle < STALE_OWNER_MS) return;
+      void runOwnership.getOwner(cid).then((owner) => {
+        if (conversationIdRef.current !== cid) return;
+        // getOwner returns null for both "no owner" and "stale owner".
+        if (owner === null) {
+          void chatDb.getMessages(cid).then((dbMsgs) => {
+            if (conversationIdRef.current !== cid) return;
+            if (dbMsgs.length > 0) {
+              setMessages(dbMsgs.map(dbMessageToUIMessage));
+            }
+            seqGuardRef.current.reset();
+            setIsViewer(false);
+          });
+        }
+      });
+    }, HEARTBEAT_MS);
+    return () => clearInterval(interval);
+  }, [conversationId, isViewer, setMessages]);
+
+  // Host-side approval forwarding: a viewer tab can't resolve the live
+  // `approval-requested` tool part (it lives in the host's in-memory
+  // chat). The viewer broadcasts AGENT_APPROVE; the host (owner) applies
+  // it to its own chat here.
+  useEffect(() => {
+    if (!conversationId) return;
+    if (isViewer) return;
+    const cid = conversationId;
+    const onMessage = (msg: unknown) => {
+      if (typeof msg !== "object" || msg === null) return;
+      const m = msg as {
+        type?: string;
+        conversationId?: string;
+        toolCallId?: string;
+        approved?: boolean;
+      };
+      if (
+        m.type === RUNTIME_MESSAGES.AGENT_APPROVE &&
+        m.conversationId === cid &&
+        typeof m.toolCallId === "string" &&
+        typeof m.approved === "boolean"
+      ) {
+        void addToolApprovalResponse({ id: m.toolCallId, approved: m.approved });
+      }
+    };
+    chrome.runtime.onMessage.addListener(onMessage);
+    return () => chrome.runtime.onMessage.removeListener(onMessage);
+  }, [conversationId, isViewer, addToolApprovalResponse]);
 
   useEffect(() => {
     const listener = (message: { type: string }) => {
@@ -1367,8 +1617,8 @@ export function useAgentChat({
       // `hasMeaningfulContent` gate above. Without this, the user sees
       // a bare regenerate-icon bubble after refreshing a chat that
       // errored. After the delete, the conversation reads as if the
-      // user's last message is unanswered, so the auto-resume branch
-      // below (or a manual retry) takes over.
+      // user's last message is unanswered, so a manual retry / continue
+      // (or the host's queue-flush, once a run is started) takes over.
       let msgs = initialMsgs;
       const lastDb = msgs[msgs.length - 1];
       if (
@@ -1385,17 +1635,37 @@ export function useAgentChat({
         setMessages(uiMsgs);
         // Hydrate the agent context (and tab handle map) for any
         // subsequent action — retry, regenerate, approve a pending tool
-        // call, or auto-resume below. Doing it unconditionally on
-        // conversation load means resolveTabHandle has live state regardless
-        // of which path the user takes after opening the conversation.
+        // call. Doing it unconditionally on conversation load means
+        // resolveTabHandle has live state regardless of which path the
+        // user takes after opening the conversation.
         setAgentContext(conversationId);
+
+        // First-turn dispatch for a freshly-created conversation.
+        //
+        // The side panel / ChatView `handleSubmit` (and the home
+        // LandingPage) create a conversation, persist the first user
+        // message, and switch here via `onNewConversation` WITHOUT
+        // calling sendMessage directly — they rely on this effect to
+        // dispatch the first turn once the new chat instance mounts.
+        //
+        // We gate that dispatch on the `pending-first-turn` marker so it
+        // fires ONLY for a just-created conversation, never as an
+        // unconditional auto-resume of a trailing unanswered user message.
+        // Auto-resuming on load caused every open context (home tab, side
+        // panel, popup, duplicate home tabs) to independently restart the
+        // same task. A stale tab reopening an existing conversation has no
+        // marker, so it won't auto-start; the user resumes manually via
+        // the composer (or the error banner's Continue/Retry). If two
+        // contexts somehow both observe the marker, the ownership claim in
+        // the status effect ensures only one actually drives the run.
         const lastMsg = uiMsgs[uiMsgs.length - 1];
         if (lastMsg.role === "user" && transport) {
-          // Auto-resume: an unanswered user message at the tail of the
-          // conversation. Compaction-aware message assembly lives in the
-          // transport, so we no longer prefilter the message list here —
-          // the wrapper reads chatDb compaction state at send-time.
-          sendMessage();
+          const cid = conversationId;
+          const pending = await hasPendingFirstTurn(cid);
+          if (pending && conversationIdRef.current === cid) {
+            await clearPendingFirstTurn(cid);
+            sendMessage();
+          }
         }
       }
     });
@@ -1599,8 +1869,14 @@ export function useAgentChat({
       setAgentContext(convId);
 
       if (isNew) {
-        // Set conversation ID first — the effect will load the user message
-        // from DB and call sendMessage on the correct chat instance.
+        // Mark the conversation as needing its first turn dispatched, then
+        // switch to it. The message-load effect picks up the persisted user
+        // message and dispatches sendMessage() for the new chat instance —
+        // gated on this marker so only freshly-created conversations
+        // auto-start (a stale tab reopening an existing conversation must
+        // NOT). Cross-tab double-dispatch is prevented by the ownership
+        // claim, not this marker.
+        await markPendingFirstTurn(convId);
         onNewConversation(convId);
       } else {
         // Construct a full `UIMessage` (id + role + parts) instead of
@@ -1990,12 +2266,39 @@ export function useAgentChat({
     storage.setSettings(next);
   }, [settings]);
 
+  // Viewer-aware tool approval. When this context is a viewer (another
+  // tab owns the live run), the local `addToolApprovalResponse` would
+  // operate on a stale, non-driving chat. Instead forward the decision
+  // to the host via AGENT_APPROVE, which applies it to the live part.
+  const approveToolCall = useCallback(
+    (opts: { id: string; approved: boolean }) => {
+      if (isViewerRef.current && conversationIdRef.current) {
+        try {
+          chrome.runtime
+            ?.sendMessage?.({
+              type: RUNTIME_MESSAGES.AGENT_APPROVE,
+              conversationId: conversationIdRef.current,
+              toolCallId: opts.id,
+              approved: opts.approved,
+            })
+            ?.catch?.(() => {});
+        } catch {
+          /* non-extension context; ignore */
+        }
+        return;
+      }
+      return addToolApprovalResponse(opts);
+    },
+    [addToolApprovalResponse],
+  );
+
   return {
     messages,
     input,
     setInput,
     isLoading,
     isStreaming,
+    isViewer,
     isCompacting,
     isConfigured,
     // True once the chat transport has finished building. The transport is
@@ -2019,6 +2322,7 @@ export function useAgentChat({
     handleContinue,
     confirmEdit,
     addToolApprovalResponse,
+    approveToolCall,
     stop,
     error,
     clearError,

--- a/apps/extension/src/lib/agent/__tests__/pending-first-turn.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/pending-first-turn.test.ts
@@ -58,4 +58,30 @@ describe("pending-first-turn", () => {
     await expect(hasPendingFirstTurn("conv-1")).resolves.toBe(false);
     await expect(clearPendingFirstTurn("conv-1")).resolves.toBeUndefined();
   });
+
+  it("ignores ids with unsafe characters or bad length (no storage write, reads false)", async () => {
+    const setSpy = chrome.storage.session.set as ReturnType<typeof vi.fn>;
+    for (const bad of ["a/b", "a b", "a.b", "x".repeat(200), "", "a:b"]) {
+      await markPendingFirstTurn(bad);
+      expect(await hasPendingFirstTurn(bad)).toBe(false);
+      await clearPendingFirstTurn(bad);
+    }
+    // No write ever reached storage for unsafe ids.
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a prefixed __proto__ id as a harmless namespaced key (no pollution)", async () => {
+    // `__proto__` matches the url-safe allowlist, but the KEY_PREFIX means
+    // the stored key is `pending-first-turn:__proto__`, which cannot pollute
+    // Object.prototype. The marker still round-trips like any other id.
+    await markPendingFirstTurn("__proto__");
+    expect(await hasPendingFirstTurn("__proto__")).toBe(true);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("accepts uuid-shaped ids", async () => {
+    const id = "123e4567-e89b-12d3-a456-426614174000";
+    await markPendingFirstTurn(id);
+    expect(await hasPendingFirstTurn(id)).toBe(true);
+  });
 });

--- a/apps/extension/src/lib/agent/__tests__/pending-first-turn.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/pending-first-turn.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  markPendingFirstTurn,
+  hasPendingFirstTurn,
+  clearPendingFirstTurn,
+} from "../pending-first-turn";
+
+describe("pending-first-turn", () => {
+  let store: Record<string, unknown>;
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal("chrome", {
+      storage: {
+        session: {
+          get: vi.fn(async (k: string) =>
+            k in store ? { [k]: store[k] } : {},
+          ),
+          set: vi.fn(async (obj: Record<string, unknown>) => {
+            Object.assign(store, obj);
+          }),
+          remove: vi.fn(async (k: string) => {
+            delete store[k];
+          }),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("is not pending by default", async () => {
+    expect(await hasPendingFirstTurn("conv-1")).toBe(false);
+  });
+
+  it("marks then reports pending", async () => {
+    await markPendingFirstTurn("conv-1");
+    expect(await hasPendingFirstTurn("conv-1")).toBe(true);
+  });
+
+  it("scopes the marker per conversation", async () => {
+    await markPendingFirstTurn("conv-1");
+    expect(await hasPendingFirstTurn("conv-1")).toBe(true);
+    expect(await hasPendingFirstTurn("conv-2")).toBe(false);
+  });
+
+  it("clears the marker", async () => {
+    await markPendingFirstTurn("conv-1");
+    await clearPendingFirstTurn("conv-1");
+    expect(await hasPendingFirstTurn("conv-1")).toBe(false);
+  });
+
+  it("does not throw when session storage is unavailable", async () => {
+    vi.stubGlobal("chrome", {});
+    await expect(markPendingFirstTurn("conv-1")).resolves.toBeUndefined();
+    await expect(hasPendingFirstTurn("conv-1")).resolves.toBe(false);
+    await expect(clearPendingFirstTurn("conv-1")).resolves.toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/run-ownership.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/run-ownership.test.ts
@@ -1,0 +1,172 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runOwnership, STALE_OWNER_MS } from "../run-ownership";
+
+describe("run-ownership", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    runOwnership._resetForTests();
+  });
+
+  afterEach(() => {
+    runOwnership._resetForTests();
+  });
+
+  describe("claimOwnership", () => {
+    it("lets the first claimant win and reports the owner", async () => {
+      const won = await runOwnership.claimOwnership("conv-1", "token-A");
+      expect(won).toBe(true);
+
+      const owner = await runOwnership.getOwner("conv-1");
+      expect(owner?.ownerToken).toBe("token-A");
+    });
+
+    it("rejects a second, different claimant while the first is live", async () => {
+      const now = 1_000;
+      expect(
+        await runOwnership.claimOwnership("conv-1", "token-A", "home", now),
+      ).toBe(true);
+      // A moment later, a sibling tab tries to claim.
+      expect(
+        await runOwnership.claimOwnership("conv-1", "token-B", "home", now + 5),
+      ).toBe(false);
+
+      const owner = await runOwnership.getOwner("conv-1", now + 5);
+      expect(owner?.ownerToken).toBe("token-A");
+    });
+
+    it("is idempotent for the current owner and refreshes the heartbeat", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+      const reclaim = await runOwnership.claimOwnership(
+        "conv-1",
+        "token-A",
+        "home",
+        now + 100,
+      );
+      expect(reclaim).toBe(true);
+
+      const owner = await runOwnership.getOwner("conv-1", now + 100);
+      expect(owner?.ownerToken).toBe("token-A");
+      expect(owner?.claimedAt).toBe(now); // claimedAt preserved
+      expect(owner?.heartbeatAt).toBe(now + 100); // heartbeat refreshed
+    });
+
+    it("lets a new claimant reap a stale owner", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+
+      // token-A never heartbeats; well past the stale threshold token-B claims.
+      const later = now + STALE_OWNER_MS + 1;
+      expect(
+        await runOwnership.claimOwnership("conv-1", "token-B", "home", later),
+      ).toBe(true);
+
+      const owner = await runOwnership.getOwner("conv-1", later);
+      expect(owner?.ownerToken).toBe("token-B");
+    });
+
+    it("does not allow reaping just before the stale threshold", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+
+      const justBefore = now + STALE_OWNER_MS - 1;
+      expect(
+        await runOwnership.claimOwnership(
+          "conv-1",
+          "token-B",
+          "home",
+          justBefore,
+        ),
+      ).toBe(false);
+    });
+
+    it("scopes ownership per conversation", async () => {
+      await runOwnership.claimOwnership("conv-1", "token-A");
+      const ok = await runOwnership.claimOwnership("conv-2", "token-B");
+      expect(ok).toBe(true);
+      expect((await runOwnership.getOwner("conv-1"))?.ownerToken).toBe(
+        "token-A",
+      );
+      expect((await runOwnership.getOwner("conv-2"))?.ownerToken).toBe(
+        "token-B",
+      );
+    });
+  });
+
+  describe("renewOwnership", () => {
+    it("refreshes the heartbeat for the current owner and prevents reaping", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+
+      // Heartbeat just before the threshold keeps it alive.
+      const renew = await runOwnership.renewOwnership(
+        "conv-1",
+        "token-A",
+        now + STALE_OWNER_MS - 1,
+      );
+      expect(renew).toBe(true);
+
+      // Now a claim that would have been stale relative to the ORIGINAL
+      // claim is rejected because the heartbeat moved forward.
+      const probe = now + STALE_OWNER_MS + 1;
+      expect(
+        await runOwnership.claimOwnership("conv-1", "token-B", "home", probe),
+      ).toBe(false);
+    });
+
+    it("returns false when the token no longer owns the conversation", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+      // token-B reaps it after staleness.
+      const later = now + STALE_OWNER_MS + 1;
+      await runOwnership.claimOwnership("conv-1", "token-B", "home", later);
+
+      expect(
+        await runOwnership.renewOwnership("conv-1", "token-A", later + 1),
+      ).toBe(false);
+    });
+  });
+
+  describe("releaseOwnership", () => {
+    it("clears the claim so a new owner can take over immediately", async () => {
+      await runOwnership.claimOwnership("conv-1", "token-A");
+      await runOwnership.releaseOwnership("conv-1", "token-A");
+      expect(await runOwnership.getOwner("conv-1")).toBeNull();
+
+      expect(await runOwnership.claimOwnership("conv-1", "token-B")).toBe(true);
+    });
+
+    it("does not delete another owner's claim", async () => {
+      await runOwnership.claimOwnership("conv-1", "token-A");
+      await runOwnership.releaseOwnership("conv-1", "token-B"); // wrong token
+      expect((await runOwnership.getOwner("conv-1"))?.ownerToken).toBe(
+        "token-A",
+      );
+    });
+  });
+
+  describe("getOwner / isOwner", () => {
+    it("reports a stale owner as null (reclaimable)", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+      expect(
+        await runOwnership.getOwner("conv-1", now + STALE_OWNER_MS + 1),
+      ).toBeNull();
+    });
+
+    it("isOwner is true only for the live holder", async () => {
+      const now = 1_000;
+      await runOwnership.claimOwnership("conv-1", "token-A", "home", now);
+      expect(await runOwnership.isOwner("conv-1", "token-A", now)).toBe(true);
+      expect(await runOwnership.isOwner("conv-1", "token-B", now)).toBe(false);
+      expect(
+        await runOwnership.isOwner(
+          "conv-1",
+          "token-A",
+          now + STALE_OWNER_MS + 1,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/stream-mirror.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/stream-mirror.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  applyStreamSnapshot,
+  SeqGuard,
+  isStreamPartsMessage,
+  isStreamDoneMessage,
+  broadcastStreamParts,
+  broadcastStreamDone,
+} from "../stream-mirror";
+import { RUNTIME_MESSAGES } from "@/lib/constants";
+
+interface Msg {
+  id: string;
+  role: string;
+  parts: { type: string; text?: string }[];
+}
+
+describe("stream-mirror: applyStreamSnapshot", () => {
+  it("appends when the message id is not present", () => {
+    const base: Msg[] = [{ id: "u1", role: "user", parts: [] }];
+    const snap: Msg = { id: "a1", role: "assistant", parts: [{ type: "text", text: "hi" }] };
+    const next = applyStreamSnapshot(base, snap);
+    expect(next.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("replaces in place when the message id already exists", () => {
+    const base: Msg[] = [
+      { id: "u1", role: "user", parts: [] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "h" }] },
+    ];
+    const snap: Msg = { id: "a1", role: "assistant", parts: [{ type: "text", text: "hello" }] };
+    const next = applyStreamSnapshot(base, snap);
+    expect(next).toHaveLength(2);
+    expect(next[1].parts[0].text).toBe("hello");
+  });
+
+  it("does not mutate the input array", () => {
+    const base: Msg[] = [{ id: "a1", role: "assistant", parts: [] }];
+    const snap: Msg = { id: "a1", role: "assistant", parts: [{ type: "text", text: "x" }] };
+    applyStreamSnapshot(base, snap);
+    expect(base[0].parts).toEqual([]);
+  });
+});
+
+describe("stream-mirror: SeqGuard", () => {
+  it("applies strictly increasing seqs and drops stale/equal ones", () => {
+    const g = new SeqGuard();
+    expect(g.shouldApply("a1", 1)).toBe(true);
+    expect(g.shouldApply("a1", 2)).toBe(true);
+    expect(g.shouldApply("a1", 2)).toBe(false); // equal -> stale
+    expect(g.shouldApply("a1", 1)).toBe(false); // out of order
+    expect(g.shouldApply("a1", 3)).toBe(true);
+  });
+
+  it("tracks seqs independently per message id", () => {
+    const g = new SeqGuard();
+    expect(g.shouldApply("a1", 5)).toBe(true);
+    expect(g.shouldApply("a2", 1)).toBe(true);
+    expect(g.shouldApply("a2", 2)).toBe(true);
+    expect(g.shouldApply("a1", 5)).toBe(false);
+  });
+
+  it("reset clears tracked seqs", () => {
+    const g = new SeqGuard();
+    g.shouldApply("a1", 9);
+    g.reset();
+    expect(g.shouldApply("a1", 1)).toBe(true);
+  });
+});
+
+describe("stream-mirror: type guards", () => {
+  it("recognizes a valid STREAM_PARTS message", () => {
+    expect(
+      isStreamPartsMessage({
+        type: RUNTIME_MESSAGES.STREAM_PARTS,
+        conversationId: "c1",
+        messageId: "a1",
+        parts: [],
+        seq: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed STREAM_PARTS messages", () => {
+    expect(isStreamPartsMessage(null)).toBe(false);
+    expect(isStreamPartsMessage({ type: "OTHER" })).toBe(false);
+    expect(
+      isStreamPartsMessage({
+        type: RUNTIME_MESSAGES.STREAM_PARTS,
+        conversationId: "c1",
+        messageId: "a1",
+        parts: "nope",
+        seq: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes STREAM_DONE", () => {
+    expect(
+      isStreamDoneMessage({
+        type: RUNTIME_MESSAGES.STREAM_DONE,
+        conversationId: "c1",
+      }),
+    ).toBe(true);
+    expect(isStreamDoneMessage({ type: RUNTIME_MESSAGES.STREAM_PARTS })).toBe(
+      false,
+    );
+  });
+});
+
+describe("stream-mirror: broadcasts", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("broadcastStreamParts sends a STREAM_PARTS payload", () => {
+    const send = vi.fn(() => Promise.resolve());
+    vi.stubGlobal("chrome", { runtime: { sendMessage: send } });
+    broadcastStreamParts({
+      conversationId: "c1",
+      messageId: "a1",
+      parts: [{ type: "text", text: "hi" }],
+      seq: 3,
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: RUNTIME_MESSAGES.STREAM_PARTS,
+        conversationId: "c1",
+        messageId: "a1",
+        seq: 3,
+      }),
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("broadcastStreamDone sends a STREAM_DONE payload", () => {
+    const send = vi.fn(() => Promise.resolve());
+    vi.stubGlobal("chrome", { runtime: { sendMessage: send } });
+    broadcastStreamDone("c1");
+    expect(send).toHaveBeenCalledWith({
+      type: RUNTIME_MESSAGES.STREAM_DONE,
+      conversationId: "c1",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("does not throw when chrome.runtime is unavailable", () => {
+    vi.stubGlobal("chrome", {});
+    expect(() => broadcastStreamDone("c1")).not.toThrow();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/extension/src/lib/agent/pending-first-turn.ts
+++ b/apps/extension/src/lib/agent/pending-first-turn.ts
@@ -1,0 +1,64 @@
+/**
+ * "Pending first turn" marker for newly-created conversations.
+ *
+ * When a conversation is created from a submit path (the side panel /
+ * ChatView `handleSubmit` new-conversation branch, or the home
+ * LandingPage), the first user message is persisted to chat-db and the
+ * UI switches to the new conversation via `onNewConversation`. The first
+ * agent turn is then dispatched by the message-load effect once the new
+ * conversation mounts.
+ *
+ * Historically that dispatch rode on the message-load auto-resume branch.
+ * Auto-resume was removed (it caused every open tab to restart the same
+ * task), so we need an explicit, scoped signal that says "this freshly
+ * created conversation still needs its first turn kicked off" — WITHOUT
+ * re-enabling auto-resume for stale tabs reopening existing conversations.
+ *
+ * The marker lives in `chrome.storage.session` (shared across extension
+ * contexts at the origin) so it survives the home LandingPage → side
+ * panel hand-off. It is consumed (read) by the load effect and cleared
+ * once the first turn is dispatched. Cross-tab double-dispatch is
+ * prevented by the run-ownership claim, not by this marker, so the marker
+ * does not need to be atomic.
+ */
+
+const KEY_PREFIX = "pending-first-turn:";
+
+function key(conversationId: string): string {
+  return `${KEY_PREFIX}${conversationId}`;
+}
+
+/** Mark a newly-created conversation as needing its first turn dispatched. */
+export async function markPendingFirstTurn(
+  conversationId: string,
+): Promise<void> {
+  try {
+    await chrome.storage?.session?.set?.({ [key(conversationId)]: Date.now() });
+  } catch {
+    /* session storage unavailable (non-extension/test context); ignore */
+  }
+}
+
+/** True if this conversation is still awaiting its first-turn dispatch. */
+export async function hasPendingFirstTurn(
+  conversationId: string,
+): Promise<boolean> {
+  try {
+    const k = key(conversationId);
+    const r = await chrome.storage?.session?.get?.(k);
+    return Boolean(r && r[k]);
+  } catch {
+    return false;
+  }
+}
+
+/** Clear the marker once the first turn has been dispatched (or abandoned). */
+export async function clearPendingFirstTurn(
+  conversationId: string,
+): Promise<void> {
+  try {
+    await chrome.storage?.session?.remove?.(key(conversationId));
+  } catch {
+    /* ignore */
+  }
+}

--- a/apps/extension/src/lib/agent/pending-first-turn.ts
+++ b/apps/extension/src/lib/agent/pending-first-turn.ts
@@ -24,6 +24,27 @@
 
 const KEY_PREFIX = "pending-first-turn:";
 
+/**
+ * Whether `conversationId` is safe to embed in a storage key.
+ *
+ * Conversation ids are minted by `crypto.randomUUID()`, but the active
+ * conversation id can also originate from attacker-influenceable sources
+ * (e.g. `window.location.hash` / URL params). Restricting to an
+ * allowlist of url-safe characters with a length cap means a crafted id
+ * (e.g. `__proto__`) can never become the computed property name written
+ * to storage — closing the remote-property-injection vector flagged by
+ * CodeQL. (The `KEY_PREFIX` already neutralizes prototype pollution, but
+ * this makes the key provably sanitized.)
+ */
+function isSafeConversationId(conversationId: string): boolean {
+  return (
+    typeof conversationId === "string" &&
+    conversationId.length > 0 &&
+    conversationId.length <= 128 &&
+    /^[A-Za-z0-9_-]+$/.test(conversationId)
+  );
+}
+
 function key(conversationId: string): string {
   return `${KEY_PREFIX}${conversationId}`;
 }
@@ -32,6 +53,7 @@ function key(conversationId: string): string {
 export async function markPendingFirstTurn(
   conversationId: string,
 ): Promise<void> {
+  if (!isSafeConversationId(conversationId)) return;
   try {
     await chrome.storage?.session?.set?.({ [key(conversationId)]: Date.now() });
   } catch {
@@ -43,6 +65,7 @@ export async function markPendingFirstTurn(
 export async function hasPendingFirstTurn(
   conversationId: string,
 ): Promise<boolean> {
+  if (!isSafeConversationId(conversationId)) return false;
   try {
     const k = key(conversationId);
     const r = await chrome.storage?.session?.get?.(k);
@@ -56,6 +79,7 @@ export async function hasPendingFirstTurn(
 export async function clearPendingFirstTurn(
   conversationId: string,
 ): Promise<void> {
+  if (!isSafeConversationId(conversationId)) return;
   try {
     await chrome.storage?.session?.remove?.(key(conversationId));
   } catch {

--- a/apps/extension/src/lib/agent/run-ownership.ts
+++ b/apps/extension/src/lib/agent/run-ownership.ts
@@ -1,0 +1,202 @@
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+
+/**
+ * IndexedDB-backed per-conversation run-ownership lock.
+ *
+ * Exactly one context (a home page acting as "host") may own a running
+ * conversation's agent loop at a time. Ownership is the authoritative
+ * single-writer guard that prevents multiple open tabs (home tabs, side
+ * panels, popups, duplicate home tabs) from each independently driving
+ * the same conversation.
+ *
+ * This is the atomic counterpart to `queue-db`'s `flushClaims` mutex,
+ * generalized for the whole run rather than a single queue-head flush:
+ *
+ *   - `claimOwnership` runs in a single IndexedDB `readwrite` transaction
+ *     so two contexts racing to claim the same conversation can't both
+ *     win (unlike a `chrome.storage.session` check-then-set, which has a
+ *     TOCTOU window).
+ *   - The owner must `renewOwnership` (heartbeat) periodically. A host
+ *     that closes/crashes mid-run stops heartbeating; after
+ *     {@link STALE_OWNER_MS} its claim is reclaimable by another context.
+ *   - `releaseOwnership` is the clean exit at run end.
+ *
+ * The DB is separate from `chat-db` and `queue-db` so its schema can
+ * evolve independently and a wipe never touches the transcript or queue.
+ */
+
+export type HostKind = "home";
+
+export interface RunOwnership {
+  conversationId: string;
+  ownerToken: string;
+  hostKind: HostKind;
+  claimedAt: number;
+  heartbeatAt: number;
+}
+
+interface OwnershipDB extends DBSchema {
+  ownership: {
+    key: string; // conversationId
+    value: RunOwnership;
+  };
+}
+
+const DB_NAME = "openbrowse-run-ownership";
+const DB_VERSION = 1;
+
+/**
+ * How long an owner's heartbeat may lapse before another context may
+ * reclaim ownership. Must comfortably exceed the renew cadence
+ * ({@link HEARTBEAT_MS}) so a live-but-busy host isn't reclaimed out
+ * from under itself.
+ */
+export const STALE_OWNER_MS = 30_000;
+
+/** Recommended heartbeat cadence for owners. */
+export const HEARTBEAT_MS = 10_000;
+
+let dbPromise: Promise<IDBPDatabase<OwnershipDB>> | null = null;
+
+function getDb(): Promise<IDBPDatabase<OwnershipDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<OwnershipDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains("ownership")) {
+          db.createObjectStore("ownership", { keyPath: "conversationId" });
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+function isStale(row: RunOwnership, now: number): boolean {
+  return now - row.heartbeatAt >= STALE_OWNER_MS;
+}
+
+export const runOwnership = {
+  /**
+   * Atomically claim (or re-claim) ownership of `conversationId` for
+   * `ownerToken`.
+   *
+   * Returns `true` if this token now owns the conversation. Returns
+   * `false` if a *different*, non-stale owner already holds it.
+   *
+   * Idempotent for the current owner: calling again with the same token
+   * succeeds and refreshes the heartbeat. A stale owner (no heartbeat
+   * within {@link STALE_OWNER_MS}) is reaped and replaced here so a
+   * crashed host can't lock a conversation forever.
+   */
+  async claimOwnership(
+    conversationId: string,
+    ownerToken: string,
+    hostKind: HostKind = "home",
+    now: number = Date.now(),
+  ): Promise<boolean> {
+    const db = await getDb();
+    const tx = db.transaction("ownership", "readwrite");
+    const store = tx.objectStore("ownership");
+    const existing = await store.get(conversationId);
+
+    if (
+      existing &&
+      existing.ownerToken !== ownerToken &&
+      !isStale(existing, now)
+    ) {
+      // A different, live owner holds it.
+      await tx.done;
+      return false;
+    }
+
+    const claimedAt =
+      existing && existing.ownerToken === ownerToken
+        ? existing.claimedAt
+        : now;
+
+    await store.put({
+      conversationId,
+      ownerToken,
+      hostKind,
+      claimedAt,
+      heartbeatAt: now,
+    });
+    await tx.done;
+    return true;
+  },
+
+  /**
+   * Refresh the heartbeat for an owner. Returns `true` if this token
+   * still owns the conversation (heartbeat refreshed), `false` if it has
+   * lost ownership (someone else claimed it, e.g. after a stale reap).
+   */
+  async renewOwnership(
+    conversationId: string,
+    ownerToken: string,
+    now: number = Date.now(),
+  ): Promise<boolean> {
+    const db = await getDb();
+    const tx = db.transaction("ownership", "readwrite");
+    const store = tx.objectStore("ownership");
+    const existing = await store.get(conversationId);
+    if (!existing || existing.ownerToken !== ownerToken) {
+      await tx.done;
+      return false;
+    }
+    await store.put({ ...existing, heartbeatAt: now });
+    await tx.done;
+    return true;
+  },
+
+  /**
+   * Release ownership held by `ownerToken`. No-op if the row is gone or
+   * owned by someone else (we never delete another owner's claim).
+   */
+  async releaseOwnership(
+    conversationId: string,
+    ownerToken: string,
+  ): Promise<void> {
+    const db = await getDb();
+    const tx = db.transaction("ownership", "readwrite");
+    const store = tx.objectStore("ownership");
+    const existing = await store.get(conversationId);
+    if (existing && existing.ownerToken === ownerToken) {
+      await store.delete(conversationId);
+    }
+    await tx.done;
+  },
+
+  /**
+   * Read the current owner row, or `null` if unowned. A stale owner is
+   * reported as `null` (it's reclaimable), so callers can treat the
+   * conversation as idle.
+   */
+  async getOwner(
+    conversationId: string,
+    now: number = Date.now(),
+  ): Promise<RunOwnership | null> {
+    const db = await getDb();
+    const row = await db.get("ownership", conversationId);
+    if (!row) return null;
+    if (isStale(row, now)) return null;
+    return row;
+  },
+
+  /**
+   * True if `ownerToken` currently holds a live claim on the
+   * conversation.
+   */
+  async isOwner(
+    conversationId: string,
+    ownerToken: string,
+    now: number = Date.now(),
+  ): Promise<boolean> {
+    const owner = await runOwnership.getOwner(conversationId, now);
+    return owner?.ownerToken === ownerToken;
+  },
+
+  /** Test/debug helper. Drop the cached db handle. */
+  _resetForTests(): void {
+    dbPromise = null;
+  },
+};

--- a/apps/extension/src/lib/agent/stream-mirror.ts
+++ b/apps/extension/src/lib/agent/stream-mirror.ts
@@ -1,0 +1,129 @@
+import type { SerializedUIPart } from "./message-types";
+import { RUNTIME_MESSAGES } from "@/lib/constants";
+
+/**
+ * Host → viewer streaming mirror.
+ *
+ * The live agent loop runs in exactly one context (the host). Other open
+ * contexts on the same conversation are "viewers" that cannot see the
+ * host's in-memory stream. This module ships throttled, full-message
+ * snapshots of the in-flight assistant message from the host to viewers
+ * over `chrome.runtime.sendMessage` so viewers can mirror progress live.
+ *
+ * Full snapshots (not deltas) are used on purpose: a single frame fully
+ * catches up a late-joining viewer and self-heals any dropped frame, at
+ * the cost of slightly larger messages. A monotonic `seq` lets viewers
+ * discard stale/out-of-order frames.
+ *
+ * `chrome.runtime.sendMessage` does not echo back to its sender, so the
+ * host never receives its own frames — exactly what we want (the host
+ * renders from its own live `messages`).
+ */
+
+export interface StreamPartsMessage {
+  type: typeof RUNTIME_MESSAGES.STREAM_PARTS;
+  conversationId: string;
+  messageId: string;
+  parts: SerializedUIPart[];
+  seq: number;
+}
+
+export interface StreamDoneMessage {
+  type: typeof RUNTIME_MESSAGES.STREAM_DONE;
+  conversationId: string;
+}
+
+/** Broadcast a full-message snapshot to viewer contexts. */
+export function broadcastStreamParts(msg: {
+  conversationId: string;
+  messageId: string;
+  parts: SerializedUIPart[];
+  seq: number;
+}): void {
+  const payload: StreamPartsMessage = {
+    type: RUNTIME_MESSAGES.STREAM_PARTS,
+    ...msg,
+  };
+  try {
+    chrome.runtime?.sendMessage?.(payload)?.catch?.(() => {});
+  } catch {
+    /* non-extension context; ignore */
+  }
+}
+
+/** Broadcast that a turn reached a terminal state. */
+export function broadcastStreamDone(conversationId: string): void {
+  const payload: StreamDoneMessage = {
+    type: RUNTIME_MESSAGES.STREAM_DONE,
+    conversationId,
+  };
+  try {
+    chrome.runtime?.sendMessage?.(payload)?.catch?.(() => {});
+  } catch {
+    /* non-extension context; ignore */
+  }
+}
+
+export function isStreamPartsMessage(
+  msg: unknown,
+): msg is StreamPartsMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Partial<StreamPartsMessage>;
+  return (
+    m.type === RUNTIME_MESSAGES.STREAM_PARTS &&
+    typeof m.conversationId === "string" &&
+    typeof m.messageId === "string" &&
+    typeof m.seq === "number" &&
+    Array.isArray(m.parts)
+  );
+}
+
+export function isStreamDoneMessage(
+  msg: unknown,
+): msg is StreamDoneMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const m = msg as Partial<StreamDoneMessage>;
+  return (
+    m.type === RUNTIME_MESSAGES.STREAM_DONE &&
+    typeof m.conversationId === "string"
+  );
+}
+
+/**
+ * Pure merge of a mirrored snapshot into a viewer's message list.
+ *
+ * Replaces the assistant message with `snapshot.id` if present, otherwise
+ * appends it at the tail. The snapshot is a full assistant message, so
+ * the latest frame is always the complete current state.
+ *
+ * Generic over the message shape so it can run against AI SDK
+ * `UIMessage`s in the hook and plain objects in tests.
+ */
+export function applyStreamSnapshot<
+  M extends { id: string; role: string },
+>(messages: M[], snapshot: M): M[] {
+  const idx = messages.findIndex((m) => m.id === snapshot.id);
+  if (idx === -1) return [...messages, snapshot];
+  const next = messages.slice();
+  next[idx] = snapshot;
+  return next;
+}
+
+/**
+ * Tracks the highest `seq` applied per message id so a viewer can drop
+ * stale/out-of-order frames. Returns true if the frame should be applied.
+ */
+export class SeqGuard {
+  private readonly seen = new Map<string, number>();
+
+  shouldApply(messageId: string, seq: number): boolean {
+    const last = this.seen.get(messageId);
+    if (last !== undefined && seq <= last) return false;
+    this.seen.set(messageId, seq);
+    return true;
+  }
+
+  reset(): void {
+    this.seen.clear();
+  }
+}

--- a/apps/extension/src/lib/constants.ts
+++ b/apps/extension/src/lib/constants.ts
@@ -71,3 +71,24 @@ export const STORAGE_KEYS = {
 export const HOME_PAGE_URL = "/home.html";
 
 export const AUTO_TIDY_CHECK_INTERVAL_MS = 60_000;
+
+/**
+ * Cross-context runtime message types for the single-host run model.
+ *
+ *  - STREAM_PARTS: the host broadcasts a throttled full-message snapshot
+ *    of the in-flight assistant message so viewer tabs can mirror it.
+ *  - STREAM_DONE: the host signals a turn reached a terminal state;
+ *    viewers re-read the authoritative transcript from chat-db.
+ *  - AGENT_APPROVE: a viewer forwards a tool approval/denial to the host,
+ *    which applies it to its live `approval-requested` part.
+ *
+ * `AGENT_STOP` (defined inline elsewhere) is reused for viewer→host stop.
+ */
+export const RUNTIME_MESSAGES = {
+  STREAM_PARTS: "STREAM_PARTS",
+  STREAM_DONE: "STREAM_DONE",
+  AGENT_APPROVE: "AGENT_APPROVE",
+} as const;
+
+/** Throttle interval for host→viewer streaming snapshots. */
+export const STREAM_MIRROR_THROTTLE_MS = 100;


### PR DESCRIPTION
## Summary

Fixes multiple open tabs (home tabs, side panels, popups) all auto-restarting the same agent task, and stale content in non-driving tabs during streaming.

- **Disable message-load auto-resume** — previously every open context independently re-sent a trailing unanswered user message on load, restarting the same run N times. Approval auto-resume is kept.
- **Atomic ownership lock** (`run-ownership.ts`, IndexedDB) — one context drives a run; heartbeat + stale reaping, modeled on the existing `queue-db` `claimHead` mutex.
- **Live cross-tab mirror** (`stream-mirror.ts`) — the owner broadcasts throttled (~100ms) full-message snapshots with a monotonic `seq`; viewers mirror them and converge on the persisted transcript at turn end.
- **Viewer action routing** — approvals forward to the host (`AGENT_APPROVE`), stop via existing `AGENT_STOP`, new messages via the existing queue (host drains).
- **First-turn dispatch fix** (`pending-first-turn.ts`) — disabling auto-resume broke new-conversation send (both side panel and home LandingPage relied on it); a `chrome.storage.session` marker now scopes first-turn dispatch to freshly-created conversations only.
- **Viewer watchdog** — if the host dies mid-run, the viewer exits read-only mode (host death → stop; manual continue).

New IndexedDB store `openbrowse-run-ownership` (additive; no migration).

## Test Plan

- [x] `pnpm compile` clean
- [x] `pnpm test` — 85 files / 770 tests passing (new: ownership, stream-mirror, pending-first-turn)
- [x] `pnpm build` succeeds
- [x] New side-panel chat: first message starts generating without a second send
- [x] Same conversation open in 2+ tabs: only one drives; others mirror live and are read-only
- [x] Reopen an existing conversation in a stale tab: does NOT auto-start
- [x] Approve/stop from a viewer tab routes to the host
- [x] Close the driving tab mid-run: run stops, viewer exits read-only, user can manually continue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-host multi-tab runs: one tab owns live agent execution while other tabs mirror progress read-only.
  * Viewer-aware controls: stop/approval actions from viewers are forwarded to the owning tab.
  * First-turn marker: newly created conversations are flagged to avoid unintended auto-resume.

* **Bug Fixes**
  * Prevented duplicate auto-restarts and tightened message convergence across tabs.

* **Tests**
  * Added tests for ownership, mirroring, sequencing, and pending-first-turn behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->