### PR TITLE
feat: "Completed N steps" tool-call fold + fix interrupted tool calls

### DIFF
--- a/.changeset/completed-steps-collapsible.md
+++ b/.changeset/completed-steps-collapsible.md
@@ -1,0 +1,11 @@
+---
+"openbrowse": patch
+---
+
+Fold completed tool calls into a "Completed N steps" collapsible.
+
+While tools are running they stay expanded and live; once the assistant
+begins its answer text, a run of 3+ tool calls auto-folds into a
+collapsible labeled "Completed N steps" (click to re-expand), matching
+the Perplexity Comet pattern. Runs of 1-2 tools, reasoning-only groups,
+and pending approval prompts render inline as before.

--- a/.changeset/drop-input-less-tool-calls.md
+++ b/.changeset/drop-input-less-tool-calls.md
@@ -1,0 +1,13 @@
+---
+"openbrowse": patch
+---
+
+Fix interrupted tool calls breaking the next request.
+
+A tool call aborted before its arguments finished streaming was replayed
+on the next turn as a `tool_use` block with no `input`, which providers
+reject — Anthropic/Bedrock with `tool_use.input: Field required` (a
+visible "Something went wrong" error) and Gemini/Vertex with a silent
+malformed-function-call error that just stopped the generation. The
+send-time heal now drops these input-less interrupted calls before they
+reach the provider, so the conversation can continue.

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -10,6 +10,7 @@ import { CompletionCheckBlock } from "./CompletionCheckBlock";
 import { CompletionCheckRunningBlock } from "./CompletionCheckRunningBlock";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { ToolApprovalBlock } from "./ToolApprovalBlock";
+import { StepGroup } from "./StepGroup";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 import { capturedToolOrigins, allowToolOnSite, setCloseTabsAlwaysAllowed } from "@/lib/agent/agent-transport";
 import { memo } from "react";
@@ -149,33 +150,113 @@ interface AssistantMessageProps {
   dimmed?: boolean;
 }
 
-function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, dimmed }: AssistantMessageProps) {
+/**
+ * Part types that belong inside a "step" group: tool calls and the reasoning
+ * that accompanies them. These get folded into the "Completed N steps"
+ * collapsible once the assistant begins its answer text. `step-start` is
+ * grouped too (skipped at render time) so it never breaks a run of tools.
+ */
+function isWorkPart(part: AgentUIMessage["parts"][number]): boolean {
+  const t = part.type;
   return (
-    <div className={`group/message flex flex-col items-start gap-1 ${dimmed ? "opacity-40" : ""}`}>
-      <div className="w-full text-sm text-foreground">
-        {message.parts.map((part, i) => {
-          if (part.type === "text") {
-            const isLastPart = i === message.parts.length - 1;
-            return (
-              <Markdown
-                key={i}
-                source={part.text}
-                isStreaming={isStreaming && isLastPart}
-              />
-            );
-          }
-          if (part.type === "reasoning") {
-            const nextPart = message.parts[i + 1];
-            const isActivelyReasoning = isStreaming && (!nextPart || (nextPart.type === "text" && !nextPart.text));
-            return (
-              <Reasoning
-                key={i}
-                text={part.text}
-                isStreaming={isActivelyReasoning}
-              />
-            );
-          }
-          if (part.type === "dynamic-tool") {
+    t === "reasoning" ||
+    t === "dynamic-tool" ||
+    t === "step-start" ||
+    (typeof t === "string" && t.startsWith("tool-"))
+  );
+}
+
+/** Count tool-call parts in a group (drives the "N steps" label). */
+function countToolParts(parts: { type: string }[]): number {
+  return parts.filter(
+    (p) => p.type === "dynamic-tool" || p.type.startsWith("tool-"),
+  ).length;
+}
+
+/**
+ * True if a group contains an in-flight approval request. Such a group must
+ * never be folded — the user needs to see and act on the prompt.
+ */
+function hasPendingApproval(parts: AgentUIMessage["parts"]): boolean {
+  return parts.some(
+    (p) => (p as { state?: unknown }).state === "approval-requested",
+  );
+}
+
+type Segment =
+  | { kind: "break"; part: AgentUIMessage["parts"][number]; index: number }
+  | {
+      kind: "group";
+      parts: { part: AgentUIMessage["parts"][number]; index: number }[];
+    };
+
+/** Build render segments: runs of work parts grouped, break parts standalone. */
+function buildSegments(parts: AgentUIMessage["parts"]): Segment[] {
+  const segments: Segment[] = [];
+  let current: { part: AgentUIMessage["parts"][number]; index: number }[] = [];
+
+  const flush = () => {
+    if (current.length > 0) {
+      segments.push({ kind: "group", parts: current });
+      current = [];
+    }
+  };
+
+  parts.forEach((part, index) => {
+    if (isWorkPart(part)) {
+      current.push({ part, index });
+    } else {
+      flush();
+      segments.push({ kind: "break", part, index });
+    }
+  });
+  flush();
+  return segments;
+}
+
+function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, dimmed }: AssistantMessageProps) {
+  const parts = message.parts;
+  const segments = buildSegments(parts);
+
+  // Index of the last group segment — the only one that can still be "active"
+  // (tools running, no answer text yet).
+  const lastGroupSegmentIndex = (() => {
+    for (let i = segments.length - 1; i >= 0; i--) {
+      if (segments[i].kind === "group") return i;
+    }
+    return -1;
+  })();
+
+  // Does any non-empty text part exist after a given part index? If so, the
+  // group that precedes it has produced its answer and should fold.
+  const hasTextAfter = (index: number): boolean =>
+    parts.some(
+      (p, i) => i > index && p.type === "text" && p.text.length > 0,
+    );
+
+  const renderPart = (part: AgentUIMessage["parts"][number], i: number) => {
+    if (part.type === "text") {
+      const isLastPart = i === parts.length - 1;
+      return (
+        <Markdown
+          key={i}
+          source={part.text}
+          isStreaming={isStreaming && isLastPart}
+        />
+      );
+    }
+    if (part.type === "reasoning") {
+      const nextPart = parts[i + 1];
+      const isActivelyReasoning = isStreaming && (!nextPart || (nextPart.type === "text" && !nextPart.text));
+      return (
+        <Reasoning
+          key={i}
+          text={part.text}
+          isStreaming={isActivelyReasoning}
+        />
+      );
+    }
+    if (part.type === "dynamic-tool") {
             if (part.state === "approval-requested" && "approval" in part && onToolApproval) {
               const approval = part.approval as { id: string };
               return (
@@ -300,6 +381,49 @@ function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, di
             }
           }
           return null;
+  };
+
+  return (
+    <div className={`group/message flex flex-col items-start gap-1 ${dimmed ? "opacity-40" : ""}`}>
+      <div className="w-full text-sm text-foreground">
+        {segments.map((segment, si) => {
+          if (segment.kind === "break") {
+            return renderPart(segment.part, segment.index);
+          }
+
+          // A work group. Count tool calls — a group with no tool calls (e.g.
+          // reasoning-only) renders inline without the step wrapper.
+          const groupParts = segment.parts.map((p) => p.part);
+          const toolCount = countToolParts(groupParts);
+          const rendered = segment.parts.map(({ part, index }) =>
+            renderPart(part, index),
+          );
+
+          // No tool calls, fewer than 3 tool steps, or an in-flight approval
+          // the user must see/act on: render inline (no fold). Only runs of
+          // 3+ tool calls collapse into a "Completed N steps" block.
+          if (toolCount < 3 || hasPendingApproval(groupParts)) {
+            return (
+              <div key={`g${si}`} className="flex w-full flex-col">
+                {rendered}
+              </div>
+            );
+          }
+
+          // Active = trailing group of a streaming message that hasn't produced
+          // answer text yet.
+          const lastPartIndex =
+            segment.parts[segment.parts.length - 1]?.index ?? -1;
+          const isActive =
+            isStreaming &&
+            si === lastGroupSegmentIndex &&
+            !hasTextAfter(lastPartIndex);
+
+          return (
+            <StepGroup key={`g${si}`} stepCount={toolCount} isActive={isActive}>
+              {rendered}
+            </StepGroup>
+          );
         })}
       </div>
       <MessageActions message={message} />

--- a/apps/extension/src/components/chat/StepGroup.tsx
+++ b/apps/extension/src/components/chat/StepGroup.tsx
@@ -1,0 +1,79 @@
+import { cn } from "@/lib/utils";
+import { ChevronRightIcon } from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+interface StepGroupProps {
+  /** Number of tool calls in this group — drives the "Completed N steps" label. */
+  stepCount: number;
+  /**
+   * True while this group's work is still in flight (the trailing group of a
+   * streaming message that hasn't produced its answer text yet). While active
+   * the children render expanded and chrome-free so each tool row shows its own
+   * live/pending UI. When this flips to false the group auto-folds into the
+   * "Completed N steps" collapsible — mirroring Perplexity Comet.
+   */
+  isActive: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Groups a run of tool-call (and interleaved reasoning) parts.
+ *
+ * - Active (tools running, no answer yet): renders children inline, expanded,
+ *   no collapsible chrome — identical to the pre-grouping behavior.
+ * - Inactive (answer text began / stream ended): auto-collapses into a
+ *   "Completed N steps" header with a chevron. Click to re-expand; collapsed
+ *   by default once folded.
+ *
+ * The auto-fold transition follows the same `isStreaming`-driven pattern as the
+ * `Reasoning` component.
+ */
+export function StepGroup({ stepCount, isActive, children }: StepGroupProps) {
+  // While active we render expanded+chrome-free. Once folded, the collapsible
+  // starts closed and the user can toggle it open.
+  const [open, setOpen] = useState(false);
+  const wasActiveRef = useRef(isActive);
+
+  useEffect(() => {
+    if (isActive) {
+      // (Re)entered the active phase — make sure we're not stuck open from a
+      // previous fold (shouldn't normally happen, but keeps state coherent).
+      wasActiveRef.current = true;
+      setOpen(false);
+    } else if (wasActiveRef.current) {
+      // Just transitioned active -> folded: collapse by default.
+      wasActiveRef.current = false;
+      setOpen(false);
+    }
+  }, [isActive]);
+
+  if (isActive) {
+    // Live: render children exactly as they were before grouping.
+    return <div className="flex w-full flex-col">{children}</div>;
+  }
+
+  const label = stepCount === 1 ? "Completed 1 step" : `Completed ${stepCount} steps`;
+
+  return (
+    <div className="my-0.5 w-full">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="group flex items-center gap-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <span className="font-medium">{label}</span>
+        <ChevronRightIcon
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="mt-1 ml-1 flex flex-col border-l-2 border-muted pl-3">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/extension/src/components/chat/StepGroup.tsx
+++ b/apps/extension/src/components/chat/StepGroup.tsx
@@ -59,6 +59,7 @@ export function StepGroup({ stepCount, isActive, children }: StepGroupProps) {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
         className="group flex items-center gap-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground"
       >
         <span className="font-medium">{label}</span>

--- a/apps/extension/src/lib/agent/__tests__/heal-validate-integration.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/heal-validate-integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { validateUIMessages, convertToModelMessages, tool } from "ai";
 import { healPendingTools } from "../heal-pending-tools";
+import { rewriteForLLM } from "../compacting-transport";
 import { jsonSchemaToZod } from "@/lib/mcp/schema-to-zod";
 import type { AgentUIMessage } from "@/lib/types";
 
@@ -126,5 +127,61 @@ describe("convertToModelMessages + heal (Error 2 end-to-end)", () => {
       expect(toolResultIds.has(id)).toBe(true);
     }
     expect(toolUseIds.has("toolu_9")).toBe(true);
+  });
+});
+
+describe("rewriteForLLM + convertToModelMessages (input-less interrupted call)", () => {
+  it("produces NO tool-call with missing input (provider tool_use.input rejection)", async () => {
+    // The production bug: an interrupted MCP call that never received its
+    // input. Pre-fix this folded to output-error with input: undefined, and
+    // convertToModelMessages emitted a tool-call with no input field →
+    // Anthropic/Bedrock `tool_use.input: Field required` / Gemini silent
+    // malformed-call error.
+    const stranded = [
+      userMsg("go"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "let me look that up" },
+          {
+            type: "tool-mcp_srv_list-records-in-list",
+            toolCallId: "toolu_lost",
+            state: "input-streaming",
+            // no input — args never finished streaming
+          },
+        ],
+      },
+    ] as unknown as AgentUIMessage[];
+
+    const rewritten = rewriteForLLM(stranded as never);
+    const validated = await validateUIMessages({
+      messages: rewritten as never,
+      tools,
+    });
+    const modelMessages = await convertToModelMessages(validated, { tools });
+
+    // No tool-call content may have an undefined/missing input.
+    for (const m of modelMessages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const c of m.content as Array<{ type: string; input?: unknown }>) {
+        if (c.type === "tool-call") {
+          expect(c.input).toBeDefined();
+        }
+      }
+    }
+
+    // The interrupted tool part was dropped entirely; its surrounding text
+    // survives.
+    const allParts = rewritten.flatMap((m) => m.parts);
+    expect(
+      allParts.some(
+        (p) =>
+          (p as { toolCallId?: string }).toolCallId === "toolu_lost",
+      ),
+    ).toBe(false);
+    expect(
+      allParts.some((p) => p.type === "text" && p.text === "let me look that up"),
+    ).toBe(true);
   });
 });

--- a/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
@@ -110,6 +110,105 @@ describe("rewriteForLLM tool-state heal", () => {
     expect(part.errorText).toMatch(/interrupted/i);
   });
 
+  // ── input-less interrupted calls are DROPPED, not healed ──
+  //
+  // A tool call aborted mid `input-streaming` that never received ANY input
+  // would be folded to output-error with `input: undefined`.
+  // convertToModelMessages then emits a `tool-call` whose `input` field is
+  // missing, which the provider rejects (Anthropic/Bedrock
+  // `tool_use.input: Field required`; Gemini silent malformed-call error).
+  // Such a part carries no information, so the transport heal drops it.
+
+  it("DROPS an input-less input-streaming part (provider tool_use.input rejection)", () => {
+    const part = {
+      type: "tool-navigate",
+      toolCallId: "no-input-streaming",
+      state: "input-streaming",
+      // no `input` key at all
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      // Keep a text part so the message itself survives.
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "working on it" }, part],
+      } as AgentUIMessage,
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    // The text part survives; the input-less tool part is gone.
+    expect(out[1].parts).toHaveLength(1);
+    expect(out[1].parts[0]).toMatchObject({ type: "text", text: "working on it" });
+  });
+
+  it("DROPS an input-less input-available part", () => {
+    const part = {
+      type: "dynamic-tool",
+      toolName: "navigate",
+      toolCallId: "no-input-available",
+      state: "input-available",
+      input: undefined,
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "step" }, part],
+      } as AgentUIMessage,
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out[1].parts).toHaveLength(1);
+    expect(out[1].parts[0]).toMatchObject({ type: "text" });
+  });
+
+  it("DROPS the entire message when its only content is an input-less interrupted call", () => {
+    const part = {
+      type: "tool-navigate",
+      toolCallId: "lone-no-input",
+      state: "input-streaming",
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    // The assistant message had no other content → removed entirely.
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
+  });
+
+  it("still HEALS (does not drop) an interrupted call that HAS a real input", () => {
+    // assistantToolPart supplies `input: { url: ... }`.
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(assistantToolPart("input-streaming")),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const part = out[1].parts[0] as { state: string; input: unknown };
+    expect(part.state).toBe("output-error");
+    expect(part.input).toEqual({ url: "https://example.com" });
+  });
+
+  it("falls back to rawInput when input is absent (does not drop)", () => {
+    const part = {
+      type: "tool-navigate",
+      toolCallId: "raw-input-only",
+      state: "input-streaming",
+      rawInput: '{"url":"https://partial',
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const healed = out[1].parts[0] as { state: string };
+    expect(healed.state).toBe("output-error");
+  });
+
   it("heals output-streaming parts to output-error", () => {
     const msgs: AgentUIMessage[] = [
       userMsg("hi"),
@@ -307,7 +406,10 @@ describe("rewriteForLLM tool-state heal", () => {
 
   // ── Strict-shape repair: input/output/errorText must be present ──
 
-  it("leaves missing input undefined on a non-terminal part (no {} synthesis)", () => {
+  it("DROPS a non-terminal part with missing input instead of keeping output-error/undefined", () => {
+    // Previously this folded to output-error with input: undefined, which
+    // convertToModelMessages turned into a provider-rejected tool_use with no
+    // input. The transport heal now drops such input-less interrupted calls.
     const msgs: AgentUIMessage[] = [
       userMsg("hi"),
       assistantWithPart({
@@ -318,9 +420,9 @@ describe("rewriteForLLM tool-state heal", () => {
       } as unknown as AgentUIMessage["parts"][number]),
     ];
     const out = rewriteForLLM(msgs);
-    const part = out[1].parts[0] as { state: string; input: unknown };
-    expect(part.state).toBe("output-error");
-    expect(part.input).toBeUndefined();
+    // The assistant message had no other content → removed entirely.
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
   });
 
   it("leaves missing input undefined on a terminal output-error part (no {} synthesis)", () => {

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -454,7 +454,14 @@ export function rewriteForLLM(messages: AgentUIMessage[]): AgentUIMessage[] {
   // opaque "Invalid prompt: messages do not match the ModelMessage[]
   // schema" thrown from convertToModelMessages with no detail about
   // which part is malformed.
-  return filtered.map(healNonTerminalToolParts);
+  // Heal each message, then drop any that became empty. The heal can DROP an
+  // input-less interrupted tool part (see `repairToolPart` /
+  // `healNonTerminalToolParts`), so a message whose only content was such a
+  // part must be removed too — an empty assistant message would otherwise
+  // reach `convertToModelMessages`.
+  return filtered
+    .map(healNonTerminalToolParts)
+    .filter((m) => m.parts.length > 0);
 }
 
 const TERMINAL_TOOL_STATES = new Set([
@@ -467,6 +474,13 @@ const TRANSPORT_HEAL_TEXT =
   "Tool execution was interrupted before it returned a result";
 
 /**
+ * Sentinel returned by `repairToolPart` to mean "this tool part cannot be
+ * represented as a valid provider message — drop it entirely". See the
+ * input-less-interrupted case in `repairToolPart`.
+ */
+const DROP_TOOL_PART = Symbol("drop-tool-part");
+
+/**
  * Repair a single tool UIPart so that `convertToModelMessages` can map
  * it to a fully-valid `ModelMessage`. The AI SDK's `standardizePrompt`
  * (which runs inside `streamText`) validates the converted messages
@@ -477,12 +491,24 @@ const TRANSPORT_HEAL_TEXT =
  * `ModelMessage[]` that fails validation downstream — with no
  * indication of which message was malformed.
  *
- * The healer enforces three invariants:
+ * The healer enforces these invariants:
  *
- *  1. `input` is always present. Tool calls aborted before the model
- *     finished streaming arguments may have `input: undefined`. Default
- *     to `{}` so the resulting `tool-call` content has a well-formed
- *     `input` object.
+ *  1. A tool part must carry a usable `input`. A real `input` is preserved;
+ *     a MISSING input is left `undefined` (never `{}` — that re-triggers the
+ *     tool's strict, e.g. MCP, schema validation in validateUIMessages and
+ *     fails its required fields). Critically, an INTERRUPTED tool call that
+ *     never received its `input` at all (aborted mid-`input-streaming`, no
+ *     `rawInput`) is DROPPED — returned as `DROP_TOOL_PART`. Such a part
+ *     would otherwise be folded to `output-error` with `input: undefined`,
+ *     and `convertToModelMessages` would emit a `tool-call` block whose
+ *     `input` is missing. validateUIMessages skips that (input is undefined),
+ *     but the PROVIDER rejects it: Anthropic/Bedrock with
+ *     `tool_use.input: Field required` (HTTP 400) and Gemini/Vertex with a
+ *     silent `Malformed function call ... Function call is empty` error
+ *     finish. A `tool_use` with no input carries no information for the
+ *     model, and each UI tool part expands to a self-contained
+ *     `tool-call` + paired `tool-result`, so dropping the whole part removes
+ *     both sides cleanly (no orphaned `tool_result`).
  *
  *  2. State is terminal. Any non-terminal state collapses to
  *     `output-error` with `errorText: TRANSPORT_HEAL_TEXT` and the
@@ -498,7 +524,7 @@ const TRANSPORT_HEAL_TEXT =
  */
 function repairToolPart(
   part: AgentUIMessage["parts"][number],
-): AgentUIMessage["parts"][number] {
+): AgentUIMessage["parts"][number] | typeof DROP_TOOL_PART {
   const p = part as { type?: unknown; state?: unknown };
   const isTool =
     p.type === "dynamic-tool" ||
@@ -516,6 +542,10 @@ function repairToolPart(
   // e.g. MCP) schema and fail required fields; `undefined` is skipped, and
   // convertToModelMessages tolerates undefined input on errored/denied calls.
   const hasInput = raw.input !== undefined && raw.input !== null;
+  // Fall back to a captured `rawInput` (some SDK paths stash the partial /
+  // raw argument string here) before giving up on input entirely.
+  const rawInput = raw.rawInput;
+  const hasRawInput = rawInput !== undefined && rawInput !== null;
   const input: unknown = hasInput ? raw.input : undefined;
   // The structural schema rejects a tool part missing the `input` key, so a
   // terminal part that lacks it must still be rewritten to add it.
@@ -577,6 +607,17 @@ function repairToolPart(
   // Non-terminal state → collapse to output-error. Drop any partial
   // output so the part is unambiguous.
   if (!state || !TERMINAL_TOOL_STATES.has(state)) {
+    // An interrupted call that never received ANY input (aborted mid
+    // `input-streaming`, no `rawInput` either) cannot be emitted as a valid
+    // `tool_use`: convertToModelMessages would produce a `tool-call` with no
+    // `input` field, which the provider rejects (Anthropic/Bedrock
+    // `tool_use.input: Field required`; Gemini silent malformed-call error).
+    // Such a part carries no information — drop it entirely. The paired
+    // `tool-result` is emitted from the same UI part, so dropping the whole
+    // part leaves no orphan.
+    if (!hasInput && !hasRawInput) {
+      return DROP_TOOL_PART;
+    }
     return {
       ...raw,
       input,
@@ -592,6 +633,12 @@ function repairToolPart(
   // converter.
   if (state === "output-available") {
     if (raw.output === undefined || raw.output === null) {
+      // Downgrading to output-error; same input-less guard as the
+      // non-terminal branch — a resulting `tool-call` with no input is
+      // rejected by the provider, so drop it instead.
+      if (!hasInput && !hasRawInput) {
+        return DROP_TOOL_PART;
+      }
       return {
         ...raw,
         input,
@@ -654,11 +701,19 @@ function repairToolPart(
 
 function healNonTerminalToolParts(message: AgentUIMessage): AgentUIMessage {
   let changed = false;
-  const newParts = message.parts.map((part) => {
+  const newParts: AgentUIMessage["parts"] = [];
+  for (const part of message.parts) {
     const repaired = repairToolPart(part);
+    if (repaired === DROP_TOOL_PART) {
+      // Input-less interrupted tool call — omit it entirely (see
+      // repairToolPart). Its paired tool-result comes from the same part,
+      // so nothing is orphaned.
+      changed = true;
+      continue;
+    }
     if (repaired !== part) changed = true;
-    return repaired;
-  });
+    newParts.push(repaired);
+  }
   if (!changed) return message;
   return { ...message, parts: newParts };
 }

--- a/apps/extension/src/lib/agent/heal-pending-tools.ts
+++ b/apps/extension/src/lib/agent/heal-pending-tools.ts
@@ -29,8 +29,14 @@ type AgentMessage = AgentUIMessage;
  * to fail `validateUIMessages` ("Type validation failed ... path: ['list']"):
  * the SDK schema-validates an `output-error` part's input only when it is
  * `!== undefined`, and an empty object fails a schema with required fields.
- * `convertToModelMessages` tolerates undefined input on errored/denied
- * tool-calls, so leaving it undefined is both safe and correct.
+ * NOTE: `convertToModelMessages` emits a `tool-call` with `input: undefined`
+ * for such a part, and the PROVIDER rejects that (Anthropic/Bedrock
+ * `tool_use.input: Field required`; Gemini silent malformed-call error). This
+ * persistence-level heal therefore does NOT make an input-less interrupted
+ * call safe to send on its own — the send-time transport heal
+ * (`repairToolPart`) DROPS input-less interrupted calls before they reach the
+ * provider. Keeping the persisted/UI copy lets the user still see the
+ * "Interrupted" badge.
  *
  * Returns both the new full `messages` list and the subset that actually
  * changed. Callers persist the changed subset to chatDb so the heal survives


### PR DESCRIPTION
Two changes.

### "Completed N steps" collapsible
While tools run they stay expanded and live; once the assistant begins its answer text, a run of **3+ tool calls** auto-folds into a "Completed N steps" collapsible (click to re-expand) — matching the Perplexity Comet pattern. Runs of 1-2 tools, reasoning-only groups, and pending approval prompts render inline as before.

### Fix interrupted tool calls breaking the next request
A tool call aborted before its arguments finished streaming was replayed as a `tool_use` with no `input`, which providers reject:
- Anthropic/Bedrock: `tool_use.input: Field required` (visible "Something went wrong")
- Gemini/Vertex: silent malformed-function-call error that just stopped generation

The send-time heal now drops these input-less interrupted calls before they reach the provider (each UI tool part emits its own paired `tool-result`, so dropping the whole part leaves no orphan). Persisted/UI history is untouched — the user still sees the "Interrupted" badge.

### Verification
- `pnpm compile` passes
- 946/946 tests pass; added coverage for the drop behavior and an end-to-end guard through the real `convertToModelMessages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls now collapse into a "Completed N steps" section after the assistant begins responding, while active operations remain expanded. Inline display is preserved for small runs (1–2 tools) and pending approval prompts.

* **Bug Fixes**
  * Fixed handling of interrupted tool calls that lack required input, preventing provider rejection errors. These calls are now properly dropped before transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->