### PR TITLE
chore(changeset): side-panel cowork bar + conversationId fix

### DIFF
--- a/.changeset/sidepanel-cowork-bar.md
+++ b/.changeset/sidepanel-cowork-bar.md
@@ -1,0 +1,21 @@
+---
+"openbrowse": minor
+---
+
+Surface the agent's plan, workspace files, and context in the side panel, and
+fix conversation context for new chats and subagents.
+
+The side-panel composer gains a cowork bar: a tabbed strip (Plan / Workspace
+files / Context) with a glanceable label, click-to-expand panels, an animated
+height, and an in-panel file viewer — so the narrow side panel gets the same
+plan/files/context surfaces the home view has in its rail. The chat header also
+gains the context-usage chip (token/cost radial + popover). The shared cowork
+cards were extracted into a common module so home and side panel render from
+one source.
+
+Also fixes a conversation-context bug: `executePython` and the file tools
+(Read/Write/Edit/Glob/Grep/LS) captured the conversation id in a build-time
+closure, so a brand-new chat failed with "No conversation context" and the file
+tools silently wrote to the wrong workspace root (a latent variant also
+affected subagents). They now resolve the id from the call-time tool context,
+matching the existing delegate tool.


### PR DESCRIPTION
Adds the changeset that was missing from #133 (squash-merged without one).

`openbrowse` → **minor** (new side-panel cowork bar + context chip; includes the new-chat/subagent `conversationId` fix).

Follow-up to #133.