### PR TITLE
fix: keep Attio/Stripe OAuth connectors authorized across extension updates

### DIFF
--- a/.changeset/mcp-oauth-refresh-token.md
+++ b/.changeset/mcp-oauth-refresh-token.md
@@ -1,0 +1,17 @@
+---
+"openbrowse": patch
+---
+
+Keep Attio/Stripe (and other OAuth) connectors authorized across extension
+updates.
+
+OAuth connectors were registered for the `authorization_code` grant only, so
+providers refused the later `refresh_token` token call — meaning an expired
+access token (e.g. after the service worker restarts on an extension update)
+could not be renewed silently and the connector fell back to "needs
+re-authorization". Now we register for the `refresh_token` grant too and
+request `offline_access` when the provider supports it (including providers
+like Stripe that publish no scope list but do advertise the refresh grant). An
+interactive re-auth also re-registers, repairing connectors stored by older
+builds without removing and re-adding them. Connectors whose tokens are
+long-lived (e.g. Supabase) are unaffected.

--- a/apps/extension/src/entrypoints/background/__tests__/mcp-oauth.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/mcp-oauth.test.ts
@@ -235,3 +235,49 @@ describe("isUnauthorizedError", () => {
     expect(isUnauthorizedError(new Error("500 boom"))).toBe(false);
   });
 });
+
+describe("buildAuthScope", () => {
+  afterEach(() => vi.resetModules());
+
+  it("adds offline_access when the provider lists it (Attio)", async () => {
+    const { buildAuthScope } = await import("../mcp-oauth");
+    // Real Attio auth-server metadata shape.
+    const scope = buildAuthScope({
+      scopes_supported: ["mcp", "offline_access", "openid"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+    });
+    expect(scope).toBeDefined();
+    expect(scope!.split(" ")).toContain("offline_access");
+    expect(scope!.split(" ")).toContain("mcp");
+  });
+
+  it("adds offline_access when no scopes are declared but refresh_token grant is supported (Stripe)", async () => {
+    const { buildAuthScope } = await import("../mcp-oauth");
+    // Real Stripe auth-server metadata shape: no scopes_supported field.
+    const scope = buildAuthScope({
+      grant_types_supported: ["authorization_code", "refresh_token"],
+    });
+    expect(scope).toBe("offline_access");
+  });
+
+  it("does NOT add offline_access for a granular-scope provider that omits it (Supabase)", async () => {
+    const { buildAuthScope } = await import("../mcp-oauth");
+    // Real Supabase metadata shape: granular scopes, no offline_access.
+    const scope = buildAuthScope({
+      scopes_supported: ["projects:read", "database:read"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+    });
+    expect(scope).toBe("projects:read database:read");
+    expect(scope).not.toContain("offline_access");
+  });
+
+  it("returns undefined when nothing can be requested", async () => {
+    const { buildAuthScope } = await import("../mcp-oauth");
+    // No scopes declared and no refresh_token grant → request no scope at all
+    // (don't risk an unknown-scope rejection on a strict provider).
+    expect(buildAuthScope({})).toBeUndefined();
+    expect(
+      buildAuthScope({ grant_types_supported: ["authorization_code"] }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/extension/src/entrypoints/background/mcp-messages.ts
+++ b/apps/extension/src/entrypoints/background/mcp-messages.ts
@@ -77,6 +77,7 @@ interface OAuthMetadata {
   token_endpoint: string;
   registration_endpoint?: string;
   scopes_supported?: string[];
+  grant_types_supported?: string[];
 }
 
 async function discoverOAuthMetadata(serverUrl: string): Promise<OAuthMetadata> {
@@ -104,6 +105,7 @@ async function discoverOAuthMetadata(serverUrl: string): Promise<OAuthMetadata> 
             token_endpoint: asData.token_endpoint,
             registration_endpoint: asData.registration_endpoint,
             scopes_supported: resourceData.scopes_supported ?? asData.scopes_supported,
+            grant_types_supported: asData.grant_types_supported,
           };
         }
       }
@@ -142,7 +144,16 @@ async function dynamicClientRegistration(
     body: JSON.stringify({
       client_name: "OpenBrowse",
       redirect_uris: [redirectUri],
-      grant_types: ["authorization_code"],
+      // Register for BOTH grants. Omitting `refresh_token` here means the
+      // provider authorizes the client only for `authorization_code`, so a
+      // later `grant_type=refresh_token` token call is rejected — even when
+      // the server supports refresh tokens and `offline_access` was granted.
+      // That left Attio/Stripe unable to silently renew an expired access
+      // token after a service-worker restart (e.g. an extension update),
+      // forcing a full re-auth. Providers that don't support refresh tokens
+      // simply ignore the extra grant type (verified: Supabase still returns
+      // 201).
+      grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
     }),
@@ -206,21 +217,41 @@ async function handleOAuthStart(serverId: string, sendResponse: (r: unknown) => 
     let clientId = serverConfig.auth?.clientId;
     let clientSecret = serverConfig.auth?.clientSecret;
 
-    if (!clientId && metadata.registration_endpoint) {
-      const registration = await dynamicClientRegistration(
-        metadata.registration_endpoint,
-        redirectUri,
-      );
-      clientId = registration.client_id;
-      clientSecret = registration.client_secret;
+    // Re-register on an interactive auth start even when a client_id already
+    // exists. A client registered by an older build was registered for the
+    // `authorization_code` grant only, so the provider refused later
+    // `refresh_token` token calls — the root cause of connectors silently
+    // disconnecting after an extension update. Since this is an explicit,
+    // user-initiated re-authorization, minting a fresh client (now registered
+    // for the refresh_token grant too) is safe and repairs those stored
+    // clients without requiring the user to remove and re-add the connector.
+    const needsRegistration = !clientId || Boolean(metadata.registration_endpoint);
 
-      // Persist the client_id for future use
-      const updatedServers = settings.mcpServers.map((s) =>
-        s.id === serverId
-          ? { ...s, auth: { ...s.auth, type: "oauth" as const, clientId, clientSecret } }
-          : s,
-      );
-      await storage.setSettings({ ...settings, mcpServers: updatedServers });
+    if (needsRegistration && metadata.registration_endpoint) {
+      try {
+        const registration = await dynamicClientRegistration(
+          metadata.registration_endpoint,
+          redirectUri,
+        );
+        clientId = registration.client_id;
+        clientSecret = registration.client_secret;
+
+        // Persist the client_id for future use
+        const updatedServers = settings.mcpServers.map((s) =>
+          s.id === serverId
+            ? { ...s, auth: { ...s.auth, type: "oauth" as const, clientId, clientSecret } }
+            : s,
+        );
+        await storage.setSettings({ ...settings, mcpServers: updatedServers });
+      } catch (err) {
+        // If re-registration fails but we already have a stored client_id,
+        // fall back to it rather than blocking auth entirely.
+        if (!clientId) throw err;
+        console.warn(
+          "[MCP OAuth] Re-registration failed; using existing client_id",
+          err,
+        );
+      }
     }
 
     if (!clientId) {
@@ -248,17 +279,11 @@ async function handleOAuthStart(serverId: string, sendResponse: (r: unknown) => 
     const state = generateCodeVerifier();
     oauthStates.set(serverId, state);
 
-    // Build the requested scope. Append `offline_access` ONLY when the
-    // provider advertises it in its metadata — that RFC scope is what makes
-    // many providers issue a refresh_token (so we can silently refresh later),
-    // but strict providers reject unknown scopes, so we don't add it blindly.
-    const supportedScopes = metadata.scopes_supported ?? [];
-    const scopeSet = new Set<string>(supportedScopes);
-    if (supportedScopes.includes("offline_access")) {
-      scopeSet.add("offline_access");
-    }
-    const requestedScope =
-      scopeSet.size > 0 ? Array.from(scopeSet).join(" ") : undefined;
+    // Build the requested scope. `buildAuthScope` adds `offline_access` when
+    // the provider supports it (so we receive a refresh_token), without
+    // tripping strict providers that reject unknown scopes.
+    const { buildAuthScope } = await import("./mcp-oauth");
+    const requestedScope = buildAuthScope(metadata);
 
     // Build authorization URL
     const params = new URLSearchParams({

--- a/apps/extension/src/entrypoints/background/mcp-oauth.ts
+++ b/apps/extension/src/entrypoints/background/mcp-oauth.ts
@@ -20,6 +20,38 @@ import type { McpAuthConfig } from "@/lib/mcp/types";
 const DEFAULT_EXPIRY_SKEW_MS = 60_000;
 
 /**
+ * Decide the OAuth `scope` to request at authorization time.
+ *
+ * We want `offline_access` whenever possible — that RFC scope is what makes
+ * many providers issue a refresh_token (so we can silently refresh after a
+ * service-worker restart / extension update) — but strict providers reject
+ * unknown scopes, so it can't be added blindly. Two safe cases add it:
+ *   1. The provider lists `offline_access` in `scopes_supported` (e.g. Attio).
+ *   2. The provider publishes NO `scopes_supported` at all but DOES advertise
+ *      the `refresh_token` grant (e.g. Stripe). With no declared scope set
+ *      there's nothing to reject against, and the provider still needs a
+ *      signal that we want offline access.
+ *
+ * Returns the space-joined scope string, or `undefined` when there is nothing
+ * to request (so the caller omits the `scope` param entirely).
+ */
+export function buildAuthScope(metadata: {
+  scopes_supported?: string[];
+  grant_types_supported?: string[];
+}): string | undefined {
+  const supportedScopes = metadata.scopes_supported ?? [];
+  const grantTypes = metadata.grant_types_supported ?? [];
+  const supportsRefreshGrant = grantTypes.includes("refresh_token");
+  const scopeSet = new Set<string>(supportedScopes);
+  if (supportedScopes.includes("offline_access")) {
+    scopeSet.add("offline_access");
+  } else if (supportedScopes.length === 0 && supportsRefreshGrant) {
+    scopeSet.add("offline_access");
+  }
+  return scopeSet.size > 0 ? Array.from(scopeSet).join(" ") : undefined;
+}
+
+/**
  * True when `auth` carries an expiry that is at/after the skew window — i.e.
  * the access token is expired or about to expire and should be refreshed
  * before use. Returns false when no `expiresAt` is known (we can't tell, so


### PR DESCRIPTION
### Symptom
Attio and Stripe MCP connectors lose their authorization on every extension update, while Supabase stays connected.

### Diagnosis (verified against live provider metadata, no credentials needed)
Auth state is stored durably in `chrome.storage.local` and survives updates — that was not the issue. The real cause is the **OAuth client registration**:

- `dynamicClientRegistration` registered the client with `grant_types: ["authorization_code"]` only. Probing the providers' dynamic-registration endpoints confirms they echo back exactly that grant set, so a later `grant_type=refresh_token` token call is **refused** — even though Attio/Stripe both advertise `refresh_token` support. Registering **with** `refresh_token` makes them return `["authorization_code","refresh_token"]`.
- After a service-worker restart (extension update) the stored access token has expired; with no usable refresh grant, the connector falls to `auth_required`.
- Stripe additionally publishes **no `scopes_supported`**, so `offline_access` was never requested.
- Supabase issues long-lived tokens, so it didn't exhibit the bug.

Provider metadata checked:
- Attio: `scopes_supported: ["mcp","offline_access","openid"]`, `grant_types_supported: [authorization_code, refresh_token]`
- Stripe: no `scopes_supported`, `grant_types_supported: [authorization_code, refresh_token]`
- Supabase: granular scopes, long-lived token

### Fix
- Register OAuth clients for the `refresh_token` grant in addition to `authorization_code` (providers that don't support it just ignore it — Supabase still returns 201).
- Request `offline_access` when the provider lists it **or** when it declares no scopes but advertises the refresh grant (Stripe). Extracted into a testable `buildAuthScope` helper.
- Re-register on an interactive re-auth so connectors stored by older builds are repaired without remove/re-add.

### Verification
- `pnpm compile` passes; 950/950 tests pass.
- Added `buildAuthScope` unit tests covering the real Attio/Stripe/Supabase metadata shapes.
- Provider behavior confirmed by probing discovery + registration endpoints directly.