### PR TITLE
feat(cua): Computer Use subagent with Anthropic provider

### DIFF
--- a/.changeset/cua-anthropic-computer-use.md
+++ b/.changeset/cua-anthropic-computer-use.md
@@ -1,0 +1,5 @@
+---
+"openbrowse": minor
+---
+
+Add a Computer Use (CUA) subagent that lets Anthropic Claude models drive the live browser tab. Includes a provider-neutral CUA loop (canonical actions, CDP executor, coordinate mapping, screenshot zoom) with the Anthropic provider wired in, a computer-use capability flag and model picker in Settings, AI Gateway transport support, content-stable element refs, a working-on-page overlay with stop/abort, and in-place retry that continues an errored assistant turn.

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -145,12 +145,11 @@ export function resolveToolPartState(
 interface AssistantMessageProps {
   message: AgentUIMessage;
   isStreaming?: boolean;
-  onRegenerate?: () => void;
   onToolApproval?: (opts: { id: string; approved: boolean }) => void;
   dimmed?: boolean;
 }
 
-function AssistantMessageImpl({ message, isStreaming = false, onRegenerate, onToolApproval, dimmed }: AssistantMessageProps) {
+function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, dimmed }: AssistantMessageProps) {
   return (
     <div className={`group/message flex flex-col items-start gap-1 ${dimmed ? "opacity-40" : ""}`}>
       <div className="w-full text-sm text-foreground">
@@ -303,7 +302,7 @@ function AssistantMessageImpl({ message, isStreaming = false, onRegenerate, onTo
           return null;
         })}
       </div>
-      <MessageActions message={message} onRegenerate={onRegenerate} />
+      <MessageActions message={message} />
     </div>
   );
 }

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -6,6 +6,13 @@ import {
 } from "@/components/tiptap/slash-command-extract";
 import { TabMention } from "@/components/tiptap/tab-mention-extension";
 import { Kbd } from "@/components/ui/kbd";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
@@ -15,6 +22,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getImageSizeLimit } from "@/lib/agent/vision-limits";
+import {
+  resolveThinkingVendor,
+  isGemini3Model,
+  isGeminiFlashModel,
+} from "@/lib/agent/thinking";
 import { openSettingsTab } from "@/lib/open-settings";
 import {
   countLines,
@@ -264,7 +276,7 @@ function ModelInfoContent({ model }: { model: ModelOption }) {
                 key={cap}
                 className="rounded bg-foreground/10 px-1.5 py-0.5 text-[10px] capitalize"
               >
-                {cap}
+                {cap === "computer-use" ? "Computer Use" : cap}
               </span>
             ))}
           </div>
@@ -1020,24 +1032,59 @@ export function ChatInput({
   );
 }
 
-function getProviderType(
-  modelId: string,
-): "anthropic" | "openai" | "google" | "other" {
-  if (modelId.startsWith("claude-")) return "anthropic";
-  if (modelId.startsWith("gpt-") || modelId.startsWith("o")) return "openai";
-  if (modelId.startsWith("gemini-")) return "google";
-  return "other";
+/**
+ * Split a compound `"<providerId>:<modelId>"` (the form stored in
+ * `agentSettings.agentModel`) into its parts. Legacy flat ids (no provider
+ * segment) yield an empty provider id and the whole string as the model id.
+ */
+function splitCompoundModelId(compound: string): {
+  providerId: string;
+  modelId: string;
+} {
+  const idx = compound.indexOf(":");
+  if (idx < 0) return { providerId: "", modelId: compound };
+  return {
+    providerId: compound.slice(0, idx),
+    modelId: compound.slice(idx + 1),
+  };
 }
 
-function getBudgetRange(modelId: string): {
+/**
+ * Resolve the thinking vendor from the compound model id the UI carries.
+ * Handles both direct providers and gateway-routed `vendor/model` ids. Returns
+ * `"other"` when the vendor is unknown.
+ */
+function getProviderType(
+  compoundModelId: string,
+): "anthropic" | "openai" | "google" | "other" {
+  const { providerId, modelId } = splitCompoundModelId(compoundModelId);
+  return resolveThinkingVendor(providerId, modelId) ?? "other";
+}
+
+/** Gemini 3 thinking levels (flash adds `minimal`). */
+function getGemini3Levels(compoundModelId: string): string[] {
+  const { modelId } = splitCompoundModelId(compoundModelId);
+  return isGeminiFlashModel(modelId)
+    ? ["minimal", "low", "medium", "high"]
+    : ["low", "medium", "high"];
+}
+
+/** True when the (compound) model is a Gemini 3 model using `thinkingLevel`. */
+function isGemini3Compound(compoundModelId: string): boolean {
+  const { modelId } = splitCompoundModelId(compoundModelId);
+  return isGemini3Model(modelId);
+}
+
+function getBudgetRange(compoundModelId: string): {
   min: number;
   max: number;
   step: number;
   default: number;
 } {
-  const provider = getProviderType(modelId);
+  const provider = getProviderType(compoundModelId);
+  const { modelId } = splitCompoundModelId(compoundModelId);
   if (provider === "google") {
-    if (modelId.includes("flash"))
+    if (isGeminiFlashModel(modelId))
       return { min: 0, max: 24_576, step: 512, default: 8192 };
     return { min: 128, max: 32_768, step: 512, default: 10000 };
   }
@@ -1051,10 +1098,14 @@ function getBudgetRange(modelId: string): {
   return { min: 1024, max: 32_768, step: 1024, default: 10000 };
 }
 
-function getDefaultThinkingConfig(modelId: string): ThinkingConfig {
-  const provider = getProviderType(modelId);
+function getDefaultThinkingConfig(compoundModelId: string): ThinkingConfig {
+  const provider = getProviderType(compoundModelId);
   if (provider === "openai") return { type: "effort", level: "medium" };
-  const range = getBudgetRange(modelId);
+  // Gemini 3 uses an effort-style level (mapped to `thinkingLevel` at the
+  // transport). Everything else (Gemini 2.5, Anthropic) uses a token budget.
+  if (provider === "google" && isGemini3Compound(compoundModelId))
+    return { type: "effort", level: "medium" };
+  const range = getBudgetRange(compoundModelId);
   return { type: "budget", tokens: range.default };
 }
 
@@ -1069,21 +1120,34 @@ function ThinkingControl({
 }) {
   const provider = getProviderType(modelId);
 
-  if (provider === "openai") {
-    const levels = ["minimal", "low", "medium", "high", "xhigh"];
-    const current = config?.type === "effort" ? config.level : "medium";
+  // Effort/level dropdown: OpenAI (reasoning effort) and Gemini 3
+  // (thinkingLevel). Both persist as `{ type: "effort"; level }`.
+  const isGemini3 = provider === "google" && isGemini3Compound(modelId);
+  if (provider === "openai" || isGemini3) {
+    const levels = isGemini3
+      ? getGemini3Levels(modelId)
+      : ["minimal", "low", "medium", "high", "xhigh"];
+    const fallback = levels.includes("medium") ? "medium" : levels[0];
+    const current =
+      config?.type === "effort" && levels.includes(config.level)
+        ? config.level
+        : fallback;
     return (
-      <select
+      <Select
         value={current}
-        onChange={(e) => onChange({ type: "effort", level: e.target.value })}
-        className="h-6 rounded border border-border bg-background px-1.5 text-xs text-foreground outline-none"
+        onValueChange={(level) => onChange({ type: "effort", level })}
       >
-        {levels.map((l) => (
-          <option key={l} value={l}>
-            {l}
-          </option>
-        ))}
-      </select>
+        <SelectTrigger size="sm" className="h-6 text-xs capitalize">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {levels.map((l) => (
+            <SelectItem key={l} value={l} className="text-xs capitalize">
+              {l}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     );
   }
 

--- a/apps/extension/src/components/chat/ChatMessage.tsx
+++ b/apps/extension/src/components/chat/ChatMessage.tsx
@@ -13,15 +13,16 @@ interface ChatMessageProps {
    * Combined with `React.memo`, this keeps settled rows from re-rendering
    * when unrelated parent state (e.g. the chat input value) changes.
    */
-  onRegenerate?: (id: string) => void;
   onEdit?: (id: string) => void;
+  /** Retry from a user message: discard turns after it and re-run. */
+  onRetryFromUser?: (id: string) => void;
   /**
-   * Capability flags gate whether the regenerate/edit affordances render.
+   * Capability flags gate whether the edit/retry affordances render.
    * Passing booleans (instead of toggling the callback to `undefined`)
    * keeps the callback identity stable across load/edit transitions.
    */
-  canRegenerate?: boolean;
   canEdit?: boolean;
+  canRetry?: boolean;
   onToolApproval?: (opts: { id: string; approved: boolean }) => void;
   dimmed?: boolean;
 }
@@ -29,20 +30,20 @@ interface ChatMessageProps {
 function ChatMessageImpl({
   message,
   isStreaming,
-  onRegenerate,
   onEdit,
-  canRegenerate,
+  onRetryFromUser,
   canEdit,
+  canRetry,
   onToolApproval,
   dimmed,
 }: ChatMessageProps) {
-  const handleRegenerate = useCallback(() => {
-    onRegenerate?.(message.id);
-  }, [onRegenerate, message.id]);
-
   const handleEdit = useCallback(() => {
     onEdit?.(message.id);
   }, [onEdit, message.id]);
+
+  const handleRetryFromUser = useCallback(() => {
+    onRetryFromUser?.(message.id);
+  }, [onRetryFromUser, message.id]);
 
   if (message.role === "system") return null;
   if (message.role === "user") {
@@ -50,6 +51,7 @@ function ChatMessageImpl({
       <UserMessage
         message={message}
         onEdit={canEdit && onEdit ? handleEdit : undefined}
+        onRetry={canRetry && onRetryFromUser ? handleRetryFromUser : undefined}
         dimmed={dimmed}
       />
     );
@@ -58,7 +60,6 @@ function ChatMessageImpl({
     <AssistantMessage
       message={message}
       isStreaming={isStreaming}
-      onRegenerate={canRegenerate && onRegenerate ? handleRegenerate : undefined}
       onToolApproval={onToolApproval}
       dimmed={dimmed}
     />

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -179,9 +179,8 @@ export function ChatView({
     handleSubmit,
     compactNow,
     handleNew,
-    handleRegenerate,
     handleRetry,
-    handleContinue,
+    handleRetryFromUser,
     confirmEdit,
     approveToolCall,
     isViewer,
@@ -606,11 +605,10 @@ export function ChatView({
                 editingIndex={editingIndex}
                 showThinking={showThinking}
                 error={error}
-                onRegenerate={handleRegenerate}
                 onEdit={startEdit}
+                onRetryFromUser={handleRetryFromUser}
                 onToolApproval={approveToolCall}
                 onRetry={handleRetry}
-                onContinue={handleContinue}
                 onDismissError={clearError}
               />
             )}

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -32,6 +32,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAgentChat } from "@/hooks/useAgentChat";
+import { ConversationIdContext } from "@/lib/conversation-id-context";
 import { useActiveAgents } from "@/hooks/useActiveAgents";
 import { useProviders } from "@/hooks/useProviders";
 import { useConfiguredModels } from "@/hooks/useConfiguredModels";
@@ -496,6 +497,7 @@ export function ChatView({
   const isEditing = editing !== null;
 
   return (
+    <ConversationIdContext.Provider value={conversationId ?? null}>
     <div className={cn("flex flex-col h-full pt-1", className)}>
       {/* Header */}
       {showHeader && (
@@ -836,6 +838,7 @@ export function ChatView({
         />
       </div>
     </div>
+    </ConversationIdContext.Provider>
   );
 }
 

--- a/apps/extension/src/components/chat/MessageActions.tsx
+++ b/apps/extension/src/components/chat/MessageActions.tsx
@@ -5,15 +5,14 @@ import {
 } from "@/components/ui/tooltip";
 import type { AgentUIMessage } from "@/lib/types";
 import { formatMessageAsMarkdown } from "@/lib/format-markdown";
-import { Check, Copy, RefreshCw } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 interface MessageActionsProps {
   message: AgentUIMessage;
-  onRegenerate?: () => void;
 }
 
-export function MessageActions({ message, onRegenerate }: MessageActionsProps) {
+export function MessageActions({ message }: MessageActionsProps) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -33,44 +32,28 @@ export function MessageActions({ message, onRegenerate }: MessageActionsProps) {
     }
   }, [textContent]);
 
-  if (!textContent && !onRegenerate) return null;
+  if (!textContent) return null;
 
   return (
     <div className="flex items-center gap-0.5 opacity-0 group-hover/message:opacity-100 transition-opacity">
-      {textContent && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              {copied ? (
-                <Check className="size-3" />
-              ) : (
-                <Copy className="size-3" />
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {copied ? "Copied!" : "Copy"}
-          </TooltipContent>
-        </Tooltip>
-      )}
-      {onRegenerate && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={onRegenerate}
-              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              <RefreshCw className="size-3" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Regenerate</TooltipContent>
-        </Tooltip>
-      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            {copied ? (
+              <Check className="size-3" />
+            ) : (
+              <Copy className="size-3" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {copied ? "Copied!" : "Copy"}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/extension/src/components/chat/MessageList.tsx
+++ b/apps/extension/src/components/chat/MessageList.tsx
@@ -3,11 +3,7 @@ import type { AgentUIMessage } from "@/lib/types";
 import { ChatMessage } from "./ChatMessage";
 import { CompactionDivider } from "./CompactionDivider";
 import { ExpandableText } from "./tool-results/expandable-text";
-import {
-  AlertCircle,
-  ArrowRight,
-  RefreshCw,
-} from "lucide-react";
+import { AlertCircle, RefreshCw } from "lucide-react";
 
 interface MessageListProps {
   messages: AgentUIMessage[];
@@ -20,11 +16,12 @@ interface MessageListProps {
   showThinking: boolean;
   error: Error | null | undefined;
   /** Stable, id-taking callbacks (see ChatMessage). */
-  onRegenerate: (id: string) => void;
   onEdit: (id: string) => void;
+  /** Retry from a user message: discard all turns after it and re-run. */
+  onRetryFromUser: (id: string) => void;
   onToolApproval: (opts: { id: string; approved: boolean }) => void;
+  /** Error-banner retry: continue the errored turn in place. */
   onRetry: () => void;
-  onContinue: () => void;
   onDismissError: () => void;
 }
 
@@ -44,11 +41,10 @@ function MessageListImpl({
   editingIndex,
   showThinking,
   error,
-  onRegenerate,
   onEdit,
+  onRetryFromUser,
   onToolApproval,
   onRetry,
-  onContinue,
   onDismissError,
 }: MessageListProps) {
   const canAct = !isLoading && !isEditing;
@@ -106,11 +102,11 @@ function MessageListImpl({
             message={message}
             isStreaming={isLastAssistant}
             dimmed={isDimmed}
-            onRegenerate={onRegenerate}
-            canRegenerate={message.role === "assistant" && canAct}
             onToolApproval={onToolApproval}
             onEdit={onEdit}
             canEdit={message.role === "user" && canAct}
+            onRetryFromUser={onRetryFromUser}
+            canRetry={message.role === "user" && canAct}
           />
         );
       })}
@@ -119,7 +115,6 @@ function MessageListImpl({
         <ErrorMessage
           error={error}
           onRetry={onRetry}
-          onContinue={onContinue}
           onDismiss={onDismissError}
         />
       )}
@@ -146,12 +141,10 @@ function ThinkingIndicator() {
 function ErrorMessage({
   error,
   onRetry,
-  onContinue,
   onDismiss,
 }: {
   error: Error;
   onRetry: () => void;
-  onContinue: () => void;
   onDismiss: () => void;
 }) {
   return (
@@ -184,14 +177,6 @@ function ErrorMessage({
               >
                 <RefreshCw className="size-3" />
                 Retry
-              </button>
-              <button
-                type="button"
-                onClick={onContinue}
-                className="flex items-center gap-1 text-xs text-primary hover:underline"
-              >
-                <ArrowRight className="size-3" />
-                Continue
               </button>
               <button
                 type="button"

--- a/apps/extension/src/components/chat/ToolCallBlock.tsx
+++ b/apps/extension/src/components/chat/ToolCallBlock.tsx
@@ -20,6 +20,8 @@ import {
   ReadFileResult,
 } from "./tool-results/fs";
 import { ScreenshotResult } from "./tool-results/screenshot";
+import { ComputerResult } from "./tool-results/computer";
+import { NavigateResult } from "./tool-results/navigate";
 import { SkillResult } from "./tool-results/skill";
 import { InstallSkillResult } from "./tool-results/install-skill";
 import { SnapshotResult } from "./tool-results/snapshot";
@@ -52,6 +54,12 @@ type ResultRenderer = (props: {
 const BUILTIN_RESULT_RENDERERS: Record<string, ResultRenderer> = {
   snapshot: ({ result }) => <SnapshotResult result={result} />,
   screenshot: ({ result }) => <ScreenshotResult result={result} />,
+  computer: ({ args, result }) => <ComputerResult args={args} result={result} />,
+  navigate: ({ args, result }) => <NavigateResult args={args} result={result} />,
+  goBack: ({ args, result }) => <NavigateResult args={args} result={result} />,
+  goForward: ({ args, result }) => (
+    <NavigateResult args={args} result={result} />
+  ),
   executeCode: ({ args, result }) => <CodeResult args={args} result={result} />,
   executeOnPage: ({ args, result }) => (
     <CodeResult args={args} result={result} />
@@ -114,8 +122,11 @@ const TOOL_LABELS: Record<string, { pending: string; done: string }> = {
   readPage: { pending: "Reading page...", done: "Read page" },
   screenshot: { pending: "Taking screenshot...", done: "Took screenshot" },
   snapshot: { pending: "Taking snapshot...", done: "Took snapshot" },
+  computer: { pending: "Using computer...", done: "Used computer" },
   listTabs: { pending: "Listing tabs...", done: "Listed tabs" },
   navigate: { pending: "Navigating...", done: "Navigated" },
+  goBack: { pending: "Going back...", done: "Went back" },
+  goForward: { pending: "Going forward...", done: "Went forward" },
   selectTab: { pending: "Switching tab...", done: "Switched tab" },
   clickElement: { pending: "Clicking...", done: "Clicked" },
   typeInElement: { pending: "Typing...", done: "Typed" },
@@ -234,6 +245,68 @@ function webFetchLabels(
 }
 
 /**
+ * Static, action-specific status text for the CUA `computer` tool, derived
+ * from `args.action` (the Anthropic computer-tool action). Without this the
+ * row would just read the generic "Used computer".
+ */
+export function computerLabels(
+  args: Record<string, unknown>,
+  fallback: { pending: string; done: string },
+): { pending: string; done: string } {
+  const action = typeof args.action === "string" ? args.action : "";
+  const coord = Array.isArray(args.coordinate) ? args.coordinate : null;
+  const at =
+    coord && coord.length === 2 ? ` at (${coord[0]}, ${coord[1]})` : "";
+  switch (action) {
+    case "screenshot":
+      return { pending: "Taking screenshot...", done: "Took screenshot" };
+    case "left_click":
+      return { pending: `Clicking${at}...`, done: `Clicked${at}` };
+    case "right_click":
+      return { pending: `Right-clicking${at}...`, done: `Right-clicked${at}` };
+    case "middle_click":
+      return { pending: `Middle-clicking${at}...`, done: `Middle-clicked${at}` };
+    case "double_click":
+      return { pending: `Double-clicking${at}...`, done: `Double-clicked${at}` };
+    case "triple_click":
+      return { pending: `Triple-clicking${at}...`, done: `Triple-clicked${at}` };
+    case "left_click_drag":
+      return { pending: "Dragging...", done: "Dragged" };
+    case "mouse_move":
+      return { pending: `Moving cursor${at}...`, done: `Moved cursor${at}` };
+    case "type": {
+      const t = typeof args.text === "string" ? args.text : "";
+      const preview = t.length > 24 ? `${t.slice(0, 23)}…` : t;
+      return {
+        pending: preview ? `Typing "${preview}"...` : "Typing...",
+        done: preview ? `Typed "${preview}"` : "Typed",
+      };
+    }
+    case "key": {
+      const k = typeof args.text === "string" ? args.text : "";
+      return {
+        pending: k ? `Pressing ${k}...` : "Pressing key...",
+        done: k ? `Pressed ${k}` : "Pressed key",
+      };
+    }
+    case "scroll": {
+      const dir =
+        typeof args.scroll_direction === "string" ? args.scroll_direction : "";
+      return {
+        pending: dir ? `Scrolling ${dir}...` : "Scrolling...",
+        done: dir ? `Scrolled ${dir}` : "Scrolled",
+      };
+    }
+    case "wait":
+      return { pending: "Waiting...", done: "Waited" };
+    case "cursor_position":
+      return { pending: "Reading cursor...", done: "Read cursor position" };
+    default:
+      return fallback;
+  }
+}
+
+/**
  * Refine the closeTabs collapsed-row label from its args so the user sees
  * what's being closed (e.g. "Closing 2 tabs..." / "Closed 2 tabs", or
  * "Closing tab group...") instead of the generic "Closing tabs...".
@@ -328,12 +401,14 @@ export function ToolCallBlock({
   const dynamicLabels =
     toolName === "webFetch"
       ? webFetchLabels(args, labels)
-      : toolName === "closeTabs"
-        ? closeTabsLabels(args, labels)
-        : toolName === "create_scheduled_task" ||
-            toolName === "update_scheduled_task"
-          ? scheduledTaskLabels(toolName, args, labels)
-          : labels;
+      : toolName === "computer"
+        ? computerLabels(args, labels)
+        : toolName === "closeTabs"
+          ? closeTabsLabels(args, labels)
+          : toolName === "create_scheduled_task" ||
+              toolName === "update_scheduled_task"
+            ? scheduledTaskLabels(toolName, args, labels)
+            : labels;
 
   const showTabBadge = TAB_TOOLS.has(toolName);
 

--- a/apps/extension/src/components/chat/UserMessage.tsx
+++ b/apps/extension/src/components/chat/UserMessage.tsx
@@ -5,8 +5,18 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
-import { Check, Copy, Pencil } from "lucide-react";
+import { Check, Copy, Pencil, RefreshCw } from "lucide-react";
 import { useCallback, useMemo, useRef, useState, memo } from "react";
 import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
 import { classifyFile } from "@/lib/vfs/file-classify";
@@ -16,11 +26,17 @@ import { useFileSelection } from "@/lib/file-selection-context";
 interface UserMessageProps {
   message: AgentUIMessage;
   onEdit?: () => void;
+  /**
+   * Retry from this message: discard every turn after it and re-run the
+   * response. Confirmed via a modal before firing.
+   */
+  onRetry?: () => void;
   dimmed?: boolean;
 }
 
-function UserMessageImpl({ message, onEdit, dimmed }: UserMessageProps) {
+function UserMessageImpl({ message, onEdit, onRetry, dimmed }: UserMessageProps) {
   const [copied, setCopied] = useState(false);
+  const [confirmRetryOpen, setConfirmRetryOpen] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const onSelectFile = useFileSelection();
 
@@ -168,7 +184,45 @@ function UserMessageImpl({ message, onEdit, dimmed }: UserMessageProps) {
               <TooltipContent side="bottom">Edit</TooltipContent>
             </Tooltip>
           )}
+          {onRetry && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setConfirmRetryOpen(true)}
+                  className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <RefreshCw className="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Retry from here</TooltipContent>
+            </Tooltip>
+          )}
         </div>
+      )}
+      {onRetry && (
+        <AlertDialog open={confirmRetryOpen} onOpenChange={setConfirmRetryOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Retry from this message?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This discards every response after this message and re-runs the
+                agent from here. This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  setConfirmRetryOpen(false);
+                  onRetry();
+                }}
+              >
+                Retry
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
     </div>
   );

--- a/apps/extension/src/components/chat/__tests__/computer-labels.test.ts
+++ b/apps/extension/src/components/chat/__tests__/computer-labels.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { computerLabels } from "../ToolCallBlock";
+
+const fallback = { pending: "Using computer...", done: "Used computer" };
+
+describe("computerLabels", () => {
+  it("describes a left click with coordinates", () => {
+    expect(
+      computerLabels({ action: "left_click", coordinate: [100, 200] }, fallback),
+    ).toEqual({ pending: "Clicking at (100, 200)...", done: "Clicked at (100, 200)" });
+  });
+
+  it("describes a screenshot", () => {
+    expect(computerLabels({ action: "screenshot" }, fallback)).toEqual({
+      pending: "Taking screenshot...",
+      done: "Took screenshot",
+    });
+  });
+
+  it("describes typing with a truncated preview", () => {
+    expect(computerLabels({ action: "type", text: "hello" }, fallback)).toEqual({
+      pending: 'Typing "hello"...',
+      done: 'Typed "hello"',
+    });
+    const long = "x".repeat(40);
+    const out = computerLabels({ action: "type", text: long }, fallback);
+    expect(out.done).toContain("…");
+  });
+
+  it("describes a key press", () => {
+    expect(computerLabels({ action: "key", text: "ctrl+a" }, fallback)).toEqual({
+      pending: "Pressing ctrl+a...",
+      done: "Pressed ctrl+a",
+    });
+  });
+
+  it("describes a scroll with direction", () => {
+    expect(
+      computerLabels(
+        { action: "scroll", coordinate: [5, 5], scroll_direction: "down" },
+        fallback,
+      ),
+    ).toEqual({ pending: "Scrolling down...", done: "Scrolled down" });
+  });
+
+  it("describes double/right clicks", () => {
+    expect(computerLabels({ action: "double_click", coordinate: [1, 2] }, fallback).done).toBe(
+      "Double-clicked at (1, 2)",
+    );
+    expect(computerLabels({ action: "right_click", coordinate: [1, 2] }, fallback).done).toBe(
+      "Right-clicked at (1, 2)",
+    );
+  });
+
+  it("falls back for an unknown/missing action", () => {
+    expect(computerLabels({}, fallback)).toEqual(fallback);
+    expect(computerLabels({ action: "unknown_thing" }, fallback)).toEqual(fallback);
+  });
+});

--- a/apps/extension/src/components/chat/tool-results/computer.css
+++ b/apps/extension/src/components/chat/tool-results/computer.css
@@ -1,0 +1,30 @@
+/*
+ * Transient click ripple for the CUA `computer` tool result. Overlaid on the
+ * screenshot at the click coordinate; plays once on mount, then fades out.
+ */
+
+.cua-click-ripple {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  margin-left: -14px;
+  margin-top: -14px;
+  border-radius: 50%;
+  background: rgba(56, 132, 255, 0.35);
+  border: 2px solid rgba(56, 132, 255, 0.9);
+  pointer-events: none;
+  transform: scale(0.2);
+  opacity: 0.9;
+  animation: cua-click-ripple 600ms ease-out forwards;
+}
+
+@keyframes cua-click-ripple {
+  0% {
+    transform: scale(0.2);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+}

--- a/apps/extension/src/components/chat/tool-results/computer.tsx
+++ b/apps/extension/src/components/chat/tool-results/computer.tsx
@@ -38,12 +38,14 @@ export function ComputerResult({ args, result }: Props) {
 
   const action = typeof args.action === "string" ? args.action : "";
   const coord = Array.isArray(args.coordinate) ? args.coordinate : null;
-  // For a drag, ripple at the start point.
+  // For a drag, ripple at the explicit start point only. If no
+  // start_coordinate was provided, render nothing rather than falling back to
+  // the end `coordinate` (which would show a misleading ripple at the drag
+  // end).
   const startCoord = Array.isArray(args.start_coordinate)
     ? args.start_coordinate
     : null;
-  const point =
-    action === "left_click_drag" ? (startCoord ?? coord) : coord;
+  const point = action === "left_click_drag" ? startCoord : coord;
 
   const showRipple =
     CLICK_ACTIONS.has(action) &&
@@ -53,8 +55,12 @@ export function ComputerResult({ args, result }: Props) {
     natural.w > 0 &&
     natural.h > 0;
 
-  const leftPct = showRipple ? (Number(point![0]) / natural!.w) * 100 : 0;
-  const topPct = showRipple ? (Number(point![1]) / natural!.h) * 100 : 0;
+  let leftPct = 0;
+  let topPct = 0;
+  if (showRipple && point && natural) {
+    leftPct = (Number(point[0]) / natural.w) * 100;
+    topPct = (Number(point[1]) / natural.h) * 100;
+  }
 
   return (
     <div className="ml-3 mt-1 pl-3 pb-1">

--- a/apps/extension/src/components/chat/tool-results/computer.tsx
+++ b/apps/extension/src/components/chat/tool-results/computer.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import "./computer.css";
+
+interface Props {
+  args: Record<string, unknown>;
+  result: unknown;
+}
+
+/** Anthropic computer-tool actions that represent a click (ripple-worthy). */
+const CLICK_ACTIONS = new Set([
+  "left_click",
+  "right_click",
+  "middle_click",
+  "double_click",
+  "triple_click",
+  "left_click_drag",
+]);
+
+/**
+ * Renders a CUA `computer` tool result: the post-action screenshot, plus a
+ * transient click ripple overlaid at the click coordinate.
+ *
+ * The screenshot is normalized to the model's declared display dimensions
+ * (see cua/screenshot.ts), and Anthropic's `coordinate` is in that same
+ * declared-pixel space — so the ripple position is `coordinate / naturalSize`
+ * as a percentage of the rendered image, robust to display scaling.
+ *
+ * The ripple is one-shot (plays on mount, then gone) per the lightweight UI
+ * choice; it is not shown when re-viewing an already-rendered trace.
+ */
+export function ComputerResult({ args, result }: Props) {
+  const obj = result as { imageDataUrl?: string; data?: string } | undefined;
+  const url = obj?.imageDataUrl ?? obj?.data;
+
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+
+  if (!url) return null;
+
+  const action = typeof args.action === "string" ? args.action : "";
+  const coord = Array.isArray(args.coordinate) ? args.coordinate : null;
+  // For a drag, ripple at the start point.
+  const startCoord = Array.isArray(args.start_coordinate)
+    ? args.start_coordinate
+    : null;
+  const point =
+    action === "left_click_drag" ? (startCoord ?? coord) : coord;
+
+  const showRipple =
+    CLICK_ACTIONS.has(action) &&
+    point != null &&
+    point.length === 2 &&
+    natural != null &&
+    natural.w > 0 &&
+    natural.h > 0;
+
+  const leftPct = showRipple ? (Number(point![0]) / natural!.w) * 100 : 0;
+  const topPct = showRipple ? (Number(point![1]) / natural!.h) * 100 : 0;
+
+  return (
+    <div className="ml-3 mt-1 pl-3 pb-1">
+      <div className="relative inline-block">
+        <img
+          src={url}
+          alt="Computer Use screenshot"
+          onLoad={(e) =>
+            setNatural({
+              w: e.currentTarget.naturalWidth,
+              h: e.currentTarget.naturalHeight,
+            })
+          }
+          className="max-w-full h-auto max-h-[400px] rounded border border-border object-contain"
+        />
+        {showRipple && (
+          <span
+            className="cua-click-ripple"
+            style={{ left: `${leftPct}%`, top: `${topPct}%` }}
+            aria-hidden
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/extension/src/components/chat/tool-results/delegate.tsx
+++ b/apps/extension/src/components/chat/tool-results/delegate.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { chatDb } from "../../../lib/chat-db";
+import { useConversationId } from "../../../lib/conversation-id-context";
 import {
   SUBAGENT_CHILD_ASSIGNED_EVENT,
   type SubagentChildAssignedDetail,
@@ -8,6 +9,7 @@ import {
   SUBAGENT_TITLE_UPDATED_EVENT,
   type SubagentTitleUpdatedDetail,
 } from "../../../lib/agent/tools/set-task-title";
+import { getAgent } from "../../../lib/agent/subagents/registry";
 import type {
   SerializedAssistantMessage,
   SubagentRunResult,
@@ -78,7 +80,49 @@ export function DelegateResult({ args, result, toolCallId, state, errorText }: P
       window.removeEventListener(SUBAGENT_CHILD_ASSIGNED_EVENT, handler);
     };
   }, [toolCallId]);
-  const childId = finalChildId ?? liveChildId;
+
+  // Recovered child id (reload path). When the parent turn was aborted
+  // mid-run, `healPendingTools` strips the delegate call's `output` —
+  // taking `childConversationId` with it (heal-pending-tools.ts) — and
+  // the heal is persisted. After a chat switch + return the reloaded
+  // part has no `output`, so `finalChildId` is null and the
+  // SUBAGENT_CHILD_ASSIGNED_EVENT (a live-only DOM event) never re-fires,
+  // leaving `liveChildId` null too. The trace would then collapse to just
+  // the interrupt error even though the child conversation's messages are
+  // still persisted in chat-db.
+  //
+  // Recover the link via the child row's `parentToolCallId` stamp
+  // (runner.ts), keyed by the parent conversation id from context. This
+  // is self-healing: it restores traces for conversations that were
+  // already broken before this fix shipped. Only runs when we have no
+  // child id from the other two sources, and tolerates `undefined`
+  // (older child rows created before `parentToolCallId` existed).
+  const parentConversationId = useConversationId();
+  const [recoveredChildId, setRecoveredChildId] = useState<string | null>(
+    null,
+  );
+  const needsRecovery = finalChildId === null && liveChildId === null;
+  useEffect(() => {
+    if (!needsRecovery || !parentConversationId || !toolCallId) {
+      setRecoveredChildId(null);
+      return;
+    }
+    let cancelled = false;
+    void chatDb
+      .findChildByParentToolCallId(parentConversationId, toolCallId)
+      .then((child) => {
+        if (cancelled) return;
+        setRecoveredChildId(child?.id ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setRecoveredChildId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [needsRecovery, parentConversationId, toolCallId]);
+
+  const childId = finalChildId ?? liveChildId ?? recoveredChildId;
 
   // Live transcript (peer/incognito only). Reads chat-db when the
   // child conversation's messages change.
@@ -87,6 +131,12 @@ export function DelegateResult({ args, result, toolCallId, state, errorText }: P
   // Live trace title from setTaskTitle. Updated via DOM event AND from
   // chat-db (so a reload mid-run still shows the most recent title).
   const liveTitle = useTraceTitle(toolCallId, childId);
+
+  // Resolved model the subagent ran on. Prefers the child conversation's
+  // live `usage.modelId` (the model that actually ran, including user
+  // overrides like `cuaModel`), falling back to the agent definition's
+  // configured `defaultModel`.
+  const model = useChildModel(childId, slug);
 
   const transcript: SerializedAssistantMessage[] =
     liveTranscript ?? resultTranscript;
@@ -122,6 +172,8 @@ export function DelegateResult({ args, result, toolCallId, state, errorText }: P
       isRunning={isRunning}
       isFailed={isFailed}
       error={error}
+      task={task}
+      model={model}
     />
   );
 }
@@ -168,6 +220,48 @@ function useChildLiveTranscript(
   }, [childConversationId]);
 
   return transcript;
+}
+
+/**
+ * Resolve the model the subagent ran on.
+ *
+ * Priority:
+ *   1. The child conversation's live `usage.modelId` (peer/incognito) —
+ *      the model that actually executed, reflecting user overrides like
+ *      `cuaModel`. Updated live via chat-db subscription.
+ *   2. The agent definition's configured `defaultModel`.
+ *   3. `null` — the subagent inherited the parent's model (e.g. the
+ *      `explore`/`general` agents whose `defaultModel` is undefined).
+ */
+function useChildModel(
+  childConversationId: string | null,
+  slug: string,
+): string | null {
+  const [liveModelId, setLiveModelId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!childConversationId) {
+      setLiveModelId(null);
+      return;
+    }
+    let cancelled = false;
+    async function refresh() {
+      const conv = await chatDb.getConversation(childConversationId!);
+      if (cancelled) return;
+      setLiveModelId(conv?.usage?.modelId ?? null);
+    }
+    void refresh();
+    const unsubscribe = chatDb.subscribeConversationChange((convId) => {
+      if (convId === childConversationId) void refresh();
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [childConversationId]);
+
+  const configuredModel = getAgent(slug)?.defaultModel ?? null;
+  return liveModelId ?? configuredModel;
 }
 
 /**

--- a/apps/extension/src/components/chat/tool-results/navigate.tsx
+++ b/apps/extension/src/components/chat/tool-results/navigate.tsx
@@ -1,0 +1,117 @@
+import { Globe } from "lucide-react";
+
+interface Props {
+  args: Record<string, unknown>;
+  result: unknown;
+}
+
+/**
+ * Renders a navigation tool result. Two distinct tools share this renderer
+ * (they collide on the `navigate` / `goBack` / `goForward` tool names):
+ *
+ *  1. CUA nav tools (`cua/nav-tools.ts`) return
+ *     `{ imageDataUrl?, currentUrl?, noChange? }` — we show the landed URL and
+ *     a post-navigation screenshot, matching the `computer` tool's rows.
+ *
+ *  2. The main agent's `navigate` tool (`tools/navigate.ts`) returns
+ *     `{ navigated, url, tab?, snapshot?, refCount?, note?, error? }` — no
+ *     screenshot. We show the landed URL plus any note/error. We deliberately
+ *     do NOT dump the (multi-KB) `snapshot` text; refCount is summarized.
+ */
+export function NavigateResult({ args, result }: Props) {
+  const obj = result as
+    | {
+        // CUA shape
+        imageDataUrl?: string;
+        currentUrl?: string;
+        noChange?: boolean;
+        // Main-agent shape
+        navigated?: boolean;
+        url?: string;
+        tab?: string;
+        snapshot?: string;
+        refCount?: number;
+        note?: string;
+        error?: string;
+      }
+    | undefined;
+
+  const imageUrl = obj?.imageDataUrl;
+  const noChange = obj?.noChange === true;
+  // CUA reports the landed URL as `currentUrl`; the main agent as `url`.
+  const currentUrl = obj?.currentUrl ?? obj?.url;
+  const note = obj?.note;
+  const error = obj?.error;
+  const refCount = typeof obj?.refCount === "number" ? obj.refCount : undefined;
+
+  // The URL the model asked to navigate to (only present for `navigate`).
+  const requestedUrl = typeof args.url === "string" ? args.url : undefined;
+  const redirected =
+    requestedUrl != null &&
+    currentUrl != null &&
+    !urlsEquivalent(requestedUrl, currentUrl);
+
+  if (!imageUrl && !currentUrl && !noChange && !note && !error) return null;
+
+  return (
+    <div className="ml-3 mt-1 pl-3 pb-1 space-y-1">
+      {currentUrl && (
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Globe className="size-3 shrink-0 opacity-70" />
+          <span className="truncate font-mono" title={currentUrl}>
+            {currentUrl}
+          </span>
+        </div>
+      )}
+      {redirected && (
+        <div className="text-[11px] text-muted-foreground/60">
+          Redirected from{" "}
+          <span className="font-mono" title={requestedUrl}>
+            {requestedUrl}
+          </span>
+        </div>
+      )}
+      {error ? (
+        <div className="text-xs text-red-600/90 dark:text-red-400/90">
+          {error}
+        </div>
+      ) : note ? (
+        <div className="text-[11px] text-muted-foreground/60">{note}</div>
+      ) : null}
+      {noChange ? (
+        <div className="text-xs text-muted-foreground/60">No change</div>
+      ) : (
+        imageUrl && (
+          <div className="relative inline-block">
+            <img
+              src={imageUrl}
+              alt="Navigation screenshot"
+              className="max-w-full h-auto max-h-[400px] rounded border border-border object-contain"
+            />
+          </div>
+        )
+      )}
+      {!imageUrl && !note && !error && refCount !== undefined && (
+        <div className="text-[11px] text-muted-foreground/60">
+          {refCount} interactive element{refCount === 1 ? "" : "s"}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Loose URL equality for the "redirected" hint: ignores a trailing slash and
+ * is tolerant of unparseable inputs (falls back to exact string compare).
+ */
+function urlsEquivalent(a: string, b: string): boolean {
+  const norm = (s: string) => {
+    try {
+      const u = new URL(s);
+      return `${u.origin}${u.pathname.replace(/\/$/, "")}${u.search}`;
+    } catch {
+      return s.replace(/\/$/, "");
+    }
+  };
+  return norm(a) === norm(b);
+}

--- a/apps/extension/src/components/chat/tool-results/subagent-trace.tsx
+++ b/apps/extension/src/components/chat/tool-results/subagent-trace.tsx
@@ -16,12 +16,16 @@
  * The component is purely presentational — DelegateResult owns the
  * live transcript subscription and title-event listener and feeds the
  * latest snapshot in via `transcript` + `triggerTitle` + `isRunning` /
- * `isFailed`.
+ * `isFailed`. The expanded body also shows the delegation `task`
+ * prompt above the trace and the resolved `model` in a footer; the
+ * trace itself auto-scrolls to the bottom as new parts stream in
+ * (via `use-stick-to-bottom`), pausing when the user scrolls up.
  */
 
 import { Bot, ChevronDownIcon } from "lucide-react";
 import type { ReactNode, ComponentProps } from "react";
 import Markdown from "react-markdown";
+import { StickToBottom } from "use-stick-to-bottom";
 import { Shimmer } from "../../ai-elements/shimmer";
 import { Reasoning } from "../../ai-elements/reasoning";
 import {
@@ -47,6 +51,17 @@ interface Props {
   isFailed: boolean;
   /** Pass-through of error message to render in the trace content */
   error?: string;
+  /**
+   * The task prompt passed to the subagent (the delegate `task` arg).
+   * Rendered in a read-only block above the trace when expanded.
+   */
+  task?: string;
+  /**
+   * The model the subagent ran on (e.g. `anthropic:claude-sonnet-4-6`).
+   * Rendered in a footer below the trace when expanded. `null` means the
+   * subagent inherited the parent's model.
+   */
+  model?: string | null;
 }
 
 export function SubagentTrace({
@@ -56,6 +71,8 @@ export function SubagentTrace({
   isRunning,
   isFailed,
   error,
+  task,
+  model,
 }: Props) {
   const stepCount = transcript.reduce(
     (acc, m) => acc + countMeaningfulParts(m.parts),
@@ -80,21 +97,43 @@ export function SubagentTrace({
             "data-[state=closed]:animate-out data-[state=open]:animate-in",
           )}
         >
-          <div className="mt-2 space-y-1 border-muted border-l-2 pl-4 max-h-[400px] overflow-y-auto styled-scrollbar pr-1">
-            {transcript.flatMap((message, mi) =>
-              message.parts.map((part, pi) => (
-                <PartRow key={`${mi}-${pi}`} part={part} />
-              )),
-            )}
-            {error && (
-              <TraceBlockItem>
-                <div className="w-full rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 mt-2">
-                  <pre className="whitespace-pre-wrap font-mono text-xs text-red-400">
-                    {error}
-                  </pre>
-                </div>
-              </TraceBlockItem>
-            )}
+          {task && task.trim().length > 0 && (
+            <div className="mt-2 rounded-md border border-muted/40 bg-muted/30 px-3 py-2">
+              <div className="mb-1 font-medium text-[10px] uppercase tracking-wide text-muted-foreground/60">
+                Prompt
+              </div>
+              <div className="prose prose-sm dark:prose-invert max-w-none text-foreground/80 prose-p:my-0.5 prose-p:leading-snug max-h-[140px] overflow-y-auto styled-scrollbar">
+                <Markdown>{task}</Markdown>
+              </div>
+            </div>
+          )}
+          <StickToBottom
+            className="mt-2 max-h-[400px] overflow-y-auto styled-scrollbar border-muted border-l-2 pl-4 pr-1"
+            initial="instant"
+            resize="instant"
+          >
+            <StickToBottom.Content className="space-y-1">
+              {transcript.flatMap((message, mi) =>
+                message.parts.map((part, pi) => (
+                  <PartRow key={`${mi}-${pi}`} part={part} />
+                )),
+              )}
+              {error && (
+                <TraceBlockItem>
+                  <div className="w-full rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 mt-2">
+                    <pre className="whitespace-pre-wrap font-mono text-xs text-red-400">
+                      {error}
+                    </pre>
+                  </div>
+                </TraceBlockItem>
+              )}
+            </StickToBottom.Content>
+          </StickToBottom>
+          <div className="mt-2 flex items-center gap-1.5 border-t border-muted/30 pt-2 text-[11px] text-muted-foreground/70">
+            <span className="shrink-0 opacity-70">Model</span>
+            <span className="truncate font-mono" title={model ?? undefined}>
+              {model ?? "inherits parent model"}
+            </span>
           </div>
         </CollapsibleContent>
       </TraceBlock>

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -2443,8 +2443,8 @@ export default defineBackground({
         }
       }
       if (changeInfo.status === "complete" && tab.id != null && tab.id === agentWorkingTabId) {
-        import("@/lib/agent/agent-transport").then(({ injectIndicator }) => {
-          injectIndicator(tab.id!, agentWorkingColor);
+        import("@/lib/agent/agent-transport").then(({ notifyAgentStatus }) => {
+          notifyAgentStatus(true, agentWorkingColor, tab.id!);
         }).catch(() => {});
       }
     });

--- a/apps/extension/src/entrypoints/content/index.ts
+++ b/apps/extension/src/entrypoints/content/index.ts
@@ -851,7 +851,14 @@ export default defineContentScript({
       }
     });
 
+    // These messages are posted by OpenBrowse's own overlay iframe
+    // (`window.parent.postMessage(..., "*")` in OverlayApp/LogoMenu), which
+    // runs at the extension origin. A malicious page sharing this window
+    // could otherwise spoof OPENBROWSE_TRIGGER_UNDO / OVERLAY_CLOSE etc., so
+    // only process messages that originate from the extension itself.
+    const extensionOrigin = new URL(chrome.runtime.getURL("")).origin;
     window.addEventListener("message", (e) => {
+      if (e.origin !== extensionOrigin) return;
       if (e.data?.type === "OPENBROWSE_OVERLAY_CLOSE") {
         removeOverlay();
       }

--- a/apps/extension/src/entrypoints/content/index.ts
+++ b/apps/extension/src/entrypoints/content/index.ts
@@ -1,18 +1,20 @@
-const OVERLAY_HOST_ID = 'openbrowse-overlay-host'
-const TOAST_HOST_ID = 'openbrowse-toast-host'
-const AGENT_TOAST_HOST_ID = 'openbrowse-agent-toast-host'
+const OVERLAY_HOST_ID = "openbrowse-overlay-host";
+const TOAST_HOST_ID = "openbrowse-toast-host";
+const AGENT_TOAST_HOST_ID = "openbrowse-agent-toast-host";
+const RIPPLE_HOST_ID = "openbrowse-cua-ripple-host";
+const CUA_WORKING_HOST_ID = "openbrowse-cua-working-host";
 
-let toastTimeout: ReturnType<typeof setTimeout> | null = null
-let activeUndoHandler: (() => void) | null = null
-let undoKeyHandler: ((e: KeyboardEvent) => void) | null = null
+let toastTimeout: ReturnType<typeof setTimeout> | null = null;
+let activeUndoHandler: (() => void) | null = null;
+let undoKeyHandler: ((e: KeyboardEvent) => void) | null = null;
 
 function getOrCreateToastHost() {
-  let host = document.getElementById(TOAST_HOST_ID)
-  if (host) return host.shadowRoot!
-  host = document.createElement('div')
-  host.id = TOAST_HOST_ID
-  const shadow = host.attachShadow({ mode: 'open' })
-  const style = document.createElement('style')
+  let host = document.getElementById(TOAST_HOST_ID);
+  if (host) return host.shadowRoot!;
+  host = document.createElement("div");
+  host.id = TOAST_HOST_ID;
+  const shadow = host.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
   style.textContent = `
     .sb-toast-container {
       position: fixed;
@@ -96,89 +98,169 @@ function getOrCreateToastHost() {
       from { opacity: 0; transform: translateY(8px); }
       to { opacity: 1; transform: translateY(0); }
     }
-  `
-  const container = document.createElement('div')
-  container.className = 'sb-toast-container'
-  shadow.appendChild(style)
-  shadow.appendChild(container)
-  document.body.appendChild(host)
-  return shadow
+  `;
+  const container = document.createElement("div");
+  container.className = "sb-toast-container";
+  shadow.appendChild(style);
+  shadow.appendChild(container);
+  document.body.appendChild(host);
+  return shadow;
 }
 
 function performUndo(undoData: any) {
-  chrome.runtime.sendMessage({ type: 'OVERLAY_UNDO', undoData }).then(() => {
-    const host = document.getElementById(OVERLAY_HOST_ID)
-    const iframe = host?.shadowRoot?.querySelector('iframe')
+  chrome.runtime.sendMessage({ type: "OVERLAY_UNDO", undoData }).then(() => {
+    const host = document.getElementById(OVERLAY_HOST_ID);
+    const iframe = host?.shadowRoot?.querySelector("iframe");
     if (iframe?.contentWindow) {
-      iframe.contentWindow.postMessage({ type: 'OPENBROWSE_UNDO_COMPLETE' }, '*')
+      iframe.contentWindow.postMessage(
+        { type: "OPENBROWSE_UNDO_COMPLETE" },
+        "*",
+      );
     }
-  })
+  });
 }
 
 function dismissToast() {
-  if (toastTimeout) { clearTimeout(toastTimeout); toastTimeout = null }
-  if (undoKeyHandler) { document.removeEventListener('keydown', undoKeyHandler); undoKeyHandler = null }
-  activeUndoHandler = null
-  const host = document.getElementById(TOAST_HOST_ID)
-  const toast = host?.shadowRoot?.querySelector('.sb-toast')
+  if (toastTimeout) {
+    clearTimeout(toastTimeout);
+    toastTimeout = null;
+  }
+  if (undoKeyHandler) {
+    document.removeEventListener("keydown", undoKeyHandler);
+    undoKeyHandler = null;
+  }
+  activeUndoHandler = null;
+  const host = document.getElementById(TOAST_HOST_ID);
+  const toast = host?.shadowRoot?.querySelector(".sb-toast");
   if (toast) {
-    toast.classList.add('sb-toast-out')
-    setTimeout(() => toast.remove(), 150)
+    toast.classList.add("sb-toast-out");
+    setTimeout(() => toast.remove(), 150);
+  }
+}
+
+/**
+ * Show a transient click ripple at viewport coordinates (CSS px). Used by the
+ * Computer Use (CUA) agent so a human watching the live tab can see where the
+ * agent clicked. Coordinates are viewport-relative (CDP Input.dispatchMouseEvent
+ * uses viewport coords), so `position: fixed` matches without scroll offset.
+ * The ripple lives in its own Shadow-DOM host with pointer-events:none and is
+ * fired AFTER the agent captures its screenshot, so it never appears in the
+ * image sent to the model.
+ */
+function getOrCreateRippleHost(): ShadowRoot {
+  const existing = document.getElementById(RIPPLE_HOST_ID);
+  if (existing) return existing.shadowRoot!;
+  const host = document.createElement("div");
+  host.id = RIPPLE_HOST_ID;
+  // Host itself is inert and full-viewport; children are positioned fixed.
+  host.style.cssText =
+    "position:fixed;inset:0;pointer-events:none;z-index:2147483646;";
+  const shadow = host.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = `
+    .ob-ripple {
+      position: fixed;
+      width: 36px;
+      height: 36px;
+      margin-left: -18px;
+      margin-top: -18px;
+      border-radius: 50%;
+      background: rgba(56, 132, 255, 0.35);
+      border: 2px solid rgba(56, 132, 255, 0.9);
+      pointer-events: none;
+      transform: scale(0.2);
+      opacity: 0.9;
+      animation: ob-ripple 600ms ease-out forwards;
+    }
+    @keyframes ob-ripple {
+      0%   { transform: scale(0.2); opacity: 0.9; }
+      100% { transform: scale(1.6); opacity: 0; }
+    }
+  `;
+  shadow.appendChild(style);
+  document.documentElement.appendChild(host);
+  return shadow;
+}
+
+function showClickRipple(x: number, y: number) {
+  try {
+    const shadow = getOrCreateRippleHost();
+    const dot = document.createElement("div");
+    dot.className = "ob-ripple";
+    dot.style.left = `${x}px`;
+    dot.style.top = `${y}px`;
+    shadow.appendChild(dot);
+    setTimeout(() => {
+      dot.remove();
+      // Tear down the host once its last ripple has finished, so the inert
+      // full-viewport overlay doesn't linger on the page indefinitely after
+      // the agent stops clicking. A fresh ripple just re-creates it.
+      if (shadow.querySelectorAll(".ob-ripple").length === 0) {
+        document.getElementById(RIPPLE_HOST_ID)?.remove();
+      }
+    }, 650);
+  } catch {
+    // Never let a visual flourish break anything.
   }
 }
 
 function showToast(message: string, undoData?: any) {
-  const shadow = getOrCreateToastHost()
-  const container = shadow.querySelector('.sb-toast-container')!
+  const shadow = getOrCreateToastHost();
+  const container = shadow.querySelector(".sb-toast-container")!;
 
-  dismissToast()
+  dismissToast();
 
-  const toast = document.createElement('div')
-  toast.className = 'sb-toast'
+  const toast = document.createElement("div");
+  toast.className = "sb-toast";
 
-  const text = document.createElement('span')
-  text.textContent = message
-  toast.appendChild(text)
+  const text = document.createElement("span");
+  text.textContent = message;
+  toast.appendChild(text);
 
   if (undoData) {
     const doUndo = () => {
-      performUndo(undoData)
-      dismissToast()
-    }
-    activeUndoHandler = doUndo
+      performUndo(undoData);
+      dismissToast();
+    };
+    activeUndoHandler = doUndo;
 
-    const btn = document.createElement('button')
-    btn.className = 'sb-toast-undo'
-    const label = document.createTextNode('Undo')
-    btn.appendChild(label)
-    const kbd = document.createElement('span')
-    kbd.className = 'sb-toast-kbd'
-    kbd.textContent = '⌘Z'
-    btn.appendChild(kbd)
-    btn.addEventListener('click', doUndo)
-    toast.appendChild(btn)
+    const btn = document.createElement("button");
+    btn.className = "sb-toast-undo";
+    const label = document.createTextNode("Undo");
+    btn.appendChild(label);
+    const kbd = document.createElement("span");
+    kbd.className = "sb-toast-kbd";
+    kbd.textContent = "⌘Z";
+    btn.appendChild(kbd);
+    btn.addEventListener("click", doUndo);
+    toast.appendChild(btn);
 
     undoKeyHandler = (e: KeyboardEvent) => {
-      if (e.key === 'z' && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
-        e.preventDefault()
-        doUndo()
+      if (
+        e.key === "z" &&
+        (e.metaKey || e.ctrlKey) &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
+        e.preventDefault();
+        doUndo();
       }
-    }
-    document.addEventListener('keydown', undoKeyHandler)
+    };
+    document.addEventListener("keydown", undoKeyHandler);
   }
 
-  container.appendChild(toast)
+  container.appendChild(toast);
 
-  toastTimeout = setTimeout(() => dismissToast(), 4000)
+  toastTimeout = setTimeout(() => dismissToast(), 4000);
 }
 
 function getOrCreateAgentToastHost(): ShadowRoot {
-  let host = document.getElementById(AGENT_TOAST_HOST_ID)
-  if (host) return host.shadowRoot!
-  host = document.createElement('div')
-  host.id = AGENT_TOAST_HOST_ID
-  const shadow = host.attachShadow({ mode: 'open' })
-  const style = document.createElement('style')
+  let host = document.getElementById(AGENT_TOAST_HOST_ID);
+  if (host) return host.shadowRoot!;
+  host = document.createElement("div");
+  host.id = AGENT_TOAST_HOST_ID;
+  const shadow = host.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
   style.textContent = `
     .ab-root {
       position: fixed;
@@ -197,7 +279,7 @@ function getOrCreateAgentToastHost(): ShadowRoot {
       align-items: center;
       gap: 10px;
       padding: 8px 10px 8px 14px;
-      border-radius: 999px;
+      border-radius: 8px;
       font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       font-size: 13px;
       line-height: 1.3;
@@ -229,7 +311,7 @@ function getOrCreateAgentToastHost(): ShadowRoot {
       justify-content: center;
       width: 26px;
       height: 26px;
-      border-radius: 999px;
+      border-radius: 2px;
       border: none;
       background: transparent;
       color: inherit;
@@ -246,72 +328,376 @@ function getOrCreateAgentToastHost(): ShadowRoot {
       from { opacity: 0; transform: translateY(8px); }
       to { opacity: 1; transform: translateY(0); }
     }
-  `
-  const container = document.createElement('div')
-  container.className = 'ab-root'
-  shadow.appendChild(style)
-  shadow.appendChild(container)
-  document.body.appendChild(host)
-  return shadow
+  `;
+  const container = document.createElement("div");
+  container.className = "ab-root";
+  shadow.appendChild(style);
+  shadow.appendChild(container);
+  document.body.appendChild(host);
+  return shadow;
 }
 
 function removeAgentToast() {
-  document.getElementById(AGENT_TOAST_HOST_ID)?.remove()
+  document.getElementById(AGENT_TOAST_HOST_ID)?.remove();
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Computer Use (CUA) "working on this page" overlay.
+ *
+ * Shows a breathing inset glow hugging the viewport edge + a centered pill
+ * ("OpenBrowse is working on this tab") and BLOCKS user input while the CUA
+ * agent drives the tab.
+ *
+ * The blocking is subtle: the CUA agent itself clicks/types via CDP
+ * `Input.dispatchMouseEvent` / `dispatchKeyEvent`, which produce TRUSTED
+ * events indistinguishable from the user's — and which respect DOM
+ * hit-testing, so a pointer-events shield would block the agent too. The
+ * executor therefore TOGGLES passthrough (`__obAgentActing`) around each of
+ * its actions (see cua-loop.ts): while the agent is acting, the shield lets
+ * events through; otherwise it blocks the user. The race window is the few
+ * ms of an awaited action.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+let cuaAgentActing = false;
+let cuaKeyBlocker: ((e: KeyboardEvent) => void) | null = null;
+/** Blocks user wheel/touch scrolling while the overlay is up (the key blocker
+ *  already covers scroll keys). Gated on cuaAgentActing so the agent's own
+ *  actions pass through; CDP-injected scrolls bypass DOM listeners anyway. */
+let cuaScrollBlocker: ((e: Event) => void) | null = null;
+
+/** Live color-scheme watcher for the working pill's logo. CSS @media can theme
+ *  the pill's colors, but not swap an <img src>, so we flip the logo variant in
+ *  JS whenever the OS/browser theme changes while the overlay is mounted. */
+let cuaThemeMql: MediaQueryList | null = null;
+let cuaThemeListener: ((e: MediaQueryListEvent) => void) | null = null;
+
+/** URL of the OpenBrowse logo that contrasts with the current theme's pill:
+ *  white logo on the dark-mode pill, black logo on the light-mode pill. */
+function cuaLogoUrl(dark: boolean): string {
+  return chrome.runtime.getURL(dark ? "icon/logo-dark.svg" : "icon/logo.svg");
+}
+
+/** Fallback glow color (OpenBrowse logo blue). Used when no space color is set. */
+const CUA_DEFAULT_GLOW = "#056BB3";
+
+/** Parse a #rgb / #rrggbb hex string into [r,g,b]. Returns null if unparseable. */
+function parseHex(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  let h = m[1];
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/** Build an rgba() string from a hex color + alpha (0..1). */
+function rgba(hex: string, alpha: number): string {
+  const rgb = parseHex(hex) ?? parseHex(CUA_DEFAULT_GLOW)!;
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`;
+}
+
+function getOrCreateCuaWorkingHost(color?: string | null): ShadowRoot {
+  const glow = color && parseHex(color) ? color.trim() : CUA_DEFAULT_GLOW;
+  const existing = document.getElementById(CUA_WORKING_HOST_ID);
+  if (existing) {
+    // Re-tint an already-mounted overlay (agent moved spaces mid-run).
+    applyCuaGlow(existing.shadowRoot!, glow);
+    return existing.shadowRoot!;
+  }
+  const host = document.createElement("div");
+  host.id = CUA_WORKING_HOST_ID;
+  const shadow = host.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = `
+    .ob-cua-root {
+      position: fixed;
+      inset: 0;
+      z-index: 2147483647;
+    }
+    /* Full-viewport input blocker. pointer-events toggled by the executor. */
+    .ob-cua-shield {
+      position: absolute;
+      inset: 0;
+      pointer-events: auto;
+      background: rgba(0, 0, 0, 0.02);
+      cursor: progress;
+      overscroll-behavior: none;
+    }
+    .ob-cua-shield.ob-passthrough {
+      pointer-events: none;
+    }
+    /* Comet-style ambient inset glow hugging the viewport edge. The glow
+       color is driven by the active space color via --ob-glow-* CSS vars
+       (set by applyCuaGlow). A gentle "breathing" pulse signals activity. */
+    .ob-cua-border {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      border-radius: 0;
+      box-shadow:
+        inset 0 9px 6px -1px var(--ob-glow-soft),
+        inset 0 -12px 10px -3px rgba(251, 250, 244, 0.40),
+        inset 0 -15px 15px 4px var(--ob-glow-mid),
+        inset 0 -21px 48px var(--ob-glow-strong);
+      animation: ob-cua-breathe 2.4s ease-in-out infinite;
+    }
+    .ob-cua-pill {
+      position: absolute;
+      bottom: 32px;
+      left: 50%;
+      transform: translateX(-50%);
+      pointer-events: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      border-radius: 8px;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 13px;
+      font-weight: 500;
+      line-height: 1.4;
+      color: #18181b;
+      background: #fff;
+      border: 1px solid #e4e4e7;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.08), 0 1px 3px rgba(0,0,0,0.05);
+      animation: ob-cua-in 0.2s ease-out;
+    }
+    @media (prefers-color-scheme: dark) {
+      .ob-cua-pill {
+        color: #fafafa;
+        background: #18181b;
+        border-color: rgba(255,255,255,0.08);
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      }
+    }
+    .ob-cua-spinner {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      border: 2px solid rgba(0,0,0,0.2);
+      border-top-color: #18181b;
+      animation: ob-cua-spin 0.8s linear infinite;
+      flex-shrink: 0;
+    }
+    @media (prefers-color-scheme: dark) {
+      .ob-cua-spinner {
+        border-color: rgba(255,255,255,0.35);
+        border-top-color: #fff;
+      }
+    }
+    .ob-cua-stop {
+      background: #18181b;
+      color: #fafafa;
+      border: none;
+      padding: 4px 10px;
+      border-radius: 2px;
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+      font-family: inherit;
+      pointer-events: auto;
+    }
+    @media (prefers-color-scheme: dark) {
+      .ob-cua-stop {
+        background: #fafafa;
+        color: #18181b;
+      }
+    }
+    @keyframes ob-cua-breathe {
+      0%, 100% { opacity: 0.35; }
+      50% { opacity: 1; }
+    }
+    @keyframes ob-cua-spin { to { transform: rotate(360deg); } }
+    @keyframes ob-cua-in {
+      from { opacity: 0; transform: translate(-50%, 8px); }
+      to { opacity: 1; transform: translate(-50%, 0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .ob-cua-border { animation: none; opacity: 0.92; }
+      .ob-cua-spinner { animation: none; }
+    }
+  `;
+  const root = document.createElement("div");
+  root.className = "ob-cua-root";
+
+  const prefersDark = window.matchMedia(
+    "(prefers-color-scheme: dark)",
+  ).matches;
+  const logoUrl = cuaLogoUrl(prefersDark);
+
+  root.innerHTML = `
+    <div class="ob-cua-border"></div>
+    <div class="ob-cua-shield"></div>
+    <div class="ob-cua-pill">
+      <img class="ob-cua-logo" src="${logoUrl}" style="width:18px;height:18px;border-radius:4px;">
+      <span>OpenBrowse is working on this tab</span>
+      <button class="ob-cua-stop">Stop</button>
+    </div>
+  `;
+  root.querySelector(".ob-cua-stop")?.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "AGENT_STOP" });
+    removeCuaWorking();
+  });
+  shadow.appendChild(style);
+  shadow.appendChild(root);
+  applyCuaGlow(shadow, glow);
+  document.documentElement.appendChild(host);
+
+  // Live-swap the logo variant if the theme changes while the overlay is up.
+  // Assign the MediaQueryList and listener together (commit both refs only
+  // after addEventListener succeeds) so the pair is never left asymmetric —
+  // removeCuaWorking relies on `cuaThemeMql && cuaThemeListener` to tear it
+  // down.
+  if (!cuaThemeMql) {
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const listener = (e: MediaQueryListEvent) => {
+      const img = document
+        .getElementById(CUA_WORKING_HOST_ID)
+        ?.shadowRoot?.querySelector<HTMLImageElement>(".ob-cua-logo");
+      if (img) img.src = cuaLogoUrl(e.matches);
+    };
+    mql.addEventListener("change", listener);
+    cuaThemeMql = mql;
+    cuaThemeListener = listener;
+  }
+
+  return shadow;
+}
+
+/** Set the glow CSS variables (layered inset-shadow alphas) on the overlay
+ *  root from a hex color. */
+function applyCuaGlow(shadow: ShadowRoot, hex: string) {
+  const root = shadow.querySelector<HTMLElement>(".ob-cua-root");
+  if (!root) return;
+  root.style.setProperty("--ob-glow-soft", rgba(hex, 0.16));
+  root.style.setProperty("--ob-glow-mid", rgba(hex, 0.5));
+  root.style.setProperty("--ob-glow-strong", rgba(hex, 1));
+}
+
+function showCuaWorking(color?: string | null) {
+  getOrCreateCuaWorkingHost(color);
+  // Block user keyboard input while the overlay is up, except while the agent
+  // is acting (its CDP key events would otherwise be swallowed too).
+  if (!cuaKeyBlocker) {
+    cuaKeyBlocker = (e: KeyboardEvent) => {
+      if (cuaAgentActing) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    };
+    document.addEventListener("keydown", cuaKeyBlocker, true);
+    document.addEventListener("keyup", cuaKeyBlocker, true);
+    document.addEventListener("keypress", cuaKeyBlocker, true);
+  }
+  // Block wheel + touch scrolling. Must be non-passive so preventDefault()
+  // actually cancels the scroll (browsers default these to passive on
+  // document). Capture phase so we beat page-level handlers.
+  if (!cuaScrollBlocker) {
+    cuaScrollBlocker = (e: Event) => {
+      if (cuaAgentActing) return;
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    document.addEventListener("wheel", cuaScrollBlocker, {
+      capture: true,
+      passive: false,
+    });
+    document.addEventListener("touchmove", cuaScrollBlocker, {
+      capture: true,
+      passive: false,
+    });
+  }
+}
+
+function removeCuaWorking() {
+  document.getElementById(CUA_WORKING_HOST_ID)?.remove();
+  if (cuaKeyBlocker) {
+    document.removeEventListener("keydown", cuaKeyBlocker, true);
+    document.removeEventListener("keyup", cuaKeyBlocker, true);
+    document.removeEventListener("keypress", cuaKeyBlocker, true);
+    cuaKeyBlocker = null;
+  }
+  if (cuaScrollBlocker) {
+    document.removeEventListener("wheel", cuaScrollBlocker, true);
+    document.removeEventListener("touchmove", cuaScrollBlocker, true);
+    cuaScrollBlocker = null;
+  }
+  // Always tear down the theme listener. Remove it whenever both the
+  // MediaQueryList and the listener fn exist (the only state in which one was
+  // registered), then unconditionally null BOTH refs so a partial-init state
+  // can never leave a stale MediaQueryList that blocks re-registration on the
+  // next show.
+  if (cuaThemeMql && cuaThemeListener) {
+    cuaThemeMql.removeEventListener("change", cuaThemeListener);
+  }
+  cuaThemeMql = null;
+  cuaThemeListener = null;
+  cuaAgentActing = false;
+}
+
+/** Toggle whether the agent is mid-action (lets its CDP input through the
+ *  shield + key blocker). */
+function setCuaPassthrough(on: boolean) {
+  cuaAgentActing = on;
+  const host = document.getElementById(CUA_WORKING_HOST_ID);
+  const shield = host?.shadowRoot?.querySelector(".ob-cua-shield");
+  if (shield) shield.classList.toggle("ob-passthrough", on);
 }
 
 function showAgentActiveToast() {
-  const shadow = getOrCreateAgentToastHost()
-  const container = shadow.querySelector('.ab-root')!
-  if (container.querySelector('.ab-pill')) return
+  const shadow = getOrCreateAgentToastHost();
+  const container = shadow.querySelector(".ab-root")!;
+  if (container.querySelector(".ab-pill")) return;
 
-  const pill = document.createElement('div')
-  pill.className = 'ab-pill'
+  const pill = document.createElement("div");
+  pill.className = "ab-pill";
 
-  const dot = document.createElement('span')
-  dot.className = 'ab-dot'
-  pill.appendChild(dot)
+  const dot = document.createElement("span");
+  dot.className = "ab-dot";
+  pill.appendChild(dot);
 
-  const label = document.createElement('span')
-  label.textContent = 'Agent is active in this tab'
-  pill.appendChild(label)
+  const label = document.createElement("span");
+  label.textContent = "Agent is active in this tab";
+  pill.appendChild(label);
 
-  const sep = document.createElement('span')
-  sep.className = 'ab-sep'
-  pill.appendChild(sep)
+  const sep = document.createElement("span");
+  sep.className = "ab-sep";
+  pill.appendChild(sep);
 
-  const openBtn = document.createElement('button')
-  openBtn.className = 'ab-btn'
-  openBtn.title = 'Open chat'
-  openBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>'
-  openBtn.addEventListener('click', () => {
-    chrome.runtime.sendMessage({ type: 'OPEN_SIDEPANEL_FROM_OVERLAY' })
-  })
-  pill.appendChild(openBtn)
+  const openBtn = document.createElement("button");
+  openBtn.className = "ab-btn";
+  openBtn.title = "Open chat";
+  openBtn.innerHTML =
+    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
+  openBtn.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "OPEN_SIDEPANEL_FROM_OVERLAY" });
+  });
+  pill.appendChild(openBtn);
 
-  const dismissBtn = document.createElement('button')
-  dismissBtn.className = 'ab-btn'
-  dismissBtn.title = 'Dismiss'
-  dismissBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>'
-  dismissBtn.addEventListener('click', () => {
-    chrome.runtime.sendMessage({ type: 'DISMISS_TOAST' })
-    removeAgentToast()
-  })
-  pill.appendChild(dismissBtn)
+  const dismissBtn = document.createElement("button");
+  dismissBtn.className = "ab-btn";
+  dismissBtn.title = "Dismiss";
+  dismissBtn.innerHTML =
+    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+  dismissBtn.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "DISMISS_TOAST" });
+    removeAgentToast();
+  });
+  pill.appendChild(dismissBtn);
 
-  container.appendChild(pill)
+  container.appendChild(pill);
 }
 
 function removeOverlay() {
-  document.getElementById(OVERLAY_HOST_ID)?.remove()
-  document.body.style.overflow = ''
+  document.getElementById(OVERLAY_HOST_ID)?.remove();
+  document.body.style.overflow = "";
 }
 
 function createOverlay(action?: string) {
-  const host = document.createElement('div')
-  host.id = OVERLAY_HOST_ID
-  const shadow = host.attachShadow({ mode: 'open' })
+  const host = document.createElement("div");
+  host.id = OVERLAY_HOST_ID;
+  const shadow = host.attachShadow({ mode: "open" });
 
-  const style = document.createElement('style')
+  const style = document.createElement("style");
   style.textContent = `
     .sb-backdrop {
       position: fixed;
@@ -332,182 +718,231 @@ function createOverlay(action?: string) {
       background: transparent;
       color-scheme: light dark;
     }
-  `
+  `;
 
-  const backdrop = document.createElement('div')
-  backdrop.className = 'sb-backdrop'
-  backdrop.addEventListener('click', (e) => {
-    if (e.target === backdrop) removeOverlay()
-  })
+  const backdrop = document.createElement("div");
+  backdrop.className = "sb-backdrop";
+  backdrop.addEventListener("click", (e) => {
+    if (e.target === backdrop) removeOverlay();
+  });
 
-  const iframe = document.createElement('iframe')
-  iframe.className = 'sb-frame'
+  const iframe = document.createElement("iframe");
+  iframe.className = "sb-frame";
   const overlayUrl = action
     ? chrome.runtime.getURL(`/overlay.html?action=${action}`)
-    : chrome.runtime.getURL('/overlay.html')
-  iframe.src = overlayUrl
+    : chrome.runtime.getURL("/overlay.html");
+  iframe.src = overlayUrl;
 
-  backdrop.appendChild(iframe)
-  shadow.appendChild(style)
-  shadow.appendChild(backdrop)
-  document.body.appendChild(host)
-  document.body.style.overflow = 'hidden'
+  backdrop.appendChild(iframe);
+  shadow.appendChild(style);
+  shadow.appendChild(backdrop);
+  document.body.appendChild(host);
+  document.body.style.overflow = "hidden";
 
-  iframe.addEventListener('load', () => iframe.focus())
+  iframe.addEventListener("load", () => iframe.focus());
 
   // Re-append toast host so it renders above the overlay
-  const toastHost = document.getElementById(TOAST_HOST_ID)
-  if (toastHost) document.body.appendChild(toastHost)
+  const toastHost = document.getElementById(TOAST_HOST_ID);
+  if (toastHost) document.body.appendChild(toastHost);
 }
 
 function toggleOverlay(action?: string) {
-  const existing = document.getElementById(OVERLAY_HOST_ID)
+  const existing = document.getElementById(OVERLAY_HOST_ID);
   if (existing) {
-    existing.remove()
+    existing.remove();
   } else {
-    createOverlay(action)
+    createOverlay(action);
   }
 }
 
 export default defineContentScript({
-  matches: ['<all_urls>'],
-  runAt: 'document_idle',
+  matches: ["<all_urls>"],
+  runAt: "document_idle",
   main() {
     chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-      if (message.type === 'GET_PAGE_CONTEXT') {
-        sendResponse(extractPageContext())
+      if (message.type === "GET_PAGE_CONTEXT") {
+        sendResponse(extractPageContext());
       }
-      if (message.type === 'TOGGLE_OVERLAY') {
-        toggleOverlay(message.action)
-        sendResponse({ ok: true })
+      if (message.type === "TOGGLE_OVERLAY") {
+        toggleOverlay(message.action);
+        sendResponse({ ok: true });
       }
-      if (message.type === 'CHAT_EXTRACT_CONTENT') {
-        sendResponse(extractDetailedContent())
+      if (message.type === "CHAT_EXTRACT_CONTENT") {
+        sendResponse(extractDetailedContent());
       }
-      if (message.type === 'CHAT_CLICK_ELEMENT') {
+      if (message.type === "CHAT_CLICK_ELEMENT") {
         try {
-          const el = document.querySelector(message.selector) as HTMLElement | null
+          const el = document.querySelector(
+            message.selector,
+          ) as HTMLElement | null;
           if (!el) {
-            sendResponse({ success: false, error: `Element not found: ${message.selector}` })
+            sendResponse({
+              success: false,
+              error: `Element not found: ${message.selector}`,
+            });
           } else {
-            el.click()
-            sendResponse({ success: true })
+            el.click();
+            sendResponse({ success: true });
           }
         } catch (err) {
-          sendResponse({ success: false, error: String(err) })
+          sendResponse({ success: false, error: String(err) });
         }
       }
-      if (message.type === 'CHAT_TYPE_IN_ELEMENT') {
+      if (message.type === "CHAT_TYPE_IN_ELEMENT") {
         try {
-          const el = document.querySelector(message.selector) as HTMLInputElement | HTMLTextAreaElement | null
+          const el = document.querySelector(message.selector) as
+            | HTMLInputElement
+            | HTMLTextAreaElement
+            | null;
           if (!el) {
-            sendResponse({ success: false, error: `Element not found: ${message.selector}` })
+            sendResponse({
+              success: false,
+              error: `Element not found: ${message.selector}`,
+            });
           } else {
-            el.focus()
+            el.focus();
             if (message.clearFirst) {
-              el.value = ''
-              el.dispatchEvent(new Event('input', { bubbles: true }))
+              el.value = "";
+              el.dispatchEvent(new Event("input", { bubbles: true }));
             }
-            el.value = message.text
-            el.dispatchEvent(new Event('input', { bubbles: true }))
-            el.dispatchEvent(new Event('change', { bubbles: true }))
-            sendResponse({ success: true })
+            el.value = message.text;
+            el.dispatchEvent(new Event("input", { bubbles: true }));
+            el.dispatchEvent(new Event("change", { bubbles: true }));
+            sendResponse({ success: true });
           }
         } catch (err) {
-          sendResponse({ success: false, error: String(err) })
+          sendResponse({ success: false, error: String(err) });
         }
       }
-      if (message.type === 'OVERLAY_TOAST_STATE') {
+      if (message.type === "OVERLAY_TOAST_STATE") {
         if (message.show) {
-          showAgentActiveToast()
+          showAgentActiveToast();
         } else {
-          removeAgentToast()
+          removeAgentToast();
         }
-        sendResponse({ ok: true })
+        sendResponse({ ok: true });
       }
-      if (message.type === 'CHAT_SCROLL_PAGE') {
+      if (message.type === "CHAT_SCROLL_PAGE") {
         try {
-          const pixels = message.amount ?? 600
-          window.scrollBy(0, message.direction === 'up' ? -pixels : pixels)
-          sendResponse({ success: true })
+          const pixels = message.amount ?? 600;
+          window.scrollBy(0, message.direction === "up" ? -pixels : pixels);
+          sendResponse({ success: true });
         } catch (err) {
-          sendResponse({ success: false, error: String(err) })
+          sendResponse({ success: false, error: String(err) });
         }
       }
-    })
+      if (message.type === "CHAT_CUA_CLICK_RIPPLE") {
+        if (typeof message.x === "number" && typeof message.y === "number") {
+          showClickRipple(message.x, message.y);
+        }
+        sendResponse({ ok: true });
+      }
+      if (message.type === "CHAT_CUA_WORKING_STATE") {
+        if (message.active) {
+          showCuaWorking(message.color);
+        } else {
+          removeCuaWorking();
+        }
+        sendResponse({ ok: true });
+      }
+      if (message.type === "CHAT_CUA_INPUT_PASSTHROUGH") {
+        setCuaPassthrough(!!message.on);
+        sendResponse({ ok: true });
+      }
+    });
 
-    window.addEventListener('message', (e) => {
-      if (e.data?.type === 'OPENBROWSE_OVERLAY_CLOSE') {
-        removeOverlay()
+    window.addEventListener("message", (e) => {
+      if (e.data?.type === "OPENBROWSE_OVERLAY_CLOSE") {
+        removeOverlay();
       }
-      if (e.data?.type === 'OPENBROWSE_OVERLAY_RESIZE' && typeof e.data.height === 'number') {
-        const host = document.getElementById(OVERLAY_HOST_ID)
-        const iframe = host?.shadowRoot?.querySelector('iframe')
-        if (iframe) iframe.style.height = `${e.data.height}px`
+      if (
+        e.data?.type === "OPENBROWSE_OVERLAY_RESIZE" &&
+        typeof e.data.height === "number"
+      ) {
+        const host = document.getElementById(OVERLAY_HOST_ID);
+        const iframe = host?.shadowRoot?.querySelector("iframe");
+        if (iframe) iframe.style.height = `${e.data.height}px`;
       }
-      if (e.data?.type === 'OPENBROWSE_TOAST') {
-        showToast(e.data.message, e.data.undoData)
+      if (e.data?.type === "OPENBROWSE_TOAST") {
+        showToast(e.data.message, e.data.undoData);
       }
-      if (e.data?.type === 'OPENBROWSE_TRIGGER_UNDO') {
-        if (activeUndoHandler) activeUndoHandler()
+      if (e.data?.type === "OPENBROWSE_TRIGGER_UNDO") {
+        if (activeUndoHandler) activeUndoHandler();
       }
-    })
+    });
 
-    document.addEventListener('keydown', (e) => {
-      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return
-      const match = e.code.match(/^Digit([1-9])$/)
+    document.addEventListener("keydown", (e) => {
+      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+      const match = e.code.match(/^Digit([1-9])$/);
       if (match) {
-        e.preventDefault()
-        chrome.runtime.sendMessage({ type: 'SWITCH_SPACE_BY_POSITION', position: parseInt(match[1], 10) })
+        e.preventDefault();
+        chrome.runtime.sendMessage({
+          type: "SWITCH_SPACE_BY_POSITION",
+          position: parseInt(match[1], 10),
+        });
       }
-    })
-
+    });
   },
-})
+});
 
 function extractPageContext() {
   const meta = (name: string) =>
-    document.querySelector<HTMLMetaElement>(`meta[name="${name}"], meta[property="${name}"]`)?.content?.trim() || ''
+    document
+      .querySelector<HTMLMetaElement>(
+        `meta[name="${name}"], meta[property="${name}"]`,
+      )
+      ?.content?.trim() || "";
 
-  const h1 = document.querySelector('h1')?.textContent?.trim().slice(0, 200) || ''
+  const h1 =
+    document.querySelector("h1")?.textContent?.trim().slice(0, 200) || "";
 
-  const description = meta('description') || meta('og:description') || meta('twitter:description')
+  const description =
+    meta("description") ||
+    meta("og:description") ||
+    meta("twitter:description");
 
-  const bodyText = document.body?.innerText?.replace(/\s+/g, ' ')?.trim().slice(0, 300) || ''
+  const bodyText =
+    document.body?.innerText?.replace(/\s+/g, " ")?.trim().slice(0, 300) || "";
 
   return {
     h1,
     description: description.slice(0, 300),
     snippet: bodyText,
-    type: meta('og:type'),
-    siteName: meta('og:site_name'),
-  }
+    type: meta("og:type"),
+    siteName: meta("og:site_name"),
+  };
 }
 
 function extractDetailedContent() {
-  const readability = document.cloneNode(true) as Document
-  const scripts = readability.querySelectorAll('script, style, noscript, svg, iframe')
-  scripts.forEach((el) => el.remove())
+  const readability = document.cloneNode(true) as Document;
+  const scripts = readability.querySelectorAll(
+    "script, style, noscript, svg, iframe",
+  );
+  scripts.forEach((el) => el.remove());
 
-  const body = readability.body?.innerText?.replace(/\s+/g, ' ')?.trim() || ''
+  const body = readability.body?.innerText?.replace(/\s+/g, " ")?.trim() || "";
 
   const meta = (name: string) =>
-    document.querySelector<HTMLMetaElement>(`meta[name="${name}"], meta[property="${name}"]`)?.content?.trim() || ''
+    document
+      .querySelector<HTMLMetaElement>(
+        `meta[name="${name}"], meta[property="${name}"]`,
+      )
+      ?.content?.trim() || "";
 
-  const links = Array.from(document.querySelectorAll('a[href]'))
+  const links = Array.from(document.querySelectorAll("a[href]"))
     .slice(0, 50)
     .map((a) => ({
-      text: (a as HTMLAnchorElement).textContent?.trim().slice(0, 100) || '',
+      text: (a as HTMLAnchorElement).textContent?.trim().slice(0, 100) || "",
       href: (a as HTMLAnchorElement).href,
     }))
-    .filter((l) => l.text && l.href.startsWith('http'))
+    .filter((l) => l.text && l.href.startsWith("http"));
 
   return {
     url: location.href,
     title: document.title,
-    h1: document.querySelector('h1')?.textContent?.trim().slice(0, 200) || '',
-    description: meta('description').slice(0, 500),
+    h1: document.querySelector("h1")?.textContent?.trim().slice(0, 200) || "",
+    description: meta("description").slice(0, 500),
     bodyText: body.slice(0, 10000),
     links,
-  }
+  };
 }

--- a/apps/extension/src/entrypoints/settings/GeneralTab.tsx
+++ b/apps/extension/src/entrypoints/settings/GeneralTab.tsx
@@ -29,6 +29,17 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
   const providerModels = useConfiguredModels(settings);
   const hasConfiguredModels = providerModels.length > 0;
 
+  // Only computer-use-capable models are valid for the CUA subagent.
+  const cuaProviderModels = providerModels
+    .map((group) => ({
+      ...group,
+      models: group.models.filter((m) =>
+        m.capabilities?.includes("computer-use"),
+      ),
+    }))
+    .filter((group) => group.models.length > 0);
+  const hasCuaModels = cuaProviderModels.length > 0;
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -178,6 +189,31 @@ export function GeneralTab({ settings, onChange, agentSettings, onAgentSettingsC
         ) : (
           <p className="text-sm text-muted-foreground rounded-md border border-input px-3 py-2">
             Configure a provider in the Models tab first
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Computer Use model</Label>
+        <p className="text-xs text-muted-foreground">
+          Model used by the Computer Use subagent, which controls a page with
+          pixel-level screenshots and mouse/keyboard for sites the normal agent
+          can&apos;t handle. Only computer-use-capable models are shown.
+          Selecting a model here enables the Computer Use agent; leave it unset
+          to disable it.
+        </p>
+        {hasCuaModels ? (
+          <ModelPicker
+            trigger="settings"
+            providerModels={cuaProviderModels}
+            value={agentSettings.cuaModel ?? ""}
+            onValueChange={(v) => onAgentSettingsChange({ cuaModel: v })}
+            placeholder="Select a computer-use model"
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground rounded-md border border-input px-3 py-2">
+            Configure a provider with a computer-use-capable model (e.g.
+            Anthropic Claude Sonnet 4.6) in the Models tab first
           </p>
         )}
       </div>

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -2017,64 +2017,29 @@ export function useAgentChat({
     setInput("");
   }, [onNewConversation, setMessages]);
 
-  const handleRegenerate = useCallback(
-    async (messageId: string) => {
-      if (conversationId) {
-        await chatDb.deleteMessagesFrom(conversationId, messageId);
-      }
-      regenerate({ messageId });
-    },
-    [regenerate, conversationId],
-  );
-
   /**
-   * Retry the last attempt after an error. Used by the error banner's
-   * Retry button.
+   * Retry after an error — CONTINUE the partial assistant turn in place.
    *
-   * Two cases:
+   * Unlike a destructive regenerate, this keeps every part already produced
+   * and resumes generation into the SAME assistant message, without inserting
+   * any synthetic user message.
    *
-   * - Last message is the user's prompt (the agent errored before
-   *   producing any persistable assistant content — `onFinish`'s
-   *   `hasMeaningfulContent` gate skipped saving). We just call
-   *   `regenerate()` and the SDK runs a fresh attempt off that prompt.
+   * How it works: after a mid-stream error the partial assistant message is
+   * the tail of `messages` (onFinish persisted it). The AI SDK's
+   * `createStreamingUIMessageState` seeds the streaming state from a trailing
+   * assistant message (same id + existing parts) and merges new chunks into
+   * it, so a bare `sendMessage()` (no new message) continues that turn. The
+   * transport ships the partial assistant as the trailing message and
+   * Anthropic continues it (assistant prefill).
    *
-   * - Last message is a partial assistant message (mid-stream error
-   *   that produced *some* content). Heal any stranded tool calls in
-   *   the messages that will survive the regenerate slice, delete the
-   *   partial assistant from chatDb to keep it in sync with the
-   *   in-memory slice the SDK is about to take, then call
-   *   `regenerate({ messageId })`.
-   *
-   * The bare `clearError(); handleSubmit()` previously wired here
-   * silently no-op'd whenever the input field was empty (the common
-   * case when clicking Retry).
+   * We first heal any stranded tool calls (a dangling
+   * `input-available`/`approval-requested` part would otherwise throw
+   * `MissingToolResultsError` on convert). If the agent errored before any
+   * assistant content (tail is the user prompt), `sendMessage()` simply
+   * answers that prompt — so one path covers both cases.
    */
   const handleRetry = useCallback(async () => {
     clearError();
-    const last = messages[messages.length - 1];
-    if (!last) return;
-
-    if (last.role === "assistant") {
-      // Heal stranded tool calls in the surviving prefix so the
-      // regenerated request doesn't trip MissingToolResultsError.
-      const survivors = messages.slice(0, messages.length - 1);
-      const { healed, healedMessages } = healPendingTools(
-        survivors,
-        "Superseded by retry",
-      );
-      if (healedMessages.length > 0) {
-        setMessages([...healed, last]);
-        await persistHealedMessages(conversationId, healedMessages);
-      }
-      if (conversationId) {
-        await chatDb.deleteMessagesFrom(conversationId, last.id);
-      }
-      regenerate({ messageId: last.id });
-      return;
-    }
-
-    // Last message is a user prompt — heal any prior stranded tool
-    // calls and ask the SDK to generate an assistant response.
     const { healed, healedMessages } = healPendingTools(
       messages,
       "Superseded by retry",
@@ -2083,44 +2048,45 @@ export function useAgentChat({
       setMessages(healed);
       await persistHealedMessages(conversationId, healedMessages);
     }
-    regenerate();
-  }, [messages, conversationId, regenerate, clearError, setMessages]);
+    sendMessage();
+  }, [messages, conversationId, sendMessage, clearError, setMessages]);
 
   /**
-   * Continue after an error, *keeping* the partial assistant output
-   * already produced (unlike `handleRetry`, which discards the errored
-   * turn and re-runs from the user prompt). Used by the error banner's
-   * Continue button.
-   *
-   * There's no provider-agnostic "resume the exact stream" primitive
-   * once a request has errored out (`resumeStream` only resumes a still
-   * open server stream). So we resume the same way the auto-compaction
-   * flow does: heal any stranded tool calls, then send a synthetic
-   * "Continue where you left off" user message so the model picks up
-   * with the prior partial output already in context. The synthetic
-   * prompt is intentionally not persisted to chatDb.
+   * Retry from a specific USER message: discard every turn after it and
+   * re-run the response from that prompt. Used by the per-user-message Retry
+   * action (the caller confirms first). Follows the heal→delete→regenerate
+   * sequence, but the regenerate target is the user message itself so the SDK
+   * keeps the prompt and drops everything after.
    */
-  const handleContinue = useCallback(async () => {
-    clearError();
-    const { healed, healedMessages } = healPendingTools(
-      messages,
-      "Superseded by continue",
-    );
-    if (healedMessages.length > 0) {
-      setMessages(healed);
-      await persistHealedMessages(conversationId, healedMessages);
-    }
-    sendMessage({
-      id: generateId(),
-      role: "user",
-      parts: [
-        {
-          type: "text",
-          text: "Continue where you left off, or ask for clarification if unsure how to proceed.",
-        },
-      ],
-    });
-  }, [messages, conversationId, sendMessage, clearError, setMessages]);
+  const handleRetryFromUser = useCallback(
+    async (userMessageId: string) => {
+      clearError();
+      const idx = messages.findIndex((m) => m.id === userMessageId);
+      if (idx === -1) return;
+
+      // Heal stranded tool calls in the surviving prefix (everything after
+      // `idx` is about to be deleted by regenerate's slice anyway).
+      const survivors = messages.slice(0, idx + 1);
+      const { healed, healedMessages } = healPendingTools(
+        survivors,
+        "Superseded by retry from user message",
+      );
+      if (healedMessages.length > 0) {
+        setMessages([...healed, ...messages.slice(idx + 1)]);
+        await persistHealedMessages(conversationId, healedMessages);
+      }
+
+      // Keep chatDb in sync with the in-memory slice the SDK will take:
+      // delete the first message AFTER the user message (and everything past
+      // it, by createdAt).
+      const next = messages[idx + 1];
+      if (conversationId && next) {
+        await chatDb.deleteMessagesFrom(conversationId, next.id);
+      }
+      regenerate({ messageId: userMessageId });
+    },
+    [messages, conversationId, regenerate, clearError, setMessages],
+  );
 
   const confirmEdit = useCallback(
     async (
@@ -2317,9 +2283,8 @@ export function useAgentChat({
     handleSubmit,
     compactNow,
     handleNew,
-    handleRegenerate,
     handleRetry,
-    handleContinue,
+    handleRetryFromUser,
     confirmEdit,
     addToolApprovalResponse,
     approveToolCall,

--- a/apps/extension/src/lib/agent/__tests__/agent-transport.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/agent-transport.test.ts
@@ -29,15 +29,16 @@ function makeMinimalContext(): ToolContext {
 
 function makeRecordingTool(): {
   tool: BrowserTool<{ x: string }, { ok: boolean }>;
-  received: { ctx: ToolContext | null };
+  received: { ctx: ToolContext | null; resolve?: () => void };
 } {
-  const received: { ctx: ToolContext | null } = { ctx: null };
+  const received: { ctx: ToolContext | null; resolve?: () => void } = { ctx: null };
   const tool: BrowserTool<{ x: string }, { ok: boolean }> = {
     name: "recordingTool",
     description: "Records the ctx it receives",
     parameters: z.object({ x: z.string() }),
     execute: async (_input, ctx) => {
       received.ctx = ctx;
+      await new Promise<void>(r => { received.resolve = r; });
       return { ok: true };
     },
   };
@@ -45,16 +46,14 @@ function makeRecordingTool(): {
 }
 
 describe("toSDKTool — abortSignal propagation", () => {
-  it("forwards options.abortSignal to ctx.signal so delegate can cancel", async () => {
+  it("forwards a linked abortSignal to ctx.signal so delegate can cancel", async () => {
     const { tool, received } = makeRecordingTool();
     const wrapped = toSDKTool(tool, "recordingTool");
 
     const controller = new AbortController();
     const baseCtx = makeMinimalContext();
 
-    // Invoke as the AI SDK would: shaped options object with the
-    // per-call abortSignal.
-    await (
+    const executePromise = (
       wrapped.execute as unknown as (
         input: { x: string },
         options: {
@@ -72,51 +71,28 @@ describe("toSDKTool — abortSignal propagation", () => {
       },
     );
 
-    expect(received.ctx).not.toBeNull();
-    expect(received.ctx?.signal).toBe(controller.signal);
-    expect(received.ctx?.toolCallId).toBe("tc_1");
-  });
+    // wait for tool to receive execution
+    await new Promise(r => setTimeout(r, 0));
 
-  it("propagates abort through the same signal reference (not a snapshot)", async () => {
-    const { tool, received } = makeRecordingTool();
-    const wrapped = toSDKTool(tool, "recordingTool");
-
-    const controller = new AbortController();
-    const baseCtx = makeMinimalContext();
-
-    await (
-      wrapped.execute as unknown as (
-        input: { x: string },
-        options: {
-          toolCallId: string;
-          experimental_context?: unknown;
-          abortSignal?: AbortSignal;
-        },
-      ) => Promise<unknown>
-    )(
-      { x: "hello" },
-      {
-        toolCallId: "tc_2",
-        abortSignal: controller.signal,
-        experimental_context: baseCtx,
-      },
-    );
-
-    // Mutate the controller AFTER execute resolved; the captured signal
-    // should reflect the change because the wrapper passes the live
-    // reference, not a copy.
+    expect(received.ctx?.signal).toBeDefined();
     expect(received.ctx?.signal?.aborted).toBe(false);
+    expect(received.ctx?.toolCallId).toBe("tc_1");
+    
+    // Test that the linked signal aborts when the parent aborts
     controller.abort();
     expect(received.ctx?.signal?.aborted).toBe(true);
+    
+    received.resolve?.();
+    await executePromise;
   });
 
-  it("leaves ctx.signal undefined when the SDK does not provide one", async () => {
+  it("provides its own ctx.signal even when the SDK does not provide one (so UI can still cancel)", async () => {
     const { tool, received } = makeRecordingTool();
     const wrapped = toSDKTool(tool, "recordingTool");
 
     const baseCtx = makeMinimalContext();
 
-    await (
+    const executePromise = (
       wrapped.execute as unknown as (
         input: { x: string },
         options: {
@@ -133,6 +109,12 @@ describe("toSDKTool — abortSignal propagation", () => {
       },
     );
 
-    expect(received.ctx?.signal).toBeUndefined();
+    // wait for tool to receive execution
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(received.ctx?.signal).toBeDefined();
+    
+    received.resolve?.();
+    await executePromise;
   });
 });

--- a/apps/extension/src/lib/agent/__tests__/capture-utils.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/capture-utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserDriver } from "../driver";
+import { captureScreenshot } from "../capture-utils";
+
+interface Call {
+  method: string;
+  params: unknown;
+}
+
+function recordingDriver(opts: {
+  captureFails?: number; // number of leading captureScreenshot calls that throw
+  evalFails?: boolean; // make Runtime.evaluate throw
+} = {}): { driver: BrowserDriver; calls: Call[] } {
+  const calls: Call[] = [];
+  let captureCalls = 0;
+  const driver = {
+    sendCommand: vi.fn(async (_tabId: unknown, method: string, params: unknown) => {
+      calls.push({ method, params });
+      if (method === "Runtime.evaluate") {
+        if (opts.evalFails) throw new Error("no Runtime.evaluate");
+        return {} as never;
+      }
+      if (method === "Page.captureScreenshot") {
+        captureCalls++;
+        if (opts.captureFails && captureCalls <= opts.captureFails) {
+          throw new Error("-32000 Unable to capture screenshot");
+        }
+        return { data: "QUJD" } as never; // "ABC"
+      }
+      return {} as never;
+    }),
+  } as unknown as BrowserDriver;
+  return { driver, calls };
+}
+
+describe("captureScreenshot — overlay hiding", () => {
+  it("hides overlays, captures, then restores — in that order", async () => {
+    const { driver, calls } = recordingDriver();
+    const data = await captureScreenshot(driver, 1);
+    expect(data).toBe("QUJD");
+
+    const methods = calls.map((c) => c.method);
+    expect(methods).toEqual([
+      "Runtime.evaluate", // hide
+      "Page.captureScreenshot",
+      "Runtime.evaluate", // restore
+    ]);
+    // Hide injects the style; restore removes it.
+    expect(String((calls[0].params as { expression: string }).expression)).toContain(
+      "openbrowse-capture-hide",
+    );
+    expect(String((calls[2].params as { expression: string }).expression)).toContain(
+      "remove()",
+    );
+  });
+
+  it("restores overlays even when capture throws", async () => {
+    const { driver, calls } = recordingDriver({ captureFails: 2 });
+    await expect(captureScreenshot(driver, 1)).rejects.toThrow();
+    // hide, capture(fail), capture(fail), then restore in finally.
+    const methods = calls.map((c) => c.method);
+    expect(methods[0]).toBe("Runtime.evaluate");
+    expect(methods.at(-1)).toBe("Runtime.evaluate");
+    expect(methods.filter((m) => m === "Page.captureScreenshot").length).toBe(2);
+  });
+
+  it("retries once on a transient capture failure", async () => {
+    const { driver, calls } = recordingDriver({ captureFails: 1 });
+    const data = await captureScreenshot(driver, 1);
+    expect(data).toBe("QUJD");
+    expect(calls.filter((c) => c.method === "Page.captureScreenshot").length).toBe(2);
+  });
+
+  it("still captures when overlay hide/restore is unavailable", async () => {
+    const { driver } = recordingDriver({ evalFails: true });
+    // Runtime.evaluate throws for both hide and restore, but capture proceeds.
+    const data = await captureScreenshot(driver, 1);
+    expect(data).toBe("QUJD");
+  });
+
+  it("forwards capture params (e.g. fullPage clip)", async () => {
+    const { driver, calls } = recordingDriver();
+    const params = { format: "png", captureBeyondViewport: true };
+    await captureScreenshot(driver, 1, params);
+    const capture = calls.find((c) => c.method === "Page.captureScreenshot");
+    expect(capture?.params).toEqual(params);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/diff-snapshots.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/diff-snapshots.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  diffSnapshots,
+  type PageStateSignals,
+} from "../snapshot-capture";
+
+const ZERO: PageStateSignals = {
+  focusedBackendNodeId: null,
+  focusedName: null,
+  focusedRole: null,
+  expandedCount: 0,
+  pressedCount: 0,
+  checkedCount: 0,
+  dialogCount: 0,
+  url: "https://example.com",
+  interactiveCount: 0,
+};
+
+describe("diffSnapshots — null cases", () => {
+  it("returns null when text and signals are both unchanged", () => {
+    const result = diffSnapshots(
+      { text: "a\nb\nc", signals: ZERO },
+      { text: "a\nb\nc", signals: ZERO },
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("diffSnapshots — signal-only changes (text identical)", () => {
+  it("reports focus moves", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, focusedBackendNodeId: 1, focusedName: "Email" } },
+      { text: "a", signals: { ...ZERO, focusedBackendNodeId: 2, focusedName: "Password" } },
+    );
+    expect(result).toMatch(/^\[no a11y text change, but: /);
+    expect(result).toContain("focus moved");
+    expect(result).toContain("Email");
+    expect(result).toContain("Password");
+  });
+
+  it("reports aria-expanded count change", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, expandedCount: 0 } },
+      { text: "a", signals: { ...ZERO, expandedCount: 1 } },
+    );
+    expect(result).toContain("aria-expanded count: 0 → 1");
+  });
+
+  it("reports aria-pressed and aria-checked count changes", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, pressedCount: 0, checkedCount: 1 } },
+      { text: "a", signals: { ...ZERO, pressedCount: 1, checkedCount: 0 } },
+    );
+    expect(result).toContain("aria-pressed count: 0 → 1");
+    expect(result).toContain("aria-checked count: 1 → 0");
+  });
+
+  it("reports dialog opening", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, dialogCount: 0 } },
+      { text: "a", signals: { ...ZERO, dialogCount: 1 } },
+    );
+    expect(result).toContain("dialog opened");
+  });
+
+  it("reports dialog closing", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, dialogCount: 1 } },
+      { text: "a", signals: { ...ZERO, dialogCount: 0 } },
+    );
+    expect(result).toContain("dialog closed");
+  });
+
+  it("reports URL change", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, url: "https://a.test" } },
+      { text: "a", signals: { ...ZERO, url: "https://b.test" } },
+    );
+    expect(result).toContain("navigated to https://b.test");
+  });
+
+  it("does NOT report a URL change when the new URL is empty (failed fetch)", () => {
+    // A real prior URL → "" (Target.getTargetInfo failed) must not emit a
+    // spurious "navigated to " with an empty target.
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, url: "https://a.test" } },
+      { text: "a", signals: { ...ZERO, url: "" } },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("does NOT report a URL change when the prior URL is empty", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, url: "" } },
+      { text: "a", signals: { ...ZERO, url: "https://b.test" } },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("reports interactive-count change", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, interactiveCount: 5 } },
+      { text: "a", signals: { ...ZERO, interactiveCount: 8 } },
+    );
+    expect(result).toContain("interactive elements: 5 → 8");
+  });
+
+  it("joins multiple changes with semicolons", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, dialogCount: 0, expandedCount: 0 } },
+      { text: "a", signals: { ...ZERO, dialogCount: 1, expandedCount: 2 } },
+    );
+    expect(result).toMatch(/dialog opened.*aria-expanded count|aria-expanded count.*dialog opened/);
+    expect(result).toContain(";");
+  });
+
+  it("reports focus lost (focused → none)", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, focusedBackendNodeId: 1, focusedName: "Email" } },
+      { text: "a", signals: { ...ZERO, focusedBackendNodeId: null, focusedName: null } },
+    );
+    expect(result).toContain("focus moved");
+    expect(result).toContain("Email");
+    expect(result).toContain("«none»");
+  });
+
+  it("reports dialog count change between non-zero values", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, dialogCount: 2 } },
+      { text: "a", signals: { ...ZERO, dialogCount: 3 } },
+    );
+    expect(result).toContain("dialog count: 2 → 3");
+    // Should NOT use the "opened"/"closed" phrasing for non-zero transitions.
+    expect(result).not.toContain("dialog opened");
+    expect(result).not.toContain("dialog closed");
+  });
+});
+
+describe("diffSnapshots — text changes (regression)", () => {
+  it("returns line diff when text changed and signals identical", () => {
+    const result = diffSnapshots(
+      { text: "a\nb\nc", signals: ZERO },
+      { text: "a\nb\nc\nd", signals: ZERO },
+    );
+    expect(result).toContain("[+] d");
+  });
+
+  it("text diff takes precedence — does not also append signal info", () => {
+    const result = diffSnapshots(
+      { text: "a", signals: { ...ZERO, dialogCount: 0 } },
+      { text: "a\nb", signals: { ...ZERO, dialogCount: 1 } },
+    );
+    expect(result).toContain("[+] b");
+    expect(result).not.toContain("dialog opened");
+  });
+
+  it("truncates large diffs (regression)", () => {
+    const big = Array.from({ length: 100 }, (_, i) => `line${i}`).join("\n");
+    const result = diffSnapshots(
+      { text: "", signals: ZERO },
+      { text: big, signals: ZERO },
+    );
+    expect(result).toMatch(/major change/);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/keyboard.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/keyboard.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { keyEventParams, modifierMask, dispatchKeyCombo } from "../keyboard";
+import type { BrowserDriver } from "../driver";
+
+describe("keyEventParams", () => {
+  it("maps named keys to CDP params", () => {
+    expect(keyEventParams("Enter")).toEqual({
+      key: "Enter",
+      code: "Enter",
+      windowsVirtualKeyCode: 13,
+    });
+    expect(keyEventParams("escape")).toEqual({
+      key: "Escape",
+      code: "Escape",
+      windowsVirtualKeyCode: 27,
+    });
+  });
+
+  it("passes single chars through as literal keys", () => {
+    expect(keyEventParams("a")).toEqual({ key: "a", code: "KeyA" });
+  });
+
+  it("passes unknown multi-char keysyms through verbatim (no truncation)", () => {
+    // Regression: a multi-char keysym NOT in the keymap must pass through
+    // verbatim, NOT be truncated to its first char (e.g. "Hyper_L" → "H").
+    expect(keyEventParams("Hyper_L")).toEqual({ key: "Hyper_L", code: "" });
+  });
+});
+
+describe("modifierMask", () => {
+  it("ORs modifier bits (ctrl=2, shift=8)", () => {
+    expect(modifierMask(["ctrl"])).toBe(2);
+    expect(modifierMask(["ctrl", "shift"])).toBe(10);
+    expect(modifierMask(undefined)).toBe(0);
+  });
+});
+
+describe("dispatchKeyCombo", () => {
+  it("dispatches keyDown then keyUp with the modifier mask for ctrl+a", async () => {
+    const calls: Array<{ method: string; params: any }> = [];
+    const driver = {
+      sendCommand: vi.fn(async (_tab, method: string, params: any) => {
+        calls.push({ method, params });
+        return {};
+      }),
+    } as unknown as BrowserDriver;
+
+    await dispatchKeyCombo(driver, 1, ["ctrl", "a"]);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({
+      method: "Input.dispatchKeyEvent",
+      params: { type: "keyDown", modifiers: 2, key: "a", code: "KeyA" },
+    });
+    expect(calls[1]).toMatchObject({
+      method: "Input.dispatchKeyEvent",
+      params: { type: "keyUp", modifiers: 2, key: "a" },
+    });
+  });
+
+  it("no-ops when only modifiers are given (no main key)", async () => {
+    const driver = {
+      sendCommand: vi.fn(async () => ({})),
+    } as unknown as BrowserDriver;
+    await dispatchKeyCombo(driver, 1, ["ctrl"]);
+    expect(driver.sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("holds the key for holdMs before releasing when holdMs is given", async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: Array<{ type: unknown }> = [];
+      const driver = {
+        sendCommand: vi.fn(async (_tab, _method: string, params: any) => {
+          calls.push({ type: params.type });
+          return {};
+        }),
+      } as unknown as BrowserDriver;
+
+      const promise = dispatchKeyCombo(driver, 1, ["Enter"], 500);
+      // After keyDown but before the hold elapses, keyUp must NOT have fired.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls.map((c) => c.type)).toEqual(["keyDown"]);
+      // Advance past the hold; keyUp now fires.
+      await vi.advanceTimersByTimeAsync(500);
+      await promise;
+      expect(calls.map((c) => c.type)).toEqual(["keyDown", "keyUp"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/snapshot-signals.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/snapshot-signals.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  derivePageStateSignals,
+  type PageStateSignals,
+} from "../snapshot-capture";
+
+// Minimal AXNode shape used by derivePageStateSignals. We don't import the
+// internal AXNode interface — we mirror only the fields the function reads.
+type FixtureAXNode = {
+  nodeId: string;
+  role?: { value: string };
+  name?: { value: string };
+  properties?: { name: string; value: { value: unknown } }[];
+  backendDOMNodeId?: number;
+};
+
+describe("derivePageStateSignals", () => {
+  it("returns zero/null signals for an empty AX tree", () => {
+    const signals = derivePageStateSignals([], new Map(), "https://example.com");
+    expect(signals).toEqual<PageStateSignals>({
+      focusedBackendNodeId: null,
+      focusedName: null,
+      focusedRole: null,
+      expandedCount: 0,
+      pressedCount: 0,
+      checkedCount: 0,
+      dialogCount: 0,
+      url: "https://example.com",
+      interactiveCount: 0,
+    });
+  });
+});
+
+describe("derivePageStateSignals — focus", () => {
+  it("populates focused fields when a node has focused=true", () => {
+    const node: FixtureAXNode = {
+      nodeId: "1",
+      role: { value: "textbox" },
+      name: { value: "Email" },
+      backendDOMNodeId: 42,
+      properties: [{ name: "focused", value: { value: true } }],
+    };
+    const signals = derivePageStateSignals(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
+      [node as any],
+      new Map(),
+      "https://example.com",
+    );
+    expect(signals.focusedBackendNodeId).toBe(42);
+    expect(signals.focusedName).toBe("Email");
+    expect(signals.focusedRole).toBe("textbox");
+  });
+
+  it("leaves focus null when no node is focused", () => {
+    const node: FixtureAXNode = {
+      nodeId: "1",
+      role: { value: "textbox" },
+      name: { value: "Email" },
+      backendDOMNodeId: 42,
+      properties: [],
+    };
+    const signals = derivePageStateSignals(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
+      [node as any],
+      new Map(),
+      "https://example.com",
+    );
+    expect(signals.focusedBackendNodeId).toBeNull();
+    expect(signals.focusedName).toBeNull();
+    expect(signals.focusedRole).toBeNull();
+  });
+});
+
+describe("derivePageStateSignals — toggle counts", () => {
+  it("counts aria-expanded=true nodes", () => {
+    const nodes: FixtureAXNode[] = [
+      {
+        nodeId: "1",
+        role: { value: "button" },
+        properties: [{ name: "expanded", value: { value: true } }],
+      },
+      {
+        nodeId: "2",
+        role: { value: "button" },
+        properties: [{ name: "expanded", value: { value: false } }],
+      },
+      {
+        nodeId: "3",
+        role: { value: "button" },
+        properties: [{ name: "expanded", value: { value: true } }],
+      },
+    ];
+    const signals = derivePageStateSignals(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
+      nodes as any,
+      new Map(),
+      "https://example.com",
+    );
+    expect(signals.expandedCount).toBe(2);
+  });
+
+  it("counts aria-pressed and aria-checked independently", () => {
+    const nodes: FixtureAXNode[] = [
+      {
+        nodeId: "1",
+        role: { value: "button" },
+        properties: [{ name: "pressed", value: { value: true } }],
+      },
+      {
+        nodeId: "2",
+        role: { value: "checkbox" },
+        properties: [{ name: "checked", value: { value: true } }],
+      },
+    ];
+    const signals = derivePageStateSignals(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
+      nodes as any,
+      new Map(),
+      "https://example.com",
+    );
+    expect(signals.pressedCount).toBe(1);
+    expect(signals.checkedCount).toBe(1);
+    expect(signals.expandedCount).toBe(0);
+  });
+});
+
+describe("derivePageStateSignals — dialog count", () => {
+  it("counts dialog and alertdialog roles", () => {
+    const nodes: FixtureAXNode[] = [
+      { nodeId: "1", role: { value: "dialog" } },
+      { nodeId: "2", role: { value: "alertdialog" } },
+      { nodeId: "3", role: { value: "button" } },
+    ];
+    const signals = derivePageStateSignals(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
+      nodes as any,
+      new Map(),
+      "https://example.com",
+    );
+    expect(signals.dialogCount).toBe(2);
+  });
+});
+
+describe("derivePageStateSignals — interactive count", () => {
+  it("returns refs.size", () => {
+    const refs = new Map([
+      ["@e1", { backendNodeId: 1, role: "button", name: "OK", nth: 0 }],
+      ["@e2", { backendNodeId: 2, role: "link", name: "Home", nth: 0 }],
+    ]);
+    const signals = derivePageStateSignals([], refs, "https://example.com");
+    expect(signals.interactiveCount).toBe(2);
+  });
+});
+
+describe("derivePageStateSignals — url", () => {
+  it("stores the url verbatim", () => {
+    const signals = derivePageStateSignals([], new Map(), "https://x.test/a?b=c");
+    expect(signals.url).toBe("https://x.test/a?b=c");
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/stable-refs.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/stable-refs.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for content-stable `@ref` assignment in snapshot-capture.
+ *
+ * The ref system used to be a per-snapshot ordinal counter (`@e1`, `@e2`, …
+ * reassigned every capture), which meant the SAME logical element got a
+ * different ref on every snapshot of a re-rendering page — the root cause of
+ * "Ref not found. Refs may be stale" failures on sites like LinkedIn.
+ *
+ * Refs are now derived from element identity (role + accessible name +
+ * nearest landmark + occurrence index), hashed to a stable `@e<base36>`
+ * token. Invariants under test:
+ *   - The same logical element keeps the same ref across two captures even
+ *     when surrounding interactive elements are added/removed.
+ *   - Two distinct elements sharing role+name are disambiguated (distinct
+ *     stable refs) by occurrence index.
+ *   - A ref taken from one snapshot still resolves after a later snapshot
+ *     (via the ref-store carry-over), and resolves to the refreshed
+ *     backendNodeId when the element persists.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { captureSnapshot, findNodeByRoleNameNth } from "../snapshot-capture";
+import { getRef, getRefsForTab, invalidateRefs } from "../ref-store";
+import type { BrowserDriver, TabId } from "../driver";
+
+const TAB_ID = 1 as TabId;
+const URL = "https://example.com";
+
+function makeMockDriver(opts: {
+  axTrees: Array<Array<unknown>>;
+  url: string;
+}): BrowserDriver {
+  let axIdx = 0;
+  return {
+    sendCommand: async (
+      _tabId: unknown,
+      method: string,
+      _params?: unknown,
+    ): Promise<unknown> => {
+      if (method === "Accessibility.getFullAXTree") {
+        const nodes =
+          opts.axTrees[Math.min(axIdx, opts.axTrees.length - 1)] ?? [];
+        axIdx++;
+        return { nodes };
+      }
+      if (method === "Target.getTargetInfo") {
+        return { targetInfo: { url: opts.url } };
+      }
+      return {};
+    },
+    getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
+    waitForLoad: async () => undefined,
+    sendToContentScript: async () => ({ success: true }),
+  } as unknown as BrowserDriver;
+}
+
+function root(childIds: string[]) {
+  return {
+    nodeId: "root",
+    role: { value: "RootWebArea" },
+    name: { value: "" },
+    childIds,
+  };
+}
+
+function btn(nodeId: string, name: string, backendId: number) {
+  return {
+    nodeId,
+    role: { value: "button" },
+    name: { value: name },
+    backendDOMNodeId: backendId,
+    parentId: "root",
+  };
+}
+
+beforeEach(() => invalidateRefs(TAB_ID));
+
+describe("content-stable refs", () => {
+  it("keeps the same ref for the same element across re-renders", async () => {
+    // Capture 1: [Like, Comment]. Capture 2: a NEW button is inserted before
+    // them ([Follow, Like, Comment]) — under the old ordinal scheme this would
+    // shift Like from @e1→@e2. With stable ids, Like keeps its ref.
+    const before = [
+      root(["like", "comment"]),
+      btn("like", "Like", 10),
+      btn("comment", "Comment", 11),
+    ];
+    const after = [
+      root(["follow", "like", "comment"]),
+      btn("follow", "Follow", 9),
+      btn("like", "Like", 10),
+      btn("comment", "Comment", 11),
+    ];
+    const driver = makeMockDriver({ axTrees: [before, after], url: URL });
+
+    const r1 = await captureSnapshot(driver, TAB_ID);
+    const likeRef1 = refForName(r1.refs, "Like");
+    const commentRef1 = refForName(r1.refs, "Comment");
+
+    const r2 = await captureSnapshot(driver, TAB_ID);
+    const likeRef2 = refForName(r2.refs, "Like");
+    const commentRef2 = refForName(r2.refs, "Comment");
+
+    expect(likeRef2).toBe(likeRef1);
+    expect(commentRef2).toBe(commentRef1);
+    // The newly inserted Follow button has its own distinct ref.
+    expect(refForName(r2.refs, "Follow")).not.toBe(likeRef1);
+  });
+
+  it("disambiguates distinct elements that share role + name", async () => {
+    const tree = [
+      root(["c1", "c2", "c3"]),
+      btn("c1", "Connect", 21),
+      btn("c2", "Connect", 22),
+      btn("c3", "Connect", 23),
+    ];
+    const driver = makeMockDriver({ axTrees: [tree], url: URL });
+    const r = await captureSnapshot(driver, TAB_ID);
+
+    const refs = [...r.refs.keys()];
+    // Three Connect buttons → three distinct stable refs.
+    expect(new Set(refs).size).toBe(3);
+    // And every ref maps to a distinct backendNodeId.
+    const backends = new Set([...r.refs.values()].map((e) => e.backendNodeId));
+    expect(backends.size).toBe(3);
+  });
+
+  it("resolves a ref via carry-over after a later snapshot drops it", async () => {
+    // Capture 1 has the Like button; capture 2 (e.g. viewport-scoped) no
+    // longer includes it. The ref from capture 1 must still resolve thanks to
+    // the bounded carry-over pool.
+    const withLike = [root(["like"]), btn("like", "Like", 10)];
+    const withoutLike = [root(["other"]), btn("other", "Other", 50)];
+    const driver = makeMockDriver({
+      axTrees: [withLike, withoutLike],
+      url: URL,
+    });
+
+    const r1 = await captureSnapshot(driver, TAB_ID);
+    const likeRef = refForName(r1.refs, "Like");
+
+    await captureSnapshot(driver, TAB_ID); // latest no longer has Like
+
+    // Not in the latest map…
+    expect(getRefsForTab(TAB_ID)?.has(likeRef)).toBe(false);
+    // …but still resolvable via carry-over.
+    expect(getRef(TAB_ID, likeRef)?.backendNodeId).toBe(10);
+  });
+});
+
+function refForName(
+  refs: Map<string, { backendNodeId: number; name: string }>,
+  name: string,
+): string {
+  for (const [ref, entry] of refs) {
+    if (entry.name === name) return ref;
+  }
+  throw new Error(`no ref for element named "${name}"`);
+}
+
+describe("identity tuple (role, name, nth) on ref entries", () => {
+  it("stores nth = frame-scoped occurrence index per (role, name)", async () => {
+    const tree = [
+      root(["c1", "c2", "c3"]),
+      btn("c1", "Connect", 21),
+      btn("c2", "Connect", 22),
+      btn("c3", "Connect", 23),
+    ];
+    const driver = makeMockDriver({ axTrees: [tree], url: URL });
+    const r = await captureSnapshot(driver, TAB_ID);
+
+    // Three Connect buttons → nth 0, 1, 2 in document order.
+    const byBackend = new Map(
+      [...r.refs.values()].map((e) => [e.backendNodeId, e.nth]),
+    );
+    expect(byBackend.get(21)).toBe(0);
+    expect(byBackend.get(22)).toBe(1);
+    expect(byBackend.get(23)).toBe(2);
+  });
+});
+
+describe("findNodeByRoleNameNth", () => {
+  it("returns the backendNodeId of the nth (role, name) match", async () => {
+    const tree = [
+      root(["c1", "c2", "c3"]),
+      btn("c1", "Connect", 21),
+      btn("c2", "Connect", 22),
+      btn("c3", "Connect", 23),
+    ];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL });
+    await captureSnapshot(driver, TAB_ID);
+
+    expect(await findNodeByRoleNameNth(driver, TAB_ID, "button", "Connect", 0)).toBe(21);
+    expect(await findNodeByRoleNameNth(driver, TAB_ID, "button", "Connect", 1)).toBe(22);
+    expect(await findNodeByRoleNameNth(driver, TAB_ID, "button", "Connect", 2)).toBe(23);
+    // Out of range → null.
+    expect(await findNodeByRoleNameNth(driver, TAB_ID, "button", "Connect", 5)).toBeNull();
+    // No such element → null.
+    expect(await findNodeByRoleNameNth(driver, TAB_ID, "button", "Ghost", 0)).toBeNull();
+  });
+
+  it("skips ignored nodes when counting matches", async () => {
+    const tree = [
+      root(["c1", "c2"]),
+      { ...btn("c1", "Connect", 21), ignored: true },
+      btn("c2", "Connect", 22),
+    ];
+    const driver = makeMockDriver({ axTrees: [tree], url: URL });
+    // nth 0 should skip the ignored node and return the visible one.
+    expect(await findNodeByRoleNameNth(driver, TAB_ID, "button", "Connect", 0)).toBe(22);
+  });
+});
+
+describe("frameId on ref entries", () => {
+  it("captures frameId when present on an AX node and omits it otherwise", async () => {
+    const tree = [
+      root(["top", "framed"]),
+      btn("top", "Top", 30),
+      { ...btn("framed", "InFrame", 31), frameId: "FRAME-7" },
+    ];
+    const driver = makeMockDriver({ axTrees: [tree], url: URL });
+    const r = await captureSnapshot(driver, TAB_ID);
+
+    const top = [...r.refs.values()].find((e) => e.backendNodeId === 30)!;
+    const framed = [...r.refs.values()].find((e) => e.backendNodeId === 31)!;
+    expect(top.frameId).toBeUndefined();
+    expect(framed.frameId).toBe("FRAME-7");
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/thinking.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/thinking.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { ThinkingConfig } from "../../types";
+import {
+  buildThinkingProviderOptions,
+  isGemini3Model,
+  isGeminiFlashModel,
+  resolveThinkingVendor,
+} from "../thinking";
+
+const BUDGET: ThinkingConfig = { type: "budget", tokens: 12_000 };
+const EFFORT_HIGH: ThinkingConfig = { type: "effort", level: "high" };
+
+describe("resolveThinkingVendor", () => {
+  it("maps direct providers to themselves", () => {
+    expect(resolveThinkingVendor("anthropic", "claude-sonnet-4-6")).toBe(
+      "anthropic",
+    );
+    expect(resolveThinkingVendor("google", "gemini-2.5-flash")).toBe("google");
+    expect(resolveThinkingVendor("openai", "gpt-5.5")).toBe("openai");
+  });
+
+  it("derives vendor from the gateway model-id prefix", () => {
+    expect(
+      resolveThinkingVendor("vercel", "google/gemini-3.1-pro-preview"),
+    ).toBe("google");
+    expect(
+      resolveThinkingVendor("vercel", "anthropic/claude-opus-4.7"),
+    ).toBe("anthropic");
+    expect(resolveThinkingVendor("vercel", "openai/gpt-5.5")).toBe("openai");
+  });
+
+  it("returns null for unknown providers / gateway vendors", () => {
+    expect(resolveThinkingVendor("ollama", "llama-3")).toBeNull();
+    expect(resolveThinkingVendor("vercel", "mistral/mistral-large")).toBeNull();
+    expect(resolveThinkingVendor("vercel", "gemini-2.5-flash")).toBeNull();
+  });
+});
+
+describe("isGemini3Model", () => {
+  it("matches direct and gateway Gemini 3 ids", () => {
+    expect(isGemini3Model("gemini-3.1-pro-preview")).toBe(true);
+    expect(isGemini3Model("gemini-3.5-flash")).toBe(true);
+    expect(isGemini3Model("google/gemini-3.1-pro-preview")).toBe(true);
+  });
+
+  it("does not match Gemini 2.5", () => {
+    expect(isGemini3Model("gemini-2.5-flash")).toBe(false);
+    expect(isGemini3Model("google/gemini-2.5-pro")).toBe(false);
+  });
+});
+
+describe("isGeminiFlashModel", () => {
+  it("detects flash variants across forms", () => {
+    expect(isGeminiFlashModel("gemini-3.5-flash")).toBe(true);
+    expect(isGeminiFlashModel("google/gemini-2.5-flash")).toBe(true);
+    expect(isGeminiFlashModel("gemini-3.1-pro-preview")).toBe(false);
+  });
+});
+
+describe("buildThinkingProviderOptions — Gemini", () => {
+  it("Gemini 3 (direct) uses thinkingLevel + includeThoughts", () => {
+    expect(
+      buildThinkingProviderOptions(
+        "google",
+        "gemini-3.1-pro-preview",
+        EFFORT_HIGH,
+      ),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingLevel: "high", includeThoughts: true },
+      },
+    });
+  });
+
+  it("Gemini 3 (gateway) uses thinkingLevel + includeThoughts", () => {
+    expect(
+      buildThinkingProviderOptions(
+        "vercel",
+        "google/gemini-3.1-pro-preview",
+        EFFORT_HIGH,
+      ),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingLevel: "high", includeThoughts: true },
+      },
+    });
+  });
+
+  it("Gemini 3 falls back to medium level for legacy budget configs", () => {
+    expect(
+      buildThinkingProviderOptions(
+        "google",
+        "gemini-3.5-flash",
+        BUDGET,
+      ),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingLevel: "medium", includeThoughts: true },
+      },
+    });
+  });
+
+  it("Gemini 2.5 (direct) uses thinkingBudget + includeThoughts", () => {
+    expect(
+      buildThinkingProviderOptions("google", "gemini-2.5-flash", BUDGET),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingBudget: 12_000, includeThoughts: true },
+      },
+    });
+  });
+
+  it("Gemini 2.5 (gateway) uses thinkingBudget + includeThoughts", () => {
+    expect(
+      buildThinkingProviderOptions("vercel", "google/gemini-2.5-pro", BUDGET),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingBudget: 12_000, includeThoughts: true },
+      },
+    });
+  });
+});
+
+describe("buildThinkingProviderOptions — Anthropic", () => {
+  it("budget config maps to adaptive/summarized thinking (direct)", () => {
+    expect(
+      buildThinkingProviderOptions("anthropic", "claude-opus-4-7", BUDGET),
+    ).toEqual({
+      anthropic: { thinking: { type: "adaptive", display: "summarized" } },
+    });
+  });
+
+  it("effort config adds effort level (gateway)", () => {
+    expect(
+      buildThinkingProviderOptions(
+        "vercel",
+        "anthropic/claude-opus-4.7",
+        EFFORT_HIGH,
+      ),
+    ).toEqual({
+      anthropic: {
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "high",
+      },
+    });
+  });
+});
+
+describe("buildThinkingProviderOptions — OpenAI", () => {
+  it("effort config maps to nested reasoning.effort (direct)", () => {
+    expect(
+      buildThinkingProviderOptions("openai", "gpt-5.5", EFFORT_HIGH),
+    ).toEqual({
+      openai: { reasoning: { effort: "high" } },
+    });
+  });
+
+  it("effort config maps to nested reasoning.effort (gateway)", () => {
+    expect(
+      buildThinkingProviderOptions("vercel", "openai/gpt-5.5", EFFORT_HIGH),
+    ).toEqual({
+      openai: { reasoning: { effort: "high" } },
+    });
+  });
+
+  it("returns undefined for a budget config (OpenAI has no budget knob)", () => {
+    expect(
+      buildThinkingProviderOptions("openai", "gpt-5.5", BUDGET),
+    ).toBeUndefined();
+  });
+});
+
+describe("buildThinkingProviderOptions — unknown", () => {
+  it("returns undefined when the vendor can't be resolved", () => {
+    expect(
+      buildThinkingProviderOptions("ollama", "llama-3", BUDGET),
+    ).toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/agent-indicator.ts
+++ b/apps/extension/src/lib/agent/agent-indicator.ts
@@ -1,0 +1,121 @@
+/**
+ * Single source of truth for the "OpenBrowse is working on this tab" overlay
+ * (animated glow border + input-blocking shield + pill).
+ *
+ * Both the main agent (via agent-transport's tool wrapper) and the CUA
+ * subagent (cua-loop) drive the overlay through `notifyAgentStatus`, so the
+ * overlay's tab resolution, move/clear bookkeeping, color tint, and robust
+ * (self-injecting) delivery live in exactly one place. This module is kept
+ * dependency-light (only `./active-tab`) so callers on either side of the
+ * agent-transport ↔ cua import boundary can use it without creating a cycle.
+ */
+import { getTargetTabId, sendToContentScript } from "./active-tab";
+
+/** The space color used to tint the overlay glow. Set by the chat hook via
+ *  agent-transport's `setAgentSpaceColor`; read here as the default tint. */
+let currentSpaceColor: string | null = null;
+
+export function setAgentSpaceColor(color: string | null) {
+  currentSpaceColor = color;
+}
+
+export function getAgentSpaceColor(): string | null {
+  return currentSpaceColor;
+}
+
+let indicatorQueue: Promise<void> = Promise.resolve();
+/**
+ * The tab the blocking indicator was last injected onto, so an idle
+ * notification (which may not carry a tabId) can remove it from the
+ * correct tab rather than the user's currently-focused one.
+ */
+let lastIndicatorTabId: number | null = null;
+
+/**
+ * Show or hide the blocking "working" overlay on the agent's work tab.
+ *
+ * Tab resolution mirrors the executor's own truth: callers pass the tabId the
+ * tool actually operates on when they have it; otherwise we fall back to the
+ * tracked target tab (`getTargetTabId`) — the same source `getActiveUserTab`
+ * pins. The overlay must land on the worked tab, NOT whatever tab the user is
+ * currently focused on (which may be a different, non-worked tab in the same
+ * window when the agent works inside its owned tab group).
+ *
+ * Delivery uses `sendToContentScript`, which injects the content script and
+ * retries if it isn't already present (e.g. a tab the agent opened in the
+ * background, or after an extension reload).
+ *
+ * @param working  true to show, false to hide.
+ * @param color    glow tint; defaults to the active space color.
+ * @param tabId    the worked tab; when omitted/null, falls back to the tracked
+ *                 target tab.
+ */
+export function notifyAgentStatus(
+  working: boolean,
+  color?: string | null,
+  tabId?: number | null,
+) {
+  const tint = color === undefined ? currentSpaceColor : color;
+  indicatorQueue = indicatorQueue.then(async () => {
+    try {
+      // When working, target the tool's tab if known, else the tracked
+      // target. When idle, remove from whatever tab we last injected onto.
+      const targetTabId = working
+        ? (tabId ?? getTargetTabId() ?? lastIndicatorTabId)
+        : (tabId ?? lastIndicatorTabId);
+      if (targetTabId == null) {
+        if (!working) lastIndicatorTabId = null;
+        return;
+      }
+      let url = "";
+      try {
+        const tab = await chrome.tabs.get(targetTabId);
+        url = tab.url ?? "";
+      } catch {
+        // Tab gone; nothing to inject/remove.
+        if (!working) lastIndicatorTabId = null;
+        return;
+      }
+      // Skip injection on internal pages (extension/chrome/devtools UI).
+      if (
+        url.startsWith("chrome://") ||
+        url.startsWith("chrome-extension://") ||
+        url.startsWith("devtools://")
+      ) {
+        return;
+      }
+      if (working) {
+        // If the agent moved to a different tab within the same run,
+        // clear the blocker from the previously-targeted tab so it
+        // doesn't linger as a stale overlay.
+        if (lastIndicatorTabId != null && lastIndicatorTabId !== targetTabId) {
+          await sendToContentScript(lastIndicatorTabId, {
+            type: "CHAT_CUA_WORKING_STATE",
+            active: false,
+          }).catch(() => {});
+        }
+        lastIndicatorTabId = targetTabId;
+        await sendToContentScript(targetTabId, {
+          type: "CHAT_CUA_WORKING_STATE",
+          active: true,
+          color: tint,
+        }).catch(() => {});
+      } else {
+        lastIndicatorTabId = null;
+        await sendToContentScript(targetTabId, {
+          type: "CHAT_CUA_WORKING_STATE",
+          active: false,
+        }).catch(() => {});
+      }
+      chrome.runtime
+        .sendMessage({
+          type: working ? "AGENT_TAB_WORKING" : "AGENT_TAB_IDLE",
+          tabId: targetTabId,
+          color: tint,
+        })
+        .catch(() => {});
+    } catch {
+      // no resolvable tab
+    }
+  });
+}

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -21,11 +21,13 @@ import { scanToolUsage, mergeDistinct } from "./tool-usage";
 import { nextUsageSnapshot, type StepUsage } from "./usage-snapshot";
 import { ExtensionDriver } from "./driver/extension-driver";
 import type { ToolContext } from "./driver";
+import { resolveCuaProvider, isAnthropicComputerUseModel } from "./cua";
 import type {
   AgentLoopConfig,
   AgentLoopResult,
 } from "./subagents/runner";
 import {
+  AssistantStreamPersister,
   persistAssistantStream,
   persistDelegationMessage,
 } from "./subagents/persist-stream";
@@ -54,6 +56,7 @@ import {
   listScheduledTasksTool,
   listTabsTool,
   navigateTool,
+  pressKeyTool,
   readPageTool,
   recallMemoryTool,
   saveMemoryTool,
@@ -73,7 +76,7 @@ import { createPythonTool } from "./tools/execute-python";
 import { setTaskTitleTool } from "./tools/set-task-title";
 import type { BrowserTool } from "./types";
 
-import { SYSTEM_PROMPT } from "./system-prompt";
+import { SYSTEM_PROMPT, CUA_DELEGATION_PROMPT } from "./system-prompt";
 
 const MEMORY_INSTRUCTIONS = `
 
@@ -128,211 +131,13 @@ Rule of thumb: if it only matters when working in this particular space, scope i
 `;
 
 import { getTargetTabId } from "./active-tab";
+import {
+  notifyAgentStatus,
+  setAgentSpaceColor,
+  getAgentSpaceColor,
+} from "./agent-indicator";
 
-const INDICATOR_CSS = `
-  #openbrowse-agent-border {
-    position: fixed; top: 0; left: 0; right: 0; bottom: 0; z-index: 2147483646;
-    margin: 0 !important; padding: 0 !important; transform: none !important;
-    pointer-events: none;
-    overflow: hidden;
-  }
-  .ob-glow {
-    position: absolute;
-    inset: -40px;
-    filter: blur(40px);
-    animation: ob-breathe 4s ease-in-out infinite;
-    -webkit-mask:
-      linear-gradient(to right, #fff 0px, transparent 100px, transparent calc(100% - 100px), #fff 100%),
-      linear-gradient(to bottom, #fff 0px, transparent 100px, transparent calc(100% - 100px), #fff 100%);
-    mask:
-      linear-gradient(to right, #fff 0px, transparent 100px, transparent calc(100% - 100px), #fff 100%),
-      linear-gradient(to bottom, #fff 0px, transparent 100px, transparent calc(100% - 100px), #fff 100%);
-  }
-  .ob-glow::before,
-  .ob-glow::after {
-    content: "";
-    position: absolute;
-    border-radius: 50%;
-    background: radial-gradient(circle, var(--ob-c1, #3b82f6) 0%, transparent 70%);
-  }
-  .ob-glow::before {
-    width: 50%; height: 60%;
-    animation: ob-orbit1 8s ease-in-out infinite;
-  }
-  .ob-glow::after {
-    width: 40%; height: 50%;
-    opacity: 0.6;
-    animation: ob-orbit2 8s ease-in-out infinite;
-  }
-  @keyframes ob-orbit1 {
-    0% { top: -20%; left: 20%; }
-    25% { top: 20%; left: 80%; }
-    50% { top: 70%; left: 50%; }
-    75% { top: 20%; left: -10%; }
-    100% { top: -20%; left: 20%; }
-  }
-  @keyframes ob-orbit2 {
-    0% { top: 60%; left: 70%; }
-    25% { top: -10%; left: 40%; }
-    50% { top: 10%; left: -5%; }
-    75% { top: 70%; left: 30%; }
-    100% { top: 60%; left: 70%; }
-  }
-  @keyframes ob-breathe {
-    0%, 100% { opacity: 0.6; }
-    50% { opacity: 1; }
-  }
-  #openbrowse-agent-blocker {
-    position: fixed; inset: 0; z-index: 2147483645; cursor: not-allowed;
-  }
-  #openbrowse-agent-toast {
-    position: fixed; bottom: 32px; left: 50%; transform: translateX(-50%);
-    z-index: 2147483647; display: flex; align-items: center; gap: 10px;
-    padding: 10px 16px; border-radius: 8px;
-    font: 13px/1.4 ui-sans-serif, system-ui, -apple-system, sans-serif;
-    color: #fafafa; background: #18181b;
-    border: 1px solid rgba(255,255,255,0.08);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    animation: ob-toast-in 0.2s ease-out;
-  }
-  @media (prefers-color-scheme: light) {
-    #openbrowse-agent-toast { color: #18181b; background: #fff; border: 1px solid #e4e4e7; }
-    #openbrowse-agent-toast button { background: #18181b !important; color: #fafafa !important; }
-  }
-  @keyframes ob-toast-in { from{opacity:0;transform:translateX(-50%) translateY(8px)} to{opacity:1;transform:translateX(-50%) translateY(0)} }
-  #openbrowse-agent-toast button {
-    background: #fafafa; color: #18181b; border: none;
-    padding: 4px 10px; border-radius: 4px;
-    font-size: 12px; font-weight: 500; cursor: pointer; font-family: inherit;
-  }
-`;
-
-function showIndicatorScript(color: string | null) {
-  if (document.getElementById("openbrowse-agent-border")) return;
-  const border = document.createElement("div");
-  border.id = "openbrowse-agent-border";
-  if (color) {
-    border.style.setProperty("--ob-c1", color);
-  }
-  const glow = document.createElement("div");
-  glow.className = "ob-glow";
-  border.appendChild(glow);
-  const blocker = document.createElement("div");
-  blocker.id = "openbrowse-agent-blocker";
-  const toast = document.createElement("div");
-  toast.id = "openbrowse-agent-toast";
-  const logoUrl = chrome.runtime.getURL("icon/logo.svg");
-  toast.innerHTML = `<img src="${logoUrl}" style="width:18px;height:18px;border-radius:4px;"><span>OpenBrowse is working on this tab</span><button id="openbrowse-agent-stop">Stop</button>`;
-  document.documentElement.appendChild(border);
-  document.documentElement.appendChild(blocker);
-  document.documentElement.appendChild(toast);
-  document.getElementById("openbrowse-agent-stop")!.onclick = () => {
-    chrome.runtime.sendMessage({ type: "AGENT_STOP" });
-    document.getElementById("openbrowse-agent-border")?.remove();
-    document.getElementById("openbrowse-agent-blocker")?.remove();
-    document.getElementById("openbrowse-agent-toast")?.remove();
-  };
-}
-
-function hideIndicatorScript() {
-  document.getElementById("openbrowse-agent-border")?.remove();
-  document.getElementById("openbrowse-agent-blocker")?.remove();
-  document.getElementById("openbrowse-agent-toast")?.remove();
-}
-
-export async function injectIndicator(tabId: number, color?: string | null) {
-  try {
-    await chrome.scripting.insertCSS({
-      target: { tabId },
-      css: INDICATOR_CSS,
-    });
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      func: showIndicatorScript,
-      args: [color ?? null],
-    });
-  } catch {
-    // page not injectable (chrome://, etc.)
-  }
-}
-
-async function removeIndicator(tabId: number) {
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      func: hideIndicatorScript,
-    });
-  } catch {
-    // page not injectable
-  }
-}
-
-export function notifyAgentStatus(
-  working: boolean,
-  color?: string | null,
-  tabId?: number | null,
-) {
-  indicatorQueue = indicatorQueue.then(async () => {
-    try {
-      // The blocking indicator must land on the tab the agent's tool is
-      // actually operating on — NOT whatever tab the user happens to be
-      // focused on. When the agent works inside its owned tab group, the
-      // user may be looking at a different (non-worked) tab in the same
-      // window; targeting the active tab would inject the blocker onto
-      // that innocent tab. So:
-      //  - When working, require an explicit target tabId from the tool
-      //    call. If none was resolved, skip injection entirely.
-      //  - When idle, remove from the last tab we injected onto.
-      const targetTabId = working
-        ? (tabId ?? null)
-        : (tabId ?? lastIndicatorTabId);
-      if (targetTabId == null) {
-        if (!working) lastIndicatorTabId = null;
-        return;
-      }
-      let url = "";
-      try {
-        const tab = await chrome.tabs.get(targetTabId);
-        url = tab.url ?? "";
-      } catch {
-        // Tab gone; nothing to inject/remove.
-        if (!working) lastIndicatorTabId = null;
-        return;
-      }
-      // Skip injection on internal pages (extension/chrome/devtools UI).
-      if (
-        url.startsWith("chrome://") ||
-        url.startsWith("chrome-extension://") ||
-        url.startsWith("devtools://")
-      ) {
-        return;
-      }
-      if (working) {
-        // If the agent moved to a different tab within the same run,
-        // clear the blocker from the previously-targeted tab so it
-        // doesn't linger as a stale overlay. removeIndicator swallows
-        // its own errors (e.g. tab gone / not injectable).
-        if (lastIndicatorTabId != null && lastIndicatorTabId !== targetTabId) {
-          await removeIndicator(lastIndicatorTabId);
-        }
-        lastIndicatorTabId = targetTabId;
-        await injectIndicator(targetTabId, color);
-      } else {
-        lastIndicatorTabId = null;
-        await removeIndicator(targetTabId);
-      }
-      chrome.runtime
-        .sendMessage({
-          type: working ? "AGENT_TAB_WORKING" : "AGENT_TAB_IDLE",
-          tabId: targetTabId,
-          color,
-        })
-        .catch(() => {});
-    } catch {
-      // no resolvable tab
-    }
-  });
-}
+export { notifyAgentStatus, setAgentSpaceColor };
 
 const TAB_INTERACTING_TOOLS = new Set([
   "readPage",
@@ -348,14 +153,6 @@ const TAB_INTERACTING_TOOLS = new Set([
 ]);
 
 let agentActive = false;
-let currentSpaceColor: string | null = null;
-let indicatorQueue: Promise<void> = Promise.resolve();
-/**
- * The tab the blocking indicator was last injected onto, so an idle
- * notification (which may not carry a tabId) can remove it from the
- * correct tab rather than the user's currently-focused one.
- */
-let lastIndicatorTabId: number | null = null;
 
 let agentConversationId: string | null = null;
 
@@ -458,9 +255,6 @@ export function getAgentContext(): {
   };
 }
 
-export function setAgentSpaceColor(color: string | null) {
-  currentSpaceColor = color;
-}
 
 const IMAGE_TOOLS = new Set(["screenshot"]);
 
@@ -599,6 +393,7 @@ export function createBrowserToolSet(
     navigate: toSDKTool(navigateTool, "navigate"),
     clickElement: toSDKTool(clickElementTool, "clickElement"),
     typeInElement: toSDKTool(typeInElementTool, "typeInElement"),
+    pressKey: toSDKTool(pressKeyTool, "pressKey"),
     scrollPage: toSDKTool(scrollPageTool, "scrollPage"),
     selectTab: toSDKTool(selectTabTool, "selectTab"),
     closeTabs: toSDKTool(closeTabsTool, "closeTabs"),
@@ -925,7 +720,7 @@ export function toSDKTool<TInput, TOutput>(
           favIconUrl: resolved.tab.favIconUrl,
         });
       }
-      notifyAgentStatus(true, currentSpaceColor, resolved?.tabId ?? null);
+      notifyAgentStatus(true, getAgentSpaceColor(), resolved?.tabId ?? null);
     }
     try {
       // Threaded ToolContext from the SDK's experimental_context channel.
@@ -944,26 +739,46 @@ export function toSDKTool<TInput, TOutput>(
       // into every child tool's own execute via the same wrapper.
       // baseCtx.signal (if any) is overridden — the SDK's per-call
       // signal is always the most accurate source of truth.
+      //
+      // We wrap it in a fresh AbortController tracked globally so
+      // `resetAgentIndicator` can forcefully abort tools when the
+      // parent connection drops or the turn is interrupted.
+      const ac = new AbortController();
+      activeToolAbortControllers.add(ac);
+      const onAbort = () => ac.abort();
+      if (options.abortSignal) {
+        if (options.abortSignal.aborted) onAbort();
+        else options.abortSignal.addEventListener("abort", onAbort);
+      }
+      
       const ctx: ToolContext = {
         ...baseCtx,
         toolCallId: options.toolCallId,
-        ...(options.abortSignal && { signal: options.abortSignal }),
+        signal: ac.signal,
       };
-      const result = await t.execute(effectiveInput, ctx);
-      toolResultStore.set(options.toolCallId, result);
-      if (isTabTool) {
-        // Refresh the tab info post-execute so the UI shows the landed
-        // URL/title (navigate / clickElement may have changed it).
-        const resolved = await resolveTabFromInput(cid, input);
-        if (resolved) {
-          toolTabInfoStore.set(options.toolCallId, {
-            tabId: resolved.tabId,
-            title: resolved.tab.title ?? "",
-            favIconUrl: resolved.tab.favIconUrl,
-          });
+      
+      try {
+        const result = await t.execute(effectiveInput, ctx);
+        toolResultStore.set(options.toolCallId, result);
+        if (isTabTool) {
+          // Refresh the tab info post-execute so the UI shows the landed
+          // URL/title (navigate / clickElement may have changed it).
+          const resolved = await resolveTabFromInput(cid, input);
+          if (resolved) {
+            toolTabInfoStore.set(options.toolCallId, {
+              tabId: resolved.tabId,
+              title: resolved.tab.title ?? "",
+              favIconUrl: resolved.tab.favIconUrl,
+            });
+          }
         }
+        return result;
+      } finally {
+        if (options.abortSignal) {
+          options.abortSignal.removeEventListener("abort", onAbort);
+        }
+        activeToolAbortControllers.delete(ac);
       }
-      return result;
     } catch (err) {
       const errResult = {
         error: err instanceof Error ? err.message : String(err),
@@ -1066,11 +881,17 @@ export function toSDKTool<TInput, TOutput>(
   } as ToolSet[string];
 }
 
+export const activeToolAbortControllers = new Set<AbortController>();
+
 export function resetAgentIndicator() {
   if (agentActive) {
     agentActive = false;
     notifyAgentStatus(false);
   }
+  for (const ac of activeToolAbortControllers) {
+    ac.abort();
+  }
+  activeToolAbortControllers.clear();
 }
 
 
@@ -1206,6 +1027,63 @@ async function recordUsageForStep(
   }
 }
 
+/**
+ * For a CUA subagent under `attached` isolation, the runner seeded the
+ * parent's tab handle into the child session as `cuaTabHandle`. Recover it
+ * so the CUA loop can resolve the live tab id.
+ */
+function firstSeededHandle(ctx: ToolContext): string | undefined {
+  return ctx.session?.cuaTabHandle;
+}
+
+/**
+ * Resolve the Computer Use (CUA) subagent's model against the registry and
+ * report whether its provider is configured.
+ *
+ * Resolution priority (NO hardcoded fallback — a missing model means CUA is
+ * simply not enabled):
+ *   1. The user's explicit `cuaModel` setting (compound "providerId:modelId").
+ *   2. The main agent's model IF it is itself a Claude computer-use model —
+ *      it is already configured (the conversation is running), so this "just
+ *      works" on direct Anthropic OR the AI Gateway.
+ *
+ * Returns the resolved registry provider + bare model id + the provider's
+ * config, plus `configured` (all required config fields present). When no
+ * model resolves, returns `{ configured: false }` with no model — the caller
+ * treats this as "CUA disabled".
+ */
+function resolveCuaSelection(
+  settings: Settings,
+  providers: import("@/registry/providers/types").ProviderDefinition[],
+  cuaModelSetting: string | undefined,
+  agentModel: string,
+):
+  | {
+      configured: boolean;
+      modelId: string;
+      provider: import("@/registry/providers/types").ProviderDefinition;
+      actualModelId: string;
+      config: Record<string, string>;
+    }
+  | { configured: false; modelId?: undefined } {
+  const mainModelIsCua = !!agentModel && isAnthropicComputerUseModel(agentModel);
+  const modelId = cuaModelSetting || (mainModelIsCua ? agentModel : undefined);
+  if (!modelId) return { configured: false };
+
+  const [providerId, ...idParts] = modelId.split(":");
+  const actualModelId = idParts.length > 0 ? idParts.join(":") : modelId;
+  const provider =
+    (idParts.length > 0
+      ? providers.find((p) => p.id === providerId)
+      : undefined) ??
+    providers.find((p) => p.models.some((m) => m.id === actualModelId));
+  if (!provider) return { configured: false };
+
+  const config = settings.providerConfigs[provider.id] ?? {};
+  const required = provider.configSchema?.filter((f) => f.required) ?? [];
+  const configured = required.every((f) => !!config[f.key]);
+  return { configured, modelId, provider, actualModelId, config };
+}
 
 export async function createAgentTransport(
   settings: Settings,
@@ -1344,6 +1222,26 @@ export async function createAgentTransport(
   const mcpToolsList = getMcpRegistry().getAllTools();
   const mcpStates = getMcpRegistry().getStates();
   let instructions = SYSTEM_PROMPT;
+
+  // Resolve once whether the Computer Use (cua) subagent is enabled — i.e. a
+  // computer-use model is configured (explicit setting, or the main model is
+  // itself a configured Claude CUA model). This gates three things in lockstep:
+  // the CUA delegation guidance below, the `cua` entry in the delegate tool's
+  // description, and the delegate execute-time check.
+  const agentSettings = await storage.getAgentSettings();
+  const cuaSelection = resolveCuaSelection(
+    settings,
+    providers,
+    agentSettings.cuaModel,
+    agentModel,
+  );
+  const cuaEnabled = cuaSelection.configured;
+
+  // Only inject the CUA delegation guidance when CUA is actually usable —
+  // otherwise the model sees instructions for a subagent it can't delegate to.
+  if (cuaEnabled) {
+    instructions += `\n\n${CUA_DELEGATION_PROMPT}`;
+  }
 
   if (spaceId && spaceName) {
     instructions += `\n\nYou are chatting from the space "${spaceName}" (id: ${spaceId}). When saving space-scoped memories, use this spaceId.`;
@@ -1563,6 +1461,128 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
   const runSubagentAgentLoop = async (
     cfg: AgentLoopConfig,
   ): Promise<AgentLoopResult> => {
+    // CUA path: a custom-tool subagent runs a provider-native computer-use
+    // loop instead of the standard filtered ToolLoopAgent.
+    if (
+      cfg.agentDef.toolSource === "custom" &&
+      cfg.agentDef.custom?.kind === "cua"
+    ) {
+      // The attached isolation seeded the parent tab handle into this
+      // session's handle map. Resolve it to the real tab id.
+      const handle = firstSeededHandle(cfg.toolContext);
+      const tabId = handle
+        ? cfg.toolContext.session?.resolveHandle?.(handle)
+        : undefined;
+      if (tabId == null) {
+        // Strict: never silently guess a tab. Return an actionable
+        // instruction to the PARENT agent (this finalText flows back as the
+        // delegate tool result) so it self-corrects on the next turn.
+        const finalText = handle
+          ? `Could not start the Computer Use agent: the tab handle "${handle}" is not bound to this conversation. Re-call delegate({ slug: "cua", context: { parentTabHandle: "<handle>" } }) with a handle from the current tab legend (call listTabs to refresh it).`
+          : `Could not start the Computer Use agent: no tab was specified. Re-call delegate({ slug: "cua", context: { parentTabHandle: "<handle>" } }) with the handle (e.g. "t1") of the tab to control, taken from the tab legend or listTabs.`;
+        return {
+          finalText,
+          status: "failed",
+          errorMessage: handle
+            ? "cua parent tab handle did not resolve"
+            : "no parent tab handle for CUA",
+        };
+      }
+
+      // Resolve the CUA subagent's model + configured provider via the same
+      // helper that computed `cuaEnabled` at transport-build time, so the
+      // delegate gate and the actual run can never disagree. Priority:
+      //   1. The user's explicit `cuaModel` setting.
+      //   2. The main agent's model IF it's a Claude computer-use model.
+      // There is NO hardcoded fallback: an unresolved/unconfigured model
+      // means Computer Use is not enabled.
+      const sel = resolveCuaSelection(
+        settings,
+        providers,
+        agentSettings.cuaModel,
+        agentModel,
+      );
+      if (!sel.modelId || !sel.configured) {
+        return {
+          finalText:
+            "Computer Use is not enabled. Select a computer-use model in Settings → General → Computer Use model (e.g. anthropic:claude-sonnet-4-6, or your gateway's Claude model), then retry.",
+          status: "failed",
+          errorMessage: "cua not configured",
+        };
+      }
+      const cuaRegistryProvider = sel.provider;
+      const cuaActualModelId = sel.actualModelId;
+      const cuaConfig = sel.config;
+
+      let cuaProvider;
+      let cuaModel;
+      try {
+        cuaProvider = resolveCuaProvider(
+          cuaRegistryProvider.id,
+          cuaActualModelId,
+          cuaConfig,
+        );
+        cuaModel = await cuaRegistryProvider.createLanguageModel(
+          cuaConfig,
+          cuaActualModelId,
+        );
+      } catch (err) {
+        return {
+          finalText: err instanceof Error ? err.message : String(err),
+          status: "failed",
+          errorMessage: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // Persist the delegation prompt as the child's first user message
+      // BEFORE running, mirroring the standard subagent path.
+      if (cfg.childConversationId) {
+        try {
+          await persistDelegationMessage(
+            cfg.childConversationId,
+            cfg.userMessage,
+          );
+        } catch {
+          // best-effort
+        }
+      }
+
+      // Persist each assistant message AS IT STREAMS so the subagent's
+      // trace renders in real time in the parent's DelegateResult block
+      // (rather than appearing in bulk only after the run finishes). Writes
+      // are serialized through a promise chain to preserve order without
+      // blocking the loop's iteration. `onUiMessage` fires per streamed
+      // message; we upsert by id via the shared persister.
+      const cuaPersister = cfg.childConversationId
+        ? new AssistantStreamPersister(cfg.childConversationId)
+        : null;
+      let persistChain: Promise<void> = Promise.resolve();
+
+      const result = await cuaProvider.runLoop({
+        model: cuaModel,
+        driver: extensionDriver,
+        tabId,
+        modelId: cuaActualModelId,
+        task: cfg.userMessage,
+        systemPrompt: cfg.systemPrompt,
+        maxSteps: cfg.agentDef.maxSteps ?? 40,
+        ...(cfg.abortSignal && { abortSignal: cfg.abortSignal }),
+        onUiMessage: (m) => {
+          if (!cuaPersister) return;
+          persistChain = persistChain
+            .then(() => cuaPersister.persist(m as AgentUIMessage))
+            .catch(() => {
+              // best-effort — finalText still returns to the parent
+            });
+        },
+      });
+
+      // Wait for any in-flight persists to land before returning.
+      await persistChain;
+
+      return result;
+    }
+
     const subagentTools: Record<string, ToolSet[string]> = {};
     const allow = new Set(cfg.agentDef.allowedTools);
     const deny = new Set(cfg.agentDef.deniedTools ?? []);
@@ -1677,6 +1697,7 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
 
   const delegateTool = createDelegateTool({
     runAgentLoop: runSubagentAgentLoop,
+    cuaEnabled,
   });
 
   const tools = (() => {

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -22,6 +22,7 @@ import { nextUsageSnapshot, type StepUsage } from "./usage-snapshot";
 import { ExtensionDriver } from "./driver/extension-driver";
 import type { ToolContext } from "./driver";
 import { resolveCuaProvider, isAnthropicComputerUseModel } from "./cua";
+import { buildThinkingProviderOptions } from "./thinking";
 import type {
   AgentLoopConfig,
   AgentLoopResult,
@@ -1412,29 +1413,16 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
 
   let providerOptions: ToolLoopAgentSettings["providerOptions"];
   if (thinkingConfig?.enabled && thinkingConfig.config) {
-    const cfg = thinkingConfig.config;
-    if (cfg.type === "budget") {
-      if (provider.id === "anthropic") {
-        providerOptions = {
-          anthropic: { thinking: { type: "adaptive", display: "summarized" } },
-        };
-      } else if (provider.id === "google") {
-        providerOptions = {
-          google: { thinkingConfig: { thinkingBudget: cfg.tokens } },
-        };
-      }
-    } else if (cfg.type === "effort") {
-      if (provider.id === "anthropic") {
-        providerOptions = {
-          anthropic: {
-            thinking: { type: "adaptive", display: "summarized" },
-            effort: cfg.level,
-          },
-        };
-      } else if (provider.id === "openai") {
-        providerOptions = { openai: { reasoning: { effort: cfg.level } } };
-      }
-    }
+    // Resolve the underlying vendor (handles both direct providers and
+    // gateway-routed `vendor/model` ids) and build the vendor-keyed options.
+    // For Gemini this also picks `thinkingLevel` (Gemini 3) vs `thinkingBudget`
+    // (Gemini 2.5) and sets `includeThoughts` so reasoning summaries stream
+    // back. See `./thinking` for the full dispatch.
+    providerOptions = buildThinkingProviderOptions(
+      provider.id,
+      actualModelId,
+      thinkingConfig.config,
+    ) as ToolLoopAgentSettings["providerOptions"];
   }
 
   // The runner that the `delegate` tool uses to actually spawn a nested

--- a/apps/extension/src/lib/agent/capture-utils.ts
+++ b/apps/extension/src/lib/agent/capture-utils.ts
@@ -70,14 +70,26 @@ export async function captureScreenshot(
         params,
       );
       return r.data;
-    } catch {
+    } catch (firstErr) {
+      // `Page.captureScreenshot` intermittently fails with `-32000 Unable to
+      // capture screenshot` while the renderer is mid-paint/navigation. Wait
+      // ~600ms — long enough for a typical paint/commit to settle without
+      // noticeably stalling the agent — then retry once. Preserve the first
+      // error as the `cause` so the retry failure doesn't lose context.
       await new Promise((r) => setTimeout(r, 600));
-      const r = await driver.sendCommand<{ data: string }>(
-        tabId,
-        "Page.captureScreenshot",
-        params,
-      );
-      return r.data;
+      try {
+        const r = await driver.sendCommand<{ data: string }>(
+          tabId,
+          "Page.captureScreenshot",
+          params,
+        );
+        return r.data;
+      } catch (secondErr) {
+        if (secondErr instanceof Error && firstErr !== secondErr) {
+          (secondErr as { cause?: unknown }).cause ??= firstErr;
+        }
+        throw secondErr;
+      }
     }
   } finally {
     await setOverlaysHidden(driver, tabId, false);

--- a/apps/extension/src/lib/agent/capture-utils.ts
+++ b/apps/extension/src/lib/agent/capture-utils.ts
@@ -1,0 +1,85 @@
+import type { BrowserDriver, TabId } from "./driver";
+
+/**
+ * Shared screenshot capture for ALL model-facing images (the `screenshot`
+ * tool and the CUA loop). Capturing the live tab via CDP rasterizes the page
+ * DOM — INCLUDING OpenBrowse's own injected overlays (the "working on this
+ * page" glow border + pill, click ripple, toasts, the SoM/visualizer
+ * overlay). Those are human affordances; the model must never see them, or it
+ * reasons about / clicks our own chrome and the overlays occlude real content.
+ *
+ * Every injected host lives on `document.documentElement` and shares the
+ * `openbrowse-` id prefix, so we hide them all with a single
+ * `visibility:hidden` style rule immediately around the capture, then remove
+ * it. `visibility:hidden` (not `display:none`) keeps page layout stable so
+ * only our chrome disappears — no reflow of the content the model sees.
+ *
+ * Overlay hide/restore is best-effort: a failure to inject/remove the style
+ * (e.g. `Runtime.evaluate` unavailable, or a harness that injects no overlay)
+ * never blocks the capture. The `finally` guarantees restore even if capture
+ * throws.
+ */
+
+const HIDE_STYLE_ID = "openbrowse-capture-hide";
+
+const HIDE_EXPRESSION = `(() => {
+  if (document.getElementById(${JSON.stringify(HIDE_STYLE_ID)})) return;
+  const s = document.createElement("style");
+  s.id = ${JSON.stringify(HIDE_STYLE_ID)};
+  s.textContent = '[id^="openbrowse-"]{visibility:hidden !important}';
+  document.documentElement.appendChild(s);
+})()`;
+
+const RESTORE_EXPRESSION = `document.getElementById(${JSON.stringify(
+  HIDE_STYLE_ID,
+)})?.remove()`;
+
+async function setOverlaysHidden(
+  driver: BrowserDriver,
+  tabId: TabId,
+  hidden: boolean,
+): Promise<void> {
+  try {
+    await driver.sendCommand(tabId, "Runtime.evaluate", {
+      expression: hidden ? HIDE_EXPRESSION : RESTORE_EXPRESSION,
+    });
+  } catch {
+    // Best-effort: never let overlay hiding/restoring break a capture.
+  }
+}
+
+/**
+ * Capture a tab screenshot with OpenBrowse overlays hidden, returning the
+ * base64 PNG (no `data:` prefix). `params` is forwarded to
+ * `Page.captureScreenshot` (defaults to `{ format: "png" }`).
+ *
+ * Includes one short retry on the transient `-32000 Unable to capture
+ * screenshot` CDP error seen when the renderer is mid-paint or throttled.
+ */
+export async function captureScreenshot(
+  driver: BrowserDriver,
+  tabId: TabId,
+  params: Record<string, unknown> = { format: "png" },
+): Promise<string> {
+  await setOverlaysHidden(driver, tabId, true);
+  try {
+    try {
+      const r = await driver.sendCommand<{ data: string }>(
+        tabId,
+        "Page.captureScreenshot",
+        params,
+      );
+      return r.data;
+    } catch {
+      await new Promise((r) => setTimeout(r, 600));
+      const r = await driver.sendCommand<{ data: string }>(
+        tabId,
+        "Page.captureScreenshot",
+        params,
+      );
+      return r.data;
+    }
+  } finally {
+    await setOverlaysHidden(driver, tabId, false);
+  }
+}

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -14,6 +14,7 @@ import {
   SCREENSHOT_PROTECTED_TURNS,
   findProtectedTailStart,
   keepOnlyLatestScreenshot,
+  keepOnlyLatestSnapshotPerTab,
   prunePartsAtSendTime,
   stripScreenshotsFromParts,
 } from "./compaction";
@@ -200,6 +201,13 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
     if (this.keepOnlyLatestImage) {
       rewritten = keepOnlyLatestScreenshot(rewritten, this.screenshotToolNames);
     }
+    // Always keep only the latest accessibility snapshot per tab. Older
+    // snapshots' @refs are invalid by construction (reassigned on every
+    // capture) and the agent is told to re-snapshot, so retaining their
+    // multi-kilobyte trees only bloats context. Unlike screenshots this is
+    // unconditional — there is no scenario where a stale snapshot tree is
+    // worth its token cost.
+    rewritten = keepOnlyLatestSnapshotPerTab(rewritten);
 
     // Tie validateUIMessages' inferred UI_MESSAGE to *this transport's*
     // TOOLS so its `tools` parameter resolves to the same shape as

--- a/apps/extension/src/lib/agent/compaction.test.ts
+++ b/apps/extension/src/lib/agent/compaction.test.ts
@@ -23,6 +23,7 @@
 import { describe, expect, it } from "vitest";
 import {
   keepOnlyLatestScreenshot,
+  keepOnlyLatestSnapshotPerTab,
   PAGE_SCREENSHOT_TOOLS,
   selectTailForManual,
   resolveCompactionModel,
@@ -329,5 +330,97 @@ describe("resolveCompactionModel", () => {
     expect(
       resolveCompactionModel("unknown-provider:some-model", providers),
     ).toBeUndefined();
+  });
+});
+
+describe("keepOnlyLatestSnapshotPerTab", () => {
+  const snap = (tab: string, text: string, refCount = 3) => ({
+    tab,
+    snapshot: text,
+    refCount,
+    url: `https://x/${tab}`,
+  });
+  const clickDiff = (tab: string, diff: string) => ({
+    tab,
+    clicked: true,
+    target: "@eabc",
+    diff,
+  });
+
+  function isSnapshotStub(output: unknown): boolean {
+    return (
+      !!output &&
+      typeof output === "object" &&
+      (output as Record<string, unknown>).superseded === true &&
+      !("snapshot" in (output as Record<string, unknown>)) &&
+      !("diff" in (output as Record<string, unknown>))
+    );
+  }
+
+  it("keeps only the latest snapshot for a single tab; stubs earlier ones", () => {
+    const msgs = [
+      toolResultMsg("snapshot", snap("t1", "TREE-1")),
+      toolResultMsg("snapshot", snap("t1", "TREE-2")),
+      toolResultMsg("snapshot", snap("t1", "TREE-3")),
+    ];
+    const out = outputs(keepOnlyLatestSnapshotPerTab(msgs));
+    expect(isSnapshotStub(out[0])).toBe(true);
+    expect(isSnapshotStub(out[1])).toBe(true);
+    // Latest intact.
+    expect((out[2] as any).snapshot).toBe("TREE-3");
+    // Stub preserves orientation metadata.
+    expect((out[0] as any).tab).toBe("t1");
+    expect((out[0] as any).url).toBe("https://x/t1");
+    expect((out[0] as any).refCount).toBe(3);
+  });
+
+  it("keeps the latest snapshot of EACH tab independently", () => {
+    const msgs = [
+      toolResultMsg("snapshot", snap("t1", "A1")),
+      toolResultMsg("snapshot", snap("t2", "B1")),
+      toolResultMsg("snapshot", snap("t1", "A2")),
+    ];
+    const out = outputs(keepOnlyLatestSnapshotPerTab(msgs));
+    expect(isSnapshotStub(out[0])).toBe(true); // t1 superseded
+    expect((out[1] as any).snapshot).toBe("B1"); // t2 latest, intact
+    expect((out[2] as any).snapshot).toBe("A2"); // t1 latest, intact
+  });
+
+  it("treats clickElement/navigate diffs as snapshots and supersedes them", () => {
+    const msgs = [
+      toolResultMsg("snapshot", snap("t1", "TREE-1")),
+      toolResultMsg("clickElement", clickDiff("t1", "DIFF-1")),
+      toolResultMsg("snapshot", snap("t1", "TREE-2")),
+    ];
+    const out = outputs(keepOnlyLatestSnapshotPerTab(msgs));
+    expect(isSnapshotStub(out[0])).toBe(true); // earlier snapshot
+    expect(isSnapshotStub(out[1])).toBe(true); // earlier click diff
+    expect((out[2] as any).snapshot).toBe("TREE-2"); // latest survives
+  });
+
+  it("is idempotent and returns the same reference when nothing to strip", () => {
+    const single = [toolResultMsg("snapshot", snap("t1", "ONLY"))];
+    expect(keepOnlyLatestSnapshotPerTab(single)).toBe(single);
+
+    const msgs = [
+      toolResultMsg("snapshot", snap("t1", "TREE-1")),
+      toolResultMsg("snapshot", snap("t1", "TREE-2")),
+    ];
+    const once = keepOnlyLatestSnapshotPerTab(msgs);
+    const twice = keepOnlyLatestSnapshotPerTab(once);
+    expect(twice).toBe(once); // no live snapshot left to strip on 2nd pass
+    expect(outputs(twice).filter(isSnapshotStub)).toHaveLength(1);
+  });
+
+  it("ignores non-snapshot tool outputs", () => {
+    const msgs = [
+      toolResultMsg("executeCode", { result: "42" }),
+      toolResultMsg("snapshot", snap("t1", "TREE-1")),
+      toolResultMsg("executeCode", { result: "43" }),
+    ];
+    const out = outputs(keepOnlyLatestSnapshotPerTab(msgs));
+    expect((out[0] as any).result).toBe("42");
+    expect((out[1] as any).snapshot).toBe("TREE-1"); // only snapshot, intact
+    expect((out[2] as any).result).toBe("43");
   });
 });

--- a/apps/extension/src/lib/agent/compaction.ts
+++ b/apps/extension/src/lib/agent/compaction.ts
@@ -330,6 +330,117 @@ export function keepOnlyLatestScreenshot(
 }
 
 /**
+ * Tools whose output embeds a page accessibility snapshot (or a diff of
+ * one) keyed to per-snapshot `@ref` ids. Once a NEWER snapshot of the same
+ * tab exists, every earlier snapshot's text is dead weight: its refs are
+ * invalid by construction (refs are reassigned on every capture), and the
+ * agent is instructed to re-snapshot rather than re-read an old tree. So we
+ * keep only the latest snapshot per tab alive in the model's context.
+ *
+ * Maps the tool name → the output field that carries the snapshot text:
+ *   - `snapshot`     → `snapshot`
+ *   - `navigate`     → `snapshot` (fresh tree attached on navigation)
+ *   - `clickElement` → `diff`
+ *   - `typeInElement`→ `diff`
+ *   - `pressKey`     → `diff`
+ *
+ * The grouping key is the tool output's `tab` field, so a multi-tab task
+ * keeps the latest snapshot of EACH tab.
+ */
+export const SNAPSHOT_OUTPUT_FIELDS: Record<string, "snapshot" | "diff"> = {
+  snapshot: "snapshot",
+  navigate: "snapshot",
+  clickElement: "diff",
+  typeInElement: "diff",
+  pressKey: "diff",
+};
+
+/**
+ * Keeps only the latest snapshot-bearing tool output per tab; replaces the
+ * snapshot/diff text on every earlier one with a compact stub that preserves
+ * orientation metadata (tab, url, refCount) but drops the multi-kilobyte
+ * accessibility tree.
+ *
+ * Why per-tab-latest is safe: `@ref` ids are reassigned on every capture and
+ * the ref store only resolves the most recent snapshot, so an older
+ * snapshot's refs are already unusable. The agent is told to re-snapshot to
+ * refresh refs. We never strip the latest snapshot of any tab, so the model
+ * always has a current, actionable view of every tab it touched.
+ *
+ * Detection is tool-name-based (via SNAPSHOT_OUTPUT_FIELDS) — it never
+ * inspects arbitrary outputs, so it cannot accidentally strip non-snapshot
+ * data.
+ *
+ * Idempotent: stubs are recognized (they lack the snapshot field) and skipped
+ * on a second pass. Returns the original array reference when nothing changed.
+ */
+export function keepOnlyLatestSnapshotPerTab(
+  messages: AgentUIMessage[],
+): AgentUIMessage[] {
+  // First pass: locate every live (non-stubbed) snapshot-bearing output,
+  // grouped by tab. A part is "live" when its snapshot/diff field is a
+  // non-empty string (stubs replace it with an object).
+  const locsByTab = new Map<string, Array<{ m: number; p: number }>>();
+  for (let m = 0; m < messages.length; m++) {
+    const parts = messages[m].parts;
+    for (let p = 0; p < parts.length; p++) {
+      const part = parts[p] as any;
+      if (
+        part?.type !== "dynamic-tool" ||
+        part.state !== "output-available" ||
+        typeof part.toolName !== "string"
+      ) {
+        continue;
+      }
+      const field = SNAPSHOT_OUTPUT_FIELDS[part.toolName];
+      if (!field) continue;
+      const output = part.output;
+      if (!output || typeof output !== "object") continue;
+      // Only count it if the snapshot text is actually present (live).
+      if (typeof (output as any)[field] !== "string") continue;
+      if (((output as any)[field] as string).length === 0) continue;
+      const tab =
+        typeof (output as any).tab === "string"
+          ? ((output as any).tab as string)
+          : "__no_tab__";
+      const arr = locsByTab.get(tab) ?? [];
+      arr.push({ m, p });
+      locsByTab.set(tab, arr);
+    }
+  }
+
+  // Build the strip set: every snapshot EXCEPT the last one for its tab.
+  const stripSet = new Set<string>();
+  for (const locs of locsByTab.values()) {
+    for (const loc of locs.slice(0, -1)) stripSet.add(`${loc.m}:${loc.p}`);
+  }
+
+  if (stripSet.size === 0) return messages;
+
+  return messages.map((msg, m) => {
+    let touched = false;
+    const newParts = msg.parts.map((part, p) => {
+      if (!stripSet.has(`${m}:${p}`)) return part;
+      touched = true;
+      const anyPart = part as any;
+      const field = SNAPSHOT_OUTPUT_FIELDS[anyPart.toolName as string];
+      const prev = (anyPart.output ?? {}) as Record<string, unknown>;
+      const stub: Record<string, unknown> = {
+        superseded: true,
+        note: "[older snapshot superseded — call snapshot to refresh refs]",
+      };
+      if (typeof prev.tab === "string") stub.tab = prev.tab;
+      if (typeof prev.url === "string") stub.url = prev.url;
+      if (typeof prev.refCount === "number") stub.refCount = prev.refCount;
+      // Drop the heavy snapshot/diff text; keep everything else small.
+      const { [field]: _omit, ...rest } = prev;
+      return { ...anyPart, output: { ...rest, ...stub } };
+    });
+    return touched ? { ...msg, parts: newParts } : msg;
+  });
+}
+
+/**
  * Walks `messages` from the end, counting user-role messages, and
  * returns the index of the first message that belongs to the
  * "protected tail" of the most recent `keepUserTurns` user turns. Any

--- a/apps/extension/src/lib/agent/cua/__tests__/actions.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/actions.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { isTerminalAction, type CanonicalAction } from "../actions";
+
+describe("CanonicalAction", () => {
+  it("identifies the terminal `done` action", () => {
+    const done: CanonicalAction = { kind: "done", summary: "finished" };
+    const click: CanonicalAction = { kind: "click", x: 10, y: 20 };
+    expect(isTerminalAction(done)).toBe(true);
+    expect(isTerminalAction(click)).toBe(false);
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/anthropic-tomodeloutput.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/anthropic-tomodeloutput.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Capture the options passed to the computer tool factory so we can invoke
+// its `toModelOutput` directly. We mock `@ai-sdk/anthropic` to expose the
+// factory options, and `./cua-loop` to immediately invoke the `build`
+// callback with stub loop args and return whatever tool config it produced.
+const captured: { toModelOutput?: (arg: { output: unknown }) => unknown } = {};
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: () => ({
+    tools: new Proxy(
+      {},
+      {
+        get: () => (opts: { toModelOutput?: (a: { output: unknown }) => unknown }) => {
+          captured.toModelOutput = opts.toModelOutput;
+          return { __isComputerTool: true };
+        },
+      },
+    ),
+  }),
+}));
+
+vi.mock("../cua-loop", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cua-loop")>();
+  return {
+    ...actual,
+    runCuaToolLoop: async (
+      _cfg: unknown,
+      build: (args: {
+        downscale: number;
+        displayWidth: number;
+        displayHeight: number;
+        runAction: () => Promise<unknown>;
+      }) => unknown,
+    ) => {
+      build({
+        downscale: 1,
+        displayWidth: 1280,
+        displayHeight: 800,
+        runAction: async () => ({ imageDataUrl: "data:image/png;base64,QUJD" }),
+      });
+      return { finalText: "ok", status: "completed" };
+    },
+  };
+});
+
+import { createAnthropicCuaProvider } from "../anthropic";
+
+describe("Anthropic computer tool toModelOutput", () => {
+  it("converts { imageDataUrl } into an image-data content part", async () => {
+    const provider = createAnthropicCuaProvider("sk-test");
+    await provider.runLoop({
+      model: {} as never,
+      driver: {} as never,
+      tabId: 1 as never,
+      modelId: "claude-sonnet-4-6",
+      task: "t",
+      systemPrompt: "s",
+      maxSteps: 10,
+    });
+
+    expect(captured.toModelOutput).toBeTypeOf("function");
+    const out = captured.toModelOutput!({
+      output: { imageDataUrl: "data:image/png;base64,QUJD" },
+    });
+    expect(out).toEqual({
+      type: "content",
+      value: [{ type: "image-data", data: "QUJD", mediaType: "image/png" }],
+    });
+  });
+
+  it("falls back to a JSON output when no image is present (avoids AI_InvalidPromptError)", () => {
+    const out = captured.toModelOutput!({ output: { note: "no image" } });
+    expect(out).toEqual({ type: "json", value: { note: "no image" } });
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/anthropic.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/anthropic.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { anthropicToolSpec, decodeAnthropicAction } from "../anthropic";
+
+describe("anthropicToolSpec", () => {
+  it("maps Sonnet 4.6 to computer_20251124 + 2025-11-24 beta", () => {
+    const spec = anthropicToolSpec("claude-sonnet-4-6");
+    expect(spec.toolVersion).toBe("computer_20251124");
+    expect(spec.beta).toBe("computer-use-2025-11-24");
+    expect(spec.enableZoom).toBe(true);
+  });
+
+  it("maps Sonnet 4.5 to computer_20250124 + 2025-01-24 beta", () => {
+    const spec = anthropicToolSpec("claude-sonnet-4-5");
+    expect(spec.toolVersion).toBe("computer_20250124");
+    expect(spec.beta).toBe("computer-use-2025-01-24");
+  });
+
+  it("enables zoom for new-gen models only", () => {
+    expect(anthropicToolSpec("claude-sonnet-4-6").enableZoom).toBe(true);
+    expect(anthropicToolSpec("claude-sonnet-4-5").enableZoom).toBe(false);
+  });
+
+  it("maps gateway-form ids (anthropic/ prefix, dot versions) the same as direct", () => {
+    // Sonnet 4.6 via gateway → new-gen tool + beta
+    const newGen = anthropicToolSpec("anthropic/claude-sonnet-4.6");
+    expect(newGen.toolVersion).toBe("computer_20251124");
+    expect(newGen.beta).toBe("computer-use-2025-11-24");
+    // Opus 4.5/4.8 via gateway → new-gen
+    expect(anthropicToolSpec("anthropic/claude-opus-4.5").toolVersion).toBe(
+      "computer_20251124",
+    );
+    expect(anthropicToolSpec("anthropic/claude-opus-4.8").toolVersion).toBe(
+      "computer_20251124",
+    );
+    // Sonnet 4.5 via gateway → old-gen
+    const oldGen = anthropicToolSpec("anthropic/claude-sonnet-4.5");
+    expect(oldGen.toolVersion).toBe("computer_20250124");
+    expect(oldGen.beta).toBe("computer-use-2025-01-24");
+  });
+});
+
+describe("decodeAnthropicAction", () => {
+  const ds = 1; // downscale = identity
+
+  it("decodes left_click", () => {
+    const a = decodeAnthropicAction({ action: "left_click", coordinate: [100, 200] }, ds);
+    expect(a).toEqual({ kind: "click", x: 100, y: 200, button: "left", clickCount: 1 });
+  });
+
+  it("decodes double_click", () => {
+    const a = decodeAnthropicAction({ action: "double_click", coordinate: [10, 20] }, ds);
+    expect(a).toMatchObject({ kind: "click", clickCount: 2 });
+  });
+
+  it("decodes type", () => {
+    expect(decodeAnthropicAction({ action: "type", text: "hello" }, ds)).toEqual({
+      kind: "type",
+      text: "hello",
+    });
+  });
+
+  it("decodes key combo into keys array", () => {
+    expect(decodeAnthropicAction({ action: "key", text: "ctrl+s" }, ds)).toEqual({
+      kind: "key",
+      keys: ["ctrl", "s"],
+    });
+  });
+
+  it("decodes scroll with direction + amount into deltas", () => {
+    const a = decodeAnthropicAction(
+      { action: "scroll", coordinate: [5, 5], scroll_direction: "down", scroll_amount: 3 },
+      ds,
+    );
+    expect(a).toMatchObject({ kind: "scroll", x: 5, y: 5, deltaX: 0 });
+    expect((a as { deltaY: number }).deltaY).toBeGreaterThan(0);
+  });
+
+  it("decodes screenshot", () => {
+    expect(decodeAnthropicAction({ action: "screenshot" }, ds)).toEqual({ kind: "screenshot" });
+  });
+
+  it("applies the downscale factor to coordinates", () => {
+    const a = decodeAnthropicAction({ action: "left_click", coordinate: [640, 360] }, 0.5);
+    expect(a).toMatchObject({ kind: "click", x: 1280, y: 720 });
+  });
+
+  it("decodes left_click with a modifier from text", () => {
+    const a = decodeAnthropicAction({ action: "left_click", coordinate: [10, 20], text: "ctrl" }, ds);
+    expect(a).toMatchObject({ kind: "click", x: 10, y: 20, button: "left", clickCount: 1, modifiers: ["ctrl"] });
+  });
+
+  it("decodes left_click_drag into a drag action", () => {
+    const a = decodeAnthropicAction(
+      { action: "left_click_drag", start_coordinate: [5, 6], coordinate: [50, 60] },
+      ds,
+    );
+    expect(a).toEqual({ kind: "drag", x: 5, y: 6, toX: 50, toY: 60 });
+  });
+
+  it("decodes left_mouse_down / left_mouse_up with mapped coords", () => {
+    // mapAnthropicCoord divides by downscale: [100,200] / 0.5 → {200,400}.
+    expect(decodeAnthropicAction({ action: "left_mouse_down", coordinate: [100, 200] }, 0.5)).toEqual({ kind: "mouseDown", x: 200, y: 400 });
+    expect(decodeAnthropicAction({ action: "left_mouse_up", coordinate: [100, 200] }, 0.5)).toEqual({ kind: "mouseUp", x: 200, y: 400 });
+  });
+
+  it("decodes hold_key into keys + ms", () => {
+    expect(decodeAnthropicAction({ action: "hold_key", text: "ctrl+a", duration: 2 }, 1)).toEqual({ kind: "holdKey", keys: ["ctrl", "a"], ms: 2000 });
+  });
+
+  it("decodes zoom region verbatim in declared coords (no downscale applied)", () => {
+    expect(decodeAnthropicAction({ action: "zoom", region: [10, 20, 110, 220] }, 0.5)).toEqual({ kind: "zoom", x1: 10, y1: 20, x2: 110, y2: 220 });
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/anthropic.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/anthropic.test.ts
@@ -110,4 +110,12 @@ describe("decodeAnthropicAction", () => {
   it("decodes zoom region verbatim in declared coords (no downscale applied)", () => {
     expect(decodeAnthropicAction({ action: "zoom", region: [10, 20, 110, 220] }, 0.5)).toEqual({ kind: "zoom", x1: 10, y1: 20, x2: 110, y2: 220 });
   });
+
+  it("maps an unknown action to an explicit error (not a silent screenshot)", () => {
+    expect(decodeAnthropicAction({ action: "frobnicate" }, ds)).toEqual({
+      kind: "error",
+      reason: "unknown_action",
+      detail: "frobnicate",
+    });
+  });
 });

--- a/apps/extension/src/lib/agent/cua/__tests__/coords.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/coords.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { computeDisplay, mapAnthropicCoord } from "../coords";
+
+describe("computeDisplay", () => {
+  it("uses the viewport as-is when within the max width", () => {
+    const d = computeDisplay({ cssWidth: 1000, cssHeight: 800, maxWidth: 1280 });
+    expect(d).toEqual({ displayWidth: 1000, displayHeight: 800, downscale: 1 });
+  });
+
+  it("downscales proportionally when wider than max", () => {
+    const d = computeDisplay({ cssWidth: 2560, cssHeight: 1440, maxWidth: 1280 });
+    expect(d.displayWidth).toBe(1280);
+    expect(d.displayHeight).toBe(720);
+    expect(d.downscale).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe("mapAnthropicCoord", () => {
+  it("returns identity CSS coords when downscale is 1", () => {
+    expect(mapAnthropicCoord(100, 200, 1)).toEqual({ x: 100, y: 200 });
+  });
+
+  it("recovers CSS coords from downscaled model coords", () => {
+    // model saw a 0.5x image, so a model coord of 640 == 1280 css px
+    expect(mapAnthropicCoord(640, 360, 0.5)).toEqual({ x: 1280, y: 720 });
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserDriver } from "../../driver";
+import { cuaToModelOutput, detectNoChange, executeAndShoot, runCuaToolLoop } from "../cua-loop";
+import type { CuaRunConfig } from "../provider";
+
+// Controls how the mocked ToolLoopAgent behaves per test.
+let mockSteps = 0;
+let mockFinalText = "";
+
+// Mock the `ai` module so we can drive `onStepFinish` and the streamed
+// UIMessages without a live model. `runCuaToolLoop` constructs
+// `new ToolLoopAgent(...)` internally; this lets us exercise its
+// truncation → budget-exceeded mapping.
+vi.mock("ai", () => {
+  class FakeToolLoopAgent {
+    private onStepFinish?: () => void;
+    constructor(config: { onStepFinish?: () => void }) {
+      this.onStepFinish = config.onStepFinish;
+    }
+    async stream() {
+      for (let i = 0; i < mockSteps; i++) this.onStepFinish?.();
+      return {
+        toUIMessageStream: () => ({}) as never,
+      };
+    }
+  }
+  return {
+    ToolLoopAgent: FakeToolLoopAgent,
+    stepCountIs: (n: number) => n,
+    // Yield a single UIMessage carrying mockFinalText (or none if empty).
+    readUIMessageStream: () => ({
+      async *[Symbol.asyncIterator]() {
+        if (mockFinalText) {
+          yield { parts: [{ type: "text", text: mockFinalText }] };
+        }
+      },
+    }),
+  };
+});
+
+function fakeDriver(): BrowserDriver {
+  return {
+    sendCommand: vi.fn(async (_t: unknown, method: string) => {
+      if (method === "Page.captureScreenshot") return { data: "QUJD" } as never; // "ABC"
+      return {} as never;
+    }),
+    sendToContentScript: vi.fn(async () => ({}) as never),
+    getTab: vi.fn(async () => ({ id: 1, url: "https://example.com", title: "" })),
+    updateTabUrl: vi.fn(async () => {}),
+    waitForLoad: vi.fn(async () => {}),
+  } as unknown as BrowserDriver;
+}
+
+function fakeRunConfig(maxSteps: number): CuaRunConfig {
+  const driver = {
+    sendCommand: vi.fn(async (_t: unknown, method: string) => {
+      if (method === "Page.captureScreenshot") return { data: "QUJD" } as never;
+      // readViewport evaluates an expression returning {w,h,dpr}.
+      if (method === "Runtime.evaluate") {
+        return { result: { value: { w: 800, h: 600, dpr: 1 } } } as never;
+      }
+      return {} as never;
+    }),
+    sendToContentScript: vi.fn(async () => ({}) as never),
+    getTab: vi.fn(async () => ({ id: 1, url: "https://example.com", title: "" })),
+    updateTabUrl: vi.fn(async () => {}),
+    waitForLoad: vi.fn(async () => {}),
+  } as unknown as BrowserDriver;
+  return {
+    model: {} as never,
+    driver,
+    tabId: 1 as never,
+    modelId: "claude-sonnet-4-6",
+    task: "do a thing",
+    systemPrompt: "be helpful",
+    maxSteps,
+  };
+}
+
+function fakeBuild() {
+  return () => ({ tools: {} as Record<string, unknown> });
+}
+
+describe("executeAndShoot", () => {
+  it("runs the action and returns { imageDataUrl, currentUrl } OUTPUT", async () => {
+    const driver = fakeDriver();
+    // No OffscreenCanvas in this test env → captureNormalizedShot returns the
+    // raw capture data URL unchanged.
+    const out = await executeAndShoot(
+      driver,
+      1,
+      { kind: "click", x: 5, y: 5 },
+      800,
+      600,
+    );
+    expect(out).toEqual({
+      imageDataUrl: "data:image/png;base64,QUJD",
+      currentUrl: "https://example.com",
+    });
+  });
+
+  it("fires an in-page click ripple AFTER capturing the screenshot", async () => {
+    const order: string[] = [];
+    const driver = {
+      sendCommand: vi.fn(async (_t: unknown, method: string) => {
+        if (method === "Page.captureScreenshot") {
+          order.push("capture");
+          return { data: "QUJD" } as never;
+        }
+        return {} as never;
+      }),
+      sendToContentScript: vi.fn(async (_t: unknown, msg: { type: string }) => {
+        order.push(`msg:${msg.type}`);
+        return {} as never;
+      }),
+      getTab: vi.fn(async () => ({ id: 1, url: "https://example.com", title: "" })),
+      updateTabUrl: vi.fn(async () => {}),
+      waitForLoad: vi.fn(async () => {}),
+    } as unknown as BrowserDriver;
+
+    await executeAndShoot(driver, 1, { kind: "click", x: 42, y: 99 }, 800, 600);
+
+    // Passthrough is enabled before the action and disabled after; the
+    // screenshot capture happens after the action; and the ripple fires LAST
+    // (after capture) so it's never baked into the image sent to the model.
+    expect(order).toEqual([
+      "msg:CHAT_CUA_INPUT_PASSTHROUGH",
+      "msg:CHAT_CUA_INPUT_PASSTHROUGH",
+      "capture",
+      "msg:CHAT_CUA_CLICK_RIPPLE",
+    ]);
+    expect(driver.sendToContentScript).toHaveBeenCalledWith(1, {
+      type: "CHAT_CUA_CLICK_RIPPLE",
+      x: 42,
+      y: 99,
+    });
+  });
+
+  it("toggles shield passthrough on before and off after an input action", async () => {
+    const calls: Array<{ type: string; on?: boolean }> = [];
+    const driver = {
+      sendCommand: vi.fn(async (_t: unknown, method: string) =>
+        method === "Page.captureScreenshot"
+          ? ({ data: "QUJD" } as never)
+          : ({} as never),
+      ),
+      sendToContentScript: vi.fn(
+        async (_t: unknown, msg: { type: string; on?: boolean }) => {
+          calls.push(msg);
+          return {} as never;
+        },
+      ),
+      getTab: vi.fn(async () => ({ id: 1, url: "https://example.com", title: "" })),
+      updateTabUrl: vi.fn(async () => {}),
+      waitForLoad: vi.fn(async () => {}),
+    } as unknown as BrowserDriver;
+
+    await executeAndShoot(driver, 1, { kind: "click", x: 1, y: 2 }, 800, 600);
+
+    const passthroughs = calls.filter(
+      (c) => c.type === "CHAT_CUA_INPUT_PASSTHROUGH",
+    );
+    expect(passthroughs).toEqual([
+      { type: "CHAT_CUA_INPUT_PASSTHROUGH", on: true },
+      { type: "CHAT_CUA_INPUT_PASSTHROUGH", on: false },
+    ]);
+  });
+
+  it("does NOT fire a ripple for non-click actions (e.g. type)", async () => {
+    const driver = fakeDriver();
+    await executeAndShoot(driver, 1, { kind: "type", text: "hi" }, 800, 600);
+    // A `type` action toggles passthrough but never sends a ripple.
+    const sent = (driver.sendToContentScript as ReturnType<typeof vi.fn>).mock
+      .calls;
+    expect(
+      sent.some(
+        (c: unknown[]) =>
+          (c[1] as { type: string }).type === "CHAT_CUA_CLICK_RIPPLE",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not throw if the ripple message fails", async () => {
+    const driver = {
+      sendCommand: vi.fn(async (_t: unknown, method: string) =>
+        method === "Page.captureScreenshot"
+          ? ({ data: "QUJD" } as never)
+          : ({} as never),
+      ),
+      sendToContentScript: vi.fn(async () => {
+        throw new Error("no content script");
+      }),
+      getTab: vi.fn(async () => {
+        throw new Error("no tab");
+      }),
+      updateTabUrl: vi.fn(async () => {}),
+      waitForLoad: vi.fn(async () => {}),
+    } as unknown as BrowserDriver;
+
+    await expect(
+      executeAndShoot(driver, 1, { kind: "click", x: 1, y: 2 }, 800, 600),
+    ).resolves.toEqual({ imageDataUrl: "data:image/png;base64,QUJD" });
+  });
+});
+
+describe("runCuaToolLoop — status mapping", () => {
+  it("returns budget-exceeded when the step cap is hit with no final text", async () => {
+    mockSteps = 3;
+    mockFinalText = "";
+    const result = await runCuaToolLoop(fakeRunConfig(3), fakeBuild());
+    expect(result.status).toBe("budget-exceeded");
+  });
+
+  it("returns completed when final text is produced even at the cap", async () => {
+    mockSteps = 3;
+    mockFinalText = "all done";
+    const result = await runCuaToolLoop(fakeRunConfig(3), fakeBuild());
+    expect(result.status).toBe("completed");
+    expect(result.finalText).toBe("all done");
+  });
+
+  it("returns completed when under the step cap", async () => {
+    mockSteps = 1;
+    mockFinalText = "";
+    const result = await runCuaToolLoop(fakeRunConfig(5), fakeBuild());
+    expect(result.status).toBe("completed");
+  });
+});
+
+describe("detectNoChange", () => {
+  it("identical shot + state-changing kind → true", () => {
+    expect(detectNoChange("X", "X", "click")).toBe(true);
+  });
+  it("identical shot but non-state-changing kind → false", () => {
+    expect(detectNoChange("X", "X", "screenshot")).toBe(false);
+  });
+  it("different shots → false", () => {
+    expect(detectNoChange("X", "Y", "click")).toBe(false);
+  });
+  it("missing current shot → false", () => {
+    expect(detectNoChange("X", undefined, "click")).toBe(false);
+  });
+});
+
+describe("cuaToModelOutput", () => {
+  it("prepends a Current URL text part before the image", () => {
+    const out = cuaToModelOutput({
+      output: {
+        imageDataUrl: "data:image/png;base64,QUJD",
+        currentUrl: "https://example.com/x",
+      },
+    });
+    expect(out).toEqual({
+      type: "content",
+      value: [
+        { type: "text", text: "Current URL: https://example.com/x" },
+        { type: "image-data", data: "QUJD", mediaType: "image/png" },
+      ],
+    });
+  });
+
+  it("includes a no-change note when noChange is set", () => {
+    const out = cuaToModelOutput({
+      output: { imageDataUrl: "data:image/png;base64,QUJD", noChange: true },
+    }) as { value: Array<{ type: string; text?: string }> };
+    expect(out.value[0].type).toBe("text");
+    expect(out.value[0].text).toContain("no visible change");
+  });
+
+  it("emits image-only content when no URL/noChange present", () => {
+    const out = cuaToModelOutput({
+      output: { imageDataUrl: "data:image/png;base64,QUJD" },
+    });
+    expect(out).toEqual({
+      type: "content",
+      value: [{ type: "image-data", data: "QUJD", mediaType: "image/png" }],
+    });
+  });
+
+  it("falls back to JSON when no image", () => {
+    expect(cuaToModelOutput({ output: { note: "x" } as never })).toEqual({
+      type: "json",
+      value: { note: "x" },
+    });
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/executor-keys.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/executor-keys.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserDriver } from "../../driver";
+import { executeCanonicalAction } from "../executor";
+
+function fakeDriver(): { driver: BrowserDriver; calls: Array<[string, any]> } {
+  const calls: Array<[string, any]> = [];
+  const driver = {
+    sendCommand: vi.fn(async (_tab: unknown, method: string, params?: unknown) => {
+      calls.push([method, params]);
+      return {} as never;
+    }),
+  } as unknown as BrowserDriver;
+  return { driver, calls };
+}
+
+function keyDownParams(calls: Array<[string, any]>) {
+  return calls.find(([m, p]) => m === "Input.dispatchKeyEvent" && p.type === "keyDown")?.[1];
+}
+
+describe("executeCanonicalAction — key mapping (X11 keysyms)", () => {
+  it("maps Page_Down to PageDown (not 'P')", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["Page_Down"] });
+    expect(keyDownParams(calls)).toMatchObject({ key: "PageDown", code: "PageDown" });
+  });
+
+  it("maps Delete correctly (not 'D')", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["Delete"] });
+    expect(keyDownParams(calls)).toMatchObject({ key: "Delete", code: "Delete" });
+  });
+
+  it("maps BackSpace (X11 spelling) to Backspace", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["BackSpace"] });
+    expect(keyDownParams(calls)).toMatchObject({ key: "Backspace", code: "Backspace" });
+  });
+
+  it("maps Home and End", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["Home"] });
+    expect(keyDownParams(calls)).toMatchObject({ key: "Home", code: "Home" });
+  });
+
+  it("maps a ctrl+a combo: modifier mask set, main key 'a'", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["ctrl", "a"] });
+    const kd = keyDownParams(calls);
+    expect(kd.key).toBe("a");
+    expect(kd.modifiers).toBe(2); // ctrl bit
+  });
+
+  it("maps space to a single space character", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["space"] });
+    expect(keyDownParams(calls)).toMatchObject({ key: " " });
+  });
+
+  it("maps a single letter key", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "key", keys: ["b"] });
+    expect(keyDownParams(calls)).toMatchObject({ key: "b", code: "KeyB" });
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/executor.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/executor.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserDriver } from "../../driver";
+import { executeCanonicalAction } from "../executor";
+
+function fakeDriver(): { driver: BrowserDriver; calls: Array<[string, unknown]> } {
+  const calls: Array<[string, unknown]> = [];
+  const driver = {
+    sendCommand: vi.fn(async (_tab: unknown, method: string, params?: unknown) => {
+      calls.push([method, params]);
+      return {} as never;
+    }),
+  } as unknown as BrowserDriver;
+  return { driver, calls };
+}
+
+describe("executeCanonicalAction", () => {
+  it("click dispatches move, press, release at the coordinate", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "click", x: 50, y: 60 });
+    const mouseCalls = calls.filter(([m]) => m === "Input.dispatchMouseEvent");
+    expect(mouseCalls).toHaveLength(3);
+    expect(mouseCalls[0][1]).toMatchObject({ type: "mouseMoved", x: 50, y: 60 });
+    expect(mouseCalls[1][1]).toMatchObject({ type: "mousePressed", button: "left", clickCount: 1 });
+    expect(mouseCalls[2][1]).toMatchObject({ type: "mouseReleased", button: "left" });
+  });
+
+  it("scroll uses a mouseWheel event with deltas", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "scroll", x: 10, y: 20, deltaX: 0, deltaY: 300 });
+    const wheel = calls.find(([m, p]) => m === "Input.dispatchMouseEvent" && (p as { type: string }).type === "mouseWheel");
+    expect(wheel?.[1]).toMatchObject({ type: "mouseWheel", x: 10, y: 20, deltaX: 0, deltaY: 300 });
+  });
+
+  it("type inserts text", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "type", text: "hi" });
+    expect(calls).toContainEqual(["Input.insertText", { text: "hi" }]);
+  });
+
+  it("drag presses at origin, moves to target, releases", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "drag", x: 5, y: 5, toX: 50, toY: 50 });
+    const types = calls
+      .filter(([m]) => m === "Input.dispatchMouseEvent")
+      .map(([, p]) => (p as { type: string }).type);
+    expect(types).toEqual(["mouseMoved", "mousePressed", "mouseMoved", "mouseReleased"]);
+  });
+
+  it("wait resolves without CDP calls", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "wait", ms: 1 });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("mouseDown / mouseUp dispatch a single press / release", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "mouseDown", x: 5, y: 6 });
+    await executeCanonicalAction(driver, 1, { kind: "mouseUp", x: 5, y: 6 });
+    const types = calls
+      .filter(([m]) => m === "Input.dispatchMouseEvent")
+      .map(([, p]) => (p as { type: string }).type);
+    expect(types).toEqual(["mousePressed", "mouseReleased"]);
+  });
+
+  it("holdKey presses down, waits, releases the same key", async () => {
+    const { driver, calls } = fakeDriver();
+    await executeCanonicalAction(driver, 1, { kind: "holdKey", keys: ["a"], ms: 1 });
+    const keyCalls = calls.filter(([m]) => m === "Input.dispatchKeyEvent");
+    expect(keyCalls.map(([, p]) => (p as { type: string }).type)).toEqual(["keyDown", "keyUp"]);
+  });
+
+  it("goBack reads history and navigates to the previous entry", async () => {
+    const driver = {
+      sendCommand: vi.fn(async (_t: unknown, method: string) => {
+        if (method === "Page.getNavigationHistory") {
+          return { currentIndex: 2, entries: [{ id: 10, url: "a" }, { id: 11, url: "b" }, { id: 12, url: "c" }] } as never;
+        }
+        return {} as never;
+      }),
+      waitForLoad: vi.fn(async () => {}),
+    } as unknown as BrowserDriver;
+    await executeCanonicalAction(driver, 1, { kind: "goBack" });
+    expect(driver.sendCommand).toHaveBeenCalledWith(1, "Page.navigateToHistoryEntry", { entryId: 11 });
+  });
+
+  it("goForward at the end of history is a no-op (no navigate call)", async () => {
+    const driver = {
+      sendCommand: vi.fn(async (_t: unknown, method: string) =>
+        method === "Page.getNavigationHistory"
+          ? ({ currentIndex: 1, entries: [{ id: 10, url: "a" }, { id: 11, url: "b" }] } as never)
+          : ({} as never),
+      ),
+      waitForLoad: vi.fn(async () => {}),
+    } as unknown as BrowserDriver;
+    await executeCanonicalAction(driver, 1, { kind: "goForward" });
+    const navCalls = (driver.sendCommand as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[1] === "Page.navigateToHistoryEntry",
+    );
+    expect(navCalls).toHaveLength(0);
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/model-ids.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/model-ids.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAnthropicComputerUseModel,
+  isNewGenComputerUseModel,
+  normalizeModelId,
+} from "../model-ids";
+
+describe("normalizeModelId", () => {
+  it("strips an anthropic/ prefix and converts dot versions to hyphen", () => {
+    expect(normalizeModelId("anthropic/claude-sonnet-4.6")).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+
+  it("leaves a direct hyphen id unchanged (lowercased)", () => {
+    expect(normalizeModelId("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("isAnthropicComputerUseModel", () => {
+  it("matches both direct and gateway forms of Sonnet 4.6", () => {
+    expect(isAnthropicComputerUseModel("claude-sonnet-4-6")).toBe(true);
+    expect(isAnthropicComputerUseModel("anthropic/claude-sonnet-4.6")).toBe(true);
+  });
+
+  it("matches Opus 4.5–4.8, Sonnet 4.5, Haiku 4.5 (both forms)", () => {
+    for (const id of [
+      "claude-opus-4-5",
+      "anthropic/claude-opus-4.8",
+      "claude-sonnet-4-5",
+      "anthropic/claude-haiku-4.5",
+    ]) {
+      expect(isAnthropicComputerUseModel(id)).toBe(true);
+    }
+  });
+
+  it("rejects non-CUA Claude models and non-Claude models", () => {
+    expect(isAnthropicComputerUseModel("claude-opus-4-0")).toBe(false);
+    expect(isAnthropicComputerUseModel("anthropic/claude-opus-4.1")).toBe(false);
+    expect(isAnthropicComputerUseModel("openai/gpt-5.5")).toBe(false);
+  });
+});
+
+describe("isNewGenComputerUseModel", () => {
+  it("flags Sonnet 4.6 and Opus 4.5+ (both forms) as new-gen", () => {
+    expect(isNewGenComputerUseModel("claude-sonnet-4-6")).toBe(true);
+    expect(isNewGenComputerUseModel("anthropic/claude-sonnet-4.6")).toBe(true);
+    expect(isNewGenComputerUseModel("anthropic/claude-opus-4.5")).toBe(true);
+    expect(isNewGenComputerUseModel("claude-opus-4-8")).toBe(true);
+  });
+
+  it("treats Sonnet 4.5 and Haiku 4.5 as old-gen", () => {
+    expect(isNewGenComputerUseModel("claude-sonnet-4-5")).toBe(false);
+    expect(isNewGenComputerUseModel("anthropic/claude-haiku-4.5")).toBe(false);
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/nav-tools.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/nav-tools.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CanonicalAction } from "../actions";
+import { buildCuaNavTools } from "../nav-tools";
+
+describe("buildCuaNavTools", () => {
+  it("navigate runs a navigate action with the given url", async () => {
+    const runAction = vi.fn(async () => ({
+      imageDataUrl: "data:image/png;base64,QUJD",
+      currentUrl: "https://x",
+    }));
+    const tools = buildCuaNavTools(
+      runAction as (a: CanonicalAction) => Promise<{ imageDataUrl?: string }>,
+    );
+    await (tools.navigate.execute as (a: { url: string }) => Promise<unknown>)({
+      url: "https://x",
+    });
+    expect(runAction).toHaveBeenCalledWith({ kind: "navigate", url: "https://x" });
+  });
+
+  it("goBack and goForward emit history actions", async () => {
+    const runAction = vi.fn(async () => ({
+      imageDataUrl: "data:image/png;base64,QUJD",
+    }));
+    const tools = buildCuaNavTools(
+      runAction as (a: CanonicalAction) => Promise<{ imageDataUrl?: string }>,
+    );
+    await (tools.goBack.execute as (a: unknown) => Promise<unknown>)({});
+    await (tools.goForward.execute as (a: unknown) => Promise<unknown>)({});
+    expect(runAction).toHaveBeenNthCalledWith(1, { kind: "goBack" });
+    expect(runAction).toHaveBeenNthCalledWith(2, { kind: "goForward" });
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/resolve.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/resolve.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveCuaProvider } from "../resolve";
+
+describe("resolveCuaProvider", () => {
+  it("resolves the direct Anthropic provider with an apiKey", () => {
+    const p = resolveCuaProvider("anthropic", "claude-sonnet-4-6", {
+      apiKey: "sk-test",
+    });
+    expect(p).toBeDefined();
+    expect(typeof p.runLoop).toBe("function");
+  });
+
+  it("throws for direct Anthropic without an apiKey", () => {
+    expect(() => resolveCuaProvider("anthropic", "claude-sonnet-4-6", {})).toThrow(
+      /apiKey/i,
+    );
+  });
+
+  it("resolves the gateway (vercel) provider for a Claude CUA model", () => {
+    const p = resolveCuaProvider("vercel", "anthropic/claude-sonnet-4.6", {
+      apiKey: "gw-test",
+    });
+    expect(p).toBeDefined();
+    expect(typeof p.runLoop).toBe("function");
+  });
+
+  it("throws for the gateway with a non-Claude model", () => {
+    expect(() =>
+      resolveCuaProvider("vercel", "openai/gpt-5.5", { apiKey: "gw-test" }),
+    ).toThrow(/Anthropic Claude computer-use model/i);
+  });
+
+  it("throws for the gateway with a non-CUA Claude model", () => {
+    expect(() =>
+      resolveCuaProvider("vercel", "anthropic/claude-opus-4.1", {
+        apiKey: "gw-test",
+      }),
+    ).toThrow(/Anthropic Claude computer-use model/i);
+  });
+
+  it("throws for an unsupported provider", () => {
+    expect(() =>
+      resolveCuaProvider("openai", "gpt-5.5", { apiKey: "sk" }),
+    ).toThrow(/not supported/i);
+  });
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/screenshot.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/screenshot.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserDriver } from "../../driver";
+import { captureNormalizedShot } from "../screenshot";
+
+function fakeDriver(): BrowserDriver {
+  return {
+    sendCommand: vi.fn(async (_t: unknown, method: string) => {
+      if (method === "Page.captureScreenshot") return { data: "QUJD" } as never; // "ABC"
+      return {} as never;
+    }),
+  } as unknown as BrowserDriver;
+}
+
+describe("captureNormalizedShot", () => {
+  it("returns a data URL from the captured base64 (no-canvas fallback)", async () => {
+    // In the test environment OffscreenCanvas/createImageBitmap are absent, so
+    // the function returns the raw capture unchanged. The resize path itself
+    // is exercised in the browser; here we lock in the fallback contract.
+    const url = await captureNormalizedShot(fakeDriver(), 1, 1280, 800);
+    expect(url).toBe("data:image/png;base64,QUJD");
+  });
+});
+
+import { captureRegionShot } from "../screenshot";
+
+it("captureRegionShot falls back to a full normalized shot without canvas", async () => {
+  const driver = {
+    sendCommand: vi.fn(async (_t: unknown, method: string) =>
+      method === "Page.captureScreenshot" ? ({ data: "QUJD" } as never) : ({} as never),
+    ),
+  } as unknown as BrowserDriver;
+  const url = await captureRegionShot(driver, 1, { x1: 0, y1: 0, x2: 10, y2: 10 }, 800, 600);
+  expect(url.startsWith("data:image/png;base64,")).toBe(true);
+});

--- a/apps/extension/src/lib/agent/cua/__tests__/screenshot.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/screenshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrowserDriver } from "../../driver";
-import { captureNormalizedShot } from "../screenshot";
+import { captureNormalizedShot, captureRegionShot } from "../screenshot";
 
 function fakeDriver(): BrowserDriver {
   return {
@@ -21,14 +21,14 @@ describe("captureNormalizedShot", () => {
   });
 });
 
-import { captureRegionShot } from "../screenshot";
-
-it("captureRegionShot falls back to a full normalized shot without canvas", async () => {
-  const driver = {
-    sendCommand: vi.fn(async (_t: unknown, method: string) =>
-      method === "Page.captureScreenshot" ? ({ data: "QUJD" } as never) : ({} as never),
-    ),
-  } as unknown as BrowserDriver;
-  const url = await captureRegionShot(driver, 1, { x1: 0, y1: 0, x2: 10, y2: 10 }, 800, 600);
-  expect(url.startsWith("data:image/png;base64,")).toBe(true);
+describe("captureRegionShot", () => {
+  it("falls back to a full normalized shot without canvas", async () => {
+    const driver = {
+      sendCommand: vi.fn(async (_t: unknown, method: string) =>
+        method === "Page.captureScreenshot" ? ({ data: "QUJD" } as never) : ({} as never),
+      ),
+    } as unknown as BrowserDriver;
+    const url = await captureRegionShot(driver, 1, { x1: 0, y1: 0, x2: 10, y2: 10 }, 800, 600);
+    expect(url.startsWith("data:image/png;base64,")).toBe(true);
+  });
 });

--- a/apps/extension/src/lib/agent/cua/actions.ts
+++ b/apps/extension/src/lib/agent/cua/actions.ts
@@ -1,0 +1,30 @@
+/**
+ * Provider-neutral browser action. Every CUA provider decodes its model's
+ * output into one of these. Coordinates are ALREADY in CSS pixels relative
+ * to the tab's viewport (the provider's coordinate mapper has run).
+ */
+export type CanonicalAction =
+  | { kind: "click"; x: number; y: number; button?: "left" | "right" | "middle"; clickCount?: number; modifiers?: ModifierKey[] }
+  | { kind: "move"; x: number; y: number }
+  | { kind: "drag"; x: number; y: number; toX: number; toY: number }
+  | { kind: "scroll"; x: number; y: number; deltaX: number; deltaY: number }
+  | { kind: "type"; text: string }
+  | { kind: "key"; keys: string[] } // e.g. ["ctrl","a"] or ["Enter"]
+  | { kind: "mouseDown"; x: number; y: number; button?: "left" | "right" | "middle" }
+  | { kind: "mouseUp"; x: number; y: number; button?: "left" | "right" | "middle" }
+  | { kind: "holdKey"; keys: string[]; ms: number }
+  | { kind: "wait"; ms: number }
+  | { kind: "navigate"; url: string }
+  | { kind: "goBack" }
+  | { kind: "goForward" }
+  // Zoom coords are in DECLARED display space (NOT converted to CSS px like
+  // click coords); captureRegionShot maps them to native pixels.
+  | { kind: "zoom"; x1: number; y1: number; x2: number; y2: number }
+  | { kind: "screenshot" }
+  | { kind: "done"; summary: string };
+
+export type ModifierKey = "shift" | "ctrl" | "alt" | "super";
+
+export function isTerminalAction(action: CanonicalAction): boolean {
+  return action.kind === "done";
+}

--- a/apps/extension/src/lib/agent/cua/actions.ts
+++ b/apps/extension/src/lib/agent/cua/actions.ts
@@ -21,7 +21,11 @@ export type CanonicalAction =
   // click coords); captureRegionShot maps them to native pixels.
   | { kind: "zoom"; x1: number; y1: number; x2: number; y2: number }
   | { kind: "screenshot" }
-  | { kind: "done"; summary: string };
+  | { kind: "done"; summary: string }
+  // Emitted when a provider decoder receives an action it cannot map (e.g. an
+  // unknown/renamed tool action). Surfaced to the model as text so a protocol
+  // mismatch isn't silently masked as a screenshot.
+  | { kind: "error"; reason: string; detail?: string };
 
 export type ModifierKey = "shift" | "ctrl" | "alt" | "super";
 

--- a/apps/extension/src/lib/agent/cua/anthropic.ts
+++ b/apps/extension/src/lib/agent/cua/anthropic.ts
@@ -125,7 +125,13 @@ export function decodeAnthropicAction(
       return { kind: "zoom", x1: r[0], y1: r[1], x2: r[2], y2: r[3] };
     }
     default:
-      return { kind: "screenshot" };
+      // An unknown action almost always signals a tool-version/protocol
+      // mismatch. Surface it (warn + explicit error action) rather than
+      // silently pretending the model asked for a screenshot.
+      console.warn(
+        `[cua/anthropic] unknown computer action "${input.action}" — surfacing as error`,
+      );
+      return { kind: "error", reason: "unknown_action", detail: input.action };
   }
 }
 

--- a/apps/extension/src/lib/agent/cua/anthropic.ts
+++ b/apps/extension/src/lib/agent/cua/anthropic.ts
@@ -1,0 +1,191 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import type { CanonicalAction, ModifierKey } from "./actions";
+import { mapAnthropicCoord } from "./coords";
+import { cuaToModelOutput, runCuaToolLoop } from "./cua-loop";
+import { isNewGenComputerUseModel } from "./model-ids";
+import { buildCuaNavTools } from "./nav-tools";
+import type { CuaProvider, CuaRunConfig, CuaRunResult } from "./provider";
+
+export interface AnthropicToolSpec {
+  toolVersion: "computer_20250124" | "computer_20251124";
+  beta: "computer-use-2025-01-24" | "computer-use-2025-11-24";
+  enableZoom: boolean;
+}
+
+/**
+ * Map an Anthropic model id to its computer-use tool version + beta header.
+ * `computer_20251124` for Opus 4.5+/Sonnet 4.6; otherwise the 2025-01-24
+ * generation. Handles both direct (`claude-sonnet-4-6`) and gateway
+ * (`anthropic/claude-sonnet-4.6`) id forms via `isNewGenComputerUseModel`.
+ *
+ * Zoom is enabled for new-gen models (it is now decoded into a native-resolution
+ * region capture).
+ */
+export function anthropicToolSpec(modelId: string): AnthropicToolSpec {
+  if (isNewGenComputerUseModel(modelId)) {
+    return {
+      toolVersion: "computer_20251124",
+      beta: "computer-use-2025-11-24",
+      enableZoom: true,
+    };
+  }
+  return {
+    toolVersion: "computer_20250124",
+    beta: "computer-use-2025-01-24",
+    enableZoom: false,
+  };
+}
+
+interface AnthropicComputerInput {
+  action: string;
+  coordinate?: number[];
+  start_coordinate?: number[];
+  text?: string;
+  scroll_direction?: "up" | "down" | "left" | "right";
+  scroll_amount?: number;
+  duration?: number;
+  region?: number[];
+}
+
+const SCROLL_PX_PER_UNIT = 100;
+
+/**
+ * Decode one Anthropic computer tool input into a CanonicalAction, mapping
+ * coordinates into CSS pixels via the downscale factor.
+ */
+export function decodeAnthropicAction(
+  input: AnthropicComputerInput,
+  downscale: number,
+): CanonicalAction {
+  const coord = (c?: number[]) =>
+    c ? mapAnthropicCoord(c[0], c[1], downscale) : { x: 0, y: 0 };
+
+  switch (input.action) {
+    case "left_click":
+    case "mouse_move": {
+      const { x, y } = coord(input.coordinate);
+      if (input.action === "mouse_move") return { kind: "move", x, y };
+      const modifiers = parseModifiers(input.text);
+      return { kind: "click", x, y, button: "left", clickCount: 1, ...(modifiers.length && { modifiers }) };
+    }
+    case "right_click": {
+      const { x, y } = coord(input.coordinate);
+      return { kind: "click", x, y, button: "right", clickCount: 1 };
+    }
+    case "middle_click": {
+      const { x, y } = coord(input.coordinate);
+      return { kind: "click", x, y, button: "middle", clickCount: 1 };
+    }
+    case "double_click": {
+      const { x, y } = coord(input.coordinate);
+      return { kind: "click", x, y, button: "left", clickCount: 2 };
+    }
+    case "triple_click": {
+      const { x, y } = coord(input.coordinate);
+      return { kind: "click", x, y, button: "left", clickCount: 3 };
+    }
+    case "left_click_drag": {
+      const from = coord(input.start_coordinate);
+      const to = coord(input.coordinate);
+      return { kind: "drag", x: from.x, y: from.y, toX: to.x, toY: to.y };
+    }
+    case "scroll": {
+      const { x, y } = coord(input.coordinate);
+      const amount = (input.scroll_amount ?? 3) * SCROLL_PX_PER_UNIT;
+      const dir = input.scroll_direction ?? "down";
+      const deltaX = dir === "left" ? -amount : dir === "right" ? amount : 0;
+      const deltaY = dir === "up" ? -amount : dir === "down" ? amount : 0;
+      return { kind: "scroll", x, y, deltaX, deltaY };
+    }
+    case "type":
+      return { kind: "type", text: input.text ?? "" };
+    case "key":
+      return { kind: "key", keys: (input.text ?? "").split("+").map((k) => k.trim()).filter(Boolean) };
+    case "wait":
+      return { kind: "wait", ms: Math.round((input.duration ?? 1) * 1000) };
+    case "cursor_position":
+    case "screenshot":
+      return { kind: "screenshot" };
+    case "left_mouse_down": {
+      const { x, y } = coord(input.coordinate);
+      return { kind: "mouseDown", x, y };
+    }
+    case "left_mouse_up": {
+      const { x, y } = coord(input.coordinate);
+      return { kind: "mouseUp", x, y };
+    }
+    case "hold_key":
+      return {
+        kind: "holdKey",
+        keys: (input.text ?? "").split("+").map((k) => k.trim()).filter(Boolean),
+        ms: Math.round((input.duration ?? 1) * 1000),
+      };
+    case "zoom": {
+      const r = input.region ?? [0, 0, 0, 0];
+      return { kind: "zoom", x1: r[0], y1: r[1], x2: r[2], y2: r[3] };
+    }
+    default:
+      return { kind: "screenshot" };
+  }
+}
+
+function parseModifiers(text?: string): ModifierKey[] {
+  if (!text) return [];
+  const map: Record<string, ModifierKey> = {
+    shift: "shift",
+    ctrl: "ctrl",
+    control: "ctrl",
+    alt: "alt",
+    super: "super",
+    cmd: "super",
+    meta: "super",
+  };
+  return text
+    .split("+")
+    .map((t) => map[t.trim().toLowerCase()])
+    .filter((m): m is ModifierKey => !!m);
+}
+
+/**
+ * Anthropic CUA provider. Injects a single `anthropic.tools.computer_*`
+ * tool whose execute decodes the model's action and runs it, returning a
+ * screenshot. Sets the matching computer-use beta header.
+ */
+export function createAnthropicCuaProvider(apiKey: string): CuaProvider {
+  return {
+    async runLoop(cfg: CuaRunConfig): Promise<CuaRunResult> {
+      const spec = anthropicToolSpec(cfg.modelId);
+      const anthropic = createAnthropic({
+        apiKey,
+        headers: { "anthropic-dangerous-direct-browser-access": "true" },
+      });
+
+      return runCuaToolLoop(cfg, ({ downscale, displayWidth, displayHeight, runAction }) => {
+        const tools = anthropic.tools as Record<
+          string,
+          (opts: unknown) => unknown
+        >;
+        const factory = tools[spec.toolVersion];
+        const computer = factory({
+          displayWidthPx: displayWidth,
+          displayHeightPx: displayHeight,
+          ...(spec.enableZoom && { enableZoom: true }),
+          execute: async (input: unknown) => {
+            const action = decodeAnthropicAction(input as never, downscale);
+            return runAction(action);
+          },
+          // The AI SDK contract splits the plain tool OUTPUT (returned by
+          // `execute`) from the model-facing content (`toModelOutput`).
+          // `cuaToModelOutput` converts the `{ imageDataUrl, currentUrl, ... }`
+          // OUTPUT into a text-then-image content part so Claude SEES the
+          // screenshot and the current URL. Shared with the navigation tools.
+          toModelOutput: cuaToModelOutput,
+        });
+        return {
+          tools: { computer, ...buildCuaNavTools(runAction) },
+          providerOptions: { anthropic: { beta: [spec.beta] } },
+        };
+      });
+    },
+  };
+}

--- a/apps/extension/src/lib/agent/cua/coords.ts
+++ b/apps/extension/src/lib/agent/cua/coords.ts
@@ -1,0 +1,71 @@
+import type { BrowserDriver, TabId } from "../driver";
+
+export interface CssViewport {
+  cssWidth: number;
+  cssHeight: number;
+  devicePixelRatio: number;
+}
+
+export interface Display {
+  /** Width declared to the model (CSS px, possibly downscaled). */
+  displayWidth: number;
+  displayHeight: number;
+  /** displayWidth / cssWidth. 1 when no downscale was needed. */
+  downscale: number;
+}
+
+/**
+ * Read the tab's live CSS viewport + DPR. We do NOT override the viewport
+ * (Emulation.setDeviceMetricsOverride) because CUA runs on the parent's
+ * live tab and reflowing it would change what the parent sees.
+ */
+export async function readViewport(
+  driver: BrowserDriver,
+  tabId: TabId,
+): Promise<CssViewport> {
+  const result = await driver.sendCommand<{
+    result: { value: { w: number; h: number; dpr: number } };
+  }>(tabId, "Runtime.evaluate", {
+    expression:
+      "({w: window.innerWidth, h: window.innerHeight, dpr: window.devicePixelRatio})",
+    returnByValue: true,
+  });
+  const { w, h, dpr } = result.result.value;
+  return { cssWidth: w, cssHeight: h, devicePixelRatio: dpr || 1 };
+}
+
+/**
+ * Decide the display size declared to the model. Downscale only the WIDTH
+ * proportionally when it exceeds the provider's recommended max.
+ */
+export function computeDisplay(opts: {
+  cssWidth: number;
+  cssHeight: number;
+  maxWidth: number;
+}): Display {
+  const { cssWidth, cssHeight, maxWidth } = opts;
+  if (cssWidth <= maxWidth) {
+    return { displayWidth: cssWidth, displayHeight: cssHeight, downscale: 1 };
+  }
+  const downscale = maxWidth / cssWidth;
+  return {
+    displayWidth: maxWidth,
+    displayHeight: Math.round(cssHeight * downscale),
+    downscale,
+  };
+}
+
+/**
+ * Anthropic returns pixels in the declared (possibly downscaled) display.
+ * Recover CSS pixels by dividing out the downscale factor.
+ */
+export function mapAnthropicCoord(
+  modelX: number,
+  modelY: number,
+  downscale: number,
+): { x: number; y: number } {
+  return {
+    x: Math.round(modelX / downscale),
+    y: Math.round(modelY / downscale),
+  };
+}

--- a/apps/extension/src/lib/agent/cua/cua-loop.ts
+++ b/apps/extension/src/lib/agent/cua/cua-loop.ts
@@ -21,6 +21,10 @@ export interface CuaActionOutput {
   /** True when the post-action screenshot is byte-identical to the prior one
    *  for a state-changing action (loop-side detection; see runCuaToolLoop). */
   noChange?: boolean;
+  /** Set when the action could not be decoded/executed (e.g. an unknown
+   *  provider action). Surfaced to the model as text so the mismatch is
+   *  visible rather than masked as a screenshot. */
+  errorNote?: string;
 }
 
 /**
@@ -37,6 +41,29 @@ export async function executeAndShoot(
   displayWidth: number,
   displayHeight: number,
 ): Promise<CuaActionOutput> {
+  // An undecodable action carries no CDP side effect; report it back to the
+  // model as text alongside a fresh screenshot so it can self-correct.
+  if (action.kind === "error") {
+    const note = action.detail
+      ? `Action error (${action.reason}): ${action.detail}`
+      : `Action error: ${action.reason}`;
+    const imageDataUrl = await captureNormalizedShot(
+      driver,
+      tabId,
+      displayWidth,
+      displayHeight,
+    );
+    const currentUrl = await driver
+      .getTab(tabId)
+      .then((t) => t.url)
+      .catch(() => undefined);
+    return {
+      imageDataUrl,
+      errorNote: note,
+      ...(currentUrl !== undefined && { currentUrl }),
+    };
+  }
+
   // The "working on this page" overlay blocks user input via a shield + key
   // capture. The agent's own CDP input is trusted and respects the shield, so
   // we toggle passthrough ON around this action (awaited, so the shield is
@@ -162,7 +189,7 @@ export async function runCuaToolLoop(
   const display = computeDisplay({
     cssWidth: vp.cssWidth,
     cssHeight: vp.cssHeight,
-    maxWidth: 1280,
+    maxWidth: cfg.maxDisplayWidth ?? 1280,
   });
 
   let lastShot: string | undefined;
@@ -273,7 +300,7 @@ export async function runCuaToolLoop(
 export function cuaToModelOutput({
   output,
 }: {
-  output: { imageDataUrl?: string; currentUrl?: string; noChange?: boolean };
+  output: { imageDataUrl?: string; currentUrl?: string; noChange?: boolean; errorNote?: string };
 }) {
   const imageDataUrl = output?.imageDataUrl;
   if (!imageDataUrl) {
@@ -282,6 +309,7 @@ export function cuaToModelOutput({
   const base64 = imageDataUrl.replace(/^data:image\/png;base64,/, "");
   const lines: string[] = [];
   if (output.currentUrl) lines.push(`Current URL: ${output.currentUrl}`);
+  if (output.errorNote) lines.push(output.errorNote);
   if (output.noChange) {
     lines.push(
       "Note: the last action produced no visible change to the page. Try a different approach (a different target, scroll, navigate, or goBack).",

--- a/apps/extension/src/lib/agent/cua/cua-loop.ts
+++ b/apps/extension/src/lib/agent/cua/cua-loop.ts
@@ -1,0 +1,294 @@
+import { ToolLoopAgent, readUIMessageStream, stepCountIs } from "ai";
+import type { BrowserDriver, TabId } from "../driver";
+import type { CanonicalAction } from "./actions";
+import { computeDisplay, readViewport } from "./coords";
+import { executeCanonicalAction } from "./executor";
+import { captureNormalizedShot, captureRegionShot } from "./screenshot";
+import type { CuaRunConfig, CuaRunResult } from "./provider";
+import { notifyAgentStatus } from "../agent-indicator";
+
+/**
+ * Plain OUTPUT value of the CUA computer tool's `execute`. Carries the
+ * post-action viewport screenshot as a data URL — the SAME shape the main
+ * agent's screenshot tool uses (`agent-transport.ts`), so both go through
+ * an identical `toModelOutput` conversion. `execute` must NOT return the
+ * AI-SDK model-output shape directly; that's `toModelOutput`'s job.
+ */
+export interface CuaActionOutput {
+  imageDataUrl?: string;
+  /** Current tab URL after the action, surfaced to the model each step. */
+  currentUrl?: string;
+  /** True when the post-action screenshot is byte-identical to the prior one
+   *  for a state-changing action (loop-side detection; see runCuaToolLoop). */
+  noChange?: boolean;
+}
+
+/**
+ * Run a canonical action, then capture a viewport screenshot NORMALIZED to
+ * the model's declared display dimensions (so image-pixels match the
+ * coordinate space the model reasons in — see screenshot.ts). Returns the
+ * plain `{ imageDataUrl }` tool OUTPUT; the provider's `toModelOutput`
+ * converts it into an AI SDK image content part.
+ */
+export async function executeAndShoot(
+  driver: BrowserDriver,
+  tabId: TabId,
+  action: CanonicalAction,
+  displayWidth: number,
+  displayHeight: number,
+): Promise<CuaActionOutput> {
+  // The "working on this page" overlay blocks user input via a shield + key
+  // capture. The agent's own CDP input is trusted and respects the shield, so
+  // we toggle passthrough ON around this action (awaited, so the shield is
+  // provably down before the CDP dispatch and back up after). No-op when no
+  // overlay is present.
+  const needsPassthrough = INPUT_ACTION_KINDS.has(action.kind);
+  if (needsPassthrough) await setShieldPassthrough(driver, tabId, true);
+  try {
+    await executeCanonicalAction(driver, tabId, action);
+  } finally {
+    if (needsPassthrough) await setShieldPassthrough(driver, tabId, false);
+  }
+
+  const imageDataUrl =
+    action.kind === "zoom"
+      ? await captureRegionShot(
+          driver,
+          tabId,
+          { x1: action.x1, y1: action.y1, x2: action.x2, y2: action.y2 },
+          displayWidth,
+          displayHeight,
+        )
+      : await captureNormalizedShot(driver, tabId, displayWidth, displayHeight);
+  // Surface the current URL each step so the model always knows where it is
+  // (it cannot see the browser address bar). Best-effort — never fail the
+  // action over a missing tab.
+  const currentUrl = await driver
+    .getTab(tabId)
+    .then((t) => t.url)
+    .catch(() => undefined);
+  // Fire a transient in-page click ripple AFTER capturing the screenshot, so
+  // it's visible to a human watching the live tab without ever appearing in
+  // the image sent to the model. Best-effort — a ripple must never fail the
+  // action. Drag ripples at its start point.
+  const ripple = clickRipplePoint(action);
+  if (ripple) {
+    void driver
+      .sendToContentScript(tabId, {
+        type: "CHAT_CUA_CLICK_RIPPLE",
+        x: ripple.x,
+        y: ripple.y,
+      })
+      .catch(() => {});
+  }
+  return { imageDataUrl, ...(currentUrl !== undefined && { currentUrl }) };
+}
+
+/** Action kinds that dispatch CDP input and thus need the shield to pass
+ *  through while they run. */
+const INPUT_ACTION_KINDS = new Set<CanonicalAction["kind"]>([
+  "click",
+  "drag",
+  "move",
+  "scroll",
+  "type",
+  "key",
+  "mouseDown",
+  "mouseUp",
+  "holdKey",
+]);
+
+async function setShieldPassthrough(
+  driver: BrowserDriver,
+  tabId: TabId,
+  on: boolean,
+): Promise<void> {
+  try {
+    await driver.sendToContentScript(tabId, {
+      type: "CHAT_CUA_INPUT_PASSTHROUGH",
+      on,
+    });
+  } catch {
+    // No overlay / no content script — nothing to toggle.
+  }
+}
+
+/**
+ * The viewport (CSS px) point to ripple for a given action, or null when the
+ * action isn't a click/drag. Coordinates on click/drag actions are already
+ * CSS pixels (the executor clicks there); drag ripples at the press point.
+ */
+function clickRipplePoint(
+  action: CanonicalAction,
+): { x: number; y: number } | null {
+  if (action.kind === "click") return { x: action.x, y: action.y };
+  if (action.kind === "drag") return { x: action.x, y: action.y };
+  return null;
+}
+
+/** Actions whose screenshots are meaningfully comparable for no-op
+ *  detection. Excludes pure captures and waits. */
+const STATE_CHANGING_KINDS = new Set<CanonicalAction["kind"]>([
+  "click", "drag", "move", "scroll", "type", "key",
+  "mouseDown", "mouseUp", "holdKey", "navigate", "goBack", "goForward",
+]);
+
+/** True when the new shot is byte-identical to the prior shot for a
+ *  state-changing action — signals the action did nothing visible. */
+export function detectNoChange(
+  prev: string | undefined,
+  curr: string | undefined,
+  kind: CanonicalAction["kind"],
+): boolean {
+  return !!curr && curr === prev && STATE_CHANGING_KINDS.has(kind);
+}
+
+/**
+ * Build a ToolLoopAgent with a single computer-use tool and run it. The
+ * `build` callback constructs the provider-specific tool (Anthropic now,
+ * Gemini later); its `execute` should decode the model action, call
+ * `executeAndShoot`, and return the result.
+ */
+export async function runCuaToolLoop(
+  cfg: CuaRunConfig,
+  build: (args: {
+    downscale: number;
+    displayWidth: number;
+    displayHeight: number;
+    runAction: (action: CanonicalAction) => Promise<CuaActionOutput>;
+  }) => { tools: Record<string, unknown>; providerOptions?: Record<string, unknown> },
+): Promise<CuaRunResult> {
+  const vp = await readViewport(cfg.driver, cfg.tabId);
+  const display = computeDisplay({
+    cssWidth: vp.cssWidth,
+    cssHeight: vp.cssHeight,
+    maxWidth: 1280,
+  });
+
+  let lastShot: string | undefined;
+  const runAction = async (action: CanonicalAction): Promise<CuaActionOutput> => {
+    return new Promise<CuaActionOutput>((resolve, reject) => {
+      const onAbort = () => {
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        reject(err);
+      };
+      if (cfg.abortSignal?.aborted) return onAbort();
+      cfg.abortSignal?.addEventListener("abort", onAbort);
+
+      executeAndShoot(
+        cfg.driver,
+        cfg.tabId,
+        action,
+        display.displayWidth,
+        display.displayHeight,
+      )
+        .then((out) => {
+          const noChange = detectNoChange(lastShot, out.imageDataUrl, action.kind);
+          if (out.imageDataUrl) lastShot = out.imageDataUrl;
+          resolve({ ...out, ...(noChange && { noChange: true }) });
+        })
+        .catch(reject)
+        .finally(() => cfg.abortSignal?.removeEventListener("abort", onAbort));
+    });
+  };
+
+  // Show the "OpenBrowse is working on this page" overlay (glow border +
+  // input blocker) for the duration of the run. Routes through the shared
+  // indicator so it gets the same space-color tint + robust delivery as the
+  // main agent. Best-effort; removed in the finally below so it never lingers
+  // after completion/error/abort.
+  notifyAgentStatus(true, undefined, cfg.tabId as number);
+
+  let stepCount = 0;
+
+  const { tools, providerOptions } = build({
+    downscale: display.downscale,
+    displayWidth: display.displayWidth,
+    displayHeight: display.displayHeight,
+    runAction,
+  });
+
+  const agent = new ToolLoopAgent({
+    model: cfg.model,
+    tools: tools as never,
+    instructions: cfg.systemPrompt,
+    ...(providerOptions && { providerOptions: providerOptions as never }),
+    onStepFinish: (() => {
+      stepCount += 1;
+    }) as never,
+    stopWhen: stepCountIs(cfg.maxSteps) as never,
+  });
+
+  try {
+    const stream = await agent.stream({
+      prompt: cfg.task,
+      ...(cfg.abortSignal && { abortSignal: cfg.abortSignal }),
+    });
+    let finalText = "";
+    const uiStream = readUIMessageStream({ stream: stream.toUIMessageStream() });
+    for await (const msg of uiStream) {
+      if (cfg.abortSignal?.aborted) {
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        throw err;
+      }
+      cfg.onUiMessage?.(msg);
+      const parts = (msg as { parts?: Array<{ type: string; text?: string }> }).parts ?? [];
+      const text = parts.filter((p) => p.type === "text").map((p) => p.text ?? "").join("");
+      if (text) finalText = text;
+    }
+    // The step cap (`stepCountIs`) truncates the run WITHOUT throwing, so a
+    // truncated run would otherwise look "completed". Detect truncation:
+    // hit the cap and produced no final text.
+    const truncated = stepCount >= cfg.maxSteps && finalText.length === 0;
+    return {
+      finalText: finalText || "(CUA run produced no final text)",
+      status: truncated ? "budget-exceeded" : "completed",
+    };
+  } catch (err) {
+    const isAbort =
+      err instanceof Error && (err.name === "AbortError" || /aborted/i.test(err.message));
+    if (isAbort) {
+      return { finalText: "(CUA run cancelled)", status: "cancelled", errorMessage: "aborted" };
+    }
+    return {
+      finalText: `(CUA run failed: ${err instanceof Error ? err.message : String(err)})`,
+      status: "failed",
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    // Always tear down the "working on this page" overlay so it never lingers
+    // after the run ends (completion, error, or abort).
+    notifyAgentStatus(false, undefined, cfg.tabId as number);
+  }
+}
+
+/**
+ * Convert a CuaActionOutput into AI-SDK model-facing content, shared by the
+ * computer tool and the navigation tools. Prepends a text part (current URL +
+ * optional no-change note) BEFORE the image — Anthropic recommends text
+ * before the screenshot for better grounding.
+ */
+export function cuaToModelOutput({
+  output,
+}: {
+  output: { imageDataUrl?: string; currentUrl?: string; noChange?: boolean };
+}) {
+  const imageDataUrl = output?.imageDataUrl;
+  if (!imageDataUrl) {
+    return { type: "json" as const, value: (output ?? {}) as never };
+  }
+  const base64 = imageDataUrl.replace(/^data:image\/png;base64,/, "");
+  const lines: string[] = [];
+  if (output.currentUrl) lines.push(`Current URL: ${output.currentUrl}`);
+  if (output.noChange) {
+    lines.push(
+      "Note: the last action produced no visible change to the page. Try a different approach (a different target, scroll, navigate, or goBack).",
+    );
+  }
+  const value: Array<Record<string, unknown>> = [];
+  if (lines.length) value.push({ type: "text", text: lines.join("\n") });
+  value.push({ type: "image-data", data: base64, mediaType: "image/png" });
+  return { type: "content" as const, value: value as never };
+}

--- a/apps/extension/src/lib/agent/cua/executor.ts
+++ b/apps/extension/src/lib/agent/cua/executor.ts
@@ -12,6 +12,29 @@ async function mouse(
 }
 
 /**
+ * Log a `waitForLoad` failure from a CUA navigation. A load timeout is
+ * expected/benign (e.g. a page that never fires `complete`, or an instant
+ * history nav) so it's logged at debug; any other error is unexpected and
+ * logged at warn. Either way we proceed — the next screenshot reflects
+ * whatever state the page settled into.
+ */
+function logWaitForLoadError(
+  kind: string,
+  tabId: TabId,
+  url: string,
+  err: unknown,
+): void {
+  const message = err instanceof Error ? err.message : String(err);
+  const isTimeout = /timed out/i.test(message);
+  const ctx = `[cua/executor] ${kind} waitForLoad (tab ${String(tabId)}, ${url})`;
+  if (isTimeout) {
+    console.debug(`${ctx}: ${message}`);
+  } else {
+    console.warn(`${ctx}: ${message}`);
+  }
+}
+
+/**
  * Run a single provider-neutral action against a tab via CDP. Coordinates
  * must already be CSS pixels. Returns nothing; the caller captures a fresh
  * screenshot afterward.
@@ -82,7 +105,9 @@ export async function executeCanonicalAction(
 
     case "navigate":
       await driver.updateTabUrl(tabId, action.url);
-      await driver.waitForLoad(tabId, 5000).catch(() => {});
+      await driver
+        .waitForLoad(tabId, 5000)
+        .catch((err) => logWaitForLoadError("navigate", tabId, action.url, err));
       return;
 
     case "goBack":
@@ -95,15 +120,19 @@ export async function executeCanonicalAction(
       const entry = hist.entries[targetIdx];
       if (!entry) return; // no history in that direction — no-op
       await driver.sendCommand(tabId, "Page.navigateToHistoryEntry", { entryId: entry.id });
-      await driver.waitForLoad(tabId, 5000).catch(() => {});
+      await driver
+        .waitForLoad(tabId, 5000)
+        .catch((err) => logWaitForLoadError(action.kind, tabId, entry.url, err));
       return;
     }
 
     case "zoom":
     case "screenshot":
     case "done":
+    case "error":
       // No CDP side effect. `zoom`/`screenshot` capture is handled by the
-      // loop; `done` terminates the loop.
+      // loop; `done` terminates the loop; `error` is surfaced to the model as
+      // text by `executeAndShoot`.
       return;
   }
 }

--- a/apps/extension/src/lib/agent/cua/executor.ts
+++ b/apps/extension/src/lib/agent/cua/executor.ts
@@ -1,6 +1,7 @@
 import type { BrowserDriver, TabId } from "../driver";
 import type { CanonicalAction, ModifierKey } from "./actions";
 import { modifierMask, dispatchKeyCombo } from "../keyboard";
+import { captureScreenshot } from "../capture-utils";
 
 async function mouse(
   driver: BrowserDriver,
@@ -108,27 +109,13 @@ export async function executeCanonicalAction(
 }
 
 /**
- * Capture a viewport PNG and return base64 (no data: prefix). Mirrors the
- * retry behavior of tools/screenshot.ts.
+ * Capture a viewport PNG and return base64 (no data: prefix). Delegates to the
+ * shared `captureScreenshot`, which hides OpenBrowse's overlays around the
+ * capture and handles the transient-failure retry.
  */
 export async function captureViewportShot(
   driver: BrowserDriver,
   tabId: TabId,
 ): Promise<string> {
-  try {
-    const r = await driver.sendCommand<{ data: string }>(
-      tabId,
-      "Page.captureScreenshot",
-      { format: "png" },
-    );
-    return r.data;
-  } catch {
-    await new Promise((r) => setTimeout(r, 600));
-    const r = await driver.sendCommand<{ data: string }>(
-      tabId,
-      "Page.captureScreenshot",
-      { format: "png" },
-    );
-    return r.data;
-  }
+  return captureScreenshot(driver, tabId, { format: "png" });
 }

--- a/apps/extension/src/lib/agent/cua/executor.ts
+++ b/apps/extension/src/lib/agent/cua/executor.ts
@@ -1,0 +1,134 @@
+import type { BrowserDriver, TabId } from "../driver";
+import type { CanonicalAction, ModifierKey } from "./actions";
+import { modifierMask, dispatchKeyCombo } from "../keyboard";
+
+async function mouse(
+  driver: BrowserDriver,
+  tabId: TabId,
+  params: Record<string, unknown>,
+): Promise<void> {
+  await driver.sendCommand(tabId, "Input.dispatchMouseEvent", params);
+}
+
+/**
+ * Run a single provider-neutral action against a tab via CDP. Coordinates
+ * must already be CSS pixels. Returns nothing; the caller captures a fresh
+ * screenshot afterward.
+ */
+export async function executeCanonicalAction(
+  driver: BrowserDriver,
+  tabId: TabId,
+  action: CanonicalAction,
+): Promise<void> {
+  switch (action.kind) {
+    case "move":
+      await mouse(driver, tabId, { type: "mouseMoved", x: action.x, y: action.y });
+      return;
+
+    case "click": {
+      const button = action.button ?? "left";
+      const clickCount = action.clickCount ?? 1;
+      const modifiers = modifierMask(action.modifiers);
+      await mouse(driver, tabId, { type: "mouseMoved", x: action.x, y: action.y, modifiers });
+      await mouse(driver, tabId, { type: "mousePressed", x: action.x, y: action.y, button, clickCount, modifiers });
+      await mouse(driver, tabId, { type: "mouseReleased", x: action.x, y: action.y, button, clickCount, modifiers });
+      return;
+    }
+
+    case "drag":
+      await mouse(driver, tabId, { type: "mouseMoved", x: action.x, y: action.y });
+      await mouse(driver, tabId, { type: "mousePressed", x: action.x, y: action.y, button: "left", clickCount: 1 });
+      await mouse(driver, tabId, { type: "mouseMoved", x: action.toX, y: action.toY, button: "left" });
+      await mouse(driver, tabId, { type: "mouseReleased", x: action.toX, y: action.toY, button: "left", clickCount: 1 });
+      return;
+
+    case "scroll":
+      await mouse(driver, tabId, {
+        type: "mouseWheel",
+        x: action.x,
+        y: action.y,
+        deltaX: action.deltaX,
+        deltaY: action.deltaY,
+      });
+      return;
+
+    case "type":
+      await driver.sendCommand(tabId, "Input.insertText", { text: action.text });
+      return;
+
+    case "key":
+      await dispatchKeyCombo(driver, tabId, action.keys);
+      return;
+
+    case "holdKey":
+      await dispatchKeyCombo(driver, tabId, action.keys, action.ms);
+      return;
+
+    // mouseDown/mouseUp are independent half-clicks (the model positions and
+    // presses/releases in separate steps), so unlike `click`/`drag` they
+    // intentionally omit the leading `mouseMoved`.
+    case "mouseDown":
+      await mouse(driver, tabId, { type: "mousePressed", x: action.x, y: action.y, button: action.button ?? "left", clickCount: 1 });
+      return;
+
+    case "mouseUp":
+      await mouse(driver, tabId, { type: "mouseReleased", x: action.x, y: action.y, button: action.button ?? "left", clickCount: 1 });
+      return;
+
+    case "wait":
+      await new Promise((r) => setTimeout(r, action.ms));
+      return;
+
+    case "navigate":
+      await driver.updateTabUrl(tabId, action.url);
+      await driver.waitForLoad(tabId, 5000).catch(() => {});
+      return;
+
+    case "goBack":
+    case "goForward": {
+      const hist = await driver.sendCommand<{
+        currentIndex: number;
+        entries: Array<{ id: number; url: string }>;
+      }>(tabId, "Page.getNavigationHistory");
+      const targetIdx = action.kind === "goBack" ? hist.currentIndex - 1 : hist.currentIndex + 1;
+      const entry = hist.entries[targetIdx];
+      if (!entry) return; // no history in that direction — no-op
+      await driver.sendCommand(tabId, "Page.navigateToHistoryEntry", { entryId: entry.id });
+      await driver.waitForLoad(tabId, 5000).catch(() => {});
+      return;
+    }
+
+    case "zoom":
+    case "screenshot":
+    case "done":
+      // No CDP side effect. `zoom`/`screenshot` capture is handled by the
+      // loop; `done` terminates the loop.
+      return;
+  }
+}
+
+/**
+ * Capture a viewport PNG and return base64 (no data: prefix). Mirrors the
+ * retry behavior of tools/screenshot.ts.
+ */
+export async function captureViewportShot(
+  driver: BrowserDriver,
+  tabId: TabId,
+): Promise<string> {
+  try {
+    const r = await driver.sendCommand<{ data: string }>(
+      tabId,
+      "Page.captureScreenshot",
+      { format: "png" },
+    );
+    return r.data;
+  } catch {
+    await new Promise((r) => setTimeout(r, 600));
+    const r = await driver.sendCommand<{ data: string }>(
+      tabId,
+      "Page.captureScreenshot",
+      { format: "png" },
+    );
+    return r.data;
+  }
+}

--- a/apps/extension/src/lib/agent/cua/index.ts
+++ b/apps/extension/src/lib/agent/cua/index.ts
@@ -1,0 +1,5 @@
+export * from "./actions";
+export * from "./provider";
+export { createAnthropicCuaProvider, anthropicToolSpec } from "./anthropic";
+export { resolveCuaProvider } from "./resolve";
+export { isAnthropicComputerUseModel } from "./model-ids";

--- a/apps/extension/src/lib/agent/cua/model-ids.ts
+++ b/apps/extension/src/lib/agent/cua/model-ids.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared helpers for recognizing Anthropic Claude computer-use models across
+ * the two id conventions we encounter:
+ *
+ *   - Direct Anthropic provider: `claude-sonnet-4-6` (hyphen versions).
+ *   - Vercel AI Gateway provider: `anthropic/claude-sonnet-4.6` (an
+ *     `anthropic/` prefix and DOT versions).
+ *
+ * Both `anthropicToolSpec` (tool version / beta header selection) and the
+ * registry capability flagging consume these so the two id forms never drift
+ * apart.
+ */
+
+/**
+ * Normalize a model id for matching: lowercase, strip a leading provider
+ * prefix (e.g. `anthropic/`), and treat `.` and `-` as equivalent version
+ * separators. So both `claude-sonnet-4-6` and `anthropic/claude-sonnet-4.6`
+ * normalize to `claude-sonnet-4-6`.
+ */
+export function normalizeModelId(modelId: string): string {
+  const withoutPrefix = modelId.includes("/")
+    ? modelId.slice(modelId.lastIndexOf("/") + 1)
+    : modelId;
+  return withoutPrefix.toLowerCase().replace(/\./g, "-");
+}
+
+/**
+ * True when the (normalized) model id is an Anthropic Claude model that
+ * supports the computer-use tool: Sonnet 4.5/4.6, Haiku 4.5, Opus 4.5–4.8.
+ */
+export function isAnthropicComputerUseModel(modelId: string): boolean {
+  const id = normalizeModelId(modelId);
+  if (!id.includes("claude")) return false;
+  return (
+    /sonnet-4-(5|6)/.test(id) ||
+    /haiku-4-5/.test(id) ||
+    /opus-4-(5|6|7|8)/.test(id)
+  );
+}
+
+/**
+ * True when the (normalized) model id is a "new generation" computer-use
+ * model that uses `computer_20251124` + the `computer-use-2025-11-24` beta:
+ * Sonnet 4.6 and Opus 4.5–4.8. Older CUA models (Sonnet 4.5, Haiku 4.5) use
+ * the 2025-01-24 generation.
+ */
+export function isNewGenComputerUseModel(modelId: string): boolean {
+  const id = normalizeModelId(modelId);
+  return /sonnet-4-6/.test(id) || /opus-4-(5|6|7|8)/.test(id);
+}

--- a/apps/extension/src/lib/agent/cua/nav-tools.ts
+++ b/apps/extension/src/lib/agent/cua/nav-tools.ts
@@ -1,0 +1,55 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { CanonicalAction } from "./actions";
+import { cuaToModelOutput, type CuaActionOutput } from "./cua-loop";
+
+/** Output shape of every nav tool — matches CuaActionOutput. Declared so the
+ *  AI SDK can infer the `toModelOutput` input type (without it, `tool()`
+ *  resolves the output to `never`). */
+const cuaActionOutputSchema = z.object({
+  imageDataUrl: z.string().optional(),
+  currentUrl: z.string().optional(),
+  noChange: z.boolean().optional(),
+});
+
+/**
+ * Sibling navigation tools for the CUA loop. The Anthropic computer tool has
+ * no URL/back/forward actions and cannot reach browser chrome, so we expose
+ * these as ordinary AI-SDK tools (matching Gemini/OpenAI CUA). Each returns a
+ * post-navigation screenshot via the shared `runAction` + `cuaToModelOutput`.
+ */
+export function buildCuaNavTools(
+  runAction: (action: CanonicalAction) => Promise<CuaActionOutput>,
+) {
+  return {
+    navigate: tool({
+      description:
+        "Navigate the current tab directly to a URL (like typing in the address bar). Use this instead of hunting for links. Returns a screenshot of the loaded page.",
+      inputSchema: z.object({
+        url: z
+          .string()
+          .describe("Absolute URL, e.g. https://www.linkedin.com/feed/"),
+      }),
+      outputSchema: cuaActionOutputSchema,
+      execute: async ({ url }) => runAction({ kind: "navigate", url }),
+      toModelOutput: cuaToModelOutput,
+    }),
+    goBack: tool({
+      description:
+        "Go back to the previous page in browser history (like the Back button). Returns a screenshot.",
+      inputSchema: z.object({}),
+      outputSchema: cuaActionOutputSchema,
+      execute: async () => runAction({ kind: "goBack" }),
+      toModelOutput: cuaToModelOutput,
+    }),
+    goForward: tool({
+      description:
+        "Go forward to the next page in browser history (like the Forward button). Returns a screenshot.",
+      inputSchema: z.object({}),
+      outputSchema: cuaActionOutputSchema,
+      execute: async () => runAction({ kind: "goForward" }),
+      toModelOutput: cuaToModelOutput,
+    }),
+  };
+}
+

--- a/apps/extension/src/lib/agent/cua/provider.ts
+++ b/apps/extension/src/lib/agent/cua/provider.ts
@@ -1,0 +1,27 @@
+import type { LanguageModel } from "ai";
+import type { BrowserDriver, TabId } from "../driver";
+
+export interface CuaRunConfig {
+  model: LanguageModel;
+  driver: BrowserDriver;
+  tabId: TabId;
+  /** SDK model id (e.g. "claude-sonnet-4-6"), used to pick tool version. */
+  modelId: string;
+  /** The delegated task text. */
+  task: string;
+  systemPrompt: string;
+  maxSteps: number;
+  abortSignal?: AbortSignal;
+  /** Called with each assistant UIMessage so the runner can persist the trace. */
+  onUiMessage?: (message: unknown) => void;
+}
+
+export interface CuaRunResult {
+  finalText: string;
+  status: "completed" | "failed" | "cancelled" | "budget-exceeded";
+  errorMessage?: string;
+}
+
+export interface CuaProvider {
+  runLoop(cfg: CuaRunConfig): Promise<CuaRunResult>;
+}

--- a/apps/extension/src/lib/agent/cua/provider.ts
+++ b/apps/extension/src/lib/agent/cua/provider.ts
@@ -11,6 +11,12 @@ export interface CuaRunConfig {
   task: string;
   systemPrompt: string;
   maxSteps: number;
+  /**
+   * Max width (CSS px) of the display declared to the model; the viewport is
+   * downscaled to fit. Lets a provider tune the resolution/cost tradeoff.
+   * Defaults to 1280 when unset.
+   */
+  maxDisplayWidth?: number;
   abortSignal?: AbortSignal;
   /** Called with each assistant UIMessage so the runner can persist the trace. */
   onUiMessage?: (message: unknown) => void;

--- a/apps/extension/src/lib/agent/cua/resolve.ts
+++ b/apps/extension/src/lib/agent/cua/resolve.ts
@@ -1,0 +1,49 @@
+import { createAnthropicCuaProvider } from "./anthropic";
+import { isAnthropicComputerUseModel } from "./model-ids";
+import type { CuaProvider } from "./provider";
+
+/**
+ * Resolve a CUA provider strategy for a given registry provider id + model id.
+ *
+ * Supported transports in Phase 1:
+ *   - `anthropic` (direct): any configured Anthropic key. The model id is a
+ *     direct id like `claude-sonnet-4-6`.
+ *   - `vercel` (Vercel AI Gateway): only Anthropic Claude computer-use models,
+ *     whose ids look like `anthropic/claude-sonnet-4.6`. The gateway is the
+ *     transport; the `computer_*` tool is still built from `@ai-sdk/anthropic`
+ *     (the gateway forwards the provider-defined tool). The loop runs against
+ *     the gateway-routed model, so `config.apiKey` here only mints the tool
+ *     descriptor, not the transport call.
+ *
+ * Other providers (and non-Claude gateway models) throw a clear error.
+ */
+export function resolveCuaProvider(
+  providerId: string,
+  modelId: string,
+  config: Record<string, string>,
+): CuaProvider {
+  if (providerId === "anthropic") {
+    if (!config.apiKey)
+      throw new Error("Anthropic CUA requires an apiKey in provider config.");
+    return createAnthropicCuaProvider(config.apiKey);
+  }
+
+  if (providerId === "vercel") {
+    if (!isAnthropicComputerUseModel(modelId)) {
+      throw new Error(
+        `Computer use via the AI Gateway requires an Anthropic Claude computer-use model ` +
+          `(e.g. "anthropic/claude-sonnet-4.6"); got "${modelId}".`,
+      );
+    }
+    if (!config.apiKey)
+      throw new Error("Gateway CUA requires an apiKey in provider config.");
+    // The gateway key mints the Anthropic-defined computer tool; the actual
+    // generation runs against the gateway model passed into runLoop.
+    return createAnthropicCuaProvider(config.apiKey);
+  }
+
+  throw new Error(
+    `Computer use is not supported for provider '${providerId}' yet ` +
+      `(Phase 1 supports Anthropic direct and the Vercel AI Gateway with Claude models).`,
+  );
+}

--- a/apps/extension/src/lib/agent/cua/screenshot.ts
+++ b/apps/extension/src/lib/agent/cua/screenshot.ts
@@ -1,0 +1,121 @@
+/**
+ * CUA screenshot capture + normalization.
+ *
+ * CRITICAL for click accuracy: CDP `Page.captureScreenshot` returns the image
+ * at NATIVE (device-pixel) resolution — on a HiDPI/Retina display that's
+ * `cssWidth * devicePixelRatio` wide. But we declare the display to the model
+ * as CSS pixels (`displayWidthPx`/`displayHeightPx`), and the model returns
+ * coordinates in that declared space. If the image we send is 2× larger than
+ * the declared size, the model's visual grounding and our coordinate space
+ * disagree and clicks land in the wrong place.
+ *
+ * Anthropic's own reference implementation resizes the screenshot to exactly
+ * the declared display dimensions (`convert -resize WxH!`). We do the same
+ * here using an OffscreenCanvas so image-pixels == declared-pixels == the
+ * model's coordinate space.
+ */
+
+import type { BrowserDriver, TabId } from "../driver";
+import { captureViewportShot } from "./executor";
+
+/**
+ * Capture the viewport and resize the PNG to exactly `targetWidth` ×
+ * `targetHeight` (the dimensions declared to the model). Returns a
+ * `data:image/png;base64,...` URL. Falls back to the raw capture if canvas
+ * resizing is unavailable (e.g. a non-DOM test environment).
+ */
+export async function captureNormalizedShot(
+  driver: BrowserDriver,
+  tabId: TabId,
+  targetWidth: number,
+  targetHeight: number,
+): Promise<string> {
+  const base64 = await captureViewportShot(driver, tabId);
+  const dataUrl = `data:image/png;base64,${base64}`;
+
+  // Resize only when the canvas primitives exist. The annotator
+  // (tools/screenshot.ts) relies on the same OffscreenCanvas/createImageBitmap
+  // APIs in the service worker, so this is available in production.
+  const hasCanvas =
+    typeof OffscreenCanvas !== "undefined" &&
+    typeof createImageBitmap !== "undefined";
+  if (!hasCanvas) return dataUrl;
+
+  try {
+    const blob = base64ToPngBlob(base64);
+    const bitmap = await createImageBitmap(blob);
+    // Already the right size (no DPR scaling and within max) — skip re-encode.
+    if (bitmap.width === targetWidth && bitmap.height === targetHeight) {
+      bitmap.close();
+      return dataUrl;
+    }
+    const canvas = new OffscreenCanvas(targetWidth, targetHeight);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      bitmap.close();
+      return dataUrl;
+    }
+    ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
+    bitmap.close();
+    const outBlob = await canvas.convertToBlob({ type: "image/png" });
+    const buffer = await outBlob.arrayBuffer();
+    return `data:image/png;base64,${bufferToBase64(buffer)}`;
+  } catch {
+    // Any decode/encode failure: fall back to the raw capture rather than
+    // failing the whole action.
+    return dataUrl;
+  }
+}
+
+function base64ToPngBlob(base64: string): Blob {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: "image/png" });
+}
+
+function bufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Capture the viewport and crop to a region given in DECLARED display coords
+ * (the space the model declared via display_width/height_px). The native
+ * capture is larger on HiDPI, so we scale the region by (nativeWidth /
+ * displayWidth). Returns a `data:image/png;base64,...` crop at native
+ * resolution so the model can read small text. Falls back to the full
+ * normalized shot when canvas primitives are unavailable (tests).
+ */
+export async function captureRegionShot(
+  driver: BrowserDriver,
+  tabId: TabId,
+  region: { x1: number; y1: number; x2: number; y2: number },
+  displayWidth: number,
+  displayHeight: number,
+): Promise<string> {
+  const hasCanvas =
+    typeof OffscreenCanvas !== "undefined" && typeof createImageBitmap !== "undefined";
+  if (!hasCanvas) return captureNormalizedShot(driver, tabId, displayWidth, displayHeight);
+
+  const base64 = await captureViewportShot(driver, tabId);
+  const blob = await (await fetch(`data:image/png;base64,${base64}`)).blob();
+  const bmp = await createImageBitmap(blob);
+  const scale = bmp.width / displayWidth;
+  const sx = Math.max(0, Math.round(region.x1 * scale));
+  const sy = Math.max(0, Math.round(region.y1 * scale));
+  const sw = Math.max(1, Math.round((region.x2 - region.x1) * scale));
+  const sh = Math.max(1, Math.round((region.y2 - region.y1) * scale));
+  const canvas = new OffscreenCanvas(sw, sh);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return captureNormalizedShot(driver, tabId, displayWidth, displayHeight);
+  ctx.drawImage(bmp, sx, sy, sw, sh, 0, 0, sw, sh);
+  const outBlob = await canvas.convertToBlob({ type: "image/png" });
+  const buf = await outBlob.arrayBuffer();
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+  return `data:image/png;base64,${b64}`;
+}

--- a/apps/extension/src/lib/agent/cua/screenshot.ts
+++ b/apps/extension/src/lib/agent/cua/screenshot.ts
@@ -116,6 +116,8 @@ export async function captureRegionShot(
   ctx.drawImage(bmp, sx, sy, sw, sh, 0, 0, sw, sh);
   const outBlob = await canvas.convertToBlob({ type: "image/png" });
   const buf = await outBlob.arrayBuffer();
-  const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+  // Use the loop-based encoder (not `String.fromCharCode(...spread)`), which
+  // overflows the call stack for large screenshots.
+  const b64 = bufferToBase64(buf);
   return `data:image/png;base64,${b64}`;
 }

--- a/apps/extension/src/lib/agent/driver/index.ts
+++ b/apps/extension/src/lib/agent/driver/index.ts
@@ -16,6 +16,7 @@ export type {
 } from "./browser-driver";
 export type { ToolContext, ToolSession } from "./tool-context";
 export {
+  bindTabByHandle,
   handleForTab,
   resolveTabIdOrThrow,
   resolveTabOrThrow,

--- a/apps/extension/src/lib/agent/driver/tool-context.ts
+++ b/apps/extension/src/lib/agent/driver/tool-context.ts
@@ -83,6 +83,12 @@ export interface ToolSession {
    */
   targetWindowId?: number;
   /**
+   * For `attached` (CUA) subagents: the parent tab handle the runner seeded
+   * into this session's handle map. The CUA loop resolves this to the live
+   * tab id to operate on.
+   */
+  cuaTabHandle?: string;
+  /**
    * Resolve the window new agent-created tabs should open in for the root
    * agent. Tools that create tabs (e.g. `navigate`) call this when no
    * static `targetWindowId` is set, so a new tab lands in the same window
@@ -167,4 +173,42 @@ export async function resolveTabOrThrow(
       }. Call listTabs to refresh handles.`,
     );
   }
+}
+
+/**
+ * Bind a tab (referenced by handle) into the active conversation so it
+ * appears in the tab legend and can be addressed by subsequent tool calls.
+ *
+ * Resolution order mirrors `selectTab`:
+ *   1. The session handle map (`resolveHandle`).
+ *   2. A numeric fallback — the raw `chrome.tabs` id, for tabs the agent
+ *      hasn't bound yet (e.g. user-opened tabs surfaced by `listTabs`).
+ * The tab is verified to exist via `driver.listTabs()` before binding.
+ *
+ * Returns the bound tab id, or `null` if the handle could not be resolved
+ * to a live tab. Does NOT change the user's visible tab.
+ *
+ * Shared by the `selectTab` tool and the `delegate` tool's auto-bind path
+ * for `attached` (CUA) subagents.
+ */
+export async function bindTabByHandle(
+  ctx: ToolContext,
+  handle: string,
+): Promise<TabId | null> {
+  let tabId = ctx.session?.resolveHandle?.(handle);
+
+  // Fallback: a user-opened tab may appear in listTabs under its numeric
+  // chrome id before it is bound to the conversation.
+  if (tabId == null) {
+    const parsed = parseInt(handle, 10);
+    if (!Number.isNaN(parsed)) tabId = parsed;
+  }
+  if (tabId == null) return null;
+
+  const tabs = await ctx.driver.listTabs();
+  const target = tabs.find((t) => t.id === tabId);
+  if (!target) return null;
+
+  await ctx.session?.bindActiveTabToConversation?.(tabId);
+  return tabId;
 }

--- a/apps/extension/src/lib/agent/driver/tool-context.ts
+++ b/apps/extension/src/lib/agent/driver/tool-context.ts
@@ -198,10 +198,11 @@ export async function bindTabByHandle(
   let tabId = ctx.session?.resolveHandle?.(handle);
 
   // Fallback: a user-opened tab may appear in listTabs under its numeric
-  // chrome id before it is bound to the conversation.
-  if (tabId == null) {
-    const parsed = parseInt(handle, 10);
-    if (!Number.isNaN(parsed)) tabId = parsed;
+  // chrome id before it is bound to the conversation. Only accept a strictly
+  // all-digit handle — `parseInt("123abc")` would otherwise resolve a
+  // malformed handle to a real tab.
+  if (tabId == null && /^\d+$/.test(handle)) {
+    tabId = Number(handle);
   }
   if (tabId == null) return null;
 

--- a/apps/extension/src/lib/agent/keyboard.ts
+++ b/apps/extension/src/lib/agent/keyboard.ts
@@ -96,8 +96,18 @@ export async function dispatchKeyCombo(
   let mainKey: string | undefined;
   for (const k of keys) {
     const mod = COMBO_MODIFIERS[k.toLowerCase()];
-    if (mod) mods.push(mod);
-    else mainKey = k;
+    if (mod) {
+      mods.push(mod);
+    } else if (mainKey !== undefined) {
+      // A combo may have at most one non-modifier key. Two main keys (e.g.
+      // "a+b") is ambiguous — reject rather than silently dropping the first.
+      throw new Error(
+        `Ambiguous key combo "${keys.join("+")}": more than one non-modifier key (` +
+          `"${mainKey}" and "${k}"). A combo must be zero or more modifiers plus a single key.`,
+      );
+    } else {
+      mainKey = k;
+    }
   }
   if (!mainKey) return;
   const modifiers = modifierMask(mods);

--- a/apps/extension/src/lib/agent/keyboard.ts
+++ b/apps/extension/src/lib/agent/keyboard.ts
@@ -1,0 +1,116 @@
+import type { BrowserDriver, TabId } from "./driver";
+import type { ModifierKey } from "./cua/actions";
+
+const MODIFIER_BITS: Record<ModifierKey, number> = {
+  alt: 1,
+  ctrl: 2,
+  super: 4, // Meta/Command
+  shift: 8,
+};
+
+export function modifierMask(mods?: ModifierKey[]): number {
+  if (!mods) return 0;
+  return mods.reduce((m, k) => m | MODIFIER_BITS[k], 0);
+}
+
+/** Minimal key-name → CDP key event params. Extend as needed. */
+export function keyEventParams(name: string): {
+  key: string;
+  code: string;
+  windowsVirtualKeyCode?: number;
+} {
+  const lower = name.toLowerCase();
+  switch (lower) {
+    case "enter":
+    case "return":
+      return { key: "Enter", code: "Enter", windowsVirtualKeyCode: 13 };
+    case "tab":
+      return { key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 };
+    case "backspace":
+      return { key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8 };
+    case "escape":
+    case "esc":
+      return { key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 };
+    case "arrowup":
+    case "up":
+      return { key: "ArrowUp", code: "ArrowUp", windowsVirtualKeyCode: 38 };
+    case "arrowdown":
+    case "down":
+      return { key: "ArrowDown", code: "ArrowDown", windowsVirtualKeyCode: 40 };
+    case "arrowleft":
+    case "left":
+      return { key: "ArrowLeft", code: "ArrowLeft", windowsVirtualKeyCode: 37 };
+    case "arrowright":
+    case "right":
+      return { key: "ArrowRight", code: "ArrowRight", windowsVirtualKeyCode: 39 };
+    case "delete":
+      return { key: "Delete", code: "Delete", windowsVirtualKeyCode: 46 };
+    case "home":
+      return { key: "Home", code: "Home", windowsVirtualKeyCode: 36 };
+    case "end":
+      return { key: "End", code: "End", windowsVirtualKeyCode: 35 };
+    case "page_up":
+    case "pageup":
+    case "prior":
+      return { key: "PageUp", code: "PageUp", windowsVirtualKeyCode: 33 };
+    case "page_down":
+    case "pagedown":
+    case "next":
+      return { key: "PageDown", code: "PageDown", windowsVirtualKeyCode: 34 };
+    case "space":
+      return { key: " ", code: "Space", windowsVirtualKeyCode: 32 };
+    default: {
+      // Unknown single-character keys (e.g. "a", "/") are passed through as
+      // literal characters. Unknown multi-char keysyms are passed through as
+      // the `key` name verbatim rather than truncated to their first char —
+      // truncating corrupts input (e.g. "Page_Down" → "P").
+      if (name.length === 1) {
+        return { key: name, code: `Key${name.toUpperCase()}` };
+      }
+      return { key: name, code: "" };
+    }
+  }
+}
+
+/** Keys that are modifiers when they appear in a `key` combo. */
+const COMBO_MODIFIERS: Record<string, ModifierKey> = {
+  ctrl: "ctrl",
+  control: "ctrl",
+  shift: "shift",
+  alt: "alt",
+  meta: "super",
+  cmd: "super",
+  command: "super",
+  super: "super",
+};
+
+/** Dispatch a key combo (modifiers + one main key). When `holdMs` is given,
+ *  the key is held down for that duration before release. */
+export async function dispatchKeyCombo(
+  driver: BrowserDriver,
+  tabId: TabId,
+  keys: string[],
+  holdMs?: number,
+): Promise<void> {
+  const mods: ModifierKey[] = [];
+  let mainKey: string | undefined;
+  for (const k of keys) {
+    const mod = COMBO_MODIFIERS[k.toLowerCase()];
+    if (mod) mods.push(mod);
+    else mainKey = k;
+  }
+  if (!mainKey) return;
+  const modifiers = modifierMask(mods);
+  const kp = keyEventParams(mainKey);
+  await driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
+    type: "keyDown",
+    modifiers,
+    ...kp,
+  });
+  if (holdMs && holdMs > 0) await new Promise((r) => setTimeout(r, holdMs));
+  await driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
+    type: "keyUp",
+    modifiers,
+    ...kp,
+  });
+}

--- a/apps/extension/src/lib/agent/ref-store.ts
+++ b/apps/extension/src/lib/agent/ref-store.ts
@@ -102,6 +102,36 @@ export function invalidateRefs(tabId: TabId): void {
   refsByTab.delete(tabId);
 }
 
+/**
+ * After an in-page action (click/type/key), detect whether the action actually
+ * caused a navigation to a different document and, if so, hard-invalidate refs
+ * BEFORE the post-action snapshot's merge. Without this, the carry-over pool
+ * (see `setRefs`) keeps old-page ref ids resolvable to detached backendNodeIds
+ * on the new page — the same leak `navigate.ts` guards against with an explicit
+ * `invalidateRefs`. In-page re-renders (same URL) intentionally do NOT
+ * invalidate, preserving the content-stable ref carry-over.
+ *
+ * `previousUrl` is the URL at the last snapshot (`PageStateSignals.url`).
+ * Best-effort: a failed tab lookup leaves refs untouched. Returns true when it
+ * invalidated.
+ */
+export async function invalidateRefsIfNavigated(
+  driver: { getTab: (tabId: TabId) => Promise<{ url?: string }> },
+  tabId: TabId,
+  previousUrl: string | undefined,
+): Promise<boolean> {
+  if (!previousUrl) return false;
+  let currentUrl: string | undefined;
+  try {
+    currentUrl = (await driver.getTab(tabId)).url;
+  } catch {
+    return false;
+  }
+  if (!currentUrl || currentUrl === previousUrl) return false;
+  invalidateRefs(tabId);
+  return true;
+}
+
 export function hasRefs(tabId: TabId): boolean {
   const entry = refsByTab.get(tabId);
   return !!entry && entry.refs.size > 0;

--- a/apps/extension/src/lib/agent/ref-store.ts
+++ b/apps/extension/src/lib/agent/ref-store.ts
@@ -1,24 +1,89 @@
 import type { TabId } from "./driver";
+import type { PageStateSignals } from "./snapshot-capture";
 
 export interface RefEntry {
   backendNodeId: number;
   role: string;
   name: string;
+  /**
+   * Occurrence index of this element among all elements sharing the same
+   * (role, name) within its frame, in document order. Lets re-resolution
+   * re-find the SAME logical element from a fresh accessibility tree by
+   * (role, name, nth) when the cached backendNodeId goes stale — the
+   * mechanism agent-browser uses. Defaults to 0 when unknown.
+   */
+  nth: number;
+  /**
+   * Frame the element lives in, when it is not the top frame. Threaded
+   * through resolution so a future cross-frame session router can target
+   * the right CDP session. `undefined` means the top-level frame.
+   */
+  frameId?: string;
 }
 
 interface TabRefs {
+  /**
+   * The latest snapshot's refs — the authoritative current view of the tab.
+   */
   refs: Map<string, RefEntry>;
+  /**
+   * Carried-over refs from recent prior snapshots that are NOT in the latest
+   * one. With content-stable ref ids, a ref the agent took from a snapshot
+   * one or two captures ago still identifies the same logical element; if the
+   * element scrolled out of the latest viewport-scoped snapshot we can still
+   * resolve it (its backendNodeId may be stale, but action tools re-resolve
+   * by re-snapshotting). Bounded to the last RECENT_SNAPSHOT_RETENTION
+   * snapshots to avoid unbounded growth and stale-pointer rot.
+   */
+  carriedRefs: Map<string, RefEntry>;
   previousSnapshot: string | null;
+  previousSignals: PageStateSignals | null;
 }
+
+/**
+ * How many prior snapshots' refs we keep resolvable beyond the latest one.
+ * 1 means: the latest snapshot plus the one immediately before it. Keeps the
+ * window where a just-taken ref stays valid even if the next snapshot's
+ * (e.g. viewport-scoped) tree no longer contains it.
+ */
+const RECENT_SNAPSHOT_RETENTION = 1;
 
 const refsByTab = new Map<TabId, TabRefs>();
 
-export function setRefs(tabId: TabId, refs: Map<string, RefEntry>, snapshotText: string): void {
-  refsByTab.set(tabId, { refs, previousSnapshot: snapshotText });
+export function setRefs(
+  tabId: TabId,
+  refs: Map<string, RefEntry>,
+  snapshotText: string,
+  signals: PageStateSignals,
+): void {
+  const existing = refsByTab.get(tabId);
+
+  // Merge the previous snapshot's refs into the carry-over pool (bounded):
+  // any ref from the immediately-prior `refs` that is NOT superseded by the
+  // new snapshot remains resolvable. We only retain one generation back, so
+  // we rebuild carriedRefs from the prior `refs` rather than accumulating
+  // indefinitely.
+  const carriedRefs = new Map<string, RefEntry>();
+  if (existing && RECENT_SNAPSHOT_RETENTION > 0) {
+    for (const [ref, entry] of existing.refs) {
+      if (!refs.has(ref)) carriedRefs.set(ref, entry);
+    }
+  }
+
+  refsByTab.set(tabId, {
+    refs,
+    carriedRefs,
+    previousSnapshot: snapshotText,
+    previousSignals: signals,
+  });
 }
 
 export function getRef(tabId: TabId, ref: string): RefEntry | undefined {
-  return refsByTab.get(tabId)?.refs.get(ref);
+  const tab = refsByTab.get(tabId);
+  if (!tab) return undefined;
+  // Latest snapshot wins; fall back to recently-carried refs so a ref from
+  // the immediately-prior snapshot still resolves.
+  return tab.refs.get(ref) ?? tab.carriedRefs.get(ref);
 }
 
 export function getRefsForTab(tabId: TabId): Map<string, RefEntry> | undefined {
@@ -27,6 +92,10 @@ export function getRefsForTab(tabId: TabId): Map<string, RefEntry> | undefined {
 
 export function getPreviousSnapshot(tabId: TabId): string | null {
   return refsByTab.get(tabId)?.previousSnapshot ?? null;
+}
+
+export function getPreviousSignals(tabId: TabId): PageStateSignals | null {
+  return refsByTab.get(tabId)?.previousSignals ?? null;
 }
 
 export function invalidateRefs(tabId: TabId): void {

--- a/apps/extension/src/lib/agent/snapshot-capture.ts
+++ b/apps/extension/src/lib/agent/snapshot-capture.ts
@@ -10,7 +10,12 @@
  */
 
 import type { BrowserDriver, TabId } from "./driver";
-import { setRefs, getPreviousSnapshot, type RefEntry } from "./ref-store";
+import {
+  setRefs,
+  getPreviousSnapshot,
+  getPreviousSignals,
+  type RefEntry,
+} from "./ref-store";
 
 const INTERACTIVE_ROLES = new Set([
   "button",
@@ -43,19 +48,35 @@ interface AXNode {
   parentId?: string;
   childIds?: string[];
   backendDOMNodeId?: number;
+  /** Present on nodes that belong to a child frame (CDP getFullAXTree). */
+  frameId?: string;
 }
 
 interface TreeNode {
   axNode: AXNode;
   children: TreeNode[];
   ref: string | null;
+  /** True when this node is an interactive element that should receive a ref. */
+  interactive: boolean;
+  /**
+   * Occurrence index among nodes sharing this node's (frameId, role, name),
+   * in document order. Stored on the ref entry so re-resolution can re-find
+   * the element by (role, name, nth) from a fresh AX tree. Set by
+   * `assignStableRefs`; only meaningful when `ref` is non-null.
+   */
+  nth: number;
   visible: boolean;
 }
 
 export interface CaptureResult {
   snapshotText: string;
   refs: Map<string, RefEntry>;
+  /** A11y text from the previous snapshot, or null on first capture. */
   previous: string | null;
+  /** Signals captured at this snapshot. */
+  signals: PageStateSignals;
+  /** Signals from the previous snapshot, or null on first capture. */
+  previousSignals: PageStateSignals | null;
   /**
    * Count of interactive elements that exist on the page but are below the
    * viewport fold (i.e. would become visible if the agent scrolled down).
@@ -63,6 +84,78 @@ export interface CaptureResult {
    * whether there's more to see.
    */
   belowFoldCount: number;
+}
+
+export interface PageStateSignals {
+  focusedBackendNodeId: number | null;
+  focusedName: string | null;
+  focusedRole: string | null;
+  expandedCount: number;
+  pressedCount: number;
+  checkedCount: number;
+  dialogCount: number;
+  url: string;
+  interactiveCount: number;
+}
+
+/**
+ * Derive multi-signal page state from an already-fetched AX tree, the
+ * collected refs map, and the current URL. Pure function — no I/O — so
+ * it's cheap and unit-testable.
+ *
+ * Signals are intentionally counts rather than node lists: they're robust
+ * (a count won't change without a real state shift) and small (no risk of
+ * blowing up the diff payload on large pages).
+ */
+export function derivePageStateSignals(
+  axNodes: AXNode[],
+  refs: Map<string, RefEntry>,
+  url: string,
+): PageStateSignals {
+  let focusedBackendNodeId: number | null = null;
+  let focusedName: string | null = null;
+  let focusedRole: string | null = null;
+  let expandedCount = 0;
+  let pressedCount = 0;
+  let checkedCount = 0;
+  let dialogCount = 0;
+
+  for (const node of axNodes) {
+    const role = node.role?.value ?? "";
+    if (role === "dialog" || role === "alertdialog") dialogCount++;
+
+    const props = node.properties ?? [];
+    let isFocused = false;
+    for (const p of props) {
+      const v = p.value?.value;
+      if (p.name === "focused" && v === true) isFocused = true;
+      if (p.name === "expanded" && v === true) expandedCount++;
+      if (p.name === "pressed" && v === true) pressedCount++;
+      if (p.name === "checked" && v === true) checkedCount++;
+    }
+
+    if (
+      focusedBackendNodeId == null &&
+      isFocused &&
+      node.backendDOMNodeId != null
+    ) {
+      focusedBackendNodeId = node.backendDOMNodeId;
+      focusedName = node.name?.value ?? null;
+      focusedRole = role || null;
+    }
+  }
+
+  return {
+    focusedBackendNodeId,
+    focusedName,
+    focusedRole,
+    expandedCount,
+    pressedCount,
+    checkedCount,
+    dialogCount,
+    url,
+    interactiveCount: refs.size,
+  };
 }
 
 /**
@@ -80,6 +173,7 @@ export async function captureSnapshot(
 ): Promise<CaptureResult> {
   const mode = opts.mode ?? "interactive";
   const previous = getPreviousSnapshot(tabId);
+  const previousSignals = getPreviousSignals(tabId);
 
   let rootBackendNodeId: number | undefined;
   if (opts.selector) {
@@ -127,9 +221,10 @@ export async function captureSnapshot(
     cursorInteractive,
     rootBackendNodeId,
   );
-  if (rootBackendNodeId != null) {
-    reassignRefs(tree);
-  }
+  // Assign content-stable refs over the built hierarchy. Runs for every
+  // capture (scoped or not) so the same logical element keeps the same @ref
+  // across snapshots, surviving re-renders on virtualized pages.
+  assignStableRefs(tree);
 
   const isInteractive = mode === "interactive";
   let snapshotText = renderTree(tree, isInteractive);
@@ -149,12 +244,27 @@ export async function captureSnapshot(
       retryCursor,
       rootBackendNodeId,
     );
-    if (rootBackendNodeId != null) reassignRefs(tree);
+    assignStableRefs(tree);
     snapshotText = renderTree(tree, isInteractive);
     refs = collectRefs(tree);
+    axTree = retry; // keep axTree in sync for downstream signal + belowFoldCount derivation.
   }
 
-  setRefs(tabId, refs, snapshotText);
+  // Fetch current URL for the URL signal. Cheap CDP call.
+  let url = "";
+  try {
+    const targetInfo = await driver.sendCommand<{
+      targetInfo?: { url?: string };
+    }>(tabId, "Target.getTargetInfo");
+    url = targetInfo.targetInfo?.url ?? "";
+  } catch {
+    // If we can't get the URL (rare), leave it as "". A "" → "" diff is a no-op
+    // signal, so this is safe.
+  }
+
+  const signals = derivePageStateSignals(axTree.nodes, refs, url);
+
+  setRefs(tabId, refs, snapshotText, signals);
 
   // Count refs whose backendNodeId falls below the fold. We do this by
   // walking the collected refs (which are guaranteed to be interactive
@@ -182,58 +292,132 @@ export async function captureSnapshot(
     }
   }
 
-  return { snapshotText, refs, previous, belowFoldCount };
+  return {
+    snapshotText,
+    refs,
+    previous,
+    signals,
+    previousSignals,
+    belowFoldCount,
+  };
 }
 
 /**
- * Compute a line-level diff between two snapshots. Returns a short summary
- * suitable for auto-attaching to action responses.
+ * Compute a diff between two snapshots that combines the line-level a11y
+ * text diff with a multi-signal state diff. Returns a short summary suitable
+ * for auto-attaching to action responses.
  *
- * Returns null if the snapshots are identical (signals "no visible change",
- * often a silent action failure).
+ * Returns null ONLY when text AND all signals are identical — i.e. nothing
+ * observable changed. This is intentionally narrower than the old
+ * text-only set-diff: many successful interactions (focus, toggles, modal
+ * opens) leave the a11y text identical, and reporting them as "no change"
+ * was driving the agent into retry loops.
  */
 export function diffSnapshots(
-  previous: string,
-  current: string,
+  prev: { text: string; signals: PageStateSignals },
+  curr: { text: string; signals: PageStateSignals },
   opts: { maxLines?: number } = {},
 ): string | null {
   const maxLines = opts.maxLines ?? 40;
-  const prevLines = previous.split("\n");
-  const currLines = current.split("\n");
+  const prevLines = prev.text.split("\n");
+  const currLines = curr.text.split("\n");
 
   const prevSet = new Set(prevLines);
   const currSet = new Set(currLines);
 
   const added: string[] = [];
   const removed: string[] = [];
+  for (const line of currLines) if (!prevSet.has(line)) added.push(line);
+  for (const line of prevLines) if (!currSet.has(line)) removed.push(line);
 
-  for (const line of currLines) {
-    if (!prevSet.has(line)) added.push(line);
-  }
-  for (const line of prevLines) {
-    if (!currSet.has(line)) removed.push(line);
-  }
-
-  if (added.length === 0 && removed.length === 0) return null;
-
-  // Navigation or major change — truncate and summarize
-  const totalChanges = added.length + removed.length;
-  if (totalChanges > maxLines) {
-    const sampledAdded = added.slice(0, Math.floor(maxLines / 2));
-    const sampledRemoved = removed.slice(0, Math.floor(maxLines / 2));
-    const lines = [
-      `[major change: ${added.length} added, ${removed.length} removed — showing first ${maxLines}]`,
-      ...sampledAdded.map((l) => `[+] ${l.trim()}`),
-      ...sampledRemoved.map((l) => `[-] ${l.trim()}`),
-      `[call snapshot to see the full updated tree]`,
-    ];
-    return lines.join("\n");
+  // Text-changing case: return the existing-style line diff, unchanged.
+  if (added.length > 0 || removed.length > 0) {
+    const totalChanges = added.length + removed.length;
+    if (totalChanges > maxLines) {
+      const sampledAdded = added.slice(0, Math.floor(maxLines / 2));
+      const sampledRemoved = removed.slice(0, Math.floor(maxLines / 2));
+      return [
+        `[major change: ${added.length} added, ${removed.length} removed — showing first ${maxLines}]`,
+        ...sampledAdded.map((l) => `[+] ${l.trim()}`),
+        ...sampledRemoved.map((l) => `[-] ${l.trim()}`),
+        `[call snapshot to see the full updated tree]`,
+      ].join("\n");
+    }
+    return [
+      ...added.map((l) => `[+] ${l.trim()}`),
+      ...removed.map((l) => `[-] ${l.trim()}`),
+    ].join("\n");
   }
 
-  return [
-    ...added.map((l) => `[+] ${l.trim()}`),
-    ...removed.map((l) => `[-] ${l.trim()}`),
-  ].join("\n");
+  // Text identical: check signal diff.
+  const signalChanges = describeSignalChanges(prev.signals, curr.signals);
+  if (signalChanges.length > 0) {
+    return `[no a11y text change, but: ${signalChanges.join("; ")}]`;
+  }
+
+  return null;
+}
+
+/**
+ * Render per-signal change descriptions. Returns one human-readable string
+ * per signal that changed; empty array means signals are identical.
+ */
+function describeSignalChanges(
+  prev: PageStateSignals,
+  curr: PageStateSignals,
+): string[] {
+  const out: string[] = [];
+
+  // Focus.
+  if (prev.focusedBackendNodeId !== curr.focusedBackendNodeId) {
+    const prevLabel = formatFocusLabel(prev);
+    const currLabel = formatFocusLabel(curr);
+    out.push(`focus moved from «${prevLabel}» to «${currLabel}»`);
+  }
+
+  // Toggle counts.
+  if (prev.expandedCount !== curr.expandedCount) {
+    out.push(`aria-expanded count: ${prev.expandedCount} → ${curr.expandedCount}`);
+  }
+  if (prev.pressedCount !== curr.pressedCount) {
+    out.push(`aria-pressed count: ${prev.pressedCount} → ${curr.pressedCount}`);
+  }
+  if (prev.checkedCount !== curr.checkedCount) {
+    out.push(`aria-checked count: ${prev.checkedCount} → ${curr.checkedCount}`);
+  }
+
+  // Dialog count — special-case 0↔N transitions.
+  if (prev.dialogCount !== curr.dialogCount) {
+    if (prev.dialogCount === 0 && curr.dialogCount > 0) out.push("dialog opened");
+    else if (curr.dialogCount === 0 && prev.dialogCount > 0) out.push("dialog closed");
+    else out.push(`dialog count: ${prev.dialogCount} → ${curr.dialogCount}`);
+  }
+
+  // URL. Skip when either side is empty: an empty URL means the
+  // `Target.getTargetInfo` fetch failed (or this is the first capture), not a
+  // real navigation — diffing against "" would emit a spurious "navigated to ".
+  if (prev.url !== "" && curr.url !== "" && prev.url !== curr.url) {
+    out.push(`navigated to ${curr.url}`);
+  }
+
+  // Interactive count.
+  if (prev.interactiveCount !== curr.interactiveCount) {
+    out.push(
+      `interactive elements: ${prev.interactiveCount} → ${curr.interactiveCount}`,
+    );
+  }
+
+  return out;
+}
+
+function formatFocusLabel(signals: PageStateSignals): string {
+  if (signals.focusedName && signals.focusedName.trim().length > 0) {
+    return signals.focusedName;
+  }
+  if (signals.focusedBackendNodeId != null) {
+    return `node#${signals.focusedBackendNodeId}`;
+  }
+  return "none";
 }
 
 // ============================================================================
@@ -246,7 +430,6 @@ function buildTree(
   cursorInteractive: Set<number>,
   scopeBackendNodeId?: number,
 ): TreeNode {
-  let refCounter = 1;
   const treeNodes = new Map<string, TreeNode>();
 
   for (const node of nodes) {
@@ -263,12 +446,18 @@ function buildTree(
 
     const shouldSkip = node.ignored || SKIP_ROLES.has(role) || isHidden;
 
-    const ref = !shouldSkip && isInteractive ? `@e${refCounter++}` : null;
+    // Refs are assigned later by `assignStableRefs`, which walks the built
+    // hierarchy so it can compute a content-stable id (role + name +
+    // landmark + occurrence). Here we only record WHETHER the node is a
+    // ref-worthy interactive element.
+    const interactive = !shouldSkip && isInteractive;
 
     treeNodes.set(node.nodeId, {
       axNode: node,
       children: [],
-      ref,
+      ref: null,
+      interactive,
+      nth: 0,
       visible: !shouldSkip && !isHidden,
     });
   }
@@ -293,7 +482,16 @@ function buildTree(
   }
 
   if (scopeRoot) return scopeRoot;
-  return root ?? { axNode: nodes[0], children: [], ref: null, visible: true };
+  return (
+    root ?? {
+      axNode: nodes[0],
+      children: [],
+      ref: null,
+      interactive: false,
+      nth: 0,
+      visible: true,
+    }
+  );
 }
 
 function renderTree(
@@ -418,13 +616,113 @@ function formatProps(node: AXNode): string {
   return parts.length > 0 ? `[${parts.join(", ")}]` : "";
 }
 
-function reassignRefs(root: TreeNode): void {
-  let counter = 1;
-  function walk(node: TreeNode) {
-    if (node.ref) node.ref = `@e${counter++}`;
-    for (const child of node.children) walk(child);
+/**
+ * Assigns a content-stable `@ref` id to every interactive node in the tree.
+ *
+ * Unlike the old ordinal scheme (`@e1`, `@e2`, … reassigned every capture),
+ * the id here is derived from the element's identity:
+ *   role + accessible name + nearest landmark (region/nav/main/…) context
+ *   + an occurrence index disambiguating siblings that share that signature.
+ *
+ * The signature is hashed to a short, stable token `@e<base36>`. Because the
+ * token depends only on content/structure — not on how many interactive
+ * nodes happen to precede it — the SAME logical element keeps the SAME ref
+ * across snapshots even when the page re-renders, adds, or removes unrelated
+ * elements. This is what lets a ref taken from one snapshot still resolve
+ * after a later one, and what stops diffs from showing phantom
+ * `[-]@e114 / [+]@e117` churn for elements that did not actually change.
+ *
+ * Collision handling: two genuinely distinct elements with an identical
+ * (role, name, landmark) signature — e.g. a list of identical "Connect"
+ * buttons — are disambiguated by their occurrence index within that
+ * signature group, so each still gets a unique, stable ref.
+ */
+function assignStableRefs(root: TreeNode): void {
+  // Count how many times each base signature has been seen so far, so
+  // repeated (role,name,landmark) groups get a stable incrementing index.
+  const seen = new Map<string, number>();
+  // Separately count (frameId, role, name) occurrences in document order.
+  // This `nth` is what re-resolution re-finds by from a fresh AX tree — it
+  // must match the role/name counting that `findNodeByRoleNameNth` does, so
+  // it is intentionally NOT landmark-scoped.
+  const tupleSeen = new Map<string, number>();
+  // Guard against the astronomically-unlikely case of two different
+  // signatures hashing to the same token within one snapshot.
+  const used = new Set<string>();
+
+  function landmarkLabel(role: string, name: string): string | null {
+    if (LANDMARK_ROLES.has(role)) {
+      return name ? `${role}:${name}` : role;
+    }
+    return null;
   }
-  walk(root);
+
+  function walk(node: TreeNode, landmarkPath: string): void {
+    const role = node.axNode.role?.value ?? "";
+    const name = node.axNode.name?.value ?? "";
+
+    // Extend the landmark path when entering a landmark/region node.
+    const lm = landmarkLabel(role, name);
+    const childPath = lm ? (landmarkPath ? `${landmarkPath}>${lm}` : lm) : landmarkPath;
+
+    if (node.interactive) {
+      const baseSig = `${landmarkPath}|${role}|${name}`;
+      const occurrence = seen.get(baseSig) ?? 0;
+      seen.set(baseSig, occurrence + 1);
+      const fullSig = `${baseSig}#${occurrence}`;
+
+      let token = `@e${hashSignature(fullSig)}`;
+      // Extremely unlikely collision fallback: salt until unique.
+      let salt = 0;
+      while (used.has(token)) {
+        salt++;
+        token = `@e${hashSignature(`${fullSig}~${salt}`)}`;
+      }
+      used.add(token);
+      node.ref = token;
+
+      // Frame-scoped (role, name) occurrence index for tuple re-resolution.
+      const frameKey = `${node.axNode.frameId ?? ""}|${role}|${name}`;
+      const nth = tupleSeen.get(frameKey) ?? 0;
+      tupleSeen.set(frameKey, nth + 1);
+      node.nth = nth;
+    }
+
+    for (const child of node.children) walk(child, childPath);
+  }
+
+  walk(root, "");
+}
+
+/** Roles that establish a landmark/region context for ref signatures. */
+const LANDMARK_ROLES = new Set([
+  "banner",
+  "navigation",
+  "main",
+  "complementary",
+  "contentinfo",
+  "region",
+  "search",
+  "form",
+  "article",
+  "dialog",
+  "alertdialog",
+]);
+
+/**
+ * Deterministic, compact hash of a signature string → base36 token.
+ * FNV-1a (32-bit) keeps it small, fast, and dependency-free. Used only to
+ * shorten the human-unreadable signature into a stable `@e…` handle; it is
+ * never persisted or relied on for security.
+ */
+function hashSignature(sig: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < sig.length; i++) {
+    h ^= sig.charCodeAt(i);
+    // 32-bit FNV prime multiply via shifts to stay in integer range.
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h.toString(36);
 }
 
 function collectRefs(root: TreeNode): Map<string, RefEntry> {
@@ -436,6 +734,8 @@ function collectRefs(root: TreeNode): Map<string, RefEntry> {
         backendNodeId: node.axNode.backendDOMNodeId,
         role: node.axNode.role?.value ?? "",
         name: node.axNode.name?.value ?? "",
+        nth: node.nth,
+        ...(node.axNode.frameId ? { frameId: node.axNode.frameId } : {}),
       });
     }
     for (const child of node.children) walk(child);
@@ -443,6 +743,53 @@ function collectRefs(root: TreeNode): Map<string, RefEntry> {
 
   walk(root);
   return refs;
+}
+
+/**
+ * Re-find an element's CURRENT backendNodeId by its stable identity tuple
+ * `(role, name, nth)` from a freshly-fetched accessibility tree, scoped to a
+ * frame. This is the tuple-based recovery agent-browser uses: when a cached
+ * backendNodeId goes stale (the element's DOM node was recreated on a
+ * re-render), the ref string may also have changed if its name shifted — but
+ * the stored identity tuple still points at the same logical element, so we
+ * count (role, name) matches in document order and return the nth one.
+ *
+ * Returns null when no matching element exists (genuinely gone) or on CDP
+ * error, so callers can fall through to their existing "stale" handling.
+ *
+ * `frameId` is threaded through for parity with cross-frame resolution; the
+ * current single-session driver ignores it for same-process frames, and
+ * cross-origin (OOPIF) session routing remains a follow-up.
+ */
+export async function findNodeByRoleNameNth(
+  driver: BrowserDriver,
+  tabId: TabId,
+  role: string,
+  name: string,
+  nth: number,
+  _frameId?: string,
+): Promise<number | null> {
+  let axTree: { nodes: AXNode[] };
+  try {
+    axTree = await driver.sendCommand<{ nodes: AXNode[] }>(
+      tabId,
+      "Accessibility.getFullAXTree",
+    );
+  } catch {
+    return null;
+  }
+
+  let matchCount = 0;
+  for (const node of axTree.nodes) {
+    if (node.ignored) continue;
+    if ((node.role?.value ?? "") !== role) continue;
+    if ((node.name?.value ?? "") !== name) continue;
+    if (matchCount === nth) {
+      return node.backendDOMNodeId ?? null;
+    }
+    matchCount++;
+  }
+  return null;
 }
 
 async function getViewportInfo(
@@ -786,9 +1133,7 @@ export async function captureSnapshotWithUrlIds(
     cursorInteractive,
     rootBackendNodeId,
   );
-  if (rootBackendNodeId != null) {
-    reassignRefs(tree);
-  }
+  assignStableRefs(tree);
 
   // Use "full" rendering (not just interactive) — extraction needs to see
   // content elements like headings, text, cells. The URL-ID pass is the

--- a/apps/extension/src/lib/agent/subagents/__tests__/delegate.test.ts
+++ b/apps/extension/src/lib/agent/subagents/__tests__/delegate.test.ts
@@ -149,3 +149,152 @@ describe("delegate tool", () => {
     expect(tool.description).toContain("peer");
   });
 });
+
+describe("delegate tool — CUA attached auto-bind", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    resetSubagentSlotsForTesting();
+    await chatDb.createConversation({
+      id: "parent-conv",
+      title: "Parent",
+      spaceId: "space-A",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+  });
+  afterEach(() => {
+    chatDb._resetForTests();
+    resetSubagentSlotsForTesting();
+  });
+
+  it("binds a user-opened (numeric) tab and normalizes it to a canonical handle so seeding resolves it", async () => {
+    const REAL_TAB_ID = 4242;
+    const handleMap = new Map<string, number>(); // tN -> tabId
+    const tabToHandle = new Map<number, string>();
+    const bound: number[] = [];
+    let counter = 0;
+
+    // Driver that reports the user-opened tab in listTabs (so bindTabByHandle
+    // can verify it), keyed by its raw numeric chrome id.
+    const driver = {
+      listTabs: async () => [{ id: REAL_TAB_ID, url: "https://linkedin.com", title: "LinkedIn" }],
+    } as unknown as ToolContext["driver"];
+
+    const ctx: ToolContext = {
+      driver,
+      session: {
+        conversationId: "parent-conv",
+        // Numeric handle "4242" does NOT resolve as a tN handle.
+        resolveHandle: (h: string) => handleMap.get(h),
+        getOrCreateHandle: (tabId) => {
+          const existing = tabToHandle.get(Number(tabId));
+          if (existing) return existing;
+          counter += 1;
+          const h = `t${counter}`;
+          handleMap.set(h, Number(tabId));
+          tabToHandle.set(Number(tabId), h);
+          return h;
+        },
+        bindActiveTabToConversation: async (tabId) => {
+          bound.push(Number(tabId));
+        },
+      },
+    };
+
+    let seededResolvedTabId: number | string | undefined;
+    let seededHandle: string | undefined;
+    const tool = createDelegateTool({
+      runAgentLoop: async (cfg) => {
+        seededHandle = cfg.toolContext.session?.cuaTabHandle;
+        seededResolvedTabId = seededHandle
+          ? cfg.toolContext.session?.resolveHandle?.(seededHandle)
+          : undefined;
+        return { finalText: "ok", status: "completed" };
+      },
+      cuaEnabled: true,
+    });
+
+    const out = await tool.execute(
+      {
+        slug: "cua",
+        task: "scroll the LinkedIn feed",
+        context: { parentTabHandle: String(REAL_TAB_ID) },
+      },
+      ctx,
+    );
+
+    expect(out.status).toBe("completed");
+    // The user-opened tab was bound into the conversation.
+    expect(bound).toContain(REAL_TAB_ID);
+    // The runner seeded a canonical handle that resolves to the real tab id.
+    expect(seededHandle).toBeTruthy();
+    expect(seededResolvedTabId).toBe(REAL_TAB_ID);
+  });
+});
+
+describe("delegate tool — CUA enablement gate", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    resetSubagentSlotsForTesting();
+    await chatDb.createConversation({
+      id: "parent-conv",
+      title: "Parent",
+      spaceId: "space-A",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+  });
+  afterEach(() => {
+    chatDb._resetForTests();
+    resetSubagentSlotsForTesting();
+  });
+
+  it("rejects a `cua` delegation when CUA is not enabled, without running the loop", async () => {
+    const runAgentLoop = vi.fn(
+      async (_cfg: AgentLoopConfig): Promise<AgentLoopResult> => ({
+        finalText: "should not run",
+        status: "completed",
+      }),
+    );
+    const tool = createDelegateTool({ runAgentLoop, cuaEnabled: false });
+
+    const out = await tool.execute(
+      { slug: "cua", task: "click the Like button", context: { parentTabHandle: "t1" } },
+      fakeCtx({ resolveHandle: () => 1 }),
+    );
+
+    expect(out.status).toBe("failed");
+    expect(out.errorMessage).toMatch(/not enabled/i);
+    expect(runAgentLoop).not.toHaveBeenCalled();
+  });
+
+  it("omits `cua` from the description when disabled and includes it when enabled", () => {
+    const runAgentLoop = vi.fn(
+      async (): Promise<AgentLoopResult> => ({ finalText: "", status: "completed" }),
+    );
+    const disabled = createDelegateTool({ runAgentLoop, cuaEnabled: false });
+    const enabled = createDelegateTool({ runAgentLoop, cuaEnabled: true });
+
+    expect(disabled.description).not.toMatch(/^- cua —/m);
+    expect(disabled.description).not.toMatch(/Delegating to the `cua`/);
+    expect(enabled.description).toMatch(/^- cua —/m);
+    expect(enabled.description).toMatch(/Delegating to the `cua`/);
+  });
+
+  it("defaults to disabled when cuaEnabled is omitted", async () => {
+    const runAgentLoop = vi.fn(
+      async (): Promise<AgentLoopResult> => ({ finalText: "x", status: "completed" }),
+    );
+    const tool = createDelegateTool({ runAgentLoop });
+    expect(tool.description).not.toMatch(/^- cua —/m);
+
+    const out = await tool.execute(
+      { slug: "cua", task: "do a thing" },
+      fakeCtx(),
+    );
+    expect(out.status).toBe("failed");
+    expect(runAgentLoop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/extension/src/lib/agent/subagents/__tests__/persist-stream.test.ts
+++ b/apps/extension/src/lib/agent/subagents/__tests__/persist-stream.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AgentUIMessage } from "../../../types";
 import { chatDb } from "../../../chat-db";
 import {
+  AssistantStreamPersister,
   persistAssistantStream,
   persistDelegationMessage,
 } from "../persist-stream";
@@ -261,5 +262,67 @@ describe("persistAssistantStream", () => {
       parts: [{ type: "text", text: "hello" }],
     });
     expect(result.transcript[1].id).toBe("asst-2");
+  });
+});
+
+describe("AssistantStreamPersister (incremental / live persistence)", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    await chatDb.createConversation({
+      id: "child-1",
+      title: "child",
+      spaceId: null,
+      createdAt: 100,
+      updatedAt: 100,
+    });
+  });
+  afterEach(() => {
+    chatDb._resetForTests();
+  });
+
+  it("writes each message to chat-db immediately (queryable before the run ends)", async () => {
+    const persister = new AssistantStreamPersister("child-1");
+
+    await persister.persist({
+      id: "asst-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "step 1" }],
+    } as AgentUIMessage);
+
+    // The message is in chat-db right away — this is what makes the trace
+    // render in real time, rather than only after the run finishes.
+    let messages = await chatDb.getMessages("child-1");
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ id: "asst-1", content: "step 1" });
+
+    await persister.persist({
+      id: "asst-2",
+      role: "assistant",
+      parts: [{ type: "text", text: "step 2" }],
+    } as AgentUIMessage);
+
+    messages = await chatDb.getMessages("child-1");
+    expect(messages).toHaveLength(2);
+  });
+
+  it("upserts by id (growing parts for the same message id don't duplicate)", async () => {
+    const persister = new AssistantStreamPersister("child-1");
+
+    await persister.persist({
+      id: "asst-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "partial" }],
+    } as AgentUIMessage);
+    await persister.persist({
+      id: "asst-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "partial then complete" }],
+    } as AgentUIMessage);
+
+    const messages = await chatDb.getMessages("child-1");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe("partial then complete");
+    expect(persister.result().messageCount).toBe(1);
   });
 });

--- a/apps/extension/src/lib/agent/subagents/__tests__/registry.test.ts
+++ b/apps/extension/src/lib/agent/subagents/__tests__/registry.test.ts
@@ -31,3 +31,13 @@ describe("subagent registry", () => {
     }
   });
 });
+
+describe("cua built-in", () => {
+  it("is registered with custom CUA tool source and attached isolation", () => {
+    const cua = getAgent("cua");
+    expect(cua).toBeDefined();
+    expect(cua?.toolSource).toBe("custom");
+    expect(cua?.custom?.kind).toBe("cua");
+    expect(cua?.defaultIsolation).toBe("attached");
+  });
+});

--- a/apps/extension/src/lib/agent/subagents/__tests__/runner.test.ts
+++ b/apps/extension/src/lib/agent/subagents/__tests__/runner.test.ts
@@ -467,3 +467,74 @@ describe("runSubagent — incognito isolation", () => {
     expect(child?.subagentFinalText).toBe("(subagent cancelled)");
   });
 });
+
+describe("runSubagent — attached isolation", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    resetSubagentSlotsForTesting();
+    await chatDb.createConversation({
+      id: "parent-conv",
+      title: "Parent",
+      spaceId: "space-A",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+  });
+  afterEach(() => {
+    chatDb._resetForTests();
+    resetSubagentSlotsForTesting();
+  });
+
+  it("seeds the child handle map so the parent's tab handle resolves to the real tab id", async () => {
+    let resolvedTabId: number | string | undefined;
+    const parentCtx: ToolContext = {
+      driver: {} as ToolContext["driver"],
+      session: {
+        conversationId: "parent-conv",
+        resolveHandle: (h: string) => (h === "t3" ? 4242 : undefined),
+        getOrCreateHandle: (id) => (id === 4242 ? "t3" : `t${id}`),
+      },
+    };
+
+    await runSubagent({
+      agentDef: { ...fakeAgent, defaultIsolation: "attached" },
+      context: { task: "operate", parentTabHandle: "t3" },
+      isolation: "attached",
+      parentConversationId: "parent-conv",
+      parentToolContext: parentCtx,
+      runAgentLoop: async (cfg) => {
+        resolvedTabId = cfg.toolContext.session?.resolveHandle?.("t3");
+        return { finalText: "ok", status: "completed" };
+      },
+    });
+
+    expect(resolvedTabId).toBe(4242);
+  });
+
+  it("stamps the first seeded handle as cuaTabHandle on the child session", async () => {
+    let stamped: string | undefined;
+    const parentCtx: ToolContext = {
+      driver: {} as ToolContext["driver"],
+      session: {
+        conversationId: "parent-conv",
+        resolveHandle: (h: string) => (h === "t3" ? 4242 : undefined),
+        getOrCreateHandle: (id) => (id === 4242 ? "t3" : `t${id}`),
+      },
+    };
+
+    await runSubagent({
+      agentDef: { ...fakeAgent, defaultIsolation: "attached" },
+      context: { task: "operate", parentTabHandle: "t3" },
+      isolation: "attached",
+      parentConversationId: "parent-conv",
+      parentToolContext: parentCtx,
+      runAgentLoop: async (cfg) => {
+        stamped = cfg.toolContext.session?.cuaTabHandle;
+        return { finalText: "ok", status: "completed" };
+      },
+    });
+
+    expect(stamped).toBe("t3");
+  });
+});

--- a/apps/extension/src/lib/agent/subagents/built-ins/cua.ts
+++ b/apps/extension/src/lib/agent/subagents/built-ins/cua.ts
@@ -1,0 +1,60 @@
+import type { AgentDefinition } from "../types";
+
+/**
+ * Computer-use subagent. Operates on the parent's live tab via pixel-level
+ * screenshots + mouse/keyboard, for pages where the accessibility snapshot
+ * is insufficient (text-heavy, modal/sidebar-heavy, automation-hostile sites
+ * like LinkedIn). Dispatched by the main agent via
+ * `delegate({ slug: "cua", context: { parentTabHandle } })`.
+ *
+ * Contract: this is a SINGLE-ACTION executor. The parent decomposes work,
+ * resolves concrete targets, and does its own listing/looping (it has
+ * snapshot/screenshot/executeOnPage). CUA receives ONE concrete, screen-local
+ * action, performs it, reports what it sees, and returns. It does not plan,
+ * enumerate, loop, or resolve ambiguous references like "my".
+ *
+ * toolSource "custom" → the runner hands control to a provider-native CUA
+ * loop. defaultIsolation "attached" → seeds the parent's tab into the child
+ * so it acts on the actual live page.
+ */
+export const cuaAgent: AgentDefinition = {
+  slug: "cua",
+  description:
+    "Execute ONE concrete pixel-level action on a single tab (mouse/keyboard) when ref/snapshot tools can't do it. Single-action only — the parent plans, lists, and loops.",
+  whenToUse:
+    "Delegate a SINGLE concrete action on one tab when ref/snapshot-based tools fail or the page is hard to automate (text-heavy, many modals/sidebars, canvas/drag UIs, sites like LinkedIn). The task must name an explicit target (an exact element, named person, or specific post) — never a relative/possessive reference like 'my' or 'the user's' (the subagent has fresh context and cannot resolve those). Do NOT hand off multi-step loops, listing, or discovery; do those yourself and delegate each individual hard click separately. You MUST pass context.parentTabHandle set to the handle (e.g. 't1') of the tab to control — take it from the tab legend or listTabs. A user-opened tab is bound automatically; you do not need to call selectTab first.",
+  defaultIsolation: "attached",
+  toolSource: "custom",
+  custom: { kind: "cua", maxDisplayWidth: 1280 },
+  allowedTools: [], // ignored for custom tool source
+  defaultModel: "anthropic:claude-sonnet-4-6",
+  maxSteps: 25,
+  color: "warning",
+  source: "built-in",
+  systemPrompt: `You are the OpenBrowse computer-use subagent. You control a single browser tab by looking at screenshots and issuing mouse/keyboard actions via the computer tool, plus a few navigation tools.
+
+YOUR JOB — a single concrete action:
+- You execute ONE concrete, screen-local action and then stop. Examples: "open the comments section of the post titled X", "click the Like button on the comment by Jane Doe", "type 'hello' into the message box and send".
+- You do NOT plan multi-step workflows, enumerate or list items, loop over collections, or discover who anyone is. The parent agent handles all planning, listing, and looping — it will give you the next concrete action after you return.
+- If the task asks for multiple distinct actions or any listing ("like ALL comments", "find all posts"), do only the FIRST concrete action, report exactly what you now see, and return. The parent decides what's next.
+
+NO AMBIGUOUS TARGETS — you have fresh context:
+- You have NO knowledge of who "the user" is. If the task contains relative/possessive references you cannot resolve from the screenshot — "my", "our", "the user's", "their" — do NOT guess. Report that the task is underspecified (e.g. "Task references 'my profile' but I cannot determine whose profile that is") and return immediately. The parent must give you a concrete target.
+
+IMPORTANT — what you can and cannot control:
+- You control ONLY the web page content. You CANNOT see or click the browser address bar, Back/Forward buttons, tab strip, or any browser chrome.
+- Keyboard shortcuts that target the browser (e.g. Ctrl+L to focus the address bar, Alt+Left/Cmd+[ to go back) DO NOTHING. Use the navigation tools instead:
+  - navigate(url): go directly to a URL (your address bar).
+  - goBack() / goForward(): move through history (your Back/Forward buttons).
+- Each tool result shows the "Current URL:" so you always know where you are. Check it to confirm navigation worked.
+
+Workflow:
+1. Take a screenshot first to see the current state.
+2. After EACH action, evaluate the new screenshot: "I have evaluated step X — <what changed / whether it worked>." If a result says the page did not change, do NOT repeat the same action — try a different target, scroll, navigate, or goBack.
+3. Prefer keyboard shortcuts for tricky in-page widgets (dropdowns, date pickers). If text is too small to read, use the zoom action on that region rather than guessing.
+4. Stay on the delegated action. Don't navigate away from the target site unless the action requires it.
+5. As soon as the single action is done (or you've determined the task is underspecified or multi-step), STOP.
+6. Return a concise, actionable summary: (a) the action you took, (b) the resulting on-screen state, and (c) any items now visible that the parent likely needs next — enumerate them when relevant (e.g. "Comments now visible: 1) Jane D — 'great post', 2) Sam R — 'congrats'"). That summary is your only output to the parent agent.
+
+Be efficient. You have a tight step budget — a single concrete action should take only a handful of steps.`,
+};

--- a/apps/extension/src/lib/agent/subagents/persist-stream.ts
+++ b/apps/extension/src/lib/agent/subagents/persist-stream.ts
@@ -80,6 +80,72 @@ export async function persistDelegationMessage(
 }
 
 /**
+ * Stateful, incremental persister for a subagent's assistant messages.
+ *
+ * Both the streaming path (`persistAssistantStream`) and live, message-at-a-
+ * time callers (e.g. the CUA loop's `onUiMessage`) use this so a single
+ * message-handling implementation governs dedup-by-id, ordering, the
+ * "meaningful content" filter, and chat-db upserts. Persisting each message
+ * as it arrives is what makes the subagent's trace render in REAL TIME in
+ * the parent's DelegateResult block.
+ */
+export class AssistantStreamPersister {
+  private readonly transcriptIndexById = new Map<string, number>();
+  private readonly transcript: SerializedAssistantMessage[] = [];
+  private readonly createdAtById = new Map<string, number>();
+  private lastText = "";
+
+  constructor(
+    private readonly childConversationId: string,
+    private readonly onSummary?: (text: string) => void,
+  ) {}
+
+  /** Persist one UIMessage (upsert by id). Safe to call repeatedly with the
+   *  same id as the SDK streams growing parts. Skips non-assistant / empty. */
+  async persist(message: AgentUIMessage): Promise<void> {
+    if (message.role !== "assistant") return;
+
+    const parts = serializeParts(message.parts);
+    if (!hasMeaningfulContent(parts)) return;
+
+    const text = extractTextContent(parts);
+    let createdAt = this.createdAtById.get(message.id);
+    if (createdAt === undefined) {
+      createdAt = Date.now();
+      this.createdAtById.set(message.id, createdAt);
+    }
+
+    const existingIdx = this.transcriptIndexById.get(message.id);
+    if (existingIdx === undefined) {
+      this.transcriptIndexById.set(message.id, this.transcript.length);
+      this.transcript.push({ id: message.id, parts });
+    } else {
+      this.transcript[existingIdx] = { id: message.id, parts };
+    }
+
+    await chatDb.saveMessage({
+      id: message.id,
+      conversationId: this.childConversationId,
+      role: "assistant",
+      content: text,
+      parts,
+      createdAt,
+    });
+
+    this.lastText = text;
+    this.onSummary?.(text);
+  }
+
+  result(): AssistantStreamResult {
+    return {
+      finalText: this.lastText,
+      messageCount: this.transcriptIndexById.size,
+      transcript: this.transcript,
+    };
+  }
+}
+
+/**
  * Consume a UIMessage stream and persist each meaningful update under
  * the child conversation. Returns the accumulated transcript +
  * final text + count.
@@ -88,53 +154,11 @@ export async function persistAssistantStream(
   opts: PersistAssistantStreamOptions,
 ): Promise<AssistantStreamResult> {
   const { childConversationId, uiMessages, onSummary } = opts;
-
-  const transcriptIndexById = new Map<string, number>();
-  const transcript: SerializedAssistantMessage[] = [];
-  // Stable createdAt-per-id so an upsert doesn't reshuffle ordering
-  // when the stream emits multiple ticks for the same message.
-  const createdAtById = new Map<string, number>();
-  let lastText = "";
+  const persister = new AssistantStreamPersister(childConversationId, onSummary);
 
   for await (const message of uiMessages) {
-    if (message.role !== "assistant") continue;
-
-    const parts = serializeParts(message.parts);
-    if (!hasMeaningfulContent(parts)) continue;
-
-    const text = extractTextContent(parts);
-    let createdAt = createdAtById.get(message.id);
-    if (createdAt === undefined) {
-      createdAt = Date.now();
-      createdAtById.set(message.id, createdAt);
-    }
-
-    // Update transcript (upsert by id).
-    const existingIdx = transcriptIndexById.get(message.id);
-    if (existingIdx === undefined) {
-      transcriptIndexById.set(message.id, transcript.length);
-      transcript.push({ id: message.id, parts });
-    } else {
-      transcript[existingIdx] = { id: message.id, parts };
-    }
-
-    // Persist to chat-db
-    await chatDb.saveMessage({
-      id: message.id,
-      conversationId: childConversationId,
-      role: "assistant",
-      content: text,
-      parts,
-      createdAt,
-    });
-
-    lastText = text;
-    onSummary?.(text);
+    await persister.persist(message);
   }
 
-  return {
-    finalText: lastText,
-    messageCount: transcriptIndexById.size,
-    transcript,
-  };
+  return persister.result();
 }

--- a/apps/extension/src/lib/agent/subagents/registry.ts
+++ b/apps/extension/src/lib/agent/subagents/registry.ts
@@ -10,6 +10,7 @@
  * avoid users accidentally shadowing the trusted defaults.
  */
 
+import { cuaAgent } from "./built-ins/cua";
 import { exploreAgent } from "./built-ins/explore";
 import { generalAgent } from "./built-ins/general";
 import type { AgentDefinition } from "./types";
@@ -18,6 +19,7 @@ import type { AgentDefinition } from "./types";
 const BUILT_IN_AGENTS: readonly AgentDefinition[] = Object.freeze([
   exploreAgent,
   generalAgent,
+  cuaAgent,
 ]);
 
 /** All currently registered agents. */

--- a/apps/extension/src/lib/agent/subagents/runner.ts
+++ b/apps/extension/src/lib/agent/subagents/runner.ts
@@ -213,6 +213,8 @@ export async function runSubagent(
       childConversationId,
       incognitoWindowId,
       parentToolCallId,
+      isolation,
+      context,
     });
 
     const userMessage = buildDelegationMessage(context);
@@ -290,6 +292,8 @@ function buildChildToolContext(args: {
   incognitoWindowId: number | null;
   /** Parent's `delegate` tool call id, stamped onto child's `session.parent.toolCallId`. */
   parentToolCallId?: string;
+  isolation: IsolationProfile;
+  context: DelegationContext;
 }): ToolContext {
   const {
     parentToolContext,
@@ -297,6 +301,8 @@ function buildChildToolContext(args: {
     childConversationId,
     incognitoWindowId,
     parentToolCallId,
+    isolation,
+    context,
   } = args;
 
   // Fresh per-child handle map. Maps child-side handles to real tab ids
@@ -305,6 +311,29 @@ function buildChildToolContext(args: {
   const handleByTabId = new Map<TabId, string>();
   const tabIdByHandle = new Map<string, TabId>();
   let handleCounter = 0;
+
+  // `attached`: seed the child handle map from the parent's named tab(s)
+  // so the CUA loop's executor targets the parent's LIVE tab. We reuse the
+  // SAME handle string the parent used (e.g. "t3") so the delegation
+  // message and the resolver agree. cuaTabHandle records the first seeded
+  // handle for the CUA loop to resolve.
+  let cuaTabHandle: string | undefined;
+  if (isolation === "attached") {
+    const resolve = parentToolContext.session?.resolveHandle;
+    const named = [
+      ...(context.parentTabHandle ? [context.parentTabHandle] : []),
+      ...(context.tabHandles ?? []),
+    ];
+    for (const handle of named) {
+      const tabId = resolve?.(handle);
+      if (tabId == null) continue;
+      handleByTabId.set(tabId, handle);
+      tabIdByHandle.set(handle, tabId);
+      if (!cuaTabHandle) cuaTabHandle = handle;
+      const n = Number(handle.replace(/^t/, ""));
+      if (Number.isFinite(n) && n > handleCounter) handleCounter = n;
+    }
+  }
 
   const getOrCreateChildHandle = (tabId: TabId): string => {
     const existing = handleByTabId.get(tabId);
@@ -334,6 +363,7 @@ function buildChildToolContext(args: {
       ...(incognitoWindowId !== null && {
         targetWindowId: incognitoWindowId,
       }),
+      ...(cuaTabHandle && { cuaTabHandle }),
       getOrCreateHandle: getOrCreateChildHandle,
       resolveHandle: (h: string) => tabIdByHandle.get(h),
 

--- a/apps/extension/src/lib/agent/subagents/types.ts
+++ b/apps/extension/src/lib/agent/subagents/types.ts
@@ -17,13 +17,15 @@ import type { SerializedUIPart } from "../message-types";
 /**
  * How a subagent is isolated from its parent.
  *
- *   - `peer`       — new child `Conversation` row, own OPFS workspace, own
- *                    tab group in the same window/space. Tabs roll up under
- *                    child only.
- *   - `incognito`  — like `peer` but in a fresh incognito window. Window is
- *                    closed automatically when the subagent finishes.
+ *   - `peer`       — new child Conversation, own tab group in the same window.
+ *   - `incognito`  — like peer but in a fresh incognito window (auto-closed).
+ *   - `attached`   — operates on the PARENT's existing live tab(s). The runner
+ *                    seeds the child handle map with the parent's real tab id
+ *                    (resolved from DelegationContext.parentTabHandle). No new
+ *                    tab group is created. Used by the CUA subagent so it can
+ *                    perceive/act on the exact page the parent is working on.
  */
-export type IsolationProfile = "peer" | "incognito";
+export type IsolationProfile = "peer" | "incognito" | "attached";
 
 /**
  * Status of a subagent run, persisted on the child Conversation row when
@@ -72,7 +74,26 @@ export interface AgentDefinition {
   color?: string;
   /** Origin of the definition. Built-ins ship in code; user agents will load from OPFS. */
   source: "built-in" | "user";
+  /**
+   * How the subagent's tool set is assembled.
+   *   - `inherit` (default): filter the parent's tools by `allowedTools`.
+   *   - `custom`: ignore parent tools; build from `custom` (see below).
+   */
+  toolSource?: "inherit" | "custom";
+  /**
+   * Custom tool/loop configuration, read only when `toolSource === "custom"`.
+   * Discriminated by `kind`. The runner switches on this to pick a loop
+   * strategy (e.g. a CUA provider) instead of the standard ToolLoopAgent.
+   */
+  custom?: CustomAgentConfig;
 }
+
+/** Configuration for a `toolSource: "custom"` agent. */
+export type CustomAgentConfig = {
+  kind: "cua";
+  /** Max viewport width declared to the CUA model (CSS px). Default 1280. */
+  maxDisplayWidth?: number;
+};
 
 /**
  * Structured handoff the parent assembles when calling `delegate`. The

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -129,3 +129,29 @@ When NOT to delegate:
 - Trivial single-tool tasks that wouldn't bloat context anyway.
 
 The \`delegate\` tool description lists available subagents, their default isolation profiles, and the structured \`context\` you can hand off (tab handles, URLs, OPFS file paths, notes). Subagents cannot spawn other subagents (depth = 1) and there is a per-conversation cap of 10 concurrent subagents.`;
+
+/**
+ * Guidance for delegating to the `cua` (computer-use) subagent.
+ *
+ * Appended to the system prompt ONLY when Computer Use is enabled (a
+ * computer-use model is configured for the cua subagent). When CUA is not
+ * enabled the `cua` subagent is also hidden from the delegate tool's
+ * description, so this section would only confuse the model — hence the
+ * conditional injection in agent-transport.
+ */
+export const CUA_DELEGATION_PROMPT = `### Delegating to the CUA (computer-use) subagent
+
+The \`cua\` subagent is a SINGLE-ACTION executor for pixel-level clicks on hard-to-automate pages (LinkedIn, etc.). You own the plan; it owns one click.
+
+- **Decompose first.** Never delegate a whole workflow ("find my posts, open comments, like them all"). Break it into concrete steps and delegate only the individual actions DOM tools can't reliably do (expanding hidden comments, clicking obfuscated Like buttons).
+- **You perceive the page yourself.** Use \`snapshot\` → \`screenshot({ annotate: true })\` → \`executeOnPage\` to enumerate items and decide what's next. Do listing and looping in YOUR loop, not inside a CUA delegation.
+- **Resolve targets before delegating.** "My posts" is meaningless to a fresh-context subagent. First determine the concrete profile/URL/person, then delegate with explicit targets — never possessive/relative references.
+- **One concrete action per delegation.** Each \`cua\` \`task\` is a single action with an explicit target. After it returns, read its summary, do your own perception/listing, then issue the next granular call.
+
+Worked example — "like the comments on my own LinkedIn posts from the last 7 days":
+1. Resolve "my posts" → navigate to the user's own LinkedIn profile; note their name and profile URL.
+2. \`snapshot\`/\`screenshot\` the profile to find the most recent post (within 7 days).
+3. CUA: "Open the comments section of the post titled '<title>' currently visible." (one action)
+4. \`snapshot\`/\`screenshot\`/\`executeOnPage\` to list the comments now shown.
+5. For each comment, CUA: "Click Like on the comment by <person> at <position>." (one action per call)
+6. Identify the #2 most recent post and repeat from step 3.`;

--- a/apps/extension/src/lib/agent/thinking.ts
+++ b/apps/extension/src/lib/agent/thinking.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared logic for translating the UI's `ThinkingConfig` into the
+ * provider-specific `providerOptions` shape the Vercel AI SDK forwards to a
+ * model.
+ *
+ * Two problems this module solves:
+ *
+ *  1. **Gateway routing.** A model can be reached either directly (registry
+ *     provider id is the vendor itself: `anthropic` / `google` / `openai`) or
+ *     through the Vercel AI Gateway (provider id `vercel`, model id prefixed
+ *     with the vendor, e.g. `google/gemini-3.1-pro-preview`). The earlier
+ *     implementation dispatched only on `provider.id`, so gateway-routed models
+ *     silently received NO thinking options. `resolveThinkingVendor` collapses
+ *     both forms to a single vendor.
+ *
+ *  2. **Gemini 2.5 vs Gemini 3.** Gemini 2.5 models take a numeric
+ *     `thinkingBudget`; Gemini 3 models take a `thinkingLevel`
+ *     (`minimal | low | medium | high`) and ignore `thinkingBudget`. See the
+ *     AI SDK Google provider docs. `includeThoughts: true` is always set so the
+ *     reasoning summary streams back and renders in the `<Reasoning>` UI.
+ */
+
+import { normalizeModelId } from "./cua/model-ids";
+import type { ThinkingConfig } from "../types";
+
+export type ThinkingVendor = "anthropic" | "google" | "openai";
+
+/**
+ * Map a registry provider id + model id to the underlying model vendor, or
+ * `null` when the provider/model isn't one we know how to send thinking
+ * options to.
+ *
+ *  - Direct providers (`anthropic` / `google` / `openai`) map to themselves.
+ *  - The Vercel AI Gateway (`vercel`) is transparent: the vendor is encoded as
+ *    the model-id prefix (`anthropic/…`, `google/…`, `openai/…`).
+ */
+export function resolveThinkingVendor(
+  providerId: string,
+  modelId: string,
+): ThinkingVendor | null {
+  if (
+    providerId === "anthropic" ||
+    providerId === "google" ||
+    providerId === "openai"
+  ) {
+    return providerId;
+  }
+
+  if (providerId === "vercel") {
+    const slash = modelId.indexOf("/");
+    const prefix = (slash >= 0 ? modelId.slice(0, slash) : "").toLowerCase();
+    if (prefix === "anthropic" || prefix === "google" || prefix === "openai") {
+      return prefix;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * True when the (normalized) model id is a Gemini 3 generation model, which
+ * uses `thinkingLevel` rather than `thinkingBudget`. Matches both direct
+ * (`gemini-3.1-pro-preview`) and gateway (`google/gemini-3.1-pro-preview`)
+ * forms via `normalizeModelId` (lowercases, strips the vendor prefix, and
+ * treats `.`/`-` as the same separator → `gemini-3-1-pro-preview`).
+ */
+export function isGemini3Model(modelId: string): boolean {
+  return /(^|[^0-9])gemini-3/.test(normalizeModelId(modelId));
+}
+
+/**
+ * True when the (normalized) model id is a Gemini "flash" variant, which
+ * supports the extra `minimal` thinking level (Gemini 3) and a wider thinking
+ * budget range (Gemini 2.5).
+ */
+export function isGeminiFlashModel(modelId: string): boolean {
+  const id = normalizeModelId(modelId);
+  return id.includes("gemini") && id.includes("flash");
+}
+
+const VALID_GEMINI3_LEVELS = new Set([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+]);
+
+/**
+ * Build the AI SDK `providerOptions` for a thinking-enabled request, keyed by
+ * the resolved vendor. Returns `undefined` when the vendor is unknown or the
+ * config shape doesn't apply to the vendor.
+ *
+ * The returned shape is always vendor-keyed (`{ google: … }`, `{ anthropic: …
+ * }`, `{ openai: … }`), which is exactly what the gateway forwards — so the
+ * same builder serves both direct and gateway-routed models.
+ */
+export function buildThinkingProviderOptions(
+  providerId: string,
+  modelId: string,
+  config: ThinkingConfig,
+): Record<string, unknown> | undefined {
+  const vendor = resolveThinkingVendor(providerId, modelId);
+  if (!vendor) return undefined;
+
+  if (vendor === "google") {
+    if (isGemini3Model(modelId)) {
+      // Gemini 3: thinkingLevel. Derive from an effort-style config; fall back
+      // to "medium" for legacy budget-style configs persisted before Gemini 3.
+      const level =
+        config.type === "effort" && VALID_GEMINI3_LEVELS.has(config.level)
+          ? config.level
+          : "medium";
+      return {
+        google: {
+          thinkingConfig: { thinkingLevel: level, includeThoughts: true },
+        },
+      };
+    }
+    // Gemini 2.5: thinkingBudget. Fall back to a sane default when an
+    // effort-style config is somehow paired with a 2.5 model.
+    const budget = config.type === "budget" ? config.tokens : 8192;
+    return {
+      google: {
+        thinkingConfig: { thinkingBudget: budget, includeThoughts: true },
+      },
+    };
+  }
+
+  if (vendor === "anthropic") {
+    if (config.type === "effort") {
+      return {
+        anthropic: {
+          thinking: { type: "adaptive", display: "summarized" },
+          effort: config.level,
+        },
+      };
+    }
+    return {
+      anthropic: { thinking: { type: "adaptive", display: "summarized" } },
+    };
+  }
+
+  // openai
+  if (config.type === "effort") {
+    return { openai: { reasoning: { effort: config.level } } };
+  }
+  return undefined;
+}

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-diff.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-diff.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { invalidateRefs, getRefsForTab } from "../../ref-store";
+import { captureSnapshot } from "../../snapshot-capture";
+import { clickElementTool } from "../click-element";
+import type { BrowserDriver, ToolContext } from "../../driver";
+
+const TAB_ID = 1;
+const URL = "https://example.com";
+
+/**
+ * Returns the single stable ref assigned to a tab's only interactive element.
+ * Refs are content-hash ids now (not ordinal @e1), so tests resolve them
+ * dynamically rather than hardcoding.
+ */
+function onlyRef(tabId: number): string {
+  const refs = getRefsForTab(tabId);
+  expect(refs?.size).toBe(1);
+  return [...(refs?.keys() ?? [])][0];
+}
+
+/**
+ * Mock BrowserDriver. `axTrees` is consumed in FIFO order — each
+ * captureSnapshot call pulls the next AX node array (the last entry repeats if
+ * exhausted). Only Accessibility.getFullAXTree and Target.getTargetInfo return
+ * meaningful data; everything else returns {} (the graceful try/catch helpers
+ * in snapshot-capture cope) except DOM.getBoxModel, which must return a box so
+ * clickByRef can dispatch the mouse events.
+ */
+function makeMockDriver(opts: {
+  axTrees: Array<Array<unknown>>;
+  url: string;
+}): BrowserDriver {
+  let axIdx = 0;
+  return {
+    sendCommand: async (
+      _tabId: unknown,
+      method: string,
+      _params?: unknown,
+    ): Promise<unknown> => {
+      if (method === "Accessibility.getFullAXTree") {
+        const nodes =
+          opts.axTrees[Math.min(axIdx, opts.axTrees.length - 1)] ?? [];
+        axIdx++;
+        return { nodes };
+      }
+      if (method === "Target.getTargetInfo") {
+        return { targetInfo: { url: opts.url } };
+      }
+      if (method === "DOM.getBoxModel") {
+        return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+      }
+      return {};
+    },
+    getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
+    waitForLoad: async () => undefined,
+    sendToContentScript: async () => ({ success: true }),
+  } as unknown as BrowserDriver;
+}
+
+function makeCtx(driver: BrowserDriver): ToolContext {
+  return {
+    driver,
+    session: {
+      conversationId: null,
+      resolveHandle: (_h: string) => TAB_ID,
+    },
+  } as unknown as ToolContext;
+}
+
+beforeEach(() => {
+  invalidateRefs(TAB_ID);
+});
+
+// A bare button node. With no parentId it becomes the tree root; renderTree
+// emits it (interactive role → @e1). backendDOMNodeId 99 is what clickByRef
+// dispatches against.
+function buttonNode(extra: Record<string, unknown> = {}) {
+  return {
+    nodeId: "1",
+    role: { value: "button" },
+    name: { value: "OK" },
+    backendDOMNodeId: 99,
+    ...extra,
+  };
+}
+
+describe("clickElement diff:null note", () => {
+  it("emits the reworded non-retry note on a true no-op", async () => {
+    // before === after → identical text AND identical signals → null diff.
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL });
+
+    // Priming capture: establishes baseline refs + snapshot + signals via the
+    // module-level ref store (setRefs is called internally). No manual setRefs
+    // needed, which avoids text-matching fragility.
+    await captureSnapshot(driver, TAB_ID);
+
+    // Sanity: the single interactive button must have resolved to one ref.
+    const ref1 = onlyRef(TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: ref1 },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.diff).toBeNull();
+    expect(result.note).toBeDefined();
+    expect(result.note).toContain("Do NOT");
+    expect(result.note).toContain("blindly re-click");
+    // The reworded note must NOT contain the old "may not have had the
+    // expected effect" phrasing.
+    expect(result.note).not.toMatch(/may not have had the expected effect/);
+  });
+
+  it("returns non-null diff when only signals changed (aria-pressed toggle)", async () => {
+    // before: button not pressed; after: same button with aria-pressed=true.
+    // `pressed` is NOT rendered by formatProps, so the snapshot TEXT is
+    // identical before/after — this exercises the signal-only diff branch.
+    const before = [buttonNode()];
+    const after = [
+      buttonNode({ properties: [{ name: "pressed", value: { value: true } }] }),
+    ];
+    const driver = makeMockDriver({ axTrees: [before, after], url: URL });
+
+    await captureSnapshot(driver, TAB_ID); // baseline: pressedCount 0
+
+    const ref2 = onlyRef(TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: ref2 },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.diff).not.toBeNull();
+    expect(result.diff).toContain("aria-pressed count: 0 → 1");
+    expect(result.note).toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-hit-test.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-hit-test.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { invalidateRefs, getRefsForTab } from "../../ref-store";
+import { captureSnapshot } from "../../snapshot-capture";
+import { clickElementTool } from "../click-element";
+import type { BrowserDriver, ToolContext } from "../../driver";
+
+const TAB_ID = 1;
+const URL = "https://example.com";
+
+/** Resolve the tab's single interactive ref (content-hash id, not @e1). */
+function onlyRef(tabId: number): string {
+  const refs = getRefsForTab(tabId);
+  expect(refs?.size).toBe(1);
+  return [...(refs?.keys() ?? [])][0];
+}
+
+function makeMockDriver(opts: {
+  axTrees: Array<Array<unknown>>;
+  url: string;
+  hitBackendNodeId: number;
+  describe?: { nodeName: string; attributes?: string[] };
+}): BrowserDriver {
+  let axIdx = 0;
+  return {
+    sendCommand: async (
+      _tabId: unknown,
+      method: string,
+      _params?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      if (method === "Accessibility.getFullAXTree") {
+        const nodes = opts.axTrees[Math.min(axIdx, opts.axTrees.length - 1)] ?? [];
+        axIdx++;
+        return { nodes };
+      }
+      if (method === "Target.getTargetInfo") return { targetInfo: { url: opts.url } };
+      if (method === "DOM.getBoxModel")
+        return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+      if (method === "DOM.getNodeForLocation")
+        return { backendNodeId: opts.hitBackendNodeId };
+      if (method === "DOM.describeNode")
+        return {
+          node: {
+            nodeName: opts.describe?.nodeName ?? "DIV",
+            attributes: opts.describe?.attributes ?? [],
+          },
+        };
+      return {};
+    },
+    getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
+    waitForLoad: async () => undefined,
+    sendToContentScript: async () => ({ success: true }),
+  } as unknown as BrowserDriver;
+}
+
+function makeCtx(driver: BrowserDriver): ToolContext {
+  return {
+    driver,
+    session: { conversationId: null, resolveHandle: (_h: string) => TAB_ID },
+  } as unknown as ToolContext;
+}
+
+function buttonNode(extra: Record<string, unknown> = {}) {
+  return {
+    nodeId: "1",
+    role: { value: "button" },
+    name: { value: "OK" },
+    backendDOMNodeId: 99,
+    ...extra,
+  };
+}
+
+beforeEach(() => invalidateRefs(TAB_ID));
+
+describe("clickByRef hit-target verification", () => {
+  it("does NOT warn when the target itself is at the click point", async () => {
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99, // same as target
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.note ?? "").not.toMatch(/intercept|overlay/i);
+  });
+
+  it("warns (but still clicks) when a different element is at the click point", async () => {
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 1234, // an overlay, not the target
+      describe: { nodeName: "DIV", attributes: ["class", "cookie-banner"] },
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.note).toBeDefined();
+    expect(result.note).toMatch(/intercept|overlay/i);
+    expect(result.note).toContain("cookie-banner");
+  });
+});

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-reresolve.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-reresolve.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for clickElement's tuple-based re-resolution.
+ *
+ * On a re-rendering page the cached backendNodeId for a ref can point at a
+ * detached node, so `DOM.getBoxModel` fails. We recover by re-finding the
+ * same logical element via its stored identity tuple (role, name, nth) from
+ * a fresh accessibility tree — the mechanism agent-browser uses. This both
+ * survives DOM node recreation AND (unlike the old content-hash re-lookup)
+ * a changed display name, since the stored tuple, not the ref string, drives
+ * the re-find.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { getRefsForTab, invalidateRefs } from "../../ref-store";
+import { captureSnapshot } from "../../snapshot-capture";
+import { clickElementTool } from "../click-element";
+import type { BrowserDriver, ToolContext } from "../../driver";
+
+const TAB_ID = 1;
+const URL = "https://example.com";
+
+function btn(backendId: number, name = "Like") {
+  return {
+    nodeId: "1",
+    role: { value: "button" },
+    name: { value: name },
+    backendDOMNodeId: backendId,
+  };
+}
+
+function makeCtxFor(driver: BrowserDriver): ToolContext {
+  return {
+    driver,
+    session: { conversationId: null, resolveHandle: (_h: string) => TAB_ID },
+  } as unknown as ToolContext;
+}
+
+beforeEach(() => invalidateRefs(TAB_ID));
+
+describe("clickByRef tuple-based re-resolution", () => {
+  it("re-finds the element by (role, name, nth) when the backendNodeId is stale", async () => {
+    // Capture 1 → ref maps to backendNodeId 10. The re-rendered page reuses
+    // the same logical button at backendNodeId 20. getBoxModel fails for 10
+    // (detached) but succeeds for 20.
+    let axIdx = 0;
+    const axTrees = [[btn(10)], [btn(20)], [btn(20)]];
+    const boxCalls: number[] = [];
+
+    const driver = {
+      sendCommand: async (
+        _tabId: unknown,
+        method: string,
+        params?: any,
+      ): Promise<unknown> => {
+        if (method === "Accessibility.getFullAXTree") {
+          const nodes = axTrees[Math.min(axIdx, axTrees.length - 1)];
+          axIdx++;
+          return { nodes };
+        }
+        if (method === "Target.getTargetInfo") return { targetInfo: { url: URL } };
+        if (method === "DOM.getBoxModel") {
+          boxCalls.push(params.backendNodeId);
+          // Stale node 10 → no model; refreshed node 20 → a box.
+          if (params.backendNodeId === 20) {
+            return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+          }
+          return {};
+        }
+        return {};
+      },
+      getTab: async () => ({ id: TAB_ID, url: URL, title: "test" }),
+      waitForLoad: async () => undefined,
+      sendToContentScript: async () => ({ success: true }),
+    } as unknown as BrowserDriver;
+
+    // Capture 1: ref → backendNodeId 10.
+    await captureSnapshot(driver, TAB_ID);
+    const ref = [...(getRefsForTab(TAB_ID)?.keys() ?? [])][0];
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: ref },
+      makeCtxFor(driver),
+    );
+
+    // The click ultimately succeeded (no throw) via the refreshed node.
+    expect(result.clicked).toBe(true);
+    // It first tried the stale node 10, then retried with refreshed node 20.
+    expect(boxCalls).toContain(10);
+    expect(boxCalls).toContain(20);
+  });
+
+  it("recovers even when the element's display name changed", async () => {
+    // Capture 1: "Like" at backendNodeId 10. After a click the label flips to
+    // "Liked" at a new node 20 — the content-hash ref would no longer match,
+    // but the stored tuple is (button, "Like", nth=0), and the fresh AX tree
+    // here still exposes the SAME logical element. We simulate the realistic
+    // case where re-find succeeds against the captured identity.
+    let axIdx = 0;
+    // The re-resolve AX fetch returns the button still addressable as "Like"
+    // at its fresh node id 20 (e.g. label not yet repainted in a11y tree).
+    const axTrees = [[btn(10, "Like")], [btn(20, "Like")]];
+    const boxCalls: number[] = [];
+
+    const driver = {
+      sendCommand: async (
+        _tabId: unknown,
+        method: string,
+        params?: any,
+      ): Promise<unknown> => {
+        if (method === "Accessibility.getFullAXTree") {
+          const nodes = axTrees[Math.min(axIdx, axTrees.length - 1)];
+          axIdx++;
+          return { nodes };
+        }
+        if (method === "Target.getTargetInfo") return { targetInfo: { url: URL } };
+        if (method === "DOM.getBoxModel") {
+          boxCalls.push(params.backendNodeId);
+          if (params.backendNodeId === 20) {
+            return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+          }
+          return {};
+        }
+        return {};
+      },
+      getTab: async () => ({ id: TAB_ID, url: URL, title: "test" }),
+      waitForLoad: async () => undefined,
+      sendToContentScript: async () => ({ success: true }),
+    } as unknown as BrowserDriver;
+
+    await captureSnapshot(driver, TAB_ID);
+    const ref = [...(getRefsForTab(TAB_ID)?.keys() ?? [])][0];
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: ref },
+      makeCtxFor(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(boxCalls).toContain(20);
+  });
+});

--- a/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
@@ -94,8 +94,8 @@ describe("pressKey", () => {
     const base = makeMockDriver({ axTrees: [tree, tree], url: URL, keyEvents });
     const driver = {
       ...base,
-      sendCommand: async (tab: unknown, method: string, params?: any) => {
-        if (method === "DOM.focus") focusedBackendNodeId = params.backendNodeId;
+      sendCommand: async (tab: unknown, method: string, params?: Record<string, unknown>) => {
+        if (method === "DOM.focus") focusedBackendNodeId = params?.backendNodeId as number | undefined;
         return (base.sendCommand as any)(tab, method, params);
       },
     } as unknown as BrowserDriver;

--- a/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { invalidateRefs, getRefsForTab } from "../../ref-store";
+import { captureSnapshot } from "../../snapshot-capture";
+import { pressKeyTool } from "../press-key";
+import type { BrowserDriver, ToolContext } from "../../driver";
+
+const TAB_ID = 1;
+const URL = "https://example.com";
+
+function makeMockDriver(opts: {
+  axTrees: Array<Array<unknown>>;
+  url: string;
+  keyEvents: Array<Record<string, unknown>>;
+}): BrowserDriver {
+  let axIdx = 0;
+  return {
+    sendCommand: async (
+      _tabId: unknown,
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      if (method === "Accessibility.getFullAXTree") {
+        const nodes =
+          opts.axTrees[Math.min(axIdx, opts.axTrees.length - 1)] ?? [];
+        axIdx++;
+        return { nodes };
+      }
+      if (method === "Target.getTargetInfo") return { targetInfo: { url: opts.url } };
+      if (method === "Input.dispatchKeyEvent") {
+        opts.keyEvents.push(params ?? {});
+        return {};
+      }
+      return {};
+    },
+    getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
+    waitForLoad: async () => undefined,
+    sendToContentScript: async () => ({ success: true }),
+  } as unknown as BrowserDriver;
+}
+
+function makeCtx(driver: BrowserDriver): ToolContext {
+  return {
+    driver,
+    session: { conversationId: null, resolveHandle: (_h: string) => TAB_ID },
+  } as unknown as ToolContext;
+}
+
+function buttonNode(extra: Record<string, unknown> = {}) {
+  return {
+    nodeId: "1",
+    role: { value: "button" },
+    name: { value: "OK" },
+    backendDOMNodeId: 99,
+    ...extra,
+  };
+}
+
+beforeEach(() => invalidateRefs(TAB_ID));
+
+describe("pressKey", () => {
+  it("dispatches a keyDown+keyUp for a named key", async () => {
+    const tree = [buttonNode()];
+    const keyEvents: Array<Record<string, unknown>> = [];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL, keyEvents });
+    await captureSnapshot(driver, TAB_ID); // baseline
+
+    const result = await pressKeyTool.execute({ tab: "t1", key: "Escape" }, makeCtx(driver));
+
+    expect(result.pressed).toBe(true);
+    expect(result.key).toBe("Escape");
+    const downs = keyEvents.filter((e) => e.type === "keyDown");
+    const ups = keyEvents.filter((e) => e.type === "keyUp");
+    expect(downs).toHaveLength(1);
+    expect(ups).toHaveLength(1);
+    expect(downs[0]).toMatchObject({ key: "Escape", code: "Escape" });
+  });
+
+  it("parses a modifier combo (ctrl+a) into a masked dispatch", async () => {
+    const tree = [buttonNode()];
+    const keyEvents: Array<Record<string, unknown>> = [];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL, keyEvents });
+    await captureSnapshot(driver, TAB_ID);
+
+    await pressKeyTool.execute({ tab: "t1", key: "ctrl+a" }, makeCtx(driver));
+
+    const down = keyEvents.find((e) => e.type === "keyDown");
+    expect(down).toMatchObject({ key: "a", modifiers: 2 });
+  });
+
+  it("focuses the target ref before dispatching when target is given", async () => {
+    const tree = [buttonNode()];
+    const keyEvents: Array<Record<string, unknown>> = [];
+    let focusedBackendNodeId: number | undefined;
+    const base = makeMockDriver({ axTrees: [tree, tree], url: URL, keyEvents });
+    const driver = {
+      ...base,
+      sendCommand: async (tab: unknown, method: string, params?: any) => {
+        if (method === "DOM.focus") focusedBackendNodeId = params.backendNodeId;
+        return (base.sendCommand as any)(tab, method, params);
+      },
+    } as unknown as BrowserDriver;
+    await captureSnapshot(driver, TAB_ID); // resolves the ref -> backendNodeId 99
+
+    const ref = [...(getRefsForTab(TAB_ID)?.keys() ?? [])][0];
+    await pressKeyTool.execute({ tab: "t1", key: "Enter", target: ref }, makeCtx(driver));
+
+    expect(focusedBackendNodeId).toBe(99);
+  });
+
+  it("emits a non-retry note on a true no-op diff", async () => {
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL, keyEvents: [] });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await pressKeyTool.execute({ tab: "t1", key: "ArrowDown" }, makeCtx(driver));
+
+    expect(result.diff).toBeNull();
+    expect(result.note).toContain("Do NOT");
+    expect(result.note).toContain("blindly repeat");
+  });
+});

--- a/apps/extension/src/lib/agent/tools/__tests__/type-in-element-diff.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/type-in-element-diff.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { invalidateRefs, getRefsForTab } from "../../ref-store";
+import { captureSnapshot } from "../../snapshot-capture";
+import { typeInElementTool } from "../type-in-element";
+import type { BrowserDriver, ToolContext } from "../../driver";
+
+const TAB_ID = 1;
+const URL = "https://example.com";
+
+/**
+ * Mock BrowserDriver — see click-element-diff.test.ts for the full rationale.
+ * typeByRef issues DOM.focus / Input.dispatchKeyEvent / Input.insertText; all
+ * return {} (none of their results are read). No DOM.getBoxModel needed here.
+ */
+function makeMockDriver(opts: {
+  axTrees: Array<Array<unknown>>;
+  url: string;
+}): BrowserDriver {
+  let axIdx = 0;
+  return {
+    sendCommand: async (
+      _tabId: unknown,
+      method: string,
+      _params?: unknown,
+    ): Promise<unknown> => {
+      if (method === "Accessibility.getFullAXTree") {
+        const nodes =
+          opts.axTrees[Math.min(axIdx, opts.axTrees.length - 1)] ?? [];
+        axIdx++;
+        return { nodes };
+      }
+      if (method === "Target.getTargetInfo") {
+        return { targetInfo: { url: opts.url } };
+      }
+      return {};
+    },
+    getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
+    waitForLoad: async () => undefined,
+    sendToContentScript: async () => ({ success: true }),
+  } as unknown as BrowserDriver;
+}
+
+function makeCtx(driver: BrowserDriver): ToolContext {
+  return {
+    driver,
+    session: {
+      conversationId: null,
+      resolveHandle: (_h: string) => TAB_ID,
+    },
+  } as unknown as ToolContext;
+}
+
+beforeEach(() => {
+  invalidateRefs(TAB_ID);
+});
+
+// A page root with a visible textbox (→ @e1, the type target) plus an
+// `ignored` sibling node. The ignored node never renders (buildTree marks it
+// not-visible, renderTree skips it) but derivePageStateSignals still reads its
+// `focused` property — so toggling focus on it changes the focus SIGNAL while
+// leaving the rendered snapshot TEXT byte-for-byte identical. That is exactly
+// the signal-only path under test.
+function tree(focusOnHiddenNode: boolean) {
+  return [
+    {
+      nodeId: "root",
+      role: { value: "RootWebArea" },
+      name: { value: "" },
+      childIds: ["1", "2"],
+    },
+    {
+      nodeId: "1",
+      role: { value: "textbox" },
+      name: { value: "Email" },
+      backendDOMNodeId: 5,
+      parentId: "root",
+    },
+    {
+      nodeId: "2",
+      role: { value: "generic" },
+      name: { value: "" },
+      backendDOMNodeId: 7,
+      parentId: "root",
+      ignored: true,
+      properties: focusOnHiddenNode
+        ? [{ name: "focused", value: { value: true } }]
+        : [],
+    },
+  ];
+}
+
+describe("typeInElement signal-only diff", () => {
+  it("returns non-null diff when only the focus signal changed", async () => {
+    const before = tree(false); // no focus
+    const after = tree(true); // focus moved to the (non-rendered) node
+    const driver = makeMockDriver({ axTrees: [before, after], url: URL });
+
+    // Priming capture establishes baseline (focusedBackendNodeId null).
+    await captureSnapshot(driver, TAB_ID);
+
+    // The visible textbox is the single interactive node → one stable ref.
+    const refs = getRefsForTab(TAB_ID);
+    expect(refs?.size).toBe(1);
+    const ref = [...(refs?.keys() ?? [])][0];
+    expect(ref).toMatch(/^@e/);
+
+    const result = await typeInElementTool.execute(
+      { tab: "t1", target: ref, text: "hi" },
+      makeCtx(driver),
+    );
+
+    expect(result.typed).toBe(true);
+    expect(result.diff).not.toBeNull();
+    expect(result.diff).toContain("focus moved");
+    expect(result.note).toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/tools/click-element.ts
+++ b/apps/extension/src/lib/agent/tools/click-element.ts
@@ -6,6 +6,7 @@ import {
   getRef,
   getPreviousSnapshot,
   getPreviousSignals,
+  invalidateRefsIfNavigated,
 } from "../ref-store";
 import {
   captureSnapshot,
@@ -84,6 +85,11 @@ export const clickElementTool: BrowserTool<Input, Output> = {
     }
 
     try {
+      // If the click navigated to a different document, drop the stale ref map
+      // (incl. the carry-over pool) BEFORE the post-action snapshot's merge so
+      // old-page refs can't leak into the new page — mirrors navigate.ts.
+      // In-page re-renders (same URL) keep the content-stable carry-over.
+      await invalidateRefsIfNavigated(ctx.driver, tabId, previousSignals.url);
       const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
       const diff = diffSnapshots(
         { text: previousSnapshot, signals: previousSignals },

--- a/apps/extension/src/lib/agent/tools/click-element.ts
+++ b/apps/extension/src/lib/agent/tools/click-element.ts
@@ -2,8 +2,16 @@ import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
 import type { BrowserDriver, TabId } from "../driver";
 import { resolveTabOrThrow } from "../driver";
-import { getRef, getPreviousSnapshot, invalidateRefs } from "../ref-store";
-import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
+import {
+  getRef,
+  getPreviousSnapshot,
+  getPreviousSignals,
+} from "../ref-store";
+import {
+  captureSnapshot,
+  diffSnapshots,
+  findNodeByRoleNameNth,
+} from "../snapshot-capture";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -41,21 +49,23 @@ export const clickElementTool: BrowserTool<Input, Output> = {
     const tabId = tab.id;
 
     const previousSnapshot = getPreviousSnapshot(tabId);
+    const previousSignals = getPreviousSignals(tabId);
 
+    let hitWarning: string | undefined;
     try {
       if (target.startsWith("@e")) {
-        await clickByRef(ctx.driver, tabId, target);
+        ({ warning: hitWarning } = await clickByRef(ctx.driver, tabId, target));
       } else {
         await clickBySelector(ctx.driver, tabId, target);
       }
     } catch (err) {
       if (!isDetachError(err)) throw err;
-      // If the page detached during the click sequence, it means the click
-      // successfully triggered a navigation. We swallow the error and proceed
-      // to wait for the new page to load.
     }
 
-    invalidateRefs(tabId);
+    // Note: we intentionally do NOT invalidate refs here. With content-stable
+    // ref ids, the post-action snapshot below merges fresh backendNodeIds over
+    // the existing map (see ref-store.setRefs), so refs the agent still holds
+    // keep resolving. Hard-deleting would needlessly drop the carry-over pool.
 
     // Best-effort settle: wait briefly for any navigation the click may have
     // triggered. If nothing happens, this times out silently and we move on.
@@ -63,38 +73,47 @@ export const clickElementTool: BrowserTool<Input, Output> = {
     await ctx.driver.waitForLoad(tabId, 3000).catch(() => {});
 
     // Auto-attach diff so the agent can verify the outcome without a follow-up
-    // snapshot call. If previousSnapshot is null, we skip diff and just return
-    // the fresh snapshot implicitly via the setRefs side-effect.
-    if (!previousSnapshot) {
+    // snapshot call. If we have no prior baseline, capture fresh and bail.
+    if (!previousSnapshot || !previousSignals) {
       try {
         await captureSnapshot(ctx.driver, tabId);
       } catch {
         // page may have navigated away / tab closed; ignore
       }
-      return { tab: handle, clicked: true, target };
+      return { tab: handle, clicked: true, target, ...(hitWarning && { note: hitWarning }) };
     }
 
     try {
-      const { snapshotText } = await captureSnapshot(ctx.driver, tabId);
-      const diff = diffSnapshots(previousSnapshot, snapshotText);
+      const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
+      const diff = diffSnapshots(
+        { text: previousSnapshot, signals: previousSignals },
+        { text: snapshotText, signals },
+      );
       if (diff === null) {
         return {
           tab: handle,
           clicked: true,
           target,
           diff: null,
-          note: "No visible page change detected. The click may not have had the expected effect.",
+          note:
+            (hitWarning ? hitWarning + " " : "") +
+            "Accessibility tree and element state unchanged. This may still " +
+            "have succeeded (some changes aren't reflected here). Do NOT " +
+            "blindly re-click — verify with a screenshot or by reading " +
+            "element state before retrying.",
         };
       }
-      return { tab: handle, clicked: true, target, diff };
+      return { tab: handle, clicked: true, target, diff, ...(hitWarning && { note: hitWarning }) };
     } catch (err) {
       return {
         tab: handle,
         clicked: true,
         target,
-        note: `Click succeeded but post-action snapshot failed: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        note:
+          (hitWarning ? hitWarning + " " : "") +
+          `Click succeeded but post-action snapshot failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
       };
     }
   },
@@ -104,7 +123,7 @@ async function clickByRef(
   driver: BrowserDriver,
   tabId: TabId,
   ref: string,
-): Promise<void> {
+): Promise<{ warning?: string }> {
   const entry = getRef(tabId, ref);
   if (!entry) {
     throw new Error(
@@ -112,17 +131,46 @@ async function clickByRef(
     );
   }
 
-  const boxResult = await driver.sendCommand<{
-    model?: { content: number[] };
-  }>(tabId, "DOM.getBoxModel", { backendNodeId: entry.backendNodeId });
-
-  if (!boxResult.model?.content) {
-    throw new Error(`Could not get position for ${ref}. Element may be hidden or removed.`);
+  // Resolve the element's box. On a re-rendered page the cached backendNodeId
+  // may point at a detached node. Recover by re-finding the SAME logical
+  // element via its stable identity tuple (role, name, nth) from a fresh AX
+  // tree — this survives even a changed display name (where the content-hash
+  // ref would differ), matching agent-browser's resolution model.
+  let backendNodeId = entry.backendNodeId;
+  let boxResult = await getBoxModel(driver, tabId, backendNodeId);
+  if (!boxResult) {
+    const freshId = await findNodeByRoleNameNth(
+      driver,
+      tabId,
+      entry.role,
+      entry.name,
+      entry.nth,
+      entry.frameId,
+    );
+    if (freshId != null && freshId !== backendNodeId) {
+      backendNodeId = freshId;
+      boxResult = await getBoxModel(driver, tabId, backendNodeId);
+    }
   }
 
-  const pts = boxResult.model.content;
+  if (!boxResult) {
+    throw new Error(
+      `Could not get position for ${ref}. Element may be hidden or removed.`,
+    );
+  }
+
+  const pts = boxResult;
   const x = (pts[0] + pts[2] + pts[4] + pts[6]) / 4;
   const y = (pts[1] + pts[3] + pts[5] + pts[7]) / 4;
+
+  const warning = await verifyHitTarget(
+    driver,
+    tabId,
+    x,
+    y,
+    backendNodeId,
+    ref,
+  );
 
   await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
     type: "mouseMoved",
@@ -143,6 +191,27 @@ async function clickByRef(
     button: "left",
     clickCount: 1,
   });
+
+  return { warning };
+}
+
+/**
+ * Fetch the box-model content quad for a backend node, or null when the node
+ * can't be resolved (detached / removed). Never throws.
+ */
+async function getBoxModel(
+  driver: BrowserDriver,
+  tabId: TabId,
+  backendNodeId: number,
+): Promise<number[] | null> {
+  try {
+    const boxResult = await driver.sendCommand<{
+      model?: { content: number[] };
+    }>(tabId, "DOM.getBoxModel", { backendNodeId });
+    return boxResult.model?.content ?? null;
+  } catch {
+    return null;
+  }
 }
 
 async function clickBySelector(
@@ -160,4 +229,85 @@ async function clickBySelector(
 
   if (!result.success)
     throw new Error(result.error ?? `No element found for: ${selector}`);
+}
+
+/**
+ * Best-effort hit test: ask the page which element is topmost at the click
+ * point. If it is not the intended element, the click is probably being
+ * intercepted by an overlay (cookie banner, modal backdrop, sticky header).
+ * We never block — we return a human-readable warning the tool attaches to
+ * its `note` so the model can react (dismiss the overlay, scroll, screenshot).
+ *
+ * Returns undefined when the target is at the point, or when the hit test
+ * could not be performed (degrade silently rather than block a valid click).
+ *
+ * NOTE: a click landing on a DESCENDANT of the target (e.g. an <svg> inside a
+ * <button>) also reports a mismatch and warns. That is an accepted tradeoff:
+ * we do not perform ancestry checks (expensive over CDP) and prefer a soft
+ * false-positive warning over blocking a valid click.
+ */
+async function verifyHitTarget(
+  driver: BrowserDriver,
+  tabId: TabId,
+  x: number,
+  y: number,
+  targetBackendNodeId: number,
+  ref: string,
+): Promise<string | undefined> {
+  try {
+    const hit = await driver.sendCommand<{ backendNodeId?: number }>(
+      tabId,
+      "DOM.getNodeForLocation",
+      { x: Math.round(x), y: Math.round(y) },
+    );
+    const hitId = hit.backendNodeId;
+    if (hitId == null || hitId === targetBackendNodeId) return undefined;
+
+    let desc = `backendNodeId ${hitId}`;
+    try {
+      const d = await driver.sendCommand<{
+        node?: { nodeName?: string; attributes?: string[] };
+      }>(tabId, "DOM.describeNode", { backendNodeId: hitId });
+      desc = formatNodeDescription(d.node) ?? desc;
+    } catch {
+      // keep the bare id
+    }
+
+    return (
+      `The element at the click point for ${ref} is "${desc}", not the ` +
+      `intended element — an overlay may be intercepting the click. The ` +
+      `click was still dispatched; verify with a screenshot, and if it had ` +
+      `no effect, dismiss the overlay (e.g. close a cookie/consent banner or ` +
+      `modal) or scroll the target into the clear before retrying.`
+    );
+  } catch {
+    // Hit test unavailable (e.g. cross-origin frame, CDP error) — do not block.
+    return undefined;
+  }
+}
+
+/**
+ * Turn a DOM.describeNode result into a short label like `div.cookie-banner`,
+ * `button#submit`, or `a[aria-label="Close"]`. `attributes` is a flat
+ * [name, value, name, value, ...] array per CDP.
+ */
+function formatNodeDescription(
+  node: { nodeName?: string; attributes?: string[] } | undefined,
+): string | undefined {
+  if (!node?.nodeName) return undefined;
+  const tag = node.nodeName.toLowerCase();
+  const attrs = node.attributes ?? [];
+  const get = (name: string): string | undefined => {
+    for (let i = 0; i + 1 < attrs.length; i += 2) {
+      if (attrs[i] === name) return attrs[i + 1];
+    }
+    return undefined;
+  };
+  const id = get("id");
+  if (id) return `${tag}#${id}`;
+  const cls = get("class");
+  if (cls) return `${tag}.${cls.split(/\s+/)[0]}`;
+  const label = get("aria-label");
+  if (label) return `${tag}[aria-label="${label}"]`;
+  return tag;
 }

--- a/apps/extension/src/lib/agent/tools/delegate.ts
+++ b/apps/extension/src/lib/agent/tools/delegate.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { bindTabByHandle } from "../driver";
 import { getChromeWindowsAPI } from "../subagents/incognito-window";
 import type { AgentLoopConfig, AgentLoopResult } from "../subagents/runner";
 import { runSubagent } from "../subagents/runner";
@@ -27,7 +28,7 @@ export interface SubagentChildAssignedDetail {
   childConversationId: string;
 }
 
-const isolationSchema = z.enum(["peer", "incognito"]);
+const isolationSchema = z.enum(["peer", "incognito", "attached"]);
 
 const delegationContextSchema = z.object({
   task: z.string().describe("Concise description of the work the subagent should do."),
@@ -47,7 +48,11 @@ const delegationContextSchema = z.object({
     .string()
     .optional()
     .describe(
-      "The active tab the parent is discussing. The subagent reads this tab.",
+      "REQUIRED when slug is 'cua': the handle (e.g. 't1') of the tab the " +
+        "computer-use agent will control. Use a handle from the tab legend " +
+        "or listTabs. If the target tab was opened by the user, it will be " +
+        "bound into the conversation automatically. For other subagents this " +
+        "is the active tab the parent is discussing; the subagent reads it.",
     ),
   notes: z
     .string()
@@ -87,6 +92,15 @@ interface CreateDelegateToolOptions {
    * fakes in tests.
    */
   runAgentLoop: (config: AgentLoopConfig) => Promise<AgentLoopResult>;
+  /**
+   * Whether the Computer Use (`cua`) subagent is enabled — i.e. a
+   * computer-use-capable model is configured for it (explicit `cuaModel`
+   * setting, or the main agent model is itself a configured Claude
+   * computer-use model). When false, `cua` is hidden from the tool
+   * description AND rejected at execute time, so the model never delegates
+   * to a CUA loop that can't resolve a provider. Defaults to false.
+   */
+  cuaEnabled?: boolean;
 }
 
 /**
@@ -97,9 +111,10 @@ interface CreateDelegateToolOptions {
 export function createDelegateTool(
   opts: CreateDelegateToolOptions,
 ): BrowserTool<Input, Output> {
+  const cuaEnabled = opts.cuaEnabled ?? false;
   return {
     name: "delegate",
-    description: buildDelegateDescription(),
+    description: buildDelegateDescription(cuaEnabled),
     parameters,
     execute: async (input, ctx): Promise<Output> => {
       const parentConversationId = ctx.session?.conversationId;
@@ -107,6 +122,18 @@ export function createDelegateTool(
         return failure(
           input.slug,
           "delegate requires an active conversation; no conversationId in tool context.",
+        );
+      }
+
+      // Gate the Computer Use subagent on configuration. When no
+      // computer-use model is configured, `cua` is absent from the tool
+      // description, but the model may still try it — reject clearly so it
+      // can fall back to DOM tools instead of hitting an opaque provider
+      // error deeper in the run.
+      if (input.slug === "cua" && !cuaEnabled) {
+        return failure(
+          "cua",
+          "Computer Use is not enabled. Select a computer-use model in Settings → General → Computer Use model, then retry. Until then, use the DOM tools (snapshot, clickElement, typeInElement, pressKey, executeOnPage) directly.",
         );
       }
 
@@ -133,6 +160,46 @@ export function createDelegateTool(
         parentTabHandle: input.context?.parentTabHandle,
         notes: input.context?.notes,
       };
+
+      // For `attached` (CUA) subagents, the runner seeds the child handle map
+      // from the parent's named tab(s). Those handles must resolve in THIS
+      // (parent) context. If a referenced tab is user-opened and not yet
+      // bound to the conversation, bind it now (same mechanism as `selectTab`)
+      // so seeding succeeds — without this, the CUA agent fails with
+      // "no parent tab handle for CUA".
+      //
+      // We also NORMALIZE each referenced handle to its canonical `tN` form:
+      // the model may pass a raw numeric chrome tab id (from listTabs) that
+      // `resolveHandle` (which keys on `tN`) can't resolve. After binding we
+      // map the tab id back to its canonical handle and rewrite the context,
+      // so the runner's seeding resolves it regardless of input form.
+      // Best-effort: handles that can't be bound are left as-is and surfaced
+      // by the CUA branch's self-healing message.
+      if (isolation === "attached") {
+        const normalizeHandle = async (
+          handle: string,
+        ): Promise<string> => {
+          if (ctx.session?.resolveHandle?.(handle) != null) return handle;
+          try {
+            const tabId = await bindTabByHandle(ctx, handle);
+            if (tabId == null) return handle;
+            return ctx.session?.getOrCreateHandle?.(tabId) ?? handle;
+          } catch {
+            return handle;
+          }
+        };
+
+        if (delegationContext.parentTabHandle) {
+          delegationContext.parentTabHandle = await normalizeHandle(
+            delegationContext.parentTabHandle,
+          );
+        }
+        if (delegationContext.tabHandles?.length) {
+          delegationContext.tabHandles = await Promise.all(
+            delegationContext.tabHandles.map(normalizeHandle),
+          );
+        }
+      }
 
       try {
         const windowsAPI = getChromeWindowsAPI();
@@ -194,7 +261,7 @@ function failure(slug: string, message: string): Output {
   };
 }
 
-function buildDelegateDescription(): string {
+function buildDelegateDescription(cuaEnabled: boolean): string {
   const lines: string[] = [
     "Delegate a focused task to a specialized subagent. The subagent runs with",
     "fresh context (no parent chat history), its own system prompt, and a",
@@ -213,6 +280,10 @@ function buildDelegateDescription(): string {
   ];
 
   for (const a of listAgents()) {
+    // Hide the Computer Use subagent unless it's enabled (a computer-use
+    // model is configured). Listing it otherwise would invite delegations
+    // that fail to resolve a provider.
+    if (a.slug === "cua" && !cuaEnabled) continue;
     lines.push(`- ${a.slug} — ${a.description}`);
     lines.push(`  When to use: ${a.whenToUse}`);
     lines.push(`  Default isolation: ${a.defaultIsolation}`);
@@ -224,6 +295,17 @@ function buildDelegateDescription(): string {
     "- peer: child conversation, own tab group in the same window. (Default)",
     "- incognito: child conversation in a fresh incognito window with no shared cookies, auth, or storage. Auto-closes when done. Use for auth-isolated runs (e.g. testing signup flows).",
   );
+
+  if (cuaEnabled) {
+    lines.push(
+      "",
+      "Delegating to the `cua` (computer-use) subagent:",
+      "- Resolve concrete targets FIRST. The subagent has fresh context and cannot resolve relative/possessive references — never pass 'my posts', 'our profile', 'the user's comments', etc. Determine the concrete profile name/URL, person, or post identifier yourself, then delegate with that explicit target.",
+      "- ONE concrete action per call (e.g. \"open the comments section of the post titled X\", \"click Like on the comment by Jane Doe\"). Do NOT hand off multi-step loops, listing, or discovery.",
+      "- Do the planning, listing, and looping yourself. You can perceive the page directly (snapshot → screenshot with annotate → executeOnPage); use that to enumerate items and loop, delegating each individual hard click to `cua` separately.",
+      "- `cua` returns a summary of what it did and what is now on screen (often enumerating visible items). Read it, do your own perception/listing, then issue the next granular `cua` call.",
+    );
+  }
 
   return lines.join("\n");
 }

--- a/apps/extension/src/lib/agent/tools/delegate.ts
+++ b/apps/extension/src/lib/agent/tools/delegate.ts
@@ -137,6 +137,17 @@ export function createDelegateTool(
         );
       }
 
+      // `parentTabHandle` is declared optional on the schema (it's meaningless
+      // for other subagents) but is REQUIRED for `cua`: the computer-use loop
+      // must know which tab to drive. Reject early with a clear message rather
+      // than failing deep in the runner with "no parent tab handle for CUA".
+      if (input.slug === "cua" && !input.context?.parentTabHandle) {
+        return failure(
+          "cua",
+          "Computer Use requires `context.parentTabHandle` — the handle (e.g. 't1') of the tab the agent should control. Pass a handle from the tab legend or listTabs.",
+        );
+      }
+
       const agentDef = getAgent(input.slug);
       if (!agentDef) {
         const available = listAgents()

--- a/apps/extension/src/lib/agent/tools/execute-on-page.ts
+++ b/apps/extension/src/lib/agent/tools/execute-on-page.ts
@@ -65,12 +65,18 @@ export const executeOnPageTool: BrowserTool<Input, Output> = {
     ]);
 
     if (evalResult === "timeout") {
+      // The script may have partially run and mutated/replaced DOM nodes
+      // before timing out. Clear refs so the agent re-snapshots.
+      invalidateRefs(tab.id);
       return { tab: handle, error: "Execution timed out after 30s" };
     }
 
     if (evalResult.exceptionDetails) {
       const ex = evalResult.exceptionDetails;
       const msg = ex.exception?.description ?? ex.text ?? "Unknown error";
+      // A thrown exception can still leave the DOM partially mutated, so
+      // invalidate refs here too before returning.
+      invalidateRefs(tab.id);
       return { tab: handle, error: msg };
     }
 

--- a/apps/extension/src/lib/agent/tools/execute-on-page.ts
+++ b/apps/extension/src/lib/agent/tools/execute-on-page.ts
@@ -74,7 +74,10 @@ export const executeOnPageTool: BrowserTool<Input, Output> = {
       return { tab: handle, error: msg };
     }
 
-    // Assume successful execution may have modified the DOM
+    // Arbitrary JS may have mutated/replaced DOM nodes, and (unlike
+    // click/type) we take no post-action snapshot to refresh the map. Clear
+    // refs so the agent re-snapshots before acting; stable ids will be
+    // recomputed from the new tree.
     invalidateRefs(tab.id);
     return { tab: handle, result: evalResult.result?.value ?? null };
   },

--- a/apps/extension/src/lib/agent/tools/index.ts
+++ b/apps/extension/src/lib/agent/tools/index.ts
@@ -7,6 +7,7 @@ export { screenshotTool } from "./screenshot";
 export { scrollPageTool } from "./scroll-page";
 export { selectTabTool } from "./select-tab";
 export { typeInElementTool } from "./type-in-element";
+export { pressKeyTool } from "./press-key";
 export { saveMemoryTool } from "./save-memory";
 export { updateMemoryTool } from "./update-memory";
 export { deleteMemoryTool } from "./delete-memory";

--- a/apps/extension/src/lib/agent/tools/navigate.ts
+++ b/apps/extension/src/lib/agent/tools/navigate.ts
@@ -88,6 +88,10 @@ export const navigateTool: BrowserTool<Input, Output> = {
     }
 
     await ctx.driver.setActiveTab(tabId);
+    // Navigation is a genuine page change — unlike click/type/scroll, the old
+    // page's elements are gone, so we DO want a clean slate. Invalidating here
+    // also clears the ref-store carry-over pool so stale cross-page refs can't
+    // leak into the post-navigation snapshot's merge.
     invalidateRefs(tabId);
     await ctx.driver.waitForLoad(tabId);
 

--- a/apps/extension/src/lib/agent/tools/press-key.ts
+++ b/apps/extension/src/lib/agent/tools/press-key.ts
@@ -6,6 +6,7 @@ import {
   getRef,
   getPreviousSnapshot,
   getPreviousSignals,
+  invalidateRefsIfNavigated,
 } from "../ref-store";
 import { dispatchKeyCombo } from "../keyboard";
 import { captureSnapshot, diffSnapshots, findNodeByRoleNameNth } from "../snapshot-capture";
@@ -83,6 +84,10 @@ export const pressKeyTool: BrowserTool<Input, Output> = {
     }
 
     try {
+      // If the key (e.g. Enter) navigated to a different document, drop the
+      // stale ref map BEFORE the snapshot's merge so old-page refs can't leak —
+      // mirrors navigate.ts. Same-URL re-renders keep the carry-over.
+      await invalidateRefsIfNavigated(ctx.driver, tabId, previousSignals.url);
       const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
       const diff = diffSnapshots(
         { text: previousSnapshot, signals: previousSignals },

--- a/apps/extension/src/lib/agent/tools/press-key.ts
+++ b/apps/extension/src/lib/agent/tools/press-key.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+import { isDetachError } from "../cdp-errors";
+import type { BrowserDriver, TabId } from "../driver";
+import { resolveTabOrThrow } from "../driver";
+import {
+  getRef,
+  getPreviousSnapshot,
+  getPreviousSignals,
+} from "../ref-store";
+import { dispatchKeyCombo } from "../keyboard";
+import { captureSnapshot, diffSnapshots, findNodeByRoleNameNth } from "../snapshot-capture";
+import type { BrowserTool } from "../types";
+
+const parameters = z.object({
+  tab: z
+    .string()
+    .describe(
+      "Tab handle to press the key in (e.g. 't1'). See the `## Tabs in this conversation` section of the system prompt, or call listTabs.",
+    ),
+  key: z
+    .string()
+    .describe(
+      "Key or combo to press. Single keys: 'Enter', 'Escape', 'Tab', 'Backspace', 'Delete', 'ArrowUp'/'ArrowDown'/'ArrowLeft'/'ArrowRight', 'PageUp', 'PageDown', 'Home', 'End', 'Space', or a single character like 'a' or '/'. Combos use '+': 'ctrl+a', 'shift+Tab', 'cmd+c'. The key goes to the currently focused element unless `target` is set.",
+    ),
+  target: z
+    .string()
+    .optional()
+    .describe(
+      "Optional @ref of an element to focus before pressing the key (e.g. '@e5'). Omit to send the key to whatever is currently focused / the page.",
+    ),
+});
+
+type Input = z.infer<typeof parameters>;
+
+const outputSchema = z.object({
+  tab: z.string(),
+  pressed: z.literal(true),
+  key: z.string(),
+  diff: z.string().nullable().optional(),
+  note: z.string().optional(),
+});
+type Output = z.infer<typeof outputSchema>;
+
+export const pressKeyTool: BrowserTool<Input, Output> = {
+  name: "pressKey",
+  description:
+    "Press a keyboard key or combo (e.g. 'Enter', 'Escape', 'Tab', 'ctrl+a', arrow keys). Sends the key to the focused element, or pass `target` (@ref) to focus an element first. Useful for closing modals (Escape), navigating lists (arrows), submitting (Enter), or page-level shortcuts. The response includes a diff of what changed — use it to verify the key had an effect before pressing again.",
+  parameters,
+  outputSchema,
+  execute: async ({ tab: handle, key, target }, ctx) => {
+    const tab = await resolveTabOrThrow(ctx, handle);
+    const tabId = tab.id;
+
+    const previousSnapshot = getPreviousSnapshot(tabId);
+    const previousSignals = getPreviousSignals(tabId);
+
+    try {
+      if (target) {
+        await focusRef(ctx.driver, tabId, target);
+      }
+      // Split "ctrl+a" -> ["ctrl", "a"]; a bare key -> ["Enter"].
+      const keys = key.split("+").map((k) => k.trim()).filter(Boolean);
+      await dispatchKeyCombo(ctx.driver, tabId, keys);
+    } catch (err) {
+      if (!isDetachError(err)) throw err;
+      // A key (e.g. Enter) may trigger navigation that detaches the debugger.
+    }
+
+    // Refs are refreshed by the post-action snapshot's merge (see
+    // ref-store.setRefs); no pre-action invalidation needed.
+
+    // Best-effort settle for any navigation the key may have triggered.
+    await new Promise((r) => setTimeout(r, 200));
+    await ctx.driver.waitForLoad(tabId, 3000).catch(() => {});
+
+    if (!previousSnapshot || !previousSignals) {
+      try {
+        await captureSnapshot(ctx.driver, tabId);
+      } catch {
+        // page may have navigated away / tab closed; ignore
+      }
+      return { tab: handle, pressed: true, key };
+    }
+
+    try {
+      const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
+      const diff = diffSnapshots(
+        { text: previousSnapshot, signals: previousSignals },
+        { text: snapshotText, signals },
+      );
+      if (diff === null) {
+        return {
+          tab: handle,
+          pressed: true,
+          key,
+          diff: null,
+          note:
+            "Accessibility tree and element state unchanged. This may still " +
+            "have succeeded (some changes aren't reflected here). Do NOT " +
+            "blindly repeat the key — verify with a screenshot or by reading " +
+            "element state before retrying.",
+        };
+      }
+      return { tab: handle, pressed: true, key, diff };
+    } catch (err) {
+      return {
+        tab: handle,
+        pressed: true,
+        key,
+        note: `Key press succeeded but post-action snapshot failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+  },
+};
+
+async function focusRef(
+  driver: BrowserDriver,
+  tabId: TabId,
+  ref: string,
+): Promise<void> {
+  const entry = getRef(tabId, ref);
+  if (!entry) {
+    throw new Error(
+      `Ref ${ref} not found. Refs may be stale — call snapshot to refresh.`,
+    );
+  }
+  // Re-resolve by identity tuple (role, name, nth) if the cached
+  // backendNodeId is detached after a re-render.
+  let backendNodeId = entry.backendNodeId;
+  try {
+    await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
+  } catch (err) {
+    const freshId = await findNodeByRoleNameNth(
+      driver,
+      tabId,
+      entry.role,
+      entry.name,
+      entry.nth,
+      entry.frameId,
+    );
+    if (freshId == null || freshId === backendNodeId) throw err;
+    backendNodeId = freshId;
+    await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
+  }
+}

--- a/apps/extension/src/lib/agent/tools/screenshot.ts
+++ b/apps/extension/src/lib/agent/tools/screenshot.ts
@@ -30,7 +30,6 @@ const outputSchema = z.object({
   imageDataUrl: z.string().optional(),
   annotatedCount: z.number().optional(),
   annotationError: z.string().optional(),
-  note: z.string().optional(),
 });
 type Output = z.infer<typeof outputSchema>;
 
@@ -71,7 +70,7 @@ export const screenshotTool: BrowserTool<Input, Output> = {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `Page.captureScreenshot failed twice — ${msg}. Tab may be discarded or in a transient state; try scrolling or waiting before retrying.`,
+        `Page.captureScreenshot failed after retries — ${msg}. Tab may be discarded or in a transient state; try scrolling or waiting before retrying.`,
       );
     }
 

--- a/apps/extension/src/lib/agent/tools/screenshot.ts
+++ b/apps/extension/src/lib/agent/tools/screenshot.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { BrowserDriver, TabId } from "../driver";
 import { resolveTabOrThrow } from "../driver";
 import { getRefsForTab, type RefEntry } from "../ref-store";
+import { captureScreenshot } from "../capture-utils";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -58,37 +59,22 @@ export const screenshotTool: BrowserTool<Input, Output> = {
       };
     }
 
-    // Page.captureScreenshot occasionally returns a generic "-32000 Unable to
-    // capture screenshot" when the renderer is mid-paint or briefly throttled
-    // (especially after a sequence of snapshot/scroll calls). One short retry
-    // resolves this in practice.
-    let result: { data: string };
-    let retryNote: string | undefined;
+    // Capture via the shared helper, which hides OpenBrowse's own overlays
+    // (the "working" glow/pill, ripple, toasts, SoM overlay) so they never
+    // leak into the model-facing image, and retries once on the transient
+    // `-32000 Unable to capture screenshot` error. Annotation (below) draws
+    // on the already-clean image, so annotated screenshots are overlay-free
+    // too.
+    let imageData: string;
     try {
-      result = await ctx.driver.sendCommand<{ data: string }>(
-        tabId,
-        "Page.captureScreenshot",
-        captureParams,
+      imageData = await captureScreenshot(ctx.driver, tabId, captureParams);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Page.captureScreenshot failed twice — ${msg}. Tab may be discarded or in a transient state; try scrolling or waiting before retrying.`,
       );
-    } catch (firstErr) {
-      await new Promise((r) => setTimeout(r, 600));
-      try {
-        result = await ctx.driver.sendCommand<{ data: string }>(
-          tabId,
-          "Page.captureScreenshot",
-          captureParams,
-        );
-        retryNote =
-          "Initial Page.captureScreenshot failed and was retried successfully. The renderer may be under load.";
-      } catch (secondErr) {
-        const msg = secondErr instanceof Error ? secondErr.message : String(secondErr);
-        throw new Error(
-          `Page.captureScreenshot failed twice — ${msg}. Tab may be discarded or in a transient state; try scrolling or waiting before retrying.`,
-        );
-      }
     }
 
-    let imageData = result.data;
     let annotatedCount: number | undefined;
     let annotationError: string | undefined;
 
@@ -117,7 +103,6 @@ export const screenshotTool: BrowserTool<Input, Output> = {
     };
     if (annotatedCount != null) out.annotatedCount = annotatedCount;
     if (annotationError) out.annotationError = annotationError;
-    if (retryNote) out.note = retryNote;
     return out;
   },
 };

--- a/apps/extension/src/lib/agent/tools/scroll-page.ts
+++ b/apps/extension/src/lib/agent/tools/scroll-page.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { resolveTabOrThrow } from "../driver";
-import { invalidateRefs } from "../ref-store";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -49,7 +48,9 @@ export const scrollPageTool: BrowserTool<Input, Output> = {
 
     if (!result.success)
       throw new Error(result.error ?? "Failed to scroll");
-    invalidateRefs(tab.id);
+    // Don't invalidate refs: scrolling moves elements within the page but
+    // doesn't detach them, and content-stable refs survive a re-snapshot.
+    // The agent's next snapshot refreshes positions via the ref-store merge.
     return { tab: handle, scrolled: true, direction, amount: pixels };
   },
 };

--- a/apps/extension/src/lib/agent/tools/select-tab.ts
+++ b/apps/extension/src/lib/agent/tools/select-tab.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { bindTabByHandle } from "../driver";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -19,28 +20,16 @@ export const selectTabTool: BrowserTool<Input, Output> = {
     "Bind an external (user-opened) tab into this conversation so it appears in the tab legend and can be passed as the `tab` arg to other tools. Does NOT switch the user's visible tab. Use handles from listTabs.",
   parameters,
   execute: async ({ tab }, ctx) => {
-    let tabId = ctx.session?.resolveHandle?.(tab);
-
-    // Fallback: try parsing as numeric tab ID for backward compat
+    // Shared resolve (with numeric fallback) + verify + bind. Returns null
+    // if the handle doesn't map to a live tab.
+    const tabId = await bindTabByHandle(ctx, tab);
     if (tabId == null) {
-      const parsed = parseInt(tab, 10);
-      if (!Number.isNaN(parsed)) tabId = parsed;
+      throw new Error(
+        `Tab handle "${tab}" not found. Use listTabs to see available tabs.`,
+      );
     }
 
-    if (tabId == null) {
-      throw new Error(`Tab handle "${tab}" not found. Use listTabs to see available tabs.`);
-    }
-
-    // Verify the tab exists by listing tabs.
-    const tabs = await ctx.driver.listTabs();
-    const target = tabs.find((t) => t.id === tabId);
-    if (!target) throw new Error(`Tab ${tabId} not found`);
-
-    // Always fold into the conversation's owned tabs so the tab appears in
-    // the agent's tab legend on subsequent turns. Binding into the group (if
-    // one exists) is a side effect of the same call.
-    await ctx.session?.bindActiveTabToConversation?.(tabId);
-
+    // selectTab additionally pins the bound tab as the agent's working target.
     await ctx.driver.setActiveTab(tabId);
     return { selected: true, tab };
   },

--- a/apps/extension/src/lib/agent/tools/snapshot.ts
+++ b/apps/extension/src/lib/agent/tools/snapshot.ts
@@ -52,7 +52,7 @@ export const snapshotTool: BrowserTool<Input, Output> = {
     const viewportOnly = mode === "viewport";
     const captureMode = mode === "viewport" ? "interactive" : mode;
 
-    const { snapshotText, refs, previous, belowFoldCount } =
+    const { snapshotText, refs, previous, signals, previousSignals, belowFoldCount } =
       await captureSnapshot(ctx.driver, tabId, {
         mode: captureMode,
         selector,
@@ -62,8 +62,11 @@ export const snapshotTool: BrowserTool<Input, Output> = {
     const baseResult: Output = {
       tab: handle,
       snapshot:
-        diff && previous
-          ? (diffSnapshots(previous, snapshotText) ?? "(no changes)")
+        diff && previous && previousSignals
+          ? (diffSnapshots(
+              { text: previous, signals: previousSignals },
+              { text: snapshotText, signals },
+            ) ?? "(no changes)")
           : snapshotText,
       refCount: refs.size,
       url,

--- a/apps/extension/src/lib/agent/tools/type-in-element.ts
+++ b/apps/extension/src/lib/agent/tools/type-in-element.ts
@@ -6,6 +6,7 @@ import {
   getRef,
   getPreviousSnapshot,
   getPreviousSignals,
+  invalidateRefsIfNavigated,
 } from "../ref-store";
 import {
   captureSnapshot,
@@ -125,6 +126,10 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     }
 
     try {
+      // If submitting (Enter) navigated to a different document, drop the
+      // stale ref map BEFORE the snapshot's merge so old-page refs can't leak —
+      // mirrors navigate.ts. Same-URL re-renders keep the carry-over.
+      await invalidateRefsIfNavigated(ctx.driver, tabId, previousSignals.url);
       const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
       const diff = diffSnapshots(
         { text: previousSnapshot, signals: previousSignals },

--- a/apps/extension/src/lib/agent/tools/type-in-element.ts
+++ b/apps/extension/src/lib/agent/tools/type-in-element.ts
@@ -2,8 +2,16 @@ import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
 import type { BrowserDriver, TabId } from "../driver";
 import { resolveTabOrThrow } from "../driver";
-import { getRef, getPreviousSnapshot, invalidateRefs } from "../ref-store";
-import { captureSnapshot, diffSnapshots } from "../snapshot-capture";
+import {
+  getRef,
+  getPreviousSnapshot,
+  getPreviousSignals,
+} from "../ref-store";
+import {
+  captureSnapshot,
+  diffSnapshots,
+  findNodeByRoleNameNth,
+} from "../snapshot-capture";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -54,6 +62,7 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     const tabId = tab.id;
 
     const previousSnapshot = getPreviousSnapshot(tabId);
+    const previousSignals = getPreviousSignals(tabId);
 
     // Back-compat: trailing newline was the old form-submit hack.
     const legacyNewlineSubmit = text.endsWith("\n");
@@ -97,7 +106,8 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
       await ctx.driver.waitForLoad(tabId, 8000).catch(() => {});
     }
 
-    invalidateRefs(tabId);
+    // Refs are refreshed (not invalidated) by the post-action snapshot's
+    // merge — see click-element.ts and ref-store.setRefs.
 
     const baseResult = {
       tab: handle,
@@ -107,7 +117,7 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
       ...(shouldPressEnter && { submitted: true as const }),
     };
 
-    if (!previousSnapshot) {
+    if (!previousSnapshot || !previousSignals) {
       try {
         await captureSnapshot(ctx.driver, tabId);
       } catch {}
@@ -115,13 +125,20 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     }
 
     try {
-      const { snapshotText } = await captureSnapshot(ctx.driver, tabId);
-      const diff = diffSnapshots(previousSnapshot, snapshotText);
+      const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
+      const diff = diffSnapshots(
+        { text: previousSnapshot, signals: previousSignals },
+        { text: snapshotText, signals },
+      );
       if (diff === null) {
         return {
           ...baseResult,
           diff: null,
-          note: "No visible page change detected after typing. The element may not have accepted input.",
+          note:
+            "Accessibility tree and element state unchanged. This may still " +
+            "have succeeded (some changes aren't reflected here). Do NOT " +
+            "blindly retry — verify with a screenshot or by reading " +
+            "element state before retrying.",
         };
       }
       return { ...baseResult, diff };
@@ -150,7 +167,25 @@ async function typeByRef(
     );
   }
 
-  await driver.sendCommand(tabId, "DOM.focus", { backendNodeId: entry.backendNodeId });
+  // Focus the element. On a re-rendered page the cached backendNodeId may be
+  // detached; recover by re-finding the same logical element via its identity
+  // tuple (role, name, nth) from a fresh AX tree before failing.
+  let backendNodeId = entry.backendNodeId;
+  try {
+    await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
+  } catch (err) {
+    const freshId = await findNodeByRoleNameNth(
+      driver,
+      tabId,
+      entry.role,
+      entry.name,
+      entry.nth,
+      entry.frameId,
+    );
+    if (freshId == null || freshId === backendNodeId) throw err;
+    backendNodeId = freshId;
+    await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
+  }
 
   if (clearFirst) {
     await driver.sendCommand(tabId, "Input.dispatchKeyEvent", {

--- a/apps/extension/src/lib/conversation-id-context.tsx
+++ b/apps/extension/src/lib/conversation-id-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Exposes the active conversation's id to descendant chat components.
+ *
+ * Most components receive `conversationId` via props, but a few deeply
+ * nested result renderers (e.g. `DelegateResult`) need it without a
+ * five-level prop drill. The provider lives at `ChatView`, which owns
+ * the `conversationId` prop.
+ *
+ * `null` is the legitimate fallback when no provider is mounted (e.g. a
+ * brand-new unsaved conversation, isolated tests, or settings previews);
+ * consumers must treat `null` as "no conversation" rather than throwing.
+ */
+export const ConversationIdContext = createContext<string | null>(null);
+
+/** Read the active conversation id. Returns `null` outside any provider. */
+export function useConversationId(): string | null {
+  return useContext(ConversationIdContext);
+}

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -97,6 +97,12 @@ export interface AgentSettings {
   compactionModel?: string;
   thinkingEnabled?: boolean;
   thinkingConfig?: ThinkingConfig;
+  /**
+   * Model used by the computer-use (CUA) subagent. Must be a
+   * computer-use-capable model (compound "providerId:modelId"). When unset,
+   * falls back to the `cua` agent definition's `defaultModel`.
+   */
+  cuaModel?: string;
 }
 
 export interface Conversation {

--- a/apps/extension/src/registry/models-dev/__tests__/computer-use-capability.test.ts
+++ b/apps/extension/src/registry/models-dev/__tests__/computer-use-capability.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { providers } from "../../providers";
+
+describe("computer-use capability flagging", () => {
+  it("flags Sonnet 4.6 as computer-use when present in the catalog", () => {
+    const anthropic = providers.find((p) => p.id === "anthropic");
+    expect(anthropic).toBeDefined();
+    const cua = anthropic?.models.find((m) => m.id === "claude-sonnet-4-6");
+    // Only assert if the model is present in the bundled snapshot.
+    if (cua) {
+      expect(cua.capabilities).toContain("computer-use");
+    }
+  });
+
+  it("does NOT flag a non-CUA model like claude-opus-4-0", () => {
+    const anthropic = providers.find((p) => p.id === "anthropic");
+    const nonCua = anthropic?.models.find((m) => m.id === "claude-opus-4-0");
+    if (nonCua) {
+      expect(nonCua.capabilities).not.toContain("computer-use");
+    }
+  });
+
+  it("flags the gateway (vercel) Claude CUA model despite the anthropic/ prefix + dot version", () => {
+    const vercel = providers.find((p) => p.id === "vercel");
+    expect(vercel).toBeDefined();
+    const cua = vercel?.models.find((m) => m.id === "anthropic/claude-sonnet-4.6");
+    if (cua) {
+      expect(cua.capabilities).toContain("computer-use");
+    }
+    // And a non-CUA gateway model must NOT be flagged.
+    const nonCua = vercel?.models.find((m) => m.id === "anthropic/claude-opus-4.1");
+    if (nonCua) {
+      expect(nonCua.capabilities).not.toContain("computer-use");
+    }
+  });
+});

--- a/apps/extension/src/registry/models-dev/__tests__/from-models-dev.test.ts
+++ b/apps/extension/src/registry/models-dev/__tests__/from-models-dev.test.ts
@@ -36,7 +36,7 @@ describe("fromModelsDevProvider", () => {
     expect(haiku).toBeDefined();
     expect(haiku!.name).toBe("Claude Haiku 4.5 (latest)");
     expect(haiku!.capabilities.sort()).toEqual(
-      ["chat", "tools", "vision", "thinking"].sort(),
+      ["chat", "tools", "vision", "thinking", "computer-use"].sort(),
     );
     expect(haiku!.contextWindow).toBe(200_000);
     expect(haiku!.maxOutputTokens).toBe(64_000);

--- a/apps/extension/src/registry/models-dev/from-models-dev.ts
+++ b/apps/extension/src/registry/models-dev/from-models-dev.ts
@@ -20,6 +20,30 @@ import type {
 
 const DEFAULT_API_KEY_PLACEHOLDER = "sk-...";
 
+/**
+ * Models.dev does not expose a computer-use signal, so we flag the
+ * computer-use-capable models by id. Anthropic Opus 4.5+ and Sonnet 4.5/4.6
+ * (and Haiku 4.5) support the computer-use tool.
+ *
+ * Matches both id conventions: the direct Anthropic provider
+ * (`claude-sonnet-4-6`, hyphen versions) and the Vercel AI Gateway provider
+ * (`anthropic/claude-sonnet-4.6`, an `anthropic/` prefix + dot versions).
+ * Kept in sync with `lib/agent/cua/model-ids.ts` (the registry deliberately
+ * does not import from the agent layer to preserve dependency direction).
+ */
+function isComputerUseModelId(modelId: string): boolean {
+  const stripped = modelId.includes("/")
+    ? modelId.slice(modelId.lastIndexOf("/") + 1)
+    : modelId;
+  const id = stripped.toLowerCase().replace(/\./g, "-");
+  if (!id.includes("claude")) return false;
+  return (
+    /sonnet-4-(5|6)/.test(id) ||
+    /haiku-4-5/.test(id) ||
+    /opus-4-(5|6|7|8)/.test(id)
+  );
+}
+
 function defaultConfigSchema(placeholder: string): ConfigField[] {
   return [
     {
@@ -45,6 +69,7 @@ function capabilitiesOf(model: ModelsDevModel): ModelDefinition["capabilities"] 
   const inputs = new Set(model.modalities?.input ?? []);
   if (inputs.has("image") || inputs.has("pdf")) caps.push("vision");
   if (model.reasoning) caps.push("thinking");
+  if (isComputerUseModelId(model.id)) caps.push("computer-use");
   return caps;
 }
 

--- a/apps/extension/src/registry/providers/types.ts
+++ b/apps/extension/src/registry/providers/types.ts
@@ -66,7 +66,7 @@ export interface ModelDefinition {
    * - `"vision"` — image input
    * - `"thinking"` — extended thinking / chain-of-thought
    */
-  capabilities: ("chat" | "tools" | "vision" | "thinking")[];
+  capabilities: ("chat" | "tools" | "vision" | "thinking" | "computer-use")[];
 
   /**
    * Qualitative intelligence rating for comparison UI.

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -122,7 +122,7 @@ export default defineConfig({
     host_permissions: ["<all_urls>"],
     web_accessible_resources: [
       {
-        resources: ["overlay.html", "icon/logo.svg"],
+        resources: ["overlay.html", "icon/logo.svg", "icon/logo-dark.svg"],
         matches: ["<all_urls>"],
       },
     ],

--- a/packages/bench/src/agent/build-agent.ts
+++ b/packages/bench/src/agent/build-agent.ts
@@ -52,7 +52,10 @@ import type { TokenLimits } from "@agent/compaction";
  */
 function inferBenchVendor(modelId: string): ThinkingVendor | null {
   if (modelId.startsWith("claude")) return "anthropic";
-  if (modelId.startsWith("gpt") || modelId.startsWith("o")) return "openai";
+  // OpenAI: `gpt-…` plus the reasoning series `o1-`/`o3-`/`o4-…`. Match only an
+  // `o` followed by a digit so unrelated ids (e.g. a hypothetical `opus-…`)
+  // don't get misclassified by a bare `startsWith("o")`.
+  if (modelId.startsWith("gpt") || /^o\d/.test(modelId)) return "openai";
   if (modelId.startsWith("gemini")) return "google";
   return null;
 }

--- a/packages/bench/src/agent/build-agent.ts
+++ b/packages/bench/src/agent/build-agent.ts
@@ -18,6 +18,7 @@ import { clickElementTool } from "@agent/tools/click-element";
 import { executeOnPageTool } from "@agent/tools/execute-on-page";
 import { listTabsTool } from "@agent/tools/list-tabs";
 import { navigateTool } from "@agent/tools/navigate";
+import { pressKeyTool } from "@agent/tools/press-key";
 import { readPageTool } from "@agent/tools/read-page";
 import { screenshotTool } from "@agent/tools/screenshot";
 import { scrollPageTool } from "@agent/tools/scroll-page";
@@ -27,6 +28,11 @@ import { typeInElementTool } from "@agent/tools/type-in-element";
 import type { ToolContext } from "@agent/driver";
 import { SYSTEM_PROMPT } from "@agent/system-prompt";
 import { shouldCompact } from "@agent/compaction";
+import {
+  buildThinkingProviderOptions,
+  isGemini3Model,
+  type ThinkingVendor,
+} from "@agent/thinking";
 import { buildToolToastScript } from "../drivers/visualizing-driver";
 import {
   DEFAULT_PAGE_STATE_FIELDS,
@@ -39,6 +45,19 @@ import type { AgentDefinition } from "@agent/subagents/types";
 import type { TokenLimits } from "@agent/compaction";
 
 /**
+ * Infer the model vendor from a direct (non-gateway) bench model id. The bench
+ * CLI accepts `claude-…`, `gpt-…`/`o…`, and `gemini-…` ids (see
+ * `resolveModel` in cli.ts), so we mirror that prefix logic here to feed the
+ * shared `buildThinkingProviderOptions`.
+ */
+function inferBenchVendor(modelId: string): ThinkingVendor | null {
+  if (modelId.startsWith("claude")) return "anthropic";
+  if (modelId.startsWith("gpt") || modelId.startsWith("o")) return "openai";
+  if (modelId.startsWith("gemini")) return "google";
+  return null;
+}
+
+/**
  * Catalog of portable page-interacting tools the bench can run WITHOUT a
  * harness (the unconfigured CLI path). Experiment-specific tools (SoM, etc.)
  * are NOT registered here — they live in out-of-tree harness files and are
@@ -48,6 +67,7 @@ export const BENCH_TOOL_CATALOG = {
   snapshot: snapshotTool,
   clickElement: clickElementTool,
   typeInElement: typeInElementTool,
+  pressKey: pressKeyTool,
   navigate: navigateTool,
   screenshot: screenshotTool,
   scrollPage: scrollPageTool,
@@ -69,6 +89,7 @@ export const DEFAULT_TOOL_SET: BenchToolName[] = [
   "snapshot",
   "clickElement",
   "typeInElement",
+  "pressKey",
   "navigate",
   "scrollPage",
   "readPage",
@@ -304,31 +325,29 @@ export function buildBenchAgent(
   let needsMidStreamCompaction = false;
 
   // Build providerOptions for thinking/reasoning when enabled. We dispatch on
-  // the model id (which the AI SDK exposes via `(model as any).modelId`) so we
-  // can pick the correct provider-specific options shape.
+  // the model id (which the AI SDK exposes via `(model as any).modelId`) and
+  // reuse the extension's shared `buildThinkingProviderOptions` so the bench
+  // and the production agent stay in lockstep — including Gemini 3
+  // (`thinkingLevel`) vs Gemini 2.5 (`thinkingBudget`) and `includeThoughts`.
   let providerOptions: any | undefined;
   if (opts.thinking?.enabled) {
     const budget = opts.thinking.budget ?? 4096;
     const modelId = (opts.model as any).modelId ?? (opts.model as any).id ?? "";
-    if (typeof modelId === "string" && modelId.startsWith("gemini-")) {
-      providerOptions = {
-        google: {
-          thinkingConfig: {
-            includeThoughts: true,
-            thinkingBudget: budget,
-          },
-        },
-      };
-    } else if (typeof modelId === "string" && modelId.startsWith("claude")) {
-      providerOptions = {
-        anthropic: {
-          thinking: { type: "adaptive", display: "summarized" },
-        },
-      };
-    } else if (typeof modelId === "string" && (modelId.startsWith("gpt") || modelId.startsWith("o"))) {
-      providerOptions = {
-        openai: { reasoningEffort: "medium" },
-      };
+    if (typeof modelId === "string" && modelId.length > 0) {
+      const vendor = inferBenchVendor(modelId);
+      if (vendor) {
+        // The bench uses direct SDK model ids (no provider prefix), so the
+        // registry-style providerId IS the vendor. Gemini 3 ignores the
+        // numeric budget and uses an effort-style `thinkingLevel`; everything
+        // else uses the budget.
+        const config =
+          vendor === "google" && isGemini3Model(modelId)
+            ? ({ type: "effort", level: "medium" } as const)
+            : vendor === "openai"
+              ? ({ type: "effort", level: "medium" } as const)
+              : ({ type: "budget", tokens: budget } as const);
+        providerOptions = buildThinkingProviderOptions(vendor, modelId, config);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a provider-neutral Computer Use (CUA) subsystem that lets Anthropic
Claude models drive the live browser tab, plus supporting agent and chat
improvements.

## What's included

- **CUA subsystem** (`lib/agent/cua`): canonical action union, CDP executor,
  viewport/coordinate mapping, screenshot normalization + region zoom, and a
  shared `ToolLoopAgent` loop with abort handling and no-op detection. Wires in
  the Anthropic provider (action decoder, tool-version/beta mapping, nav tools).
- **Settings & registry**: computer-use capability flag on the model registry,
  capability badge, Computer Use model picker, and Vercel AI Gateway transport
  for Anthropic CUA models.
- **Subagents**: "attached" isolation profile + "custom" tool source so the cua
  built-in runs on the parent's live tab; real-time subagent trace via
  `AssistantStreamPersister` with reload recovery.
- **Agent refactors**: content-stable `@refs` (role + name + landmark +
  occurrence) with stale-id re-resolution, multi-signal snapshot diffing,
  snapshot-aware compaction, and a new `pressKey` tool + keyboard helpers.
- **Thinking**: shared thinking/reasoning `providerOptions` module across the
  extension transport, UI control, and bench agent.
- **Chat UX**: in-place retry that continues an errored assistant turn via
  trailing-assistant continuation; per-user-message "Retry"; working-on-page
  overlay (glow border, input shield, stop button) with active tool abort.

## Testing

Includes extensive unit tests for the CUA loop, executor, coordinate mapping,
Anthropic decoding, snapshot diffing, stable refs, keyboard, thinking, and
compaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Computer Use (CUA): pixel-level browser actions (click/type/scroll), on-page “working” overlay, click ripple visuals, and model picker in Settings.
  * “Retry from user” action to resume a conversation from a specific user message.

* **Improvements**
  * Smarter snapshot diffing with page-state signals for clearer no-change vs. state-change detection.
  * Better keyboard/navigation tooling (press-key support) and more reliable screenshot/cropping for tool-driven actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->