### PR TITLE
fix: drop input-less terminal errored/denied tool calls (Opus tool_use.input)

### DIFF
--- a/.changeset/drop-input-less-output-error.md
+++ b/.changeset/drop-input-less-output-error.md
@@ -1,0 +1,13 @@
+---
+"openbrowse": patch
+---
+
+Fix Anthropic/Opus `tool_use.input: Field required` from failed tool calls.
+
+A terminal failed tool call (e.g. a failed MCP "Updated list entry") whose
+input was never captured was replayed on the next turn as a `tool_use` block
+with no `input`. Anthropic rejected the request with `tool_use.input: Field
+required` (a visible "Something went wrong"); Gemini coerced it, so the bug
+only reproduced on Opus. The send-time heal now drops these input-less errored
+and denied calls before they reach the provider, while keeping any call that
+has a real input or a partial `rawInput` (which the SDK fills in).

--- a/apps/extension/src/lib/agent/__tests__/heal-validate-integration.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/heal-validate-integration.test.ts
@@ -184,4 +184,59 @@ describe("rewriteForLLM + convertToModelMessages (input-less interrupted call)",
       allParts.some((p) => p.type === "text" && p.text === "let me look that up"),
     ).toBe(true);
   });
+
+  it("produces NO tool-call with missing input for a terminal output-error MCP part (Opus/Anthropic repro)", async () => {
+    // The remaining Opus failure: a FAILED MCP tool call ("Updated list entry
+    // — Failed") whose input was never captured, persisted as a terminal
+    // output-error with no input. Pre-fix, convertToModelMessages emitted a
+    // tool-call with input: undefined → Anthropic `tool_use.input: Field
+    // required` (Gemini coerced it, so it only broke on Opus).
+    const stranded = [
+      userMsg("update the list"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "updating the list entry" },
+          {
+            type: "tool-mcp_srv_list-records-in-list",
+            toolCallId: "toolu_failed",
+            state: "output-error",
+            errorText: "Updated list entry failed",
+            // no input, no rawInput — input was never captured
+          },
+        ],
+      },
+      userMsg("try again"),
+    ] as unknown as AgentUIMessage[];
+
+    const rewritten = rewriteForLLM(stranded as never);
+    const validated = await validateUIMessages({
+      messages: rewritten as never,
+      tools,
+    });
+    const modelMessages = await convertToModelMessages(validated, { tools });
+
+    for (const m of modelMessages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const c of m.content as Array<{ type: string; input?: unknown }>) {
+        if (c.type === "tool-call") {
+          expect(c.input).toBeDefined();
+        }
+      }
+    }
+
+    // The input-less errored tool part was dropped; surrounding text survives.
+    const allParts = rewritten.flatMap((m) => m.parts);
+    expect(
+      allParts.some(
+        (p) => (p as { toolCallId?: string }).toolCallId === "toolu_failed",
+      ),
+    ).toBe(false);
+    expect(
+      allParts.some(
+        (p) => p.type === "text" && p.text === "updating the list entry",
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
@@ -425,7 +425,10 @@ describe("rewriteForLLM tool-state heal", () => {
     expect(out[0].role).toBe("user");
   });
 
-  it("leaves missing input undefined on a terminal output-error part (no {} synthesis)", () => {
+  it("DROPS a terminal output-error part with no usable input (Anthropic tool_use.input rejection)", () => {
+    // A failed tool whose input was never captured. Previously this kept
+    // input: undefined, which convertToModelMessages forwarded as a
+    // provider-rejected tool_use (Anthropic `tool_use.input: Field required`).
     const msgs: AgentUIMessage[] = [
       userMsg("hi"),
       assistantWithPart({
@@ -433,15 +436,71 @@ describe("rewriteForLLM tool-state heal", () => {
         toolCallId: "err-no-input",
         state: "output-error",
         errorText: "boom",
-        // input missing — convertToModelMessages tolerates undefined input
-        // on errored tool-calls, and validateUIMessages skips schema
-        // validation when output-error input is undefined.
+        // no input, no rawInput
       } as unknown as AgentUIMessage["parts"][number]),
     ];
     const out = rewriteForLLM(msgs);
-    const part = out[1].parts[0] as { input: unknown; errorText: string };
-    expect(part.input).toBeUndefined();
+    // The lone errored part is dropped → the message becomes empty → removed.
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
+  });
+
+  it("KEEPS a terminal output-error part that HAS a real input", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "err-with-input",
+        state: "output-error",
+        errorText: "boom",
+        input: { url: "https://example.com" },
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const part = out[1].parts[0] as {
+      state: string;
+      input: unknown;
+      errorText: string;
+    };
+    expect(part.state).toBe("output-error");
+    expect(part.input).toEqual({ url: "https://example.com" });
     expect(part.errorText).toBe("boom");
+  });
+
+  it("KEEPS a terminal output-error part with no input but a rawInput", () => {
+    // convertToModelMessages fills the emitted input from rawInput, producing
+    // a defined value the provider accepts — so we must not drop these.
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "err-raw-input",
+        state: "output-error",
+        errorText: "boom",
+        rawInput: '{"url":"https://partial',
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const part = out[1].parts[0] as { state: string };
+    expect(part.state).toBe("output-error");
+  });
+
+  it("DROPS a terminal output-denied part with no usable input", () => {
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "denied-no-input",
+        state: "output-denied",
+        approval: { id: "ap1", approved: false, reason: "no" },
+        // no input, no rawInput
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
   });
 
   it("downgrades output-available with missing output to output-error", () => {

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -496,19 +496,24 @@ const DROP_TOOL_PART = Symbol("drop-tool-part");
  *  1. A tool part must carry a usable `input`. A real `input` is preserved;
  *     a MISSING input is left `undefined` (never `{}` — that re-triggers the
  *     tool's strict, e.g. MCP, schema validation in validateUIMessages and
- *     fails its required fields). Critically, an INTERRUPTED tool call that
- *     never received its `input` at all (aborted mid-`input-streaming`, no
- *     `rawInput`) is DROPPED — returned as `DROP_TOOL_PART`. Such a part
- *     would otherwise be folded to `output-error` with `input: undefined`,
- *     and `convertToModelMessages` would emit a `tool-call` block whose
- *     `input` is missing. validateUIMessages skips that (input is undefined),
- *     but the PROVIDER rejects it: Anthropic/Bedrock with
+ *     fails its required fields). Critically, ANY tool call with no usable
+ *     input at all (no real `input` and no partial `rawInput`) is DROPPED —
+ *     returned as `DROP_TOOL_PART`. This covers an interrupted call aborted
+ *     mid-`input-streaming` AND an already-terminal `output-error` /
+ *     `output-denied` part whose input was never captured (e.g. a tool whose
+ *     arguments failed to parse, or a part healed from a non-terminal state on
+ *     a prior pass). Such a part would otherwise reach
+ *     `convertToModelMessages`, which emits a `tool-call` block whose `input`
+ *     is missing. validateUIMessages skips that (input is undefined), but the
+ *     PROVIDER rejects it: Anthropic/Bedrock with
  *     `tool_use.input: Field required` (HTTP 400) and Gemini/Vertex with a
  *     silent `Malformed function call ... Function call is empty` error
- *     finish. A `tool_use` with no input carries no information for the
- *     model, and each UI tool part expands to a self-contained
- *     `tool-call` + paired `tool-result`, so dropping the whole part removes
- *     both sides cleanly (no orphaned `tool_result`).
+ *     finish (Gemini also coerces some of these, which is why the terminal
+ *     `output-error` case reproduced only on Anthropic). A `tool_use` with no
+ *     input carries no information for the model, and each UI tool part
+ *     expands to a self-contained `tool-call` + paired `tool-result`, so
+ *     dropping the whole part removes both sides cleanly (no orphaned
+ *     `tool_result`).
  *
  *  2. State is terminal. Any non-terminal state collapses to
  *     `output-error` with `errorText: TRANSPORT_HEAL_TEXT` and the
@@ -654,6 +659,20 @@ function repairToolPart(
   }
 
   if (state === "output-error") {
+    // A terminal errored call with NO usable input (neither a real `input`
+    // nor a partial `rawInput`) cannot be emitted as a valid `tool_use`:
+    // convertToModelMessages forwards `input: undefined`, which Anthropic
+    // rejects (`tool_use.input: Field required`). Gemini tolerates it, which
+    // is why the bug only reproduced on Anthropic/Opus. Such a part carries
+    // no information — drop it (its paired tool-result comes from the same
+    // part, so nothing is orphaned). When `rawInput` is present the SDK fills
+    // the emitted input from it (a defined value the provider accepts), so we
+    // keep those. This complements the non-terminal/`output-available` drop
+    // above; an `output-error` reached here either streamed in that way or was
+    // healed from a non-terminal state on a prior pass.
+    if (!hasInput && !hasRawInput) {
+      return DROP_TOOL_PART;
+    }
     const errorText =
       typeof raw.errorText === "string" && raw.errorText.length > 0
         ? raw.errorText
@@ -673,6 +692,11 @@ function repairToolPart(
     const approval = raw.approval as
       | { id?: unknown; approved?: unknown; reason?: unknown }
       | undefined;
+    // Same input-less guard as output-error: a denied call with no usable
+    // input also emits a provider-rejected `tool_use`. Drop it.
+    if (!hasInput && !hasRawInput) {
+      return DROP_TOOL_PART;
+    }
     // Strict denial shape: state=output-denied REQUIRES `approved: false`.
     // `approved: true` paired with that state is contradictory and gets
     // healed to a clean output-error rather than carried forward.


### PR DESCRIPTION
Follow-up to #125. That fix dropped input-less **non-terminal** tool calls (fixed Gemini), but a **terminal `output-error`** part with no input still slipped through and broke Opus.

### Problem
A failed tool call (e.g. a failed MCP "Updated list entry — Failed") whose `input` was never captured persists as a terminal `output-error` with no input. On the next turn `convertToModelMessages` emits a `tool-call` with `input: undefined`:
- Anthropic/Bedrock reject it → `messages.N.content.0.tool_use.input: Field required` ("Something went wrong")
- Gemini coerces it → why this only reproduced on Opus

`#125` deliberately left terminal `output-error`/`output-denied` parts untouched, which is exactly the gap.

### Fix
Extend the existing `DROP_TOOL_PART` drop to the terminal `output-error` and `output-denied` branches in `repairToolPart`: if a part has **no usable input** (no real `input` and no partial `rawInput`), drop it before it reaches the provider. Parts that have a real input — or a `rawInput` the SDK fills the call from — are kept unchanged. Each UI tool part emits its own paired `tool-result`, so dropping removes both sides cleanly. Transport-only; persisted/UI history still shows the "Failed" row.

### Verification
- `pnpm compile` passes
- 950/950 tests pass; added coverage for terminal output-error/denied drop, keep-with-input, rawInput fallback, plus an end-to-end Opus repro through the real `convertToModelMessages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error condition where failed tool calls without captured input could trigger validation errors during Anthropic Opus operations. Invalid tool calls are now filtered and dropped before transmission, while preserving calls with valid input data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->