### PR TITLE
fix(extension): unblock agent clicks eaten by working overlay; viewport snapshots replace post-action diffs

### DIFF
--- a/.changeset/cua-click-diagnostics.md
+++ b/.changeset/cua-click-diagnostics.md
@@ -1,0 +1,31 @@
+---
+"openbrowse": patch
+---
+
+Fix agent clicks being silently eaten by OpenBrowse's own "is working" overlay,
+and replace post-action diffs with viewport snapshots.
+
+Trusted CDP `Input.dispatchMouseEvent` events the agent dispatched were landing
+on `.ob-cua-root` — the full-viewport (`position:fixed; inset:0`) shadow-DOM
+wrapper inside the `openbrowse-cua-working-host` overlay — which had implicit
+`pointer-events: auto`. Because hit-testing climbs from a `pe:none` shield to
+its parent, the click never reached the page element underneath. Symptoms
+included FAQ accordions never expanding after `clickElement`, theme toggles
+that reported success but didn't flip, and CUA subagent clicks landing on
+nothing. Adding `pointer-events: none` to `.ob-cua-root` lets descendants with
+explicit `pe:auto` (the shield, the Stop button) keep working as hit-test
+targets while letting the agent's own dispatches pass through to the page.
+
+Also: `clickElement` / `typeInElement` / `pressKey` now auto-attach a fresh
+viewport-scoped accessibility snapshot in their response (replacing the legacy
+`diff` field). The diff approach hallucinated when the prior snapshot was
+viewport-scoped and the post-action capture defaulted to full-tree — the model
+saw every below-fold element as `[+] added`. The new shape is strictly more
+informative: the model can pick its next ref directly from the post-action
+state without a follow-up `snapshot` call. The `snapshot` tool keeps its
+opt-in `diff: true` mode for callers that want it.
+
+The click ripple now matches the active space tint, doubles in size, and uses
+a layered "dithered shockwave" animation (halo + dithered disc + 2 parallax
+rings + center spark) so the live tab gives clearer feedback when the agent
+clicks.

--- a/apps/extension/src/entrypoints/content/__tests__/cua-overlay-pe.test.ts
+++ b/apps/extension/src/entrypoints/content/__tests__/cua-overlay-pe.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for the click-pipeline bug fixed in `debug/cua-click-diagnostics`:
+ *
+ * `.ob-cua-root` is the full-viewport (`position:fixed; inset:0`) wrapper
+ * inside the CUA "working" shadow DOM. The browser's hit-testing for trusted
+ * CDP `Input.dispatchMouseEvent` events climbs to it when descendants are
+ * `pointer-events: none`. If `.ob-cua-root` itself has the implicit default
+ * `pointer-events: auto`, every agent click is silently eaten by the root
+ * — even when `.ob-cua-shield` is correctly toggled to `pe:none` via the
+ * `.ob-passthrough` class.
+ *
+ * Symptoms when this regresses:
+ *   - Service-worker logs: `[click-diag] :pre OVERLAY-INTERCEPT
+ *     top=div#openbrowse-cua-working-host shieldPE=none ...`
+ *   - Page-side: clicks land but visibly do nothing (FAQ accordions stay
+ *     `expanded=false`, theme toggles don't flip, etc.).
+ *
+ * Per the CSS pointer-events spec, setting `pe:none` on the parent does NOT
+ * disable descendants with explicit `pe:auto`, so `.ob-cua-shield` (default
+ * `pe:auto`) and `.ob-cua-stop` (explicit `pe:auto`) keep working as
+ * hit-test targets when the agent isn't dispatching.
+ *
+ * We assert against the source string (not a JSDOM render) because the
+ * failure mode this regresses is "someone removed the pe:none rule" — a
+ * source-level change that a string match catches reliably without
+ * spinning up shadow DOM in a test.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CONTENT_INDEX = resolve(HERE, "../index.ts");
+
+function contentSource(): string {
+  return readFileSync(CONTENT_INDEX, "utf-8");
+}
+
+/** Extract the body of a CSS rule named `selector` from the content script's
+ *  inline `style.textContent = \`...\``. Returns null when the rule is missing. */
+function extractCssRuleBody(src: string, selector: string): string | null {
+  // Escape regex meta characters in the selector (e.g. `.`).
+  const esc = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${esc}\\s*\\{([^}]*)\\}`, "m");
+  const m = re.exec(src);
+  return m ? m[1] : null;
+}
+
+describe("CUA working-overlay shadow CSS pointer-events", () => {
+  it(".ob-cua-root has pointer-events: none — without it, the root's default pe:auto eats CDP clicks even when the shield is pe:none", () => {
+    const body = extractCssRuleBody(contentSource(), ".ob-cua-root");
+    expect(
+      body,
+      ".ob-cua-root rule not found in content/index.ts — overlay CSS shape changed?",
+    ).not.toBeNull();
+    expect(body).toMatch(/pointer-events\s*:\s*none\s*;/);
+  });
+
+  it(".ob-cua-shield default pointer-events is 'auto' (catches user clicks while idle)", () => {
+    const body = extractCssRuleBody(contentSource(), ".ob-cua-shield");
+    expect(
+      body,
+      ".ob-cua-shield rule not found in content/index.ts — overlay CSS shape changed?",
+    ).not.toBeNull();
+    expect(body).toMatch(/pointer-events\s*:\s*auto\s*;/);
+  });
+
+  it(".ob-cua-shield.ob-passthrough switches pointer-events to 'none' (lets CDP clicks through during agent dispatch)", () => {
+    const body = extractCssRuleBody(
+      contentSource(),
+      ".ob-cua-shield.ob-passthrough",
+    );
+    expect(
+      body,
+      ".ob-cua-shield.ob-passthrough rule not found in content/index.ts — passthrough toggle removed?",
+    ).not.toBeNull();
+    expect(body).toMatch(/pointer-events\s*:\s*none\s*;/);
+  });
+
+  it(".ob-cua-stop button keeps explicit pointer-events: auto so the user can still click Stop while the root is pe:none", () => {
+    const body = extractCssRuleBody(contentSource(), ".ob-cua-stop");
+    expect(
+      body,
+      ".ob-cua-stop rule not found in content/index.ts — Stop button moved?",
+    ).not.toBeNull();
+    expect(body).toMatch(/pointer-events\s*:\s*auto\s*;/);
+  });
+});

--- a/apps/extension/src/entrypoints/content/index.ts
+++ b/apps/extension/src/entrypoints/content/index.ts
@@ -157,24 +157,148 @@ function getOrCreateRippleHost(): ShadowRoot {
     "position:fixed;inset:0;pointer-events:none;z-index:2147483646;";
   const shadow = host.attachShadow({ mode: "open" });
   const style = document.createElement("style");
+  // "Dithered shockwave" click ripple — Option C from the design preview.
+  // Each click spawns a 5-child burst at the click point:
+  //
+  //   .ob-ripple-burst (positioning anchor at the click coord)
+  //     .ob-ripple-halo  (soft ambient glow, fades fast — gives the colour hit)
+  //     .ob-ripple-disc  (multi-tile dither dot grid masked into a soft circle —
+  //                        the "texture" layer that reads as a digital ripple)
+  //     .ob-ripple-ring2 (outer dashed ring expanding slow — depth + parallax)
+  //     .ob-ripple-ring1 (inner solid ring expanding fast — shockwave)
+  //     .ob-ripple-spark (tiny white-cored pip at the click coord — focal punch)
+  //
+  // Animation timing:
+  //   0ms      – spark + halo fire (immediate impact frame)
+  //   0–120ms  – disc punches in from scale(0.18) → scale(0.5)  (anticipation→impact)
+  //   120–750ms– disc + rings expand and fade  (dispersion)
+  //   ~850ms   – host torn down (cleanup, no children left)
+  //
+  // Color theming uses two complementary CSS-var families set per-burst by
+  // applyRippleGlow():
+  //   --ob-ripple-tint                  raw hex of the active space colour
+  //                                      (used by halo / rings / spark — they need
+  //                                      a saturated, punchy stroke not an alpha)
+  //   --ob-ripple-{strong,mid,soft,bg}  alpha-stepped variants (used by the
+  //                                      dither disc's gradient layers)
+  //
+  // Both fall back to CUA_DEFAULT_GLOW when no space colour is cached, mirroring
+  // applyCuaGlow's pattern for the working-overlay border so a click ripple
+  // visually matches the active space tint.
+  //
+  // Reduced-motion: collapses to a 350ms cross-fade of halo + spark only;
+  // no scale, no dither expansion. Matches WCAG SC 2.3.3 expectations.
   style.textContent = `
-    .ob-ripple {
+    .ob-ripple-burst {
       position: fixed;
-      width: 36px;
-      height: 36px;
-      margin-left: -18px;
-      margin-top: -18px;
-      border-radius: 50%;
-      background: rgba(56, 132, 255, 0.35);
-      border: 2px solid rgba(56, 132, 255, 0.9);
       pointer-events: none;
-      transform: scale(0.2);
-      opacity: 0.9;
-      animation: ob-ripple 600ms ease-out forwards;
     }
-    @keyframes ob-ripple {
-      0%   { transform: scale(0.2); opacity: 0.9; }
-      100% { transform: scale(1.6); opacity: 0; }
+    .ob-ripple-halo {
+      position: absolute;
+      width: 140px;
+      height: 140px;
+      left: -70px;
+      top: -70px;
+      border-radius: 50%;
+      background: radial-gradient(circle, var(--ob-ripple-tint) 0%, transparent 65%);
+      opacity: 0.45;
+      transform: scale(0.4);
+      animation: ob-ripple-halo 750ms ease-out forwards;
+    }
+    .ob-ripple-disc {
+      position: absolute;
+      width: 110px;
+      height: 110px;
+      left: -55px;
+      top: -55px;
+      border-radius: 50%;
+      background-image:
+        radial-gradient(circle, var(--ob-ripple-strong) 32%, transparent 34%),
+        radial-gradient(circle, var(--ob-ripple-mid) 28%, transparent 36%);
+      background-size: 4px 4px, 6px 6px;
+      background-position: 0 0, 2px 2px;
+      -webkit-mask: radial-gradient(circle, #000 22%, rgba(0,0,0,0.7) 50%, transparent 78%);
+              mask: radial-gradient(circle, #000 22%, rgba(0,0,0,0.7) 50%, transparent 78%);
+      transform: scale(0.18);
+      opacity: 1;
+      animation: ob-ripple-disc 750ms cubic-bezier(0.1, 0.85, 0.25, 1) forwards;
+    }
+    .ob-ripple-ring1,
+    .ob-ripple-ring2 {
+      position: absolute;
+      border-radius: 50%;
+    }
+    .ob-ripple-ring1 {
+      width: 50px;
+      height: 50px;
+      left: -25px;
+      top: -25px;
+      border: 1.5px solid var(--ob-ripple-tint);
+      transform: scale(0.4);
+      opacity: 1;
+      animation: ob-ripple-ring1 750ms cubic-bezier(0.2, 0.8, 0.3, 1) forwards;
+    }
+    .ob-ripple-ring2 {
+      width: 80px;
+      height: 80px;
+      left: -40px;
+      top: -40px;
+      border: 1.5px dashed var(--ob-ripple-tint);
+      transform: scale(0.5);
+      opacity: 0.7;
+      animation: ob-ripple-ring2 750ms cubic-bezier(0.25, 0.7, 0.4, 1) forwards;
+    }
+    .ob-ripple-spark {
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      left: -6px;
+      top: -6px;
+      border-radius: 50%;
+      background: radial-gradient(circle, #fff 0%, var(--ob-ripple-tint) 60%, transparent 100%);
+      transform: scale(0.5);
+      opacity: 1;
+      animation: ob-ripple-spark 240ms ease-out forwards;
+    }
+    @keyframes ob-ripple-halo {
+      0%   { opacity: 0.5; transform: scale(0.4); }
+      50%  { opacity: 0.3; }
+      100% { opacity: 0;   transform: scale(1.5); }
+    }
+    @keyframes ob-ripple-disc {
+      0%   { transform: scale(0.18); opacity: 1; }
+      16%  { transform: scale(0.5);  opacity: 1; }
+      100% { transform: scale(1.55); opacity: 0; }
+    }
+    @keyframes ob-ripple-ring1 {
+      0%   { transform: scale(0.4); opacity: 1; }
+      100% { transform: scale(2.2); opacity: 0; }
+    }
+    @keyframes ob-ripple-ring2 {
+      0%   { transform: scale(0.5); opacity: 0.7; }
+      100% { transform: scale(1.8); opacity: 0; }
+    }
+    @keyframes ob-ripple-spark {
+      0%   { transform: scale(0.5); opacity: 1; }
+      100% { transform: scale(2.6); opacity: 0; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      /* Cross-fade only — no scale animation. Halo + spark do all the
+         signalling; the dither / rings would add motion noise without
+         providing extra information for a user who's asked us to dial
+         motion down. */
+      .ob-ripple-halo,
+      .ob-ripple-spark {
+        animation: ob-ripple-fade 350ms ease-out forwards;
+        transform: scale(1);
+      }
+      .ob-ripple-disc,
+      .ob-ripple-ring1,
+      .ob-ripple-ring2 { display: none; }
+      @keyframes ob-ripple-fade {
+        0%   { opacity: 0.7; }
+        100% { opacity: 0;   }
+      }
     }
   `;
   shadow.appendChild(style);
@@ -182,23 +306,67 @@ function getOrCreateRippleHost(): ShadowRoot {
   return shadow;
 }
 
+/** Set the ripple glow CSS variables on a host element from a hex color.
+ *  Mirrors `applyCuaGlow` for the working-overlay border so a click ripple
+ *  visually matches the active space tint.
+ *
+ *  Two complementary var families are set:
+ *    - `--ob-ripple-tint`: the raw hex (no alpha). Used by halo / rings /
+ *      spark — solid stroke colours that need to read clearly on any
+ *      background. Wrapping in rgba() is wrong here because the existing
+ *      element opacity (e.g. `.ob-ripple-halo { opacity: .45 }`) already
+ *      controls the layer's alpha.
+ *    - `--ob-ripple-{strong,mid,soft,bg}`: alpha-stepped rgba variants. Used
+ *      by the dither disc's stacked radial-gradients where individual dot
+ *      density / brightness needs separate alphas to read as halftone dither.
+ */
+function applyRippleGlow(host: HTMLElement, hex: string) {
+  host.style.setProperty("--ob-ripple-tint", hex);
+  host.style.setProperty("--ob-ripple-strong", rgba(hex, 0.95));
+  host.style.setProperty("--ob-ripple-mid", rgba(hex, 0.55));
+  host.style.setProperty("--ob-ripple-soft", rgba(hex, 0.25));
+  host.style.setProperty("--ob-ripple-bg", rgba(hex, 0.12));
+}
+
 function showClickRipple(x: number, y: number) {
   try {
     const shadow = getOrCreateRippleHost();
-    const dot = document.createElement("div");
-    dot.className = "ob-ripple";
-    dot.style.left = `${x}px`;
-    dot.style.top = `${y}px`;
-    shadow.appendChild(dot);
+    // Theme the ripple from the cached space color (set by the latest
+    // CHAT_CUA_WORKING_STATE message). Falls through to CUA_DEFAULT_GLOW
+    // when no space color is known — matches the working-overlay border
+    // fallback so a ripple before any working state still renders cleanly.
+    const tint =
+      cachedSpaceColor && parseHex(cachedSpaceColor)
+        ? cachedSpaceColor
+        : CUA_DEFAULT_GLOW;
+    const burst = document.createElement("div");
+    burst.className = "ob-ripple-burst";
+    burst.style.left = `${x}px`;
+    burst.style.top = `${y}px`;
+    // Apply per-burst so a mid-session space-color change tints the next
+    // ripple without re-creating the host.
+    applyRippleGlow(burst, tint);
+    // Children, in z-order: halo (back), disc, outer ring, inner ring, spark (front).
+    // Outer-ring-before-inner-ring on purpose — the inner solid ring should
+    // read as the "leading edge" of the shockwave, drawing on top of the
+    // dashed outer ring.
+    burst.innerHTML = `
+      <div class="ob-ripple-halo"></div>
+      <div class="ob-ripple-disc"></div>
+      <div class="ob-ripple-ring2"></div>
+      <div class="ob-ripple-ring1"></div>
+      <div class="ob-ripple-spark"></div>
+    `;
+    shadow.appendChild(burst);
     setTimeout(() => {
-      dot.remove();
-      // Tear down the host once its last ripple has finished, so the inert
+      burst.remove();
+      // Tear down the host once its last burst has finished, so the inert
       // full-viewport overlay doesn't linger on the page indefinitely after
-      // the agent stops clicking. A fresh ripple just re-creates it.
-      if (shadow.querySelectorAll(".ob-ripple").length === 0) {
+      // the agent stops clicking. A fresh burst just re-creates it.
+      if (shadow.querySelectorAll(".ob-ripple-burst").length === 0) {
         document.getElementById(RIPPLE_HOST_ID)?.remove();
       }
-    }, 650);
+    }, 850);
   } catch {
     // Never let a visual flourish break anything.
   }
@@ -371,6 +539,14 @@ let cuaScrollBlocker: ((e: Event) => void) | null = null;
 let cuaThemeMql: MediaQueryList | null = null;
 let cuaThemeListener: ((e: MediaQueryListEvent) => void) | null = null;
 
+/** Most-recent space color forwarded by `notifyAgentStatus(true, color)` via
+ *  `CHAT_CUA_WORKING_STATE`. Cached here so click ripples (which fire many
+ *  times per agent run, often outside the working-state lifecycle of any
+ *  individual message) can tint themselves to match the active space without
+ *  every ripple-sender re-piping the color. Falls back to CUA_DEFAULT_GLOW
+ *  in showClickRipple when no working state has set it yet. */
+let cachedSpaceColor: string | null = null;
+
 /** URL of the OpenBrowse logo that contrasts with the current theme's pill:
  *  white logo on the dark-mode pill, black logo on the light-mode pill. */
 function cuaLogoUrl(dark: boolean): string {
@@ -413,6 +589,18 @@ function getOrCreateCuaWorkingHost(color?: string | null): ShadowRoot {
       position: fixed;
       inset: 0;
       z-index: 2147483647;
+      /* CRITICAL: pointer-events:none on the root so trusted CDP mouse
+         events the agent dispatches can pass through to the page when
+         the shield is also pe:none. Without this, hit-testing climbs from
+         a pe:none shield to its parent (the root, default pe:auto) and
+         the click is silently eaten by the root — even though every
+         visible child (.ob-cua-shield with .ob-passthrough, .ob-cua-border,
+         .ob-cua-pill) is itself pe:none. Per the CSS pointer-events spec,
+         pe:none on a parent does NOT disable descendants with explicit
+         pe:auto, so .ob-cua-shield (default pe:auto) still catches user
+         clicks (idle state, blocking user input), and the .ob-cua-stop
+         button (explicit pe:auto) still works inside the pill. */
+      pointer-events: none;
     }
     /* Full-viewport input blocker. pointer-events toggled by the executor. */
     .ob-cua-shield {
@@ -635,12 +823,25 @@ function removeCuaWorking() {
 }
 
 /** Toggle whether the agent is mid-action (lets its CDP input through the
- *  shield + key blocker). */
+ *  shield + key blocker). Logs the effective shield state to the page
+ *  console so we can correlate page-side behavior with service-worker-side
+ *  diagnostics when investigating "agent click did nothing". */
 function setCuaPassthrough(on: boolean) {
   cuaAgentActing = on;
   const host = document.getElementById(CUA_WORKING_HOST_ID);
-  const shield = host?.shadowRoot?.querySelector(".ob-cua-shield");
+  const shield = host?.shadowRoot?.querySelector(
+    ".ob-cua-shield",
+  ) as HTMLElement | null;
   if (shield) shield.classList.toggle("ob-passthrough", on);
+  // Read the COMPUTED pointer-events synchronously — this is what hit-testing
+  // will actually see. If shield exists but pe != "none" after on=true, the
+  // CSS class isn't applying (specificity, shadow CSS not parsed, etc.).
+  // Logged at console.debug — fires twice per CDP action so console.info
+  // would drown the page console; surfaces only when DevTools Verbose is on.
+  const pe = shield ? getComputedStyle(shield).pointerEvents : "no-shield";
+  console.debug(
+    `[ob-passthrough] on=${on} hostMounted=${!!host} shieldFound=${!!shield} computedPE=${pe}`,
+  );
 }
 
 function showAgentActiveToast() {
@@ -782,6 +983,21 @@ export default defineContentScript({
             });
           } else {
             el.click();
+            // Visual feedback parity with the @ref / CUA click paths: ripple
+            // at the element's viewport-center so a human watching the live
+            // tab sees the same animation regardless of which click path
+            // resolved the target. Computed AFTER el.click() so we don't
+            // delay the synthetic dispatch; best-effort (rect read can fail
+            // for detached or zero-box elements — never let it break the
+            // click).
+            try {
+              const r = el.getBoundingClientRect();
+              if (r.width > 0 && r.height > 0) {
+                showClickRipple(r.left + r.width / 2, r.top + r.height / 2);
+              }
+            } catch {
+              // never let a visual flourish break a successful click
+            }
             sendResponse({ success: true });
           }
         } catch (err) {
@@ -839,15 +1055,85 @@ export default defineContentScript({
       }
       if (message.type === "CHAT_CUA_WORKING_STATE") {
         if (message.active) {
+          // Cache the space color so click ripples (which can fire after the
+          // working-state message has resolved) inherit the same tint as the
+          // border glow. Only update when a non-empty color was provided —
+          // some callers send `active: true` with no color and we'd rather
+          // keep the previously-known tint than blank it back to default.
+          if (typeof message.color === "string" && message.color.trim()) {
+            cachedSpaceColor = message.color.trim();
+          }
           showCuaWorking(message.color);
         } else {
           removeCuaWorking();
+          // Clear the cache on idle so a NEW agent run that doesn't re-send a
+          // color (rare, but possible) starts from the default fallback
+          // rather than a stale prior-space tint.
+          cachedSpaceColor = null;
         }
         sendResponse({ ok: true });
       }
       if (message.type === "CHAT_CUA_INPUT_PASSTHROUGH") {
         setCuaPassthrough(!!message.on);
         sendResponse({ ok: true });
+      }
+      // Diagnostic-only: at a given (x, y), report what the page would actually
+      // hit, the state of OpenBrowse's overlays, and viewport metrics. Used by
+      // the CUA loop to forensically log click failures (overlay interception,
+      // DPR/zoom mismatch, debugger detach, race window). Read-only — never
+      // mutates page state. See cua-loop.ts.
+      if (message.type === "CHAT_CUA_DIAG_HIT_TEST") {
+        try {
+          const x = Number(message.x);
+          const y = Number(message.y);
+          const describe = (el: Element | null): string => {
+            if (!el) return "null";
+            const tag = el.tagName.toLowerCase();
+            const id = el.id ? `#${el.id}` : "";
+            const cls = el.classList.length
+              ? `.${[...el.classList].slice(0, 2).join(".")}`
+              : "";
+            return `${tag}${id}${cls}`;
+          };
+          const top = document.elementFromPoint(x, y);
+          // `elementsFromPoint` returns the full hit-test stack (topmost first).
+          // This pierces past any overlay so the diagnostic shows what would
+          // have been clicked if the overlay weren't there. Cap at 6 entries
+          // to keep the log line readable.
+          const stack = (document.elementsFromPoint(x, y) ?? []).slice(0, 6);
+          const chain = stack.map(describe);
+          const cuaHost = document.getElementById(CUA_WORKING_HOST_ID);
+          const shield = cuaHost?.shadowRoot?.querySelector(
+            ".ob-cua-shield",
+          ) as HTMLElement | null;
+          const shieldPe = shield
+            ? getComputedStyle(shield).pointerEvents
+            : null;
+          const overlayHost = document.getElementById(OVERLAY_HOST_ID);
+          sendResponse({
+            ok: true,
+            x,
+            y,
+            top: describe(top),
+            chain,
+            cuaWorkingHostMounted: !!cuaHost,
+            shieldComputedPointerEvents: shieldPe,
+            cuaAgentActing,
+            searchOverlayMounted: !!overlayHost,
+            devicePixelRatio: window.devicePixelRatio,
+            innerWidth: window.innerWidth,
+            innerHeight: window.innerHeight,
+            visualViewportScale: window.visualViewport?.scale ?? null,
+            scrollX: window.scrollX,
+            scrollY: window.scrollY,
+            url: location.href,
+          });
+        } catch (err) {
+          sendResponse({
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     });
 

--- a/apps/extension/src/lib/agent/__tests__/click-diagnostic.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/click-diagnostic.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runClickDiagnostic } from "../click-diagnostic";
+import type { BrowserDriver } from "../driver";
+
+/**
+ * Test the click diagnostic's classifier. The diagnostic logs a single tag
+ * per click; the tag drives whether engineers should investigate. Three
+ * tags are functionally distinct:
+ *
+ *   ok / ok-retarget   — click landed on a page element. ok-retarget means
+ *                         we saw the CUA-working-host as `top` but it's a
+ *                         shadow-DOM-retargeted hit (chain[1+] is real
+ *                         page content) and the shield is in passthrough.
+ *                         Emitted at console.debug — quiet by default.
+ *   OVERLAY-INTERCEPT  — an OpenBrowse overlay is genuinely eating the
+ *                         click (shield not in passthrough, search backdrop
+ *                         mounted, etc.). Emitted at console.warn — loud.
+ *   OFF-VIEWPORT       — coords outside the visible viewport. console.warn.
+ *
+ * Pre-fix, the classifier used to flag every successful click as
+ * OVERLAY-INTERCEPT (because elementsFromPoint retargets shadow hits to
+ * the host, and the host string matches the overlay regex). This file
+ * regression-tests the post-fix classifier.
+ */
+
+const TAB_ID = 1;
+const URL = "https://example.com";
+
+function makeDriver(diagResponse: unknown): BrowserDriver {
+  return {
+    sendToContentScript: async () => diagResponse,
+  } as unknown as BrowserDriver;
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let debugSpy: ReturnType<typeof vi.spyOn>;
+let infoSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+  infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+  debugSpy.mockRestore();
+  infoSpy.mockRestore();
+});
+
+/** Extract the single string argument logged via spy.calls (`[message, raw]`). */
+function loggedMessage(spy: ReturnType<typeof vi.spyOn>): string {
+  const call = spy.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  return String(call?.[0] ?? "");
+}
+
+describe("runClickDiagnostic — benign retargeted-host classification (H2 regression)", () => {
+  it("tags as ok-retarget when top is the working host but shieldPE=none and chain has page elements", async () => {
+    // The exact shape every successful agent click produces under the
+    // post-fix overlay CSS: elementsFromPoint retargets the shadow hit to
+    // the host, so `top` is the host id. With pe:none on .ob-cua-root and
+    // .ob-cua-shield.ob-passthrough, the click DOES land on the real page
+    // element (visible in chain[1+]). Pre-fix this was flagged as
+    // OVERLAY-INTERCEPT — false positive on every click.
+    const driver = makeDriver({
+      ok: true,
+      top: "div#openbrowse-cua-working-host",
+      chain: [
+        "div#openbrowse-cua-working-host",
+        "button.faq-toggle",
+        "li",
+        "ul",
+      ],
+      shieldComputedPointerEvents: "none",
+      cuaWorkingHostMounted: true,
+      cuaAgentActing: true,
+      searchOverlayMounted: false,
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    await runClickDiagnostic(driver, TAB_ID, "test", 100, 200);
+
+    expect(warnSpy).not.toHaveBeenCalled(); // critical: no false-positive warn
+    expect(debugSpy).toHaveBeenCalled();
+    expect(loggedMessage(debugSpy)).toContain("ok-retarget");
+  });
+
+  it("STILL flags OVERLAY-INTERCEPT when shield is pe:auto (real interception)", async () => {
+    // shieldPE != "none" means the toggle didn't propagate; the shield is
+    // a hit-test target and the click really is being eaten. This is the
+    // shape that surfaced the original bug.
+    const driver = makeDriver({
+      ok: true,
+      top: "div#openbrowse-cua-working-host",
+      chain: ["div#openbrowse-cua-working-host", "button.real-page-button"],
+      shieldComputedPointerEvents: "auto",
+      cuaWorkingHostMounted: true,
+      cuaAgentActing: false,
+      searchOverlayMounted: false,
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    await runClickDiagnostic(driver, TAB_ID, "test", 100, 200);
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(loggedMessage(warnSpy)).toContain("OVERLAY-INTERCEPT");
+  });
+
+  it("flags OVERLAY-INTERCEPT when chain has no page elements behind the host (only OB elements)", async () => {
+    // Defensive: if for any reason there's nothing behind the host, the
+    // click landed on the host itself (or its shadow children) — that IS
+    // an interception even when shieldPE=none.
+    const driver = makeDriver({
+      ok: true,
+      top: "div#openbrowse-cua-working-host",
+      chain: [
+        "div#openbrowse-cua-working-host",
+        "div#openbrowse-overlay-host", // search overlay also up
+      ],
+      shieldComputedPointerEvents: "none",
+      cuaWorkingHostMounted: true,
+      cuaAgentActing: true,
+      searchOverlayMounted: true,
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    await runClickDiagnostic(driver, TAB_ID, "test", 100, 200);
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(loggedMessage(warnSpy)).toContain("OVERLAY-INTERCEPT");
+  });
+
+  it("flags OVERLAY-INTERCEPT when search overlay is mounted, regardless of host top shape", async () => {
+    // Search backdrop has pe:auto and IS a real catcher. Even if the top
+    // happens to be the CUA host (interleaved overlays), search-overlay-
+    // mounted is enough.
+    const driver = makeDriver({
+      ok: true,
+      top: "div#openbrowse-cua-working-host",
+      chain: ["div#openbrowse-cua-working-host", "main"],
+      shieldComputedPointerEvents: "none",
+      cuaWorkingHostMounted: true,
+      cuaAgentActing: true,
+      searchOverlayMounted: true, // ← the killer
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    await runClickDiagnostic(driver, TAB_ID, "test", 100, 200);
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(loggedMessage(warnSpy)).toContain("OVERLAY-INTERCEPT");
+  });
+
+  it("does NOT flag the click ripple host as an interception (.ob-ripple-* is pe:none on its host, never blocks)", async () => {
+    // L5 regression: a click that fires within ~850ms of a previous click
+    // can see the still-fading ripple at the top. The ripple host's host
+    // element has `pointer-events:none` set inline, so it never intercepts
+    // CDP input — the diagnostic must not flag it.
+    const driver = makeDriver({
+      ok: true,
+      top: "div.ob-ripple-burst",
+      chain: ["div.ob-ripple-burst", "button.real-page-button"],
+      shieldComputedPointerEvents: "none",
+      cuaWorkingHostMounted: true,
+      cuaAgentActing: true,
+      searchOverlayMounted: false,
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    await runClickDiagnostic(driver, TAB_ID, "test", 100, 200);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalled();
+    expect(loggedMessage(debugSpy)).toContain(" ok ");
+  });
+
+  it("tags OFF-VIEWPORT when coords are outside innerWidth/Height", async () => {
+    const driver = makeDriver({
+      ok: true,
+      top: "html",
+      chain: ["html"],
+      shieldComputedPointerEvents: "none",
+      cuaWorkingHostMounted: true,
+      cuaAgentActing: true,
+      searchOverlayMounted: false,
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    // y=900 > innerHeight=800
+    await runClickDiagnostic(driver, TAB_ID, "test", 640, 900);
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(loggedMessage(warnSpy)).toContain("OFF-VIEWPORT");
+  });
+
+  it("tags ok and emits at console.debug when top is a real page element", async () => {
+    const driver = makeDriver({
+      ok: true,
+      top: "button#submit",
+      chain: ["button#submit", "form", "main"],
+      shieldComputedPointerEvents: "none",
+      cuaWorkingHostMounted: false,
+      cuaAgentActing: false,
+      searchOverlayMounted: false,
+      innerWidth: 1280,
+      innerHeight: 800,
+      url: URL,
+    });
+
+    await runClickDiagnostic(driver, TAB_ID, "test", 100, 200);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalled();
+    expect(loggedMessage(debugSpy)).toContain(" ok ");
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/diff-snapshots.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/diff-snapshots.test.ts
@@ -13,7 +13,6 @@ const ZERO: PageStateSignals = {
   checkedCount: 0,
   dialogCount: 0,
   url: "https://example.com",
-  interactiveCount: 0,
 };
 
 describe("diffSnapshots — null cases", () => {
@@ -97,13 +96,11 @@ describe("diffSnapshots — signal-only changes (text identical)", () => {
     expect(result).toBeNull();
   });
 
-  it("reports interactive-count change", () => {
-    const result = diffSnapshots(
-      { text: "a", signals: { ...ZERO, interactiveCount: 5 } },
-      { text: "a", signals: { ...ZERO, interactiveCount: 8 } },
-    );
-    expect(result).toContain("interactive elements: 5 → 8");
-  });
+  // `interactiveCount` was removed from PageStateSignals entirely (it was
+  // mode-fragile and dead code after the diff→viewport-snapshot migration).
+  // The structural impossibility of diffing it is now the regression
+  // guarantee — no runtime test needed. See `describeSignalChanges` in
+  // snapshot-capture for context.
 
   it("joins multiple changes with semicolons", () => {
     const result = diffSnapshots(

--- a/apps/extension/src/lib/agent/__tests__/snapshot-signals.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/snapshot-signals.test.ts
@@ -16,7 +16,7 @@ type FixtureAXNode = {
 
 describe("derivePageStateSignals", () => {
   it("returns zero/null signals for an empty AX tree", () => {
-    const signals = derivePageStateSignals([], new Map(), "https://example.com");
+    const signals = derivePageStateSignals([], "https://example.com");
     expect(signals).toEqual<PageStateSignals>({
       focusedBackendNodeId: null,
       focusedName: null,
@@ -26,7 +26,6 @@ describe("derivePageStateSignals", () => {
       checkedCount: 0,
       dialogCount: 0,
       url: "https://example.com",
-      interactiveCount: 0,
     });
   });
 });
@@ -43,7 +42,6 @@ describe("derivePageStateSignals — focus", () => {
     const signals = derivePageStateSignals(
       // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
       [node as any],
-      new Map(),
       "https://example.com",
     );
     expect(signals.focusedBackendNodeId).toBe(42);
@@ -62,7 +60,6 @@ describe("derivePageStateSignals — focus", () => {
     const signals = derivePageStateSignals(
       // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
       [node as any],
-      new Map(),
       "https://example.com",
     );
     expect(signals.focusedBackendNodeId).toBeNull();
@@ -93,7 +90,6 @@ describe("derivePageStateSignals — toggle counts", () => {
     const signals = derivePageStateSignals(
       // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
       nodes as any,
-      new Map(),
       "https://example.com",
     );
     expect(signals.expandedCount).toBe(2);
@@ -115,7 +111,6 @@ describe("derivePageStateSignals — toggle counts", () => {
     const signals = derivePageStateSignals(
       // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
       nodes as any,
-      new Map(),
       "https://example.com",
     );
     expect(signals.pressedCount).toBe(1);
@@ -134,27 +129,20 @@ describe("derivePageStateSignals — dialog count", () => {
     const signals = derivePageStateSignals(
       // biome-ignore lint/suspicious/noExplicitAny: minimal fixture
       nodes as any,
-      new Map(),
       "https://example.com",
     );
     expect(signals.dialogCount).toBe(2);
   });
 });
 
-describe("derivePageStateSignals — interactive count", () => {
-  it("returns refs.size", () => {
-    const refs = new Map([
-      ["@e1", { backendNodeId: 1, role: "button", name: "OK", nth: 0 }],
-      ["@e2", { backendNodeId: 2, role: "link", name: "Home", nth: 0 }],
-    ]);
-    const signals = derivePageStateSignals([], refs, "https://example.com");
-    expect(signals.interactiveCount).toBe(2);
-  });
-});
+// `interactiveCount` was removed (it was mode-fragile and dead code after
+// the diff→viewport-snapshot migration). The signal lived only to power
+// `describeSignalChanges`, which now intentionally excludes it. Don't
+// reintroduce without a mode-aware comparison strategy.
 
 describe("derivePageStateSignals — url", () => {
   it("stores the url verbatim", () => {
-    const signals = derivePageStateSignals([], new Map(), "https://x.test/a?b=c");
+    const signals = derivePageStateSignals([], "https://x.test/a?b=c");
     expect(signals.url).toBe("https://x.test/a?b=c");
   });
 });

--- a/apps/extension/src/lib/agent/cdp-session.ts
+++ b/apps/extension/src/lib/agent/cdp-session.ts
@@ -116,6 +116,13 @@ async function sendCommandWithRetry<T>(
     } catch (err) {
       if (allowRetry && isDetachError(err)) {
         // Stale session — drop and retry once with a fresh attach.
+        // Logged at debug; transient and self-healing, so most engineers
+        // don't need to see it. Surfaces under DevTools Verbose for the
+        // rare "flaky CUA click" investigation.
+        console.debug(
+          `[cdp-session] tab ${tabId} detached on ${domain}.enable for ` +
+            `${method}; reattaching once`,
+        );
         sessions.delete(tabId);
         return sendCommandWithRetry<T>(tabId, method, params, false);
       }
@@ -137,6 +144,13 @@ async function sendCommandWithRetry<T>(
       // command itself fell off the wire mid-flight). Drop our stale session
       // record, give Chrome a moment to settle if a navigation is happening,
       // then re-attach and retry once.
+      // Logged at debug to correlate "flaky CUA click" reports with
+      // mid-flight debugger detaches (e.g. a navigation kicked off by a
+      // previous click). Surfaces only under DevTools Verbose.
+      console.debug(
+        `[cdp-session] tab ${tabId} detached during ${method}; reattaching ` +
+          `and retrying once`,
+      );
       sessions.delete(tabId);
       await new Promise((r) => setTimeout(r, 250));
       return sendCommandWithRetry<T>(tabId, method, params, false);

--- a/apps/extension/src/lib/agent/click-diagnostic.ts
+++ b/apps/extension/src/lib/agent/click-diagnostic.ts
@@ -1,0 +1,270 @@
+import type { BrowserDriver, TabId } from "./driver";
+
+/**
+ * Toggle the CUA "working on this page" overlay's input shield to
+ * pointer-events:none (when `on` is true) or back to pointer-events:auto.
+ *
+ * Critical for ANY tool that dispatches CDP `Input.dispatchMouseEvent`:
+ * the shield is mounted whenever an agent is running (`notifyAgentStatus`
+ * is called from agent-transport for the MAIN agent and from cua-loop for
+ * the CUA subagent), and CDP-dispatched events are trusted browser-level
+ * input events that respect DOM hit-testing — so they hit the shield first
+ * and never reach the page element. Wrap every CDP click/type/scroll with:
+ *
+ *     await setShieldPassthrough(driver, tabId, true);
+ *     try { await driver.sendCommand(tabId, "Input.dispatchMouseEvent", …); }
+ *     finally { await setShieldPassthrough(driver, tabId, false); }
+ *
+ * No-op when no shield is present (no content script / overlay not mounted).
+ * Logs a warning if the content-script round-trip fails: that means the
+ * shield (if mounted) stays in its previous state — one of the click-eaten
+ * failure modes.
+ */
+export async function setShieldPassthrough(
+  driver: BrowserDriver,
+  tabId: TabId,
+  on: boolean,
+): Promise<void> {
+  try {
+    await driver.sendToContentScript(tabId, {
+      type: "CHAT_CUA_INPUT_PASSTHROUGH",
+      on,
+    });
+  } catch (err) {
+    console.warn(
+      `[click-shield] setShieldPassthrough(${on}) tab ${String(tabId)} failed:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * Forensic click-time diagnostic shared by both click paths:
+ *   - the CUA subagent (cua/cua-loop.ts → executeAndShoot)
+ *   - the main agent's `clickElement` tool (tools/click-element.ts)
+ *
+ * Asks the content script (via `CHAT_CUA_DIAG_HIT_TEST`) what's actually at
+ * the click point and what state the OpenBrowse overlays are in. Result is
+ * logged to the service-worker console with a single status tag plus all
+ * key fields INLINED into the message string — this lets a developer read
+ * the log without expanding the `Object` summary the browser collapses by
+ * default.
+ *
+ * **Timing matters.** Both click paths run this BEFORE dispatch, INSIDE
+ * the `setShieldPassthrough(true)` window. Earlier we ran it AFTER
+ * `setShieldPassthrough(false)`, which produced a guaranteed false-positive
+ * `OVERLAY-INTERCEPT` every single click (the shield was naturally back
+ * to `pointer-events: auto` by then). At the in-window moment this is
+ * called, the shield should have `pointer-events: none` and the topmost
+ * element should be the real page element.
+ *
+ * Read-only, fire-and-forget — never throws, never blocks. Output goes only
+ * to the console; nothing is surfaced to the model.
+ *
+ * Status tags:
+ *   `OVERLAY-INTERCEPT` — an OpenBrowse overlay (CUA shield, search backdrop,
+ *      working-host) is the topmost element at the click point, OR the search
+ *      overlay is mounted at all. With our pre-dispatch timing this is a
+ *      REAL click-eater: the shield is still hit-testable despite the
+ *      passthrough class being added (toggle didn't propagate, or CSS not
+ *      yet applied). Look at `shieldPE` to confirm.
+ *
+ *      Important nuance: `top=div#openbrowse-cua-working-host` is the
+ *      retargeted form of "something inside the working-host's shadow DOM
+ *      was hit". `document.elementsFromPoint` retargets shadow-DOM hits to
+ *      the host when called from outside the shadow tree. If you see this
+ *      with `shieldPE=none` and the chain[1+] are page elements (no `ob-`
+ *      prefix), the actual catcher is a sibling of the shield inside the
+ *      shadow DOM that has implicit `pointer-events: auto` — historically
+ *      this was `.ob-cua-root` (fixed: pe:none added to the root). If
+ *      this regresses with `shieldPE=none`, look at the shadow tree's
+ *      computed PE on every element, not just the shield.
+ *   `OFF-VIEWPORT`     — the click coordinate is outside the viewport.
+ *      Suggests a scroll-needed scenario (CDP only hits the visible viewport)
+ *      or a DPR/zoom/coord-normalization bug.
+ *   `ok`               — top element looks plausible. Combine with the
+ *      `top` and `chain` fields to confirm the intended element was hit.
+ *
+ * The two bad-shape tags are logged at `console.warn`; `ok` is logged at
+ * `console.info` so all dispatch-side logs are visible at DevTools' default
+ * log level (`console.debug` is filtered out unless Verbose is enabled).
+ */
+export interface ClickDiagnosticResponse {
+  ok: boolean;
+  top?: string;
+  chain?: string[];
+  cuaWorkingHostMounted?: boolean;
+  shieldComputedPointerEvents?: string | null;
+  cuaAgentActing?: boolean;
+  searchOverlayMounted?: boolean;
+  devicePixelRatio?: number;
+  innerWidth?: number;
+  innerHeight?: number;
+  visualViewportScale?: number | null;
+  scrollX?: number;
+  scrollY?: number;
+  url?: string;
+  error?: string;
+}
+
+/** Truthy when the diagnostic's `top` element is one of OpenBrowse's overlay
+ *  hosts/children that COULD plausibly intercept a click. Recognizes:
+ *   - `div#openbrowse-cua-working-host` (host id — see classification below)
+ *   - `div#openbrowse-overlay-host`     (search overlay host — its backdrop
+ *     `.sb-backdrop` has pe:auto and DOES intercept)
+ *   - any element whose first class is `.ob-cua-…`     (working-overlay shadow
+ *     children: `.ob-cua-shield` without `.ob-passthrough` is the canonical
+ *     click-eater)
+ *   - any element whose first class is `.sb-…`         (search backdrop)
+ *
+ *  Intentionally does NOT match `.ob-ripple-*` — the click-ripple host is
+ *  `pointer-events: none` (set on its host element directly via
+ *  `host.style.cssText`), so it never intercepts trusted CDP input. Without
+ *  this exclusion, every click within ~850ms of a previous click would be
+ *  flagged OVERLAY-INTERCEPT because elementsFromPoint sees the still-fading
+ *  ripple at the top.
+ *
+ *  Also intentionally does NOT match `.ob-` more broadly — that's a footgun:
+ *  a future host using the prefix would silently get flagged. Add specific
+ *  matchers as new overlay hosts are introduced. */
+function looksLikeOpenBrowseOverlay(top: string): boolean {
+  return (
+    /^div#openbrowse-cua-working-host\b/.test(top) ||
+    /^div#openbrowse-overlay-host\b/.test(top) ||
+    /\.ob-cua-/.test(top) ||
+    /\.sb-/.test(top)
+  );
+}
+
+/** Recognize the benign case where `top` is just the CUA working host
+ *  (i.e. shadow-DOM-retargeted hit) AND the shield is in passthrough mode
+ *  AND the chain has at least one page element behind the host. This is
+ *  what every successful agent click looks like under the post-fix overlay
+ *  CSS — flagging it as OVERLAY-INTERCEPT would be a false-positive log
+ *  warn on every successful click. The retargeting nuance is documented
+ *  in the runClickDiagnostic doc above.
+ *
+ *  Returns true when this exact shape holds; callers should treat the
+ *  click as having landed on a real page element. */
+function isHostRetargetedBenign(
+  top: string,
+  chain: string[],
+  shieldPe: string | null | undefined,
+): boolean {
+  const isHostTop = /^div#openbrowse-cua-working-host\b/.test(top);
+  if (!isHostTop) return false;
+  if (shieldPe !== "none") return false;
+  // chain[0] is the host itself (the same string as `top`); chain[1+] are
+  // what's BEHIND the host. If any of those is not an OpenBrowse overlay,
+  // the page element absorbed the click as designed.
+  return chain
+    .slice(1)
+    .some((el) => !looksLikeOpenBrowseOverlay(el));
+}
+
+/**
+ * Run the diagnostic. `source` identifies which click path is calling us
+ * (e.g. "cua/click", "tool/clickByRef") so the log line is self-describing.
+ *
+ * Returns the raw diagnostic response so callers can react (e.g. abort the
+ * dispatch, retry the passthrough toggle). Returns `null` on dispatch
+ * failure. Never throws.
+ */
+export async function runClickDiagnostic(
+  driver: BrowserDriver,
+  tabId: TabId,
+  source: string,
+  x: number,
+  y: number,
+): Promise<ClickDiagnosticResponse | null> {
+  let diag: ClickDiagnosticResponse | undefined;
+  try {
+    diag = await driver.sendToContentScript<ClickDiagnosticResponse>(tabId, {
+      type: "CHAT_CUA_DIAG_HIT_TEST",
+      x,
+      y,
+    });
+  } catch (err) {
+    console.warn(
+      `[click-diag] ${source}@(${x},${y}) tab=${String(tabId)} diagnostic dispatch failed:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+  if (!diag?.ok) {
+    console.warn(
+      `[click-diag] ${source}@(${x},${y}) tab=${String(tabId)} diagnostic failed:`,
+      diag?.error ?? "no response",
+    );
+    return diag ?? null;
+  }
+  const top = diag.top ?? "";
+  const chain = diag.chain ?? [];
+  // Search overlay's backdrop is `.sb-backdrop` with pe:auto and ALWAYS
+  // intercepts. Treat it as an unconditional block — even if the click
+  // appears to land on a real page element, the backdrop is between the
+  // click point and the page element and will eat input events. This
+  // takes priority over the benign-retarget check below.
+  const searchOverlayBlocking = diag.searchOverlayMounted === true;
+  // Classify the hit. The retargeted-host signal is REAL only when an
+  // OpenBrowse overlay is on top AND it isn't the benign shadow-DOM-
+  // retargeted host shape that every successful agent click produces.
+  // See `isHostRetargetedBenign` for the precise condition.
+  const benign =
+    !searchOverlayBlocking &&
+    isHostRetargetedBenign(top, chain, diag.shieldComputedPointerEvents);
+  const obIntercepted =
+    !benign &&
+    (looksLikeOpenBrowseOverlay(top) || searchOverlayBlocking);
+  const offViewport =
+    x < 0 ||
+    y < 0 ||
+    (diag.innerWidth != null && x > diag.innerWidth) ||
+    (diag.innerHeight != null && y > diag.innerHeight);
+  // Tag granularity:
+  //   ok         — click landed on a page element (incl. via shadow-DOM
+  //                retargeting — the common, healthy case)
+  //   ok-retarget— same as ok but the diagnostic saw the retargeted host
+  //                and we resolved it to benign. Useful breadcrumb when
+  //                investigating "click lands on host?" — the answer is
+  //                "yes, but it's our host's shadow being retargeted, not
+  //                an interception". Emitted at console.debug to keep the
+  //                normal-path noise low.
+  //   OFF-VIEWPORT
+  //   OVERLAY-INTERCEPT
+  const tag = obIntercepted
+    ? "OVERLAY-INTERCEPT"
+    : offViewport
+      ? "OFF-VIEWPORT"
+      : benign
+        ? "ok-retarget"
+        : "ok";
+  // Only the genuinely-bad shapes warrant a console.warn — we previously
+  // warned on every click which trained engineers to ignore the channel.
+  // `ok-retarget` goes to console.debug (hidden by default); `ok` to
+  // console.debug too — the dispatch log already emits at info elsewhere.
+  const log =
+    tag === "OVERLAY-INTERCEPT" || tag === "OFF-VIEWPORT"
+      ? console.warn
+      : console.debug;
+  // Inline ALL the key fields so the log is readable without expanding the
+  // collapsed Object DevTools shows. We still pass the raw `diag` object as
+  // a final argument so it's available for inspection if needed.
+  log.call(
+    console,
+    `[click-diag] ${source}@(${x},${y}) tab=${String(tabId)} ${tag} ` +
+      `top=${diag.top ?? "?"} ` +
+      `chain=[${(diag.chain ?? []).slice(0, 4).join(" > ")}] ` +
+      `shieldPE=${diag.shieldComputedPointerEvents ?? "n/a"} ` +
+      `cuaActing=${diag.cuaAgentActing} ` +
+      `cuaHostMounted=${diag.cuaWorkingHostMounted} ` +
+      `searchOverlay=${diag.searchOverlayMounted} ` +
+      `dpr=${diag.devicePixelRatio} ` +
+      `vp=${diag.innerWidth}x${diag.innerHeight} ` +
+      `vvScale=${diag.visualViewportScale ?? "n/a"} ` +
+      `scroll=(${diag.scrollX},${diag.scrollY}) ` +
+      `url=${diag.url}`,
+    diag,
+  );
+  return diag;
+}

--- a/apps/extension/src/lib/agent/compaction.test.ts
+++ b/apps/extension/src/lib/agent/compaction.test.ts
@@ -340,11 +340,15 @@ describe("keepOnlyLatestSnapshotPerTab", () => {
     refCount,
     url: `https://x/${tab}`,
   });
-  const clickDiff = (tab: string, diff: string) => ({
+  // Action tools (clickElement/typeInElement/pressKey) auto-attach a
+  // viewport-scoped snapshot in the `snapshot` field — same as the snapshot
+  // tool itself. The historical `diff` field is gone (see
+  // tools/click-element.ts).
+  const clickResult = (tab: string, snapshot: string) => ({
     tab,
     clicked: true,
     target: "@eabc",
-    diff,
+    snapshot,
   });
 
   function isSnapshotStub(output: unknown): boolean {
@@ -352,8 +356,7 @@ describe("keepOnlyLatestSnapshotPerTab", () => {
       !!output &&
       typeof output === "object" &&
       (output as Record<string, unknown>).superseded === true &&
-      !("snapshot" in (output as Record<string, unknown>)) &&
-      !("diff" in (output as Record<string, unknown>))
+      !("snapshot" in (output as Record<string, unknown>))
     );
   }
 
@@ -386,15 +389,15 @@ describe("keepOnlyLatestSnapshotPerTab", () => {
     expect((out[2] as any).snapshot).toBe("A2"); // t1 latest, intact
   });
 
-  it("treats clickElement/navigate diffs as snapshots and supersedes them", () => {
+  it("treats clickElement/navigate snapshots as supersedable and stubs the older ones", () => {
     const msgs = [
       toolResultMsg("snapshot", snap("t1", "TREE-1")),
-      toolResultMsg("clickElement", clickDiff("t1", "DIFF-1")),
+      toolResultMsg("clickElement", clickResult("t1", "POST-CLICK-1")),
       toolResultMsg("snapshot", snap("t1", "TREE-2")),
     ];
     const out = outputs(keepOnlyLatestSnapshotPerTab(msgs));
     expect(isSnapshotStub(out[0])).toBe(true); // earlier snapshot
-    expect(isSnapshotStub(out[1])).toBe(true); // earlier click diff
+    expect(isSnapshotStub(out[1])).toBe(true); // earlier click result
     expect((out[2] as any).snapshot).toBe("TREE-2"); // latest survives
   });
 

--- a/apps/extension/src/lib/agent/compaction.ts
+++ b/apps/extension/src/lib/agent/compaction.ts
@@ -330,34 +330,34 @@ export function keepOnlyLatestScreenshot(
 }
 
 /**
- * Tools whose output embeds a page accessibility snapshot (or a diff of
- * one) keyed to per-snapshot `@ref` ids. Once a NEWER snapshot of the same
- * tab exists, every earlier snapshot's text is dead weight: its refs are
- * invalid by construction (refs are reassigned on every capture), and the
- * agent is instructed to re-snapshot rather than re-read an old tree. So we
- * keep only the latest snapshot per tab alive in the model's context.
+ * Tools whose output embeds a page accessibility snapshot keyed to
+ * per-snapshot `@ref` ids. Once a NEWER snapshot of the same tab exists,
+ * every earlier snapshot's text is dead weight: its refs are invalid by
+ * construction (refs are reassigned on every capture), and the agent is
+ * instructed to re-snapshot rather than re-read an old tree. So we keep
+ * only the latest snapshot per tab alive in the model's context.
  *
  * Maps the tool name → the output field that carries the snapshot text:
  *   - `snapshot`     → `snapshot`
  *   - `navigate`     → `snapshot` (fresh tree attached on navigation)
- *   - `clickElement` → `diff`
- *   - `typeInElement`→ `diff`
- *   - `pressKey`     → `diff`
+ *   - `clickElement` → `snapshot` (auto-attached viewport snapshot post-action)
+ *   - `typeInElement`→ `snapshot` (auto-attached viewport snapshot post-action)
+ *   - `pressKey`     → `snapshot` (auto-attached viewport snapshot post-action)
  *
  * The grouping key is the tool output's `tab` field, so a multi-tab task
  * keeps the latest snapshot of EACH tab.
  */
-export const SNAPSHOT_OUTPUT_FIELDS: Record<string, "snapshot" | "diff"> = {
+export const SNAPSHOT_OUTPUT_FIELDS: Record<string, "snapshot"> = {
   snapshot: "snapshot",
   navigate: "snapshot",
-  clickElement: "diff",
-  typeInElement: "diff",
-  pressKey: "diff",
+  clickElement: "snapshot",
+  typeInElement: "snapshot",
+  pressKey: "snapshot",
 };
 
 /**
  * Keeps only the latest snapshot-bearing tool output per tab; replaces the
- * snapshot/diff text on every earlier one with a compact stub that preserves
+ * snapshot text on every earlier one with a compact stub that preserves
  * orientation metadata (tab, url, refCount) but drops the multi-kilobyte
  * accessibility tree.
  *
@@ -378,7 +378,7 @@ export function keepOnlyLatestSnapshotPerTab(
   messages: AgentUIMessage[],
 ): AgentUIMessage[] {
   // First pass: locate every live (non-stubbed) snapshot-bearing output,
-  // grouped by tab. A part is "live" when its snapshot/diff field is a
+  // grouped by tab. A part is "live" when its snapshot field is a
   // non-empty string (stubs replace it with an object).
   const locsByTab = new Map<string, Array<{ m: number; p: number }>>();
   for (let m = 0; m < messages.length; m++) {
@@ -432,7 +432,7 @@ export function keepOnlyLatestSnapshotPerTab(
       if (typeof prev.tab === "string") stub.tab = prev.tab;
       if (typeof prev.url === "string") stub.url = prev.url;
       if (typeof prev.refCount === "number") stub.refCount = prev.refCount;
-      // Drop the heavy snapshot/diff text; keep everything else small.
+      // Drop the heavy snapshot text; keep everything else small.
       const { [field]: _omit, ...rest } = prev;
       return { ...anyPart, output: { ...rest, ...stub } };
     });

--- a/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
@@ -120,11 +120,19 @@ describe("executeAndShoot", () => {
 
     await executeAndShoot(driver, 1, { kind: "click", x: 42, y: 99 }, 800, 600);
 
-    // Passthrough is enabled before the action and disabled after; the
-    // screenshot capture happens after the action; and the ripple fires LAST
-    // (after capture) so it's never baked into the image sent to the model.
+    // Order:
+    //   1. Passthrough ON  (shield → pointer-events:none)
+    //   2. Pre-dispatch diagnostic  (proves the toggle took effect at click time)
+    //   3. Post-dispatch diagnostic (still inside passthrough window, confirms
+    //      no transient element hijack between hit-test and dispatch)
+    //   4. Passthrough OFF (shield back to pointer-events:auto)
+    //   5. Screenshot capture (clean, with shield up)
+    //   6. Ripple fires LAST (after capture) so it's never baked into the
+    //      image sent to the model.
     expect(order).toEqual([
       "msg:CHAT_CUA_INPUT_PASSTHROUGH",
+      "msg:CHAT_CUA_DIAG_HIT_TEST",
+      "msg:CHAT_CUA_DIAG_HIT_TEST",
       "msg:CHAT_CUA_INPUT_PASSTHROUGH",
       "capture",
       "msg:CHAT_CUA_CLICK_RIPPLE",

--- a/apps/extension/src/lib/agent/cua/cua-loop.ts
+++ b/apps/extension/src/lib/agent/cua/cua-loop.ts
@@ -6,6 +6,10 @@ import { executeCanonicalAction } from "./executor";
 import { captureNormalizedShot, captureRegionShot } from "./screenshot";
 import type { CuaRunConfig, CuaRunResult } from "./provider";
 import { notifyAgentStatus } from "../agent-indicator";
+import {
+  runClickDiagnostic,
+  setShieldPassthrough,
+} from "../click-diagnostic";
 
 /**
  * Plain OUTPUT value of the CUA computer tool's `execute`. Carries the
@@ -70,9 +74,58 @@ export async function executeAndShoot(
   // provably down before the CDP dispatch and back up after). No-op when no
   // overlay is present.
   const needsPassthrough = INPUT_ACTION_KINDS.has(action.kind);
+  // Diagnostic instrumentation for "agent click did nothing" reports.
+  // Logged at info; cheap; the only thing that lets us tell, after the
+  // fact, whether a click was eaten by an overlay vs. landed off-target
+  // vs. the debugger detached. The diagnostics fire INSIDE the passthrough
+  // window — see runClickDiagnostic for the timing rationale.
+  const t0 = needsPassthrough ? performance.now() : 0;
   if (needsPassthrough) await setShieldPassthrough(driver, tabId, true);
+  const t1 = needsPassthrough ? performance.now() : 0;
+  // Compute click point for diagnostics. Null for non-positional actions
+  // (key/type/wait) — those skip the diagnostic but still need passthrough.
+  const diagPoint = pointFromAction(action);
+  const runDiag =
+    diagPoint && (action.kind === "click" || action.kind === "drag");
   try {
+    if (needsPassthrough) {
+      logActionDispatch(action, tabId, t1 - t0);
+    }
+    if (runDiag && diagPoint) {
+      // Pre-dispatch: proves the shield's passthrough class actually took
+      // effect at click time. shieldPE != "none" here means the toggle
+      // didn't propagate and the click is about to be eaten.
+      await runClickDiagnostic(
+        driver,
+        tabId,
+        `cua/${action.kind}:pre`,
+        diagPoint.x,
+        diagPoint.y,
+      );
+    }
     await executeCanonicalAction(driver, tabId, action);
+    if (runDiag && diagPoint) {
+      // Post-dispatch (still inside the passthrough window): confirms the
+      // top element didn't change between hit-test and dispatch (animation,
+      // timeout, micro-task hijack).
+      await runClickDiagnostic(
+        driver,
+        tabId,
+        `cua/${action.kind}:post`,
+        diagPoint.x,
+        diagPoint.y,
+      );
+    }
+  } catch (err) {
+    // Surface a failed CDP dispatch with full context — previously this
+    // bubbled with no breadcrumb, making "click silently dropped" look
+    // identical to "click landed on overlay".
+    console.warn(
+      `[cua/loop] action ${action.kind} (tab ${String(tabId)}) failed:`,
+      err instanceof Error ? err.message : String(err),
+      pointFromAction(action),
+    );
+    throw err;
   } finally {
     if (needsPassthrough) await setShieldPassthrough(driver, tabId, false);
   }
@@ -125,19 +178,40 @@ const INPUT_ACTION_KINDS = new Set<CanonicalAction["kind"]>([
   "holdKey",
 ]);
 
-async function setShieldPassthrough(
-  driver: BrowserDriver,
-  tabId: TabId,
-  on: boolean,
-): Promise<void> {
-  try {
-    await driver.sendToContentScript(tabId, {
-      type: "CHAT_CUA_INPUT_PASSTHROUGH",
-      on,
-    });
-  } catch {
-    // No overlay / no content script — nothing to toggle.
+/** CSS-pixel point a given action targets, for diagnostic logging. Returns
+ *  null for actions that have no positional coordinate (key/type/wait/etc.). */
+function pointFromAction(
+  action: CanonicalAction,
+): { x: number; y: number } | null {
+  switch (action.kind) {
+    case "click":
+    case "drag":
+    case "move":
+    case "scroll":
+    case "mouseDown":
+    case "mouseUp":
+      return { x: action.x, y: action.y };
+    default:
+      return null;
   }
+}
+
+/** Compact one-line dispatch log for forensic correlation with content-script
+ *  diagnostics. `toggleMs` is how long the passthrough round-trip took — a
+ *  large value (>50ms) is a red flag for the race window. Logged at debug
+ *  so it stays out of the default DevTools log; flip on Verbose to see it
+ *  when investigating a click-pipeline issue. */
+function logActionDispatch(
+  action: CanonicalAction,
+  tabId: TabId,
+  toggleMs: number,
+): void {
+  const point = pointFromAction(action);
+  const coords = point ? `(${point.x},${point.y})` : "";
+  console.debug(
+    `[cua/loop] dispatch ${action.kind}${coords} tab=${String(tabId)} ` +
+      `passthroughToggle=${toggleMs.toFixed(1)}ms`,
+  );
 }
 
 /**

--- a/apps/extension/src/lib/agent/snapshot-capture.ts
+++ b/apps/extension/src/lib/agent/snapshot-capture.ts
@@ -1,7 +1,9 @@
 /**
- * Core snapshot capture logic, extracted so action tools (click/type/navigate)
- * can auto-attach post-action diffs to their responses without duplicating the
- * a11y tree logic from tools/snapshot.ts.
+ * Core snapshot capture logic, extracted so action tools (click/type/press)
+ * can auto-attach a fresh viewport-scoped snapshot to their responses without
+ * duplicating the a11y tree logic from tools/snapshot.ts. The `snapshot` tool
+ * additionally exposes an opt-in `diff: true` mode that uses `diffSnapshots`
+ * to compare the new capture against the prior one.
  *
  * All CDP I/O routes through the `BrowserDriver` passed in by callers, which
  * is what makes this module portable: in production it goes through
@@ -95,13 +97,16 @@ export interface PageStateSignals {
   checkedCount: number;
   dialogCount: number;
   url: string;
-  interactiveCount: number;
+  // Note: `interactiveCount` was removed because it was mode-fragile —
+  // capturing the same page under different modes (viewport vs full)
+  // produces wildly different counts even when nothing visible changed.
+  // See `describeSignalChanges` for the reasoning. Don't reintroduce
+  // unless paired with a mode-aware comparison strategy.
 }
 
 /**
- * Derive multi-signal page state from an already-fetched AX tree, the
- * collected refs map, and the current URL. Pure function — no I/O — so
- * it's cheap and unit-testable.
+ * Derive multi-signal page state from an already-fetched AX tree and the
+ * current URL. Pure function — no I/O — so it's cheap and unit-testable.
  *
  * Signals are intentionally counts rather than node lists: they're robust
  * (a count won't change without a real state shift) and small (no risk of
@@ -109,7 +114,6 @@ export interface PageStateSignals {
  */
 export function derivePageStateSignals(
   axNodes: AXNode[],
-  refs: Map<string, RefEntry>,
   url: string,
 ): PageStateSignals {
   let focusedBackendNodeId: number | null = null;
@@ -154,7 +158,6 @@ export function derivePageStateSignals(
     checkedCount,
     dialogCount,
     url,
-    interactiveCount: refs.size,
   };
 }
 
@@ -262,7 +265,7 @@ export async function captureSnapshot(
     // signal, so this is safe.
   }
 
-  const signals = derivePageStateSignals(axTree.nodes, refs, url);
+  const signals = derivePageStateSignals(axTree.nodes, url);
 
   setRefs(tabId, refs, snapshotText, signals);
 
@@ -305,13 +308,19 @@ export async function captureSnapshot(
 /**
  * Compute a diff between two snapshots that combines the line-level a11y
  * text diff with a multi-signal state diff. Returns a short summary suitable
- * for auto-attaching to action responses.
+ * for the `snapshot` tool's opt-in `diff: true` mode.
  *
  * Returns null ONLY when text AND all signals are identical — i.e. nothing
- * observable changed. This is intentionally narrower than the old
- * text-only set-diff: many successful interactions (focus, toggles, modal
- * opens) leave the a11y text identical, and reporting them as "no change"
- * was driving the agent into retry loops.
+ * observable changed. This is intentionally narrower than a text-only
+ * set-diff: many successful interactions (focus, toggles, modal opens)
+ * leave the a11y text identical, but signal changes still surface them.
+ *
+ * NOTE: action tools (clickElement/typeInElement/pressKey) intentionally do
+ * NOT call this — they auto-attach a fresh viewport snapshot to their
+ * responses instead of a diff, because mode-asymmetry between the prior
+ * snapshot (often viewport-scoped) and a post-action capture (full-tree by
+ * default) historically produced spurious "[+] entire below-fold tree"
+ * diffs that drove model hallucinations.
  */
 export function diffSnapshots(
   prev: { text: string; signals: PageStateSignals },
@@ -361,6 +370,13 @@ export function diffSnapshots(
 /**
  * Render per-signal change descriptions. Returns one human-readable string
  * per signal that changed; empty array means signals are identical.
+ *
+ * Historical note: `interactiveCount` used to live on PageStateSignals and
+ * be reported here. It was removed entirely because it's mode-fragile —
+ * capturing the same page under different modes (viewport vs full) yields
+ * wildly different counts. The auto-attached-diff history surfaced this
+ * as spurious "interactive elements: N → M" lines that drove model
+ * hallucinations. Don't reintroduce without a mode-aware comparison.
  */
 function describeSignalChanges(
   prev: PageStateSignals,
@@ -398,13 +414,6 @@ function describeSignalChanges(
   // real navigation — diffing against "" would emit a spurious "navigated to ".
   if (prev.url !== "" && curr.url !== "" && prev.url !== curr.url) {
     out.push(`navigated to ${curr.url}`);
-  }
-
-  // Interactive count.
-  if (prev.interactiveCount !== curr.interactiveCount) {
-    out.push(
-      `interactive elements: ${prev.interactiveCount} → ${curr.interactiveCount}`,
-    );
   }
 
   return out;

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -40,7 +40,7 @@ Your current plan will be appended to your instructions at every turn. Keep it i
 
 1. Use \`snapshot({ tab })\` to see interactive elements with @refs (e.g. @e1, @e2). On heavy pages (Amazon, Gmail, Notion, any e-commerce site, any social feed) — **always start with \`mode: "viewport"\` or scope with \`selector\` to keep the tree small.** A full \`interactive\` snapshot of Amazon's homepage returns 300+ refs; viewport mode typically returns 30-60. The response includes \`belowFoldCount\` when more content exists off-screen; \`scrollPage\` + re-snapshot to reach it. Use element selectors (e.g. \`"main"\`, \`"#search"\`, \`".s-main-slot"\`) — NOT attribute selectors like \`[role="main"]\` (those don't match implicit ARIA roles).
 2. Use @refs in clickElement/typeInElement: \`clickElement({ tab: "t1", target: "@e3" })\`. The \`@ref\` is tied to the tab whose snapshot produced it — do NOT pass refs from one tab to another.
-3. \`clickElement\`, \`typeInElement\`, and \`navigate\` automatically return a \`diff\` (or a fresh snapshot on navigate) — inspect it to verify your action worked before issuing the next one. A \`diff: null\` response means the action produced no visible change, which usually signals a silent failure.
+3. \`clickElement\`, \`typeInElement\`, and \`pressKey\` automatically attach a fresh viewport-scoped \`snapshot\` of the page AFTER the action so you can see the current state and pick the next ref without a follow-up snapshot call. \`navigate\` also auto-attaches a snapshot of the landed page. Inspect the returned snapshot to verify your action worked before issuing the next one. If a returned snapshot has the same content you saw before, the action probably had no visible effect — try a different target, scroll, or check for an overlay.
 4. **To submit a form, ALWAYS use \`typeInElement({ tab, target: "@e5", text: "...", submit: true })\`** — never append \\n to the text. The \`submit: true\` flag presses Enter AND waits for navigation to settle, which the legacy newline trick does not.
 5. Use \`extract({ tab, instruction, schema? })\` to pull structured data (product lists, search results, table rows) from a page. Provide an instruction and optionally a JSON Schema. Mark URL fields as \`{"type": "string", "format": "uri"}\` for reliable link extraction — the tool substitutes URLs with numeric IDs to prevent hallucination and rehydrates them before returning. Use element selectors like \`"main"\` or \`".s-main-slot"\` (NOT \`[role="main"]\`).
 6. Use \`readPage({ tab })\` when you need full text content (articles, long-form text).
@@ -108,7 +108,7 @@ Guidance:
 
 The biggest failure mode is giving up too early. Default to trying one more thing before reporting failure.
 
-- A click or type returned \`diff: null\` (no visible change): re-snapshot for fresh refs, then try a different element or selector.
+- A click, type, or key press returned a snapshot identical to what you saw before (no visible change): re-snapshot for fresh refs, then try a different element, scroll the target into view, or check for an overlay.
 - The page is still loading: scroll or screenshot to wait, don't bail.
 - A tool errored: if the error looks transient, retry; if structural, change approach.
 - An "Unknown tab handle" error means the legend has changed — call \`listTabs\` to refresh and pick a valid handle.

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-diff.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-diff.test.ts
@@ -74,13 +74,15 @@ function makeMockDriver(opts: {
         };
       }
       if (method === "Runtime.evaluate") {
-        // Two callers in scope:
+        // Three callers in scope, all routed through Runtime.evaluate:
         // - waitForLayoutFlush: awaits a rAF promise; any non-throw is fine.
-        // - viewport-only snapshot path: scroll + viewport. Returning a
-        //   uniform metrics object covers both.
+        // - readViewportMetrics (viewport.ts): reads { sx, sy, iw, ih }.
+        // - getViewportInfo (snapshot-capture.ts): reads { sy, vh }.
+        // We return a superset object so any of those readers gets all the
+        // fields it needs without per-expression branching in the mock.
         return {
           result: {
-            value: { sx: 0, sy: 0, iw: 1280, ih: 800 },
+            value: { sx: 0, sy: 0, iw: 1280, ih: 800, vh: 800 },
           },
         };
       }

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-diff.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-diff.test.ts
@@ -20,11 +20,14 @@ function onlyRef(tabId: number): string {
 
 /**
  * Mock BrowserDriver. `axTrees` is consumed in FIFO order — each
- * captureSnapshot call pulls the next AX node array (the last entry repeats if
- * exhausted). Only Accessibility.getFullAXTree and Target.getTargetInfo return
- * meaningful data; everything else returns {} (the graceful try/catch helpers
- * in snapshot-capture cope) except DOM.getBoxModel, which must return a box so
- * clickByRef can dispatch the mouse events.
+ * captureSnapshot call pulls the next AX node array (the last entry repeats
+ * if exhausted). Returns enough to satisfy clickByRef + captureSnapshot:
+ * - Accessibility.getFullAXTree: AX tree
+ * - Target.getTargetInfo: URL signal
+ * - DOM.getBoxModel: a fixed quad so the click dispatches successfully
+ * - DOM.resolveNode + Runtime.callFunctionOn: atomic gBCR for click coords
+ * - Runtime.evaluate: viewport metrics + layout-flush rAF promise
+ * Everything else returns {}.
  */
 function makeMockDriver(opts: {
   axTrees: Array<Array<unknown>>;
@@ -49,6 +52,38 @@ function makeMockDriver(opts: {
       if (method === "DOM.getBoxModel") {
         return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
       }
+      if (method === "DOM.resolveNode") {
+        return { object: { objectId: "obj-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        // Atomic gBCR read used by clickByRef. Element rect at (0,0)+10x10,
+        // viewport 1280x800, no scroll.
+        return {
+          result: {
+            value: {
+              vx: 0,
+              vy: 0,
+              vw: 10,
+              vh: 10,
+              sx: 0,
+              sy: 0,
+              iw: 1280,
+              ih: 800,
+            },
+          },
+        };
+      }
+      if (method === "Runtime.evaluate") {
+        // Two callers in scope:
+        // - waitForLayoutFlush: awaits a rAF promise; any non-throw is fine.
+        // - viewport-only snapshot path: scroll + viewport. Returning a
+        //   uniform metrics object covers both.
+        return {
+          result: {
+            value: { sx: 0, sy: 0, iw: 1280, ih: 800 },
+          },
+        };
+      }
       return {};
     },
     getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
@@ -72,7 +107,7 @@ beforeEach(() => {
 });
 
 // A bare button node. With no parentId it becomes the tree root; renderTree
-// emits it (interactive role → @e1). backendDOMNodeId 99 is what clickByRef
+// emits it (interactive role → @ref). backendDOMNodeId 99 is what clickByRef
 // dispatches against.
 function buttonNode(extra: Record<string, unknown> = {}) {
   return {
@@ -84,57 +119,87 @@ function buttonNode(extra: Record<string, unknown> = {}) {
   };
 }
 
-describe("clickElement diff:null note", () => {
-  it("emits the reworded non-retry note on a true no-op", async () => {
-    // before === after → identical text AND identical signals → null diff.
+describe("clickElement post-action snapshot", () => {
+  it("returns the post-action viewport snapshot in the `snapshot` field", async () => {
+    // Action tools no longer return a `diff`. They auto-attach a fresh
+    // viewport-scoped snapshot of the page state AFTER the click so the
+    // model can pick its next ref directly. (Diff semantics caused
+    // hallucinations when the prior snapshot was viewport-scoped and the
+    // post-action one was full-tree — see the rewrite of click-element.ts.)
     const tree = [buttonNode()];
     const driver = makeMockDriver({ axTrees: [tree, tree], url: URL });
 
-    // Priming capture: establishes baseline refs + snapshot + signals via the
-    // module-level ref store (setRefs is called internally). No manual setRefs
-    // needed, which avoids text-matching fragility.
     await captureSnapshot(driver, TAB_ID);
-
-    // Sanity: the single interactive button must have resolved to one ref.
-    const ref1 = onlyRef(TAB_ID);
+    const ref = onlyRef(TAB_ID);
 
     const result = await clickElementTool.execute(
-      { tab: "t1", target: ref1 },
+      { tab: "t1", target: ref },
       makeCtx(driver),
     );
 
     expect(result.clicked).toBe(true);
-    expect(result.diff).toBeNull();
-    expect(result.note).toBeDefined();
-    expect(result.note).toContain("Do NOT");
-    expect(result.note).toContain("blindly re-click");
-    // The reworded note must NOT contain the old "may not have had the
-    // expected effect" phrasing.
-    expect(result.note).not.toMatch(/may not have had the expected effect/);
+    // Old `diff` field is intentionally gone.
+    expect("diff" in result).toBe(false);
+    // New shape: viewport snapshot text, ref count, URL.
+    expect(result.snapshot).toBeDefined();
+    expect(result.snapshot).toContain('button "OK"');
+    expect(result.refCount).toBe(1);
+    expect(result.url).toBe(URL);
   });
 
-  it("returns non-null diff when only signals changed (aria-pressed toggle)", async () => {
-    // before: button not pressed; after: same button with aria-pressed=true.
-    // `pressed` is NOT rendered by formatProps, so the snapshot TEXT is
-    // identical before/after — this exercises the signal-only diff branch.
-    const before = [buttonNode()];
-    const after = [
-      buttonNode({ properties: [{ name: "pressed", value: { value: true } }] }),
-    ];
-    const driver = makeMockDriver({ axTrees: [before, after], url: URL });
+  it("returns the snapshot even when the post-action page state is unchanged", async () => {
+    // Identical before/after AX trees. With the diff-based design this used
+    // to emit a `diff: null` + a "do not retry" note. Now we just hand the
+    // model the viewport snapshot and let it judge whether the action
+    // worked from the snapshot text and its own memory of the prior state.
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL });
 
-    await captureSnapshot(driver, TAB_ID); // baseline: pressedCount 0
-
-    const ref2 = onlyRef(TAB_ID);
+    await captureSnapshot(driver, TAB_ID);
+    const ref = onlyRef(TAB_ID);
 
     const result = await clickElementTool.execute(
-      { tab: "t1", target: ref2 },
+      { tab: "t1", target: ref },
       makeCtx(driver),
     );
 
     expect(result.clicked).toBe(true);
-    expect(result.diff).not.toBeNull();
-    expect(result.diff).toContain("aria-pressed count: 0 → 1");
-    expect(result.note).toBeUndefined();
+    expect("diff" in result).toBe(false);
+    expect(result.snapshot).toBeDefined();
+    expect(result.snapshot).toContain('button "OK"');
+  });
+});
+
+describe("clickElement viewport-scoped post-action snapshot — regression", () => {
+  it("does NOT diff a prior viewport-scoped snapshot against a full-tree post-action capture", async () => {
+    // The historic bug: the user takes a viewport-scoped snapshot. The
+    // model clicks an element. The post-action capture defaulted to a
+    // full-tree snapshot. The diff therefore showed every below-fold
+    // element as `[+] added` and every viewport-rendered subtree pruned by
+    // a different rule as `[-] removed` — driving the model to hallucinate
+    // that the click had radically transformed the page.
+    //
+    // After the rewrite, action tools no longer diff; they capture a fresh
+    // viewport-scoped snapshot. So even with mode-asymmetric prior state,
+    // the result is just "here is the viewport now" — no false [+]/[-]
+    // lines.
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({ axTrees: [tree, tree], url: URL });
+    await captureSnapshot(driver, TAB_ID);
+    const ref = onlyRef(TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: ref },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.snapshot).toBeDefined();
+    // No diff syntax anywhere in the response.
+    expect(result.snapshot).not.toMatch(/^\[\+\] /m);
+    expect(result.snapshot).not.toMatch(/^\[-\] /m);
+    expect(result.snapshot).not.toMatch(/major change:/);
+    // Confirm the snapshot is the post-action tree, NOT a diff payload.
+    expect(result.snapshot).toContain('button "OK"');
   });
 });

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-hit-test.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-hit-test.test.ts
@@ -66,8 +66,15 @@ function makeMockDriver(opts: {
       if (method === "DOM.resolveNode")
         return { object: { objectId: "obj-1" } };
       if (method === "Runtime.evaluate") {
+        // Routed through Runtime.evaluate from three readers:
+        //   - waitForLayoutFlush (viewport.ts) — awaits a rAF promise.
+        //   - readViewportMetrics (viewport.ts) — reads { sx, sy, iw, ih }.
+        //   - getViewportInfo (snapshot-capture.ts) — reads { sy, vh }.
+        // We return a superset so any reader picks up its fields. `vh`
+        // mirrors `ih` so test-controlled `viewport.ih` flows to the
+        // post-action snapshot's below-fold computation too.
         const v = opts.viewport ?? { sx: 0, sy: 0, iw: 1280, ih: 800 };
-        return { result: { value: v } };
+        return { result: { value: { ...v, vh: v.ih } } };
       }
       if (method === "Runtime.callFunctionOn") {
         if (opts.failCallFunctionOn) {

--- a/apps/extension/src/lib/agent/tools/__tests__/click-element-hit-test.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/click-element-hit-test.test.ts
@@ -19,14 +19,29 @@ function makeMockDriver(opts: {
   url: string;
   hitBackendNodeId: number;
   describe?: { nodeName: string; attributes?: string[] };
+  /** Box model content quad in DOCUMENT coordinates — exactly what
+   *  `DOM.getBoxModel` returns. Defaults to a 10x10 box at origin. */
+  boxContent?: number[];
+  /** Live viewport metrics returned by `Runtime.evaluate` (legacy path) /
+   *  `Runtime.callFunctionOn` (atomic path). */
+  viewport?: { sx: number; sy: number; iw: number; ih: number };
+  /** Capture every CDP call into this array (used by the new tests). */
+  callLog?: Array<[string, Record<string, unknown> | undefined]>;
+  /** Capture every sendToContentScript message into this array. */
+  csLog?: Array<Record<string, unknown>>;
+  /** When true, `Runtime.callFunctionOn` throws — exercises the
+   *  `boxmodel-fallback` coord path that reads scroll/viewport via a
+   *  separate `Runtime.evaluate` instead. */
+  failCallFunctionOn?: boolean;
 }): BrowserDriver {
   let axIdx = 0;
   return {
     sendCommand: async (
       _tabId: unknown,
       method: string,
-      _params?: Record<string, unknown>,
+      params?: Record<string, unknown>,
     ): Promise<unknown> => {
+      if (opts.callLog) opts.callLog.push([method, params]);
       if (method === "Accessibility.getFullAXTree") {
         const nodes = opts.axTrees[Math.min(axIdx, opts.axTrees.length - 1)] ?? [];
         axIdx++;
@@ -34,7 +49,11 @@ function makeMockDriver(opts: {
       }
       if (method === "Target.getTargetInfo") return { targetInfo: { url: opts.url } };
       if (method === "DOM.getBoxModel")
-        return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+        return {
+          model: {
+            content: opts.boxContent ?? [0, 0, 10, 0, 10, 10, 0, 10],
+          },
+        };
       if (method === "DOM.getNodeForLocation")
         return { backendNodeId: opts.hitBackendNodeId };
       if (method === "DOM.describeNode")
@@ -44,11 +63,52 @@ function makeMockDriver(opts: {
             attributes: opts.describe?.attributes ?? [],
           },
         };
+      if (method === "DOM.resolveNode")
+        return { object: { objectId: "obj-1" } };
+      if (method === "Runtime.evaluate") {
+        const v = opts.viewport ?? { sx: 0, sy: 0, iw: 1280, ih: 800 };
+        return { result: { value: v } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        if (opts.failCallFunctionOn) {
+          throw new Error("callFunctionOn unavailable in test");
+        }
+        // Atomic geometry read: derive viewport rect from boxContent − scroll.
+        const v = opts.viewport ?? { sx: 0, sy: 0, iw: 1280, ih: 800 };
+        const c = opts.boxContent ?? [0, 0, 10, 0, 10, 10, 0, 10];
+        const docX = (c[0] + c[2] + c[4] + c[6]) / 4;
+        const docY = (c[1] + c[3] + c[5] + c[7]) / 4;
+        const w = Math.max(c[2], c[4]) - Math.min(c[0], c[6]);
+        const h = Math.max(c[5], c[7]) - Math.min(c[1], c[3]);
+        return {
+          result: {
+            value: {
+              vx: docX - v.sx - w / 2,
+              vy: docY - v.sy - h / 2,
+              vw: w,
+              vh: h,
+              sx: v.sx,
+              sy: v.sy,
+              iw: v.iw,
+              ih: v.ih,
+            },
+          },
+        };
+      }
+      // DOM.scrollIntoViewIfNeeded — return a non-null result so the call is
+      // counted as success (the helper only catches throws).
+      if (method === "DOM.scrollIntoViewIfNeeded") return {};
       return {};
     },
     getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
     waitForLoad: async () => undefined,
-    sendToContentScript: async () => ({ success: true }),
+    sendToContentScript: async (
+      _tabId: unknown,
+      message: Record<string, unknown>,
+    ) => {
+      if (opts.csLog) opts.csLog.push(message);
+      return { success: true };
+    },
   } as unknown as BrowserDriver;
 }
 
@@ -109,5 +169,233 @@ describe("clickByRef hit-target verification", () => {
     expect(result.note).toBeDefined();
     expect(result.note).toMatch(/intercept|overlay/i);
     expect(result.note).toContain("cookie-banner");
+  });
+});
+
+describe("clickByRef viewport coordinate conversion", () => {
+  it("subtracts scroll offset from box-model document coords before dispatching mouse events", async () => {
+    // Element at document coords (500, 6300)..(600, 6320). Page is scrolled
+    // to (0, 5800), so the element's VIEWPORT coords are (500..600, 500..520).
+    // Center should be (550, 510) in viewport space — NOT (550, 6310) which
+    // would be off-screen and silently no-op the click.
+    const calls: Array<[string, Record<string, unknown> | undefined]> = [];
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+      boxContent: [500, 6300, 600, 6300, 600, 6320, 500, 6320],
+      viewport: { sx: 0, sy: 5800, iw: 1280, ih: 800 },
+      callLog: calls,
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.note ?? "").not.toMatch(/outside the visible viewport/);
+
+    const mouseCalls = calls.filter(([m]) => m === "Input.dispatchMouseEvent");
+    // mouseMoved + mousePressed + mouseReleased
+    expect(mouseCalls).toHaveLength(3);
+    for (const [, params] of mouseCalls) {
+      expect(params?.x).toBe(550);
+      expect(params?.y).toBe(510);
+    }
+  });
+
+  it("calls DOM.scrollIntoViewIfNeeded before reading the final box model", async () => {
+    const calls: Array<[string, Record<string, unknown> | undefined]> = [];
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+      callLog: calls,
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+
+    const scrollIdx = calls.findIndex(
+      ([m]) => m === "DOM.scrollIntoViewIfNeeded",
+    );
+    expect(scrollIdx).toBeGreaterThanOrEqual(0);
+    // The post-scroll getBoxModel re-read happens AFTER the scroll call — and
+    // before any Input.dispatchMouseEvent.
+    const boxIdxAfterScroll = calls.findIndex(
+      ([m], i) => i > scrollIdx && m === "DOM.getBoxModel",
+    );
+    const firstMouseIdx = calls.findIndex(
+      ([m]) => m === "Input.dispatchMouseEvent",
+    );
+    expect(boxIdxAfterScroll).toBeGreaterThan(scrollIdx);
+    expect(firstMouseIdx).toBeGreaterThan(boxIdxAfterScroll);
+  });
+
+  it("warns when the element remains outside the viewport even after scrollIntoViewIfNeeded", async () => {
+    // Box at document-y 10000, viewport scroll-y 0, viewport height 800 →
+    // viewport-y 10000, which is outside [0, 800]. scrollIntoViewIfNeeded
+    // is mocked as a no-op so the post-scroll re-read returns the same box.
+    // The tool should still dispatch (so we never silently swallow an
+    // attempted click) but attach a clear off-viewport warning.
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+      boxContent: [500, 10000, 600, 10000, 600, 10020, 500, 10020],
+      viewport: { sx: 0, sy: 0, iw: 1280, ih: 800 },
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+
+    expect(result.clicked).toBe(true);
+    expect(result.note).toBeDefined();
+    expect(result.note).toMatch(/outside the visible viewport/);
+  });
+});
+
+describe("clickByRef visual ripple", () => {
+  it("emits a CHAT_CUA_CLICK_RIPPLE message at the dispatch coords (parity with the CUA loop's click animation)", async () => {
+    // Same coord setup as the viewport-conversion test: element at doc
+    // (500..600, 6300..6320), scrolled to sy=5800 → viewport-center (550, 510).
+    // After dispatch, the tool should send a ripple at exactly (550, 510)
+    // so a human watching the live tab sees the same animation the CUA
+    // subagent emits.
+    const csMessages: Array<Record<string, unknown>> = [];
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+      boxContent: [500, 6300, 600, 6300, 600, 6320, 500, 6320],
+      viewport: { sx: 0, sy: 5800, iw: 1280, ih: 800 },
+      csLog: csMessages,
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+    // The ripple is fire-and-forget — let the void promise resolve.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const ripples = csMessages.filter(
+      (m) => m.type === "CHAT_CUA_CLICK_RIPPLE",
+    );
+    expect(ripples).toHaveLength(1);
+    expect(ripples[0]).toMatchObject({
+      type: "CHAT_CUA_CLICK_RIPPLE",
+      x: 550,
+      y: 510,
+    });
+  });
+
+  it("does not block or fail the click if the ripple message dispatch throws", async () => {
+    // Override sendToContentScript to throw on the ripple. Click must still
+    // succeed — the ripple is purely a visual flourish.
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+    });
+    // Replace sendToContentScript with one that throws on ripple but returns
+    // success on every other content-script call (passthrough toggles, etc.).
+    (driver as { sendToContentScript: unknown }).sendToContentScript = async (
+      _tabId: unknown,
+      message: Record<string, unknown>,
+    ) => {
+      if (message.type === "CHAT_CUA_CLICK_RIPPLE") {
+        throw new Error("no content script");
+      }
+      return { success: true };
+    };
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+    expect(result.clicked).toBe(true);
+  });
+});
+
+describe("clickByRef boxmodel-fallback coord path (gBCR unavailable)", () => {
+  it("uses live readViewportMetrics for scroll/viewport when Runtime.callFunctionOn fails", async () => {
+    // The bug this regresses: when the atomic gBCR read throws (detached
+    // objectId, debugger doesn't support callFunctionOn), the fallback used
+    // to compute coords as `postDocX - postGeom.scrollX`, but
+    // postGeom.scrollX is the zero-sentinel from readElementGeometry's
+    // empty result on failure. Result: clicks dispatched at DOCUMENT coords
+    // and silently missed any element below scroll(0,0). The fix reads
+    // scroll/viewport via a separate Runtime.evaluate when in fallback.
+    //
+    // Element at document (500..600, 6300..6320). Page scrolled to sy=5800.
+    // Correct viewport-center: (550, 510). Wrong (pre-fix) coord: (550, 6310).
+    const calls: Array<[string, Record<string, unknown> | undefined]> = [];
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+      boxContent: [500, 6300, 600, 6300, 600, 6320, 500, 6320],
+      viewport: { sx: 0, sy: 5800, iw: 1280, ih: 800 },
+      callLog: calls,
+      failCallFunctionOn: true,
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+    expect(result.clicked).toBe(true);
+    // Must NOT report off-viewport — coords were correct, just via fallback.
+    expect(result.note ?? "").not.toMatch(/outside the visible viewport/);
+
+    const mouseCalls = calls.filter(([m]) => m === "Input.dispatchMouseEvent");
+    expect(mouseCalls).toHaveLength(3);
+    for (const [, params] of mouseCalls) {
+      expect(params?.x).toBe(550); // viewport-center X
+      expect(params?.y).toBe(510); // viewport-center Y (NOT 6310 — that's docY)
+    }
+  });
+
+  it("flags off-viewport correctly in fallback when readViewportMetrics shows the element below the fold", async () => {
+    // gBCR fails AND the element is way below the viewport. We must still
+    // surface the off-viewport warning — pre-fix, innerW/H came from
+    // postGeom (zero in the empty-result), so the guard's `innerW > 0`
+    // check was false and the warning never fired.
+    const tree = [buttonNode()];
+    const driver = makeMockDriver({
+      axTrees: [tree, tree],
+      url: URL,
+      hitBackendNodeId: 99,
+      boxContent: [500, 10000, 600, 10000, 600, 10020, 500, 10020],
+      viewport: { sx: 0, sy: 0, iw: 1280, ih: 800 },
+      failCallFunctionOn: true,
+    });
+    await captureSnapshot(driver, TAB_ID);
+
+    const result = await clickElementTool.execute(
+      { tab: "t1", target: onlyRef(TAB_ID) },
+      makeCtx(driver),
+    );
+    expect(result.clicked).toBe(true);
+    expect(result.note).toBeDefined();
+    expect(result.note).toMatch(/outside the visible viewport/);
   });
 });

--- a/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
@@ -31,10 +31,12 @@ function makeMockDriver(opts: {
         return {};
       }
       if (method === "Runtime.evaluate") {
-        // Used by the post-action viewport-only snapshot path (scroll +
-        // viewport metrics).
+        // Two readers route through Runtime.evaluate here:
+        //   - readViewportMetrics (viewport.ts) — reads { sx, sy, iw, ih }.
+        //   - getViewportInfo (snapshot-capture.ts) — reads { sy, vh }.
+        // The mock returns a superset so both readers see consistent data.
         return {
-          result: { value: { sx: 0, sy: 0, iw: 1280, ih: 800 } },
+          result: { value: { sx: 0, sy: 0, iw: 1280, ih: 800, vh: 800 } },
         };
       }
       return {};

--- a/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/press-key.test.ts
@@ -30,6 +30,13 @@ function makeMockDriver(opts: {
         opts.keyEvents.push(params ?? {});
         return {};
       }
+      if (method === "Runtime.evaluate") {
+        // Used by the post-action viewport-only snapshot path (scroll +
+        // viewport metrics).
+        return {
+          result: { value: { sx: 0, sy: 0, iw: 1280, ih: 800 } },
+        };
+      }
       return {};
     },
     getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
@@ -107,15 +114,21 @@ describe("pressKey", () => {
     expect(focusedBackendNodeId).toBe(99);
   });
 
-  it("emits a non-retry note on a true no-op diff", async () => {
+  it("returns the post-action viewport snapshot in the `snapshot` field", async () => {
+    // Action tools no longer return a `diff`. They auto-attach a fresh
+    // viewport-scoped snapshot of the page state AFTER the action so the
+    // model can pick its next ref directly.
     const tree = [buttonNode()];
     const driver = makeMockDriver({ axTrees: [tree, tree], url: URL, keyEvents: [] });
     await captureSnapshot(driver, TAB_ID);
 
     const result = await pressKeyTool.execute({ tab: "t1", key: "ArrowDown" }, makeCtx(driver));
 
-    expect(result.diff).toBeNull();
-    expect(result.note).toContain("Do NOT");
-    expect(result.note).toContain("blindly repeat");
+    expect(result.pressed).toBe(true);
+    expect("diff" in result).toBe(false);
+    expect(result.snapshot).toBeDefined();
+    expect(result.snapshot).toContain('button "OK"');
+    expect(result.refCount).toBe(1);
+    expect(result.url).toBe(URL);
   });
 });

--- a/apps/extension/src/lib/agent/tools/__tests__/type-in-element-diff.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/type-in-element-diff.test.ts
@@ -33,9 +33,12 @@ function makeMockDriver(opts: {
         return { targetInfo: { url: opts.url } };
       }
       if (method === "Runtime.evaluate") {
-        // Used by the viewport-only snapshot path (scroll + viewport size).
+        // Two readers route through Runtime.evaluate here:
+        //   - readViewportMetrics (viewport.ts) — reads { sx, sy, iw, ih }.
+        //   - getViewportInfo (snapshot-capture.ts) — reads { sy, vh }.
+        // The mock returns a superset so both readers see consistent data.
         return {
-          result: { value: { sx: 0, sy: 0, iw: 1280, ih: 800 } },
+          result: { value: { sx: 0, sy: 0, iw: 1280, ih: 800, vh: 800 } },
         };
       }
       return {};

--- a/apps/extension/src/lib/agent/tools/__tests__/type-in-element-diff.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/type-in-element-diff.test.ts
@@ -32,6 +32,12 @@ function makeMockDriver(opts: {
       if (method === "Target.getTargetInfo") {
         return { targetInfo: { url: opts.url } };
       }
+      if (method === "Runtime.evaluate") {
+        // Used by the viewport-only snapshot path (scroll + viewport size).
+        return {
+          result: { value: { sx: 0, sy: 0, iw: 1280, ih: 800 } },
+        };
+      }
       return {};
     },
     getTab: async () => ({ id: TAB_ID, url: opts.url, title: "test" }),
@@ -89,16 +95,18 @@ function tree(focusOnHiddenNode: boolean) {
   ];
 }
 
-describe("typeInElement signal-only diff", () => {
-  it("returns non-null diff when only the focus signal changed", async () => {
-    const before = tree(false); // no focus
-    const after = tree(true); // focus moved to the (non-rendered) node
+describe("typeInElement post-action snapshot", () => {
+  it("returns the post-action viewport snapshot in the `snapshot` field", async () => {
+    // Action tools no longer return a `diff`. They auto-attach a fresh
+    // viewport-scoped snapshot of the page state AFTER the action so the
+    // model can pick its next ref directly. See click-element.ts for the
+    // rewrite rationale (mode-asymmetric diffs were hallucinating).
+    const before = tree(false);
+    const after = tree(true);
     const driver = makeMockDriver({ axTrees: [before, after], url: URL });
 
-    // Priming capture establishes baseline (focusedBackendNodeId null).
     await captureSnapshot(driver, TAB_ID);
 
-    // The visible textbox is the single interactive node → one stable ref.
     const refs = getRefsForTab(TAB_ID);
     expect(refs?.size).toBe(1);
     const ref = [...(refs?.keys() ?? [])][0];
@@ -110,8 +118,13 @@ describe("typeInElement signal-only diff", () => {
     );
 
     expect(result.typed).toBe(true);
-    expect(result.diff).not.toBeNull();
-    expect(result.diff).toContain("focus moved");
-    expect(result.note).toBeUndefined();
+    expect("diff" in result).toBe(false);
+    expect(result.snapshot).toBeDefined();
+    // The post-action snapshot must contain the textbox (it's the only
+    // visible interactive element). Don't assert tree(after)'s focus
+    // property — that's an internal signal, not rendered text.
+    expect(result.snapshot).toContain('textbox "Email"');
+    expect(result.refCount).toBe(1);
+    expect(result.url).toBe(URL);
   });
 });

--- a/apps/extension/src/lib/agent/tools/click-element.ts
+++ b/apps/extension/src/lib/agent/tools/click-element.ts
@@ -1,16 +1,23 @@
 import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
+import {
+  runClickDiagnostic,
+  setShieldPassthrough,
+} from "../click-diagnostic";
 import type { BrowserDriver, TabId } from "../driver";
 import { resolveTabOrThrow } from "../driver";
 import {
   getRef,
-  getPreviousSnapshot,
-  getPreviousSignals,
   invalidateRefsIfNavigated,
 } from "../ref-store";
 import {
+  readElementGeometry,
+  readViewportMetrics,
+  scrollIntoViewIfNeeded,
+  waitForLayoutFlush,
+} from "../viewport";
+import {
   captureSnapshot,
-  diffSnapshots,
   findNodeByRoleNameNth,
 } from "../snapshot-capture";
 import type { BrowserTool } from "../types";
@@ -34,7 +41,14 @@ const outputSchema = z.object({
   tab: z.string(),
   clicked: z.literal(true),
   target: z.string(),
-  diff: z.string().nullable().optional(),
+  /** Viewport-scoped a11y tree of the page AFTER the click. Mirrors the
+   *  shape of `snapshot({mode: "viewport"})`. Empty when the post-action
+   *  capture failed (see `note`). */
+  snapshot: z.string().optional(),
+  refCount: z.number().optional(),
+  url: z.string().optional(),
+  belowFoldCount: z.number().optional(),
+  hint: z.string().optional(),
   note: z.string().optional(),
 });
 type Output = z.infer<typeof outputSchema>;
@@ -42,15 +56,13 @@ type Output = z.infer<typeof outputSchema>;
 export const clickElementTool: BrowserTool<Input, Output> = {
   name: "clickElement",
   description:
-    "Click an element on a page. Pass `tab` (handle from the tab legend or listTabs) and `target` — either an @ref from a recent snapshot of THAT tab (preferred) or a CSS selector as fallback. The response automatically includes a diff of what changed on the page — use it to verify the action worked before acting again. If diff is null the click produced no visible change.",
+    "Click an element on a page. Pass `tab` (handle from the tab legend or listTabs) and `target` — either an @ref from a recent snapshot of THAT tab (preferred) or a CSS selector as fallback. The response auto-attaches a viewport-scoped accessibility snapshot of the page AFTER the click so you can see the current state and pick the next ref without a follow-up snapshot call. Call snapshot explicitly when you need the full tree, a different scope, or the section below the fold.",
   parameters,
   outputSchema,
   execute: async ({ tab: handle, target }, ctx) => {
     const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
-
-    const previousSnapshot = getPreviousSnapshot(tabId);
-    const previousSignals = getPreviousSignals(tabId);
+    const previousUrl = tab.url ?? undefined;
 
     let hitWarning: string | undefined;
     try {
@@ -73,53 +85,58 @@ export const clickElementTool: BrowserTool<Input, Output> = {
     await new Promise((r) => setTimeout(r, 250));
     await ctx.driver.waitForLoad(tabId, 3000).catch(() => {});
 
-    // Auto-attach diff so the agent can verify the outcome without a follow-up
-    // snapshot call. If we have no prior baseline, capture fresh and bail.
-    if (!previousSnapshot || !previousSignals) {
-      try {
-        await captureSnapshot(ctx.driver, tabId);
-      } catch {
-        // page may have navigated away / tab closed; ignore
-      }
-      return { tab: handle, clicked: true, target, ...(hitWarning && { note: hitWarning }) };
-    }
+    // If the click navigated to a different document, drop the stale ref map
+    // (incl. the carry-over pool) BEFORE the post-action snapshot's merge so
+    // old-page refs can't leak into the new page — mirrors navigate.ts.
+    // In-page re-renders (same URL) keep the content-stable carry-over.
+    await invalidateRefsIfNavigated(ctx.driver, tabId, previousUrl);
 
+    // Capture a viewport-scoped snapshot of the post-action state. We auto-
+    // attach this in place of a `diff` for two reasons:
+    //   1. Diffs hallucinated when the prior snapshot was viewport-scoped
+    //      and this post-action capture was full-tree — every below-fold
+    //      element looked "added" to the model.
+    //   2. The agent almost always needs to see the current viewport state
+    //      to pick its next move (especially after scroll-triggering
+    //      clicks like anchor links). Returning the snapshot directly is
+    //      strictly more informative than returning a diff.
+    let url = previousUrl ?? "";
     try {
-      // If the click navigated to a different document, drop the stale ref map
-      // (incl. the carry-over pool) BEFORE the post-action snapshot's merge so
-      // old-page refs can't leak into the new page — mirrors navigate.ts.
-      // In-page re-renders (same URL) keep the content-stable carry-over.
-      await invalidateRefsIfNavigated(ctx.driver, tabId, previousSignals.url);
-      const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
-      const diff = diffSnapshots(
-        { text: previousSnapshot, signals: previousSignals },
-        { text: snapshotText, signals },
-      );
-      if (diff === null) {
-        return {
-          tab: handle,
-          clicked: true,
-          target,
-          diff: null,
-          note:
-            (hitWarning ? hitWarning + " " : "") +
-            "Accessibility tree and element state unchanged. This may still " +
-            "have succeeded (some changes aren't reflected here). Do NOT " +
-            "blindly re-click — verify with a screenshot or by reading " +
-            "element state before retrying.",
-        };
+      const fresh = await ctx.driver.getTab(tabId);
+      url = fresh.url ?? url;
+    } catch {
+      // tab may have closed during the action — keep the stale url
+    }
+    try {
+      const cap = await captureSnapshot(ctx.driver, tabId, {
+        mode: "interactive",
+        viewportOnly: true,
+      });
+      const result: Output = {
+        tab: handle,
+        clicked: true,
+        target,
+        snapshot: cap.snapshotText,
+        refCount: cap.refs.size,
+        url,
+      };
+      if (cap.belowFoldCount > 0) {
+        result.belowFoldCount = cap.belowFoldCount;
+        result.hint = `${cap.belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`;
       }
-      return { tab: handle, clicked: true, target, diff, ...(hitWarning && { note: hitWarning }) };
+      if (hitWarning) result.note = hitWarning;
+      return result;
     } catch (err) {
       return {
         tab: handle,
         clicked: true,
         target,
+        url,
         note:
           (hitWarning ? hitWarning + " " : "") +
           `Click succeeded but post-action snapshot failed: ${
             err instanceof Error ? err.message : String(err)
-          }`,
+          }. Call snapshot to retry.`,
       };
     }
   },
@@ -165,40 +182,205 @@ async function clickByRef(
     );
   }
 
-  const pts = boxResult;
-  const x = (pts[0] + pts[2] + pts[4] + pts[6]) / 4;
-  const y = (pts[1] + pts[3] + pts[5] + pts[7]) / 4;
+  // ── Forensic geometry pass ─────────────────────────────────────────────
+  // We capture the element's geometry FOUR ways to disambiguate the
+  // off-viewport failures the diagnostic surfaced previously:
+  //
+  //   1. Pre-scroll  getBoxModel               (DOC space)
+  //   2. Pre-scroll  getBoundingClientRect     (VIEWPORT space, atomic w/ scroll)
+  //                  ↓ scrollIntoViewIfNeeded ↓
+  //                  ↓ waitForLayoutFlush     ↓ (two rAFs — settle smooth-scroll)
+  //   3. Post-scroll getBoxModel               (DOC space)
+  //   4. Post-scroll getBoundingClientRect     (VIEWPORT space, atomic w/ scroll)
+  //
+  // Reads 2 and 4 also capture live `scrollY` and `innerHeight` IN THE SAME
+  // FRAME as the rect, eliminating the inter-call race that
+  // (getBoxModel → readViewportMetrics) was vulnerable to.
+  //
+  // The DISPATCHED click coordinates are taken from read #4 — the atomic
+  // post-scroll viewport rect — which is correct by construction. Reads
+  // 1–3 exist purely to log and confirm whether (a) scrollIntoViewIfNeeded
+  // moved the page, (b) the box-model approach agrees with gBCR, and
+  // (c) the layout-flush wait is needed.
+  const preBox = boxResult;
+  const preDocX = (preBox[0] + preBox[2] + preBox[4] + preBox[6]) / 4;
+  const preDocY = (preBox[1] + preBox[3] + preBox[5] + preBox[7]) / 4;
+  const preGeom = await readElementGeometry(driver, tabId, backendNodeId);
 
-  const warning = await verifyHitTarget(
-    driver,
-    tabId,
-    x,
-    y,
-    backendNodeId,
-    ref,
+  // Scroll the element into view. CDP `Input.dispatchMouseEvent` only
+  // dispatches into the visible viewport, so an element below the fold
+  // otherwise receives a silent no-op click. Best-effort.
+  await scrollIntoViewIfNeeded(driver, tabId, backendNodeId);
+  // Two rAFs to flush layout + commit any smooth-scroll animation. Without
+  // this wait, the post-scroll reads can return pre-scroll positions on
+  // pages with `scroll-behavior: smooth` or scroll-snap.
+  await waitForLayoutFlush(driver, tabId);
+
+  const postBox = (await getBoxModel(driver, tabId, backendNodeId)) ?? preBox;
+  const postDocX = (postBox[0] + postBox[2] + postBox[4] + postBox[6]) / 4;
+  const postDocY = (postBox[1] + postBox[3] + postBox[5] + postBox[7]) / 4;
+  const postGeom = await readElementGeometry(driver, tabId, backendNodeId);
+
+  // Pick the click point. Prefer the atomic gBCR center (read #4) because
+  // it's intrinsically scroll-consistent. Fall back to the legacy
+  // box-model − scroll path so a debugger that doesn't support
+  // `Runtime.callFunctionOn` (or a detached objectId) doesn't break clicks.
+  let x: number;
+  let y: number;
+  let coordSource: "gbcr" | "boxmodel-fallback";
+  // Resolved viewport metrics for the off-viewport guard and the dispatch
+  // log. When gBCR succeeded these come from postGeom (atomic-with-rect);
+  // when it failed we read them separately so the fallback still has truth-
+  // ful innerWidth/Height instead of postGeom's zeroed sentinels.
+  let scrollX = postGeom.scrollX;
+  let scrollY = postGeom.scrollY;
+  let innerW = postGeom.innerWidth;
+  let innerH = postGeom.innerHeight;
+  if (postGeom.ok) {
+    x = postGeom.vx + postGeom.vw / 2;
+    y = postGeom.vy + postGeom.vh / 2;
+    coordSource = "gbcr";
+  } else {
+    // gBCR failed (detached objectId, debugger doesn't support
+    // callFunctionOn, etc.). Read scroll/viewport SEPARATELY — falling
+    // back to `postGeom.scrollX/Y` is wrong because they're zeroed-out
+    // sentinels from `readElementGeometry`'s empty result, which would
+    // make us dispatch at document coords and silently miss any element
+    // that isn't at scroll(0,0). Mirrors the document↔viewport conversion
+    // the gBCR path gets atomically.
+    const vp = await readViewportMetrics(driver, tabId);
+    scrollX = vp.scrollX;
+    scrollY = vp.scrollY;
+    innerW = vp.innerWidth;
+    innerH = vp.innerHeight;
+    x = postDocX - scrollX;
+    y = postDocY - scrollY;
+    coordSource = "boxmodel-fallback";
+  }
+
+  // Off-viewport guard. After scrollIntoView + flush the element should be
+  // in view; if it still isn't, surface a clear warning instead of silently
+  // dispatching into the void. Uses the resolved viewport (from gBCR when
+  // available, else from the separate readViewportMetrics call above) so
+  // the guard works in both code paths.
+  const offViewport =
+    x < 0 ||
+    y < 0 ||
+    (innerW > 0 && x > innerW) ||
+    (innerH > 0 && y > innerH);
+  let offViewportNote: string | undefined;
+  if (offViewport) {
+    offViewportNote =
+      `Click point for ${ref} resolved to viewport (${Math.round(x)},${Math.round(y)}) ` +
+      `outside the visible viewport ${innerW}x${innerH}. ` +
+      `Pre-scroll: doc=(${Math.round(preDocX)},${Math.round(preDocY)}) ` +
+      `gBCR=(${Math.round(preGeom.vx)},${Math.round(preGeom.vy)}) ` +
+      `scroll=(${preGeom.scrollX},${preGeom.scrollY}). ` +
+      `Post-scroll: doc=(${Math.round(postDocX)},${Math.round(postDocY)}) ` +
+      `gBCR=(${Math.round(postGeom.vx)},${Math.round(postGeom.vy)}) ` +
+      `scroll=(${scrollX},${scrollY}). ` +
+      `coordSource=${coordSource}. scrollIntoViewIfNeeded did not land it ` +
+      `in view (likely a fixed-position ancestor, transform, or the ` +
+      `model's ref is stale — try snapshot then scrollPage before retrying).`;
+  }
+
+  // Verbose dispatch log. Includes pre/post snapshots so the next time we
+  // see an off-viewport failure we can tell at a glance whether
+  // scrollIntoView moved anything (compare pre vs post scroll/gBCR), and
+  // whether getBoxModel and gBCR agree (they should after settle).
+  // Logged at console.debug — hidden by default, surfaces when DevTools
+  // verbose logging is enabled. The forensic value is real but the
+  // per-click rate makes console.info too noisy for production.
+  console.debug(
+    `[click-tool] dispatch ref=${ref} dispatch=(${Math.round(x)},${Math.round(y)}) ` +
+      `src=${coordSource} ` +
+      `pre={ doc=(${Math.round(preDocX)},${Math.round(preDocY)}) ` +
+      `gbcr=(${Math.round(preGeom.vx)},${Math.round(preGeom.vy)})+(${Math.round(preGeom.vw)}x${Math.round(preGeom.vh)}) ` +
+      `scroll=(${preGeom.scrollX},${preGeom.scrollY}) ` +
+      `vp=${preGeom.innerWidth}x${preGeom.innerHeight} ok=${preGeom.ok} } ` +
+      `post={ doc=(${Math.round(postDocX)},${Math.round(postDocY)}) ` +
+      `gbcr=(${Math.round(postGeom.vx)},${Math.round(postGeom.vy)})+(${Math.round(postGeom.vw)}x${Math.round(postGeom.vh)}) ` +
+      `scroll=(${postGeom.scrollX},${postGeom.scrollY}) ` +
+      `vp=${postGeom.innerWidth}x${postGeom.innerHeight} ok=${postGeom.ok} } ` +
+      `offViewport=${offViewport} tab=${String(tabId)}` +
+      (preGeom.error ? ` preErr="${preGeom.error}"` : "") +
+      (postGeom.error ? ` postErr="${postGeom.error}"` : ""),
   );
 
-  await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
-    type: "mouseMoved",
-    x,
-    y,
-  });
-  await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
-    type: "mousePressed",
-    x,
-    y,
-    button: "left",
-    clickCount: 1,
-  });
-  await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
-    type: "mouseReleased",
-    x,
-    y,
-    button: "left",
-    clickCount: 1,
-  });
+  // The "agent is working" overlay's input shield (mounted by
+  // notifyAgentStatus(true) for ANY agent run, not just CUA) sits at the top
+  // of the DOM with pointer-events:auto. CDP `Input.dispatchMouseEvent`
+  // produces TRUSTED browser events that respect DOM hit-testing — so without
+  // this toggle every main-agent click lands on the shield and the page
+  // never sees it. Mirrors cua-loop.ts. Awaited so the shield is provably
+  // down before the click and back up after; no-op when no shield is mounted.
+  await setShieldPassthrough(driver, tabId, true);
+  // Two forensic diagnostics, BOTH inside the passthrough window:
+  //   pre-dispatch:  proves whether the shield's `pointer-events:none` toggle
+  //                  actually took effect at click time. If shieldPE != "none"
+  //                  here, the toggle didn't propagate and the click WILL be
+  //                  eaten — even though we asked for passthrough.
+  //   post-dispatch: confirms (or refutes) that nothing transient (animation,
+  //                  timeout, micro-task) put a different element at the
+  //                  click point between our hit-test and the dispatch.
+  // Both run inside the passthrough window so the shield is `pointer-events:
+  // none` for both reads (when the toggle is working). Earlier we ran ONLY a
+  // post-dispatch diagnostic AFTER the passthrough was toggled back off,
+  // which produced a guaranteed false-positive `OVERLAY-INTERCEPT` every
+  // single click and masked the actual signal.
+  let hitWarning: string | undefined;
+  try {
+    hitWarning = await verifyHitTarget(
+      driver,
+      tabId,
+      x,
+      y,
+      backendNodeId,
+      ref,
+    );
+    await runClickDiagnostic(driver, tabId, "tool/clickByRef:pre", x, y);
+    await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x,
+      y,
+    });
+    await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x,
+      y,
+      button: "left",
+      clickCount: 1,
+    });
+    await driver.sendCommand(tabId, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x,
+      y,
+      button: "left",
+      clickCount: 1,
+    });
+    await runClickDiagnostic(driver, tabId, "tool/clickByRef:post", x, y);
+  } finally {
+    await setShieldPassthrough(driver, tabId, false);
+  }
 
-  return { warning };
+  // Visual feedback: emit the same click ripple the CUA loop fires after a
+  // click, so a human watching the live tab sees a transient dot at the
+  // dispatch point. Mirrors cua-loop.ts. Fire-and-forget — a ripple must
+  // never fail or delay a click.
+  void driver
+    .sendToContentScript(tabId, { type: "CHAT_CUA_CLICK_RIPPLE", x, y })
+    .catch(() => {});
+
+  // Compose the final warning so the off-viewport note (if any) is surfaced
+  // alongside the hit-target warning. Off-viewport takes priority because
+  // it's a strictly more actionable signal — a hit-target mismatch is moot
+  // if the click never landed.
+  const warning = offViewportNote
+    ? hitWarning
+      ? `${offViewportNote} ${hitWarning}`
+      : offViewportNote
+    : hitWarning;
+  return warning ? { warning } : {};
 }
 
 /**
@@ -225,6 +407,14 @@ async function clickBySelector(
   tabId: TabId,
   selector: string,
 ): Promise<void> {
+  // Logged at debug to mirror clickByRef. NOTE: this path uses the content
+  // script's `el.click()` (synthetic JS click), NOT CDP — overlays do not
+  // hit-test synthetic clicks, so no post-dispatch [click-diag] is needed
+  // here. If a clickBySelector silently fails it's an `el.click()` no-op,
+  // not an overlay-interception issue.
+  console.debug(
+    `[click-tool] dispatch selector="${selector}" tab=${String(tabId)} (synthetic)`,
+  );
   const result = await driver.sendToContentScript<{
     success: boolean;
     error?: string;

--- a/apps/extension/src/lib/agent/tools/press-key.ts
+++ b/apps/extension/src/lib/agent/tools/press-key.ts
@@ -1,15 +1,15 @@
 import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
+import { setShieldPassthrough } from "../click-diagnostic";
 import type { BrowserDriver, TabId } from "../driver";
 import { resolveTabOrThrow } from "../driver";
 import {
   getRef,
-  getPreviousSnapshot,
-  getPreviousSignals,
   invalidateRefsIfNavigated,
 } from "../ref-store";
 import { dispatchKeyCombo } from "../keyboard";
-import { captureSnapshot, diffSnapshots, findNodeByRoleNameNth } from "../snapshot-capture";
+import { captureSnapshot, findNodeByRoleNameNth } from "../snapshot-capture";
+import { scrollIntoViewIfNeeded } from "../viewport";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -37,7 +37,14 @@ const outputSchema = z.object({
   tab: z.string(),
   pressed: z.literal(true),
   key: z.string(),
-  diff: z.string().nullable().optional(),
+  /** Viewport-scoped a11y tree of the page AFTER the key press. Mirrors
+   *  the shape of `snapshot({mode: "viewport"})`. Empty when the post-action
+   *  capture failed (see `note`). */
+  snapshot: z.string().optional(),
+  refCount: z.number().optional(),
+  url: z.string().optional(),
+  belowFoldCount: z.number().optional(),
+  hint: z.string().optional(),
   note: z.string().optional(),
 });
 type Output = z.infer<typeof outputSchema>;
@@ -45,23 +52,34 @@ type Output = z.infer<typeof outputSchema>;
 export const pressKeyTool: BrowserTool<Input, Output> = {
   name: "pressKey",
   description:
-    "Press a keyboard key or combo (e.g. 'Enter', 'Escape', 'Tab', 'ctrl+a', arrow keys). Sends the key to the focused element, or pass `target` (@ref) to focus an element first. Useful for closing modals (Escape), navigating lists (arrows), submitting (Enter), or page-level shortcuts. The response includes a diff of what changed — use it to verify the key had an effect before pressing again.",
+    "Press a keyboard key or combo (e.g. 'Enter', 'Escape', 'Tab', 'ctrl+a', arrow keys). Sends the key to the focused element, or pass `target` (@ref) to focus an element first. Useful for closing modals (Escape), navigating lists (arrows), submitting (Enter), or page-level shortcuts. The response auto-attaches a viewport-scoped accessibility snapshot of the page AFTER the action so you can see the current state and pick the next ref without a follow-up snapshot call. Call snapshot explicitly when you need the full tree, a different scope, or the section below the fold.",
   parameters,
   outputSchema,
   execute: async ({ tab: handle, key, target }, ctx) => {
     const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
-
-    const previousSnapshot = getPreviousSnapshot(tabId);
-    const previousSignals = getPreviousSignals(tabId);
+    const previousUrl = tab.url ?? undefined;
 
     try {
-      if (target) {
-        await focusRef(ctx.driver, tabId, target);
+      // The "agent is working" overlay's document-level key blocker swallows
+      // CDP-dispatched keys when `cuaAgentActing` is false. Toggle passthrough
+      // around focus + key dispatch so the keys reach the page. Mirrors
+      // cua-loop.ts. No-op when no shield is mounted.
+      console.debug(
+        `[press-key] dispatch key="${key}" tab=${String(tabId)}` +
+          (target ? ` target=${target}` : ""),
+      );
+      await setShieldPassthrough(ctx.driver, tabId, true);
+      try {
+        if (target) {
+          await focusRef(ctx.driver, tabId, target);
+        }
+        // Split "ctrl+a" -> ["ctrl", "a"]; a bare key -> ["Enter"].
+        const keys = key.split("+").map((k) => k.trim()).filter(Boolean);
+        await dispatchKeyCombo(ctx.driver, tabId, keys);
+      } finally {
+        await setShieldPassthrough(ctx.driver, tabId, false);
       }
-      // Split "ctrl+a" -> ["ctrl", "a"]; a bare key -> ["Enter"].
-      const keys = key.split("+").map((k) => k.trim()).filter(Boolean);
-      await dispatchKeyCombo(ctx.driver, tabId, keys);
     } catch (err) {
       if (!isDetachError(err)) throw err;
       // A key (e.g. Enter) may trigger navigation that detaches the debugger.
@@ -74,47 +92,47 @@ export const pressKeyTool: BrowserTool<Input, Output> = {
     await new Promise((r) => setTimeout(r, 200));
     await ctx.driver.waitForLoad(tabId, 3000).catch(() => {});
 
-    if (!previousSnapshot || !previousSignals) {
-      try {
-        await captureSnapshot(ctx.driver, tabId);
-      } catch {
-        // page may have navigated away / tab closed; ignore
-      }
-      return { tab: handle, pressed: true, key };
+    // If the key navigated to a different document, drop stale refs BEFORE
+    // the snapshot's merge so old-page refs can't leak.
+    await invalidateRefsIfNavigated(ctx.driver, tabId, previousUrl);
+
+    let url = previousUrl ?? "";
+    try {
+      const fresh = await ctx.driver.getTab(tabId);
+      url = fresh.url ?? url;
+    } catch {
+      // tab may have closed during the action — keep the stale url
     }
 
+    // Auto-attach a fresh VIEWPORT-scoped snapshot in place of a diff. See
+    // click-element.ts for the full rationale.
     try {
-      // If the key (e.g. Enter) navigated to a different document, drop the
-      // stale ref map BEFORE the snapshot's merge so old-page refs can't leak —
-      // mirrors navigate.ts. Same-URL re-renders keep the carry-over.
-      await invalidateRefsIfNavigated(ctx.driver, tabId, previousSignals.url);
-      const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
-      const diff = diffSnapshots(
-        { text: previousSnapshot, signals: previousSignals },
-        { text: snapshotText, signals },
-      );
-      if (diff === null) {
-        return {
-          tab: handle,
-          pressed: true,
-          key,
-          diff: null,
-          note:
-            "Accessibility tree and element state unchanged. This may still " +
-            "have succeeded (some changes aren't reflected here). Do NOT " +
-            "blindly repeat the key — verify with a screenshot or by reading " +
-            "element state before retrying.",
-        };
+      const cap = await captureSnapshot(ctx.driver, tabId, {
+        mode: "interactive",
+        viewportOnly: true,
+      });
+      const result: Output = {
+        tab: handle,
+        pressed: true,
+        key,
+        snapshot: cap.snapshotText,
+        refCount: cap.refs.size,
+        url,
+      };
+      if (cap.belowFoldCount > 0) {
+        result.belowFoldCount = cap.belowFoldCount;
+        result.hint = `${cap.belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`;
       }
-      return { tab: handle, pressed: true, key, diff };
+      return result;
     } catch (err) {
       return {
         tab: handle,
         pressed: true,
         key,
+        url,
         note: `Key press succeeded but post-action snapshot failed: ${
           err instanceof Error ? err.message : String(err)
-        }`,
+        }. Call snapshot to retry.`,
       };
     }
   },
@@ -133,7 +151,11 @@ async function focusRef(
   }
   // Re-resolve by identity tuple (role, name, nth) if the cached
   // backendNodeId is detached after a re-render.
+  // We scrollIntoViewIfNeeded BEFORE DOM.focus because focus alone does not
+  // scroll, and a subsequent CDP key dispatch only delivers to the visible
+  // viewport. Mirrors typeByRef in type-in-element.ts.
   let backendNodeId = entry.backendNodeId;
+  await scrollIntoViewIfNeeded(driver, tabId, backendNodeId);
   try {
     await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
   } catch (err) {
@@ -147,6 +169,7 @@ async function focusRef(
     );
     if (freshId == null || freshId === backendNodeId) throw err;
     backendNodeId = freshId;
+    await scrollIntoViewIfNeeded(driver, tabId, backendNodeId);
     await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
   }
 }

--- a/apps/extension/src/lib/agent/tools/snapshot.ts
+++ b/apps/extension/src/lib/agent/tools/snapshot.ts
@@ -41,7 +41,7 @@ type Output = z.infer<typeof outputSchema>;
 export const snapshotTool: BrowserTool<Input, Output> = {
   name: "snapshot",
   description:
-    "Get a tab's accessibility tree with @refs for interactive elements. Pass `tab` (handle from the tab legend or listTabs). Use refs with clickElement/typeInElement. On heavy pages, scope with `selector` or use `mode: 'viewport'` to see only above-the-fold elements. Action tools (click/type/navigate) already auto-attach diffs — call this explicitly only when you need the full tree, a scoped view, or after executeOnPage.",
+    "Get a tab's accessibility tree with @refs for interactive elements. Pass `tab` (handle from the tab legend or listTabs). Use refs with clickElement/typeInElement. On heavy pages, scope with `selector` or use `mode: 'viewport'` to see only above-the-fold elements. Action tools (clickElement, typeInElement, pressKey) already auto-attach a fresh viewport-scoped snapshot to their responses — call this explicitly only when you need the full tree, a different scope, or an opt-in `diff: true` against the previous snapshot.",
   parameters,
   outputSchema,
   execute: async ({ tab: handle, mode, selector, diff }, ctx) => {

--- a/apps/extension/src/lib/agent/tools/type-in-element.ts
+++ b/apps/extension/src/lib/agent/tools/type-in-element.ts
@@ -1,18 +1,17 @@
 import { z } from "zod";
 import { isDetachError } from "../cdp-errors";
+import { setShieldPassthrough } from "../click-diagnostic";
 import type { BrowserDriver, TabId } from "../driver";
 import { resolveTabOrThrow } from "../driver";
 import {
   getRef,
-  getPreviousSnapshot,
-  getPreviousSignals,
   invalidateRefsIfNavigated,
 } from "../ref-store";
 import {
   captureSnapshot,
-  diffSnapshots,
   findNodeByRoleNameNth,
 } from "../snapshot-capture";
+import { scrollIntoViewIfNeeded } from "../viewport";
 import type { BrowserTool } from "../types";
 
 const parameters = z.object({
@@ -47,7 +46,14 @@ const outputSchema = z.object({
   target: z.string(),
   text: z.string(),
   submitted: z.boolean().optional(),
-  diff: z.string().nullable().optional(),
+  /** Viewport-scoped a11y tree of the page AFTER the type/submit. Mirrors
+   *  the shape of `snapshot({mode: "viewport"})`. Empty when the post-action
+   *  capture failed (see `note`). */
+  snapshot: z.string().optional(),
+  refCount: z.number().optional(),
+  url: z.string().optional(),
+  belowFoldCount: z.number().optional(),
+  hint: z.string().optional(),
   note: z.string().optional(),
 });
 type Output = z.infer<typeof outputSchema>;
@@ -55,15 +61,13 @@ type Output = z.infer<typeof outputSchema>;
 export const typeInElementTool: BrowserTool<Input, Output> = {
   name: "typeInElement",
   description:
-    "Type text into an input or textarea. Pass `tab` (handle from the tab legend or listTabs) and `target` — either an @ref from a recent snapshot of THAT tab (preferred) or a CSS selector as fallback. Pass submit: true to press Enter and wait for the page to settle. The response automatically includes a diff of what changed on the page.",
+    "Type text into an input or textarea. Pass `tab` (handle from the tab legend or listTabs) and `target` — either an @ref from a recent snapshot of THAT tab (preferred) or a CSS selector as fallback. Pass submit: true to press Enter and wait for the page to settle. The response auto-attaches a viewport-scoped accessibility snapshot of the page AFTER the action so you can see the current state and pick the next ref without a follow-up snapshot call. Call snapshot explicitly when you need the full tree, a different scope, or the section below the fold.",
   parameters,
   outputSchema,
   execute: async ({ tab: handle, target, text, clearFirst, submit }, ctx) => {
     const tab = await resolveTabOrThrow(ctx, handle);
     const tabId = tab.id;
-
-    const previousSnapshot = getPreviousSnapshot(tabId);
-    const previousSignals = getPreviousSignals(tabId);
+    const previousUrl = tab.url ?? undefined;
 
     // Back-compat: trailing newline was the old form-submit hack.
     const legacyNewlineSubmit = text.endsWith("\n");
@@ -71,27 +75,55 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
     const shouldPressEnter = submit ?? legacyNewlineSubmit;
 
     try {
-      if (target.startsWith("@e")) {
-        await typeByRef(ctx.driver, tabId, target, textToType, clearFirst ?? true);
-      } else {
-        await typeBySelector(ctx.driver, tabId, target, textToType, clearFirst ?? true);
+      console.debug(
+        `[type-tool] dispatch target=${target} tab=${String(tabId)}` +
+          (shouldPressEnter ? " (+Enter)" : ""),
+      );
+      // Refs go through CDP `Input.dispatchKeyEvent` and need the shield's
+      // key blocker in passthrough; selector path uses content-script
+      // `el.value =` (synthetic) and doesn't. Toggle passthrough only
+      // around the CDP path(s).
+      const usingCdp = target.startsWith("@e");
+      if (usingCdp) {
+        await setShieldPassthrough(ctx.driver, tabId, true);
+      }
+      try {
+        if (usingCdp) {
+          await typeByRef(ctx.driver, tabId, target, textToType, clearFirst ?? true);
+        } else {
+          await typeBySelector(ctx.driver, tabId, target, textToType, clearFirst ?? true);
+        }
+      } finally {
+        if (usingCdp) {
+          await setShieldPassthrough(ctx.driver, tabId, false);
+        }
       }
 
       if (shouldPressEnter) {
-        await ctx.driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
-          type: "keyDown",
-          key: "Enter",
-          code: "Enter",
-          windowsVirtualKeyCode: 13,
-          nativeVirtualKeyCode: 13,
-        });
-        await ctx.driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
-          type: "keyUp",
-          key: "Enter",
-          code: "Enter",
-          windowsVirtualKeyCode: 13,
-          nativeVirtualKeyCode: 13,
-        });
+        // Enter is dispatched via CDP regardless of which type path ran —
+        // toggle passthrough specifically for it. Doing this in a separate
+        // window (instead of one big window around both type AND Enter)
+        // means the selector path doesn't pay the toggle round-trip when
+        // submit is false.
+        await setShieldPassthrough(ctx.driver, tabId, true);
+        try {
+          await ctx.driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
+            type: "keyDown",
+            key: "Enter",
+            code: "Enter",
+            windowsVirtualKeyCode: 13,
+            nativeVirtualKeyCode: 13,
+          });
+          await ctx.driver.sendCommand(tabId, "Input.dispatchKeyEvent", {
+            type: "keyUp",
+            key: "Enter",
+            code: "Enter",
+            windowsVirtualKeyCode: 13,
+            nativeVirtualKeyCode: 13,
+          });
+        } finally {
+          await setShieldPassthrough(ctx.driver, tabId, false);
+        }
       }
     } catch (err) {
       if (!isDetachError(err)) throw err;
@@ -109,8 +141,9 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
 
     // Refs are refreshed (not invalidated) by the post-action snapshot's
     // merge — see click-element.ts and ref-store.setRefs.
+    await invalidateRefsIfNavigated(ctx.driver, tabId, previousUrl);
 
-    const baseResult = {
+    const baseResult: Output = {
       tab: handle,
       typed: true as const,
       target,
@@ -118,41 +151,38 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
       ...(shouldPressEnter && { submitted: true as const }),
     };
 
-    if (!previousSnapshot || !previousSignals) {
-      try {
-        await captureSnapshot(ctx.driver, tabId);
-      } catch {}
-      return baseResult;
-    }
-
+    let url = previousUrl ?? "";
     try {
-      // If submitting (Enter) navigated to a different document, drop the
-      // stale ref map BEFORE the snapshot's merge so old-page refs can't leak —
-      // mirrors navigate.ts. Same-URL re-renders keep the carry-over.
-      await invalidateRefsIfNavigated(ctx.driver, tabId, previousSignals.url);
-      const { snapshotText, signals } = await captureSnapshot(ctx.driver, tabId);
-      const diff = diffSnapshots(
-        { text: previousSnapshot, signals: previousSignals },
-        { text: snapshotText, signals },
-      );
-      if (diff === null) {
-        return {
-          ...baseResult,
-          diff: null,
-          note:
-            "Accessibility tree and element state unchanged. This may still " +
-            "have succeeded (some changes aren't reflected here). Do NOT " +
-            "blindly retry — verify with a screenshot or by reading " +
-            "element state before retrying.",
-        };
+      const fresh = await ctx.driver.getTab(tabId);
+      url = fresh.url ?? url;
+    } catch {
+      // tab may have closed during the action — keep the stale url
+    }
+    baseResult.url = url;
+
+    // Auto-attach a fresh VIEWPORT-scoped snapshot in place of a diff. See
+    // click-element.ts for the full rationale; in short: diffing prior
+    // (often viewport-scoped) snapshots against full-tree post-action
+    // snapshots was hallucinating "[+] entire below-fold tree" lines and
+    // confusing the model.
+    try {
+      const cap = await captureSnapshot(ctx.driver, tabId, {
+        mode: "interactive",
+        viewportOnly: true,
+      });
+      baseResult.snapshot = cap.snapshotText;
+      baseResult.refCount = cap.refs.size;
+      if (cap.belowFoldCount > 0) {
+        baseResult.belowFoldCount = cap.belowFoldCount;
+        baseResult.hint = `${cap.belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`;
       }
-      return { ...baseResult, diff };
+      return baseResult;
     } catch (err) {
       return {
         ...baseResult,
         note: `Type succeeded but post-action snapshot failed: ${
           err instanceof Error ? err.message : String(err)
-        }`,
+        }. Call snapshot to retry.`,
       };
     }
   },
@@ -175,7 +205,13 @@ async function typeByRef(
   // Focus the element. On a re-rendered page the cached backendNodeId may be
   // detached; recover by re-finding the same logical element via its identity
   // tuple (role, name, nth) from a fresh AX tree before failing.
+  // We scrollIntoViewIfNeeded BEFORE DOM.focus because focus alone does not
+  // scroll (and the subsequent CDP key dispatch only delivers to the visible
+  // viewport — an off-screen focus + insertText would no-op visually even
+  // though the value gets set, hiding the cursor + caret animation that
+  // tests rely on for confirmation).
   let backendNodeId = entry.backendNodeId;
+  await scrollIntoViewIfNeeded(driver, tabId, backendNodeId);
   try {
     await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
   } catch (err) {
@@ -189,6 +225,7 @@ async function typeByRef(
     );
     if (freshId == null || freshId === backendNodeId) throw err;
     backendNodeId = freshId;
+    await scrollIntoViewIfNeeded(driver, tabId, backendNodeId);
     await driver.sendCommand(tabId, "DOM.focus", { backendNodeId });
   }
 

--- a/apps/extension/src/lib/agent/viewport.ts
+++ b/apps/extension/src/lib/agent/viewport.ts
@@ -1,0 +1,210 @@
+import type { BrowserDriver, TabId } from "./driver";
+
+/**
+ * Live viewport metrics needed to map element coordinates from the document
+ * (returned by `DOM.getBoxModel` etc.) into the visual viewport (which is
+ * what `Input.dispatchMouseEvent` and `DOM.getNodeForLocation` interpret).
+ *
+ * Without this conversion, elements below the fold receive clicks at
+ * y-coordinates outside the visible area and CDP silently no-ops the
+ * dispatch — see `tools/click-element.ts` for the original bug.
+ */
+export interface ViewportMetrics {
+  scrollX: number;
+  scrollY: number;
+  innerWidth: number;
+  innerHeight: number;
+}
+
+/**
+ * Read live `{scrollX, scrollY, innerWidth, innerHeight}` via CDP
+ * `Runtime.evaluate`. Falls back to zero scroll + zero size if the
+ * evaluation fails (e.g. the page is between navigations) — callers should
+ * treat the result as best-effort.
+ */
+export async function readViewportMetrics(
+  driver: BrowserDriver,
+  tabId: TabId,
+): Promise<ViewportMetrics> {
+  try {
+    const result = await driver.sendCommand<{
+      result?: {
+        value?: {
+          sx: number;
+          sy: number;
+          iw: number;
+          ih: number;
+        };
+      };
+    }>(tabId, "Runtime.evaluate", {
+      expression:
+        "({ sx: window.scrollX, sy: window.scrollY, iw: window.innerWidth, ih: window.innerHeight })",
+      returnByValue: true,
+    });
+    const v = result.result?.value;
+    if (!v) return { scrollX: 0, scrollY: 0, innerWidth: 0, innerHeight: 0 };
+    return {
+      scrollX: v.sx,
+      scrollY: v.sy,
+      innerWidth: v.iw,
+      innerHeight: v.ih,
+    };
+  } catch {
+    return { scrollX: 0, scrollY: 0, innerWidth: 0, innerHeight: 0 };
+  }
+}
+
+/**
+ * Scroll an element into view via CDP `DOM.scrollIntoViewIfNeeded`. Best-
+ * effort: returns true on success, false if the call fails (e.g. detached
+ * node, missing CDP support). Callers should re-read the box model after a
+ * successful scroll because the element's viewport coordinates will have
+ * changed.
+ */
+export async function scrollIntoViewIfNeeded(
+  driver: BrowserDriver,
+  tabId: TabId,
+  backendNodeId: number,
+): Promise<boolean> {
+  try {
+    await driver.sendCommand(tabId, "DOM.scrollIntoViewIfNeeded", {
+      backendNodeId,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wait for the renderer to commit pending layout/scroll changes by waiting
+ * two animation frames inside the page. Used after `scrollIntoViewIfNeeded`
+ * on pages with `scroll-behavior: smooth` or scroll-snap, where the CDP
+ * call returns immediately but the actual scroll is animated asynchronously
+ * — without this wait, the next `DOM.getBoxModel` call returns the
+ * pre-scroll position. Two rAFs is Playwright's pattern: the first lets
+ * style/layout flush, the second ensures the scroll commit has landed.
+ *
+ * Best-effort. Times out at 1 second so a stuck rAF (e.g. tab in
+ * background) can never wedge a click.
+ */
+export async function waitForLayoutFlush(
+  driver: BrowserDriver,
+  tabId: TabId,
+): Promise<void> {
+  try {
+    await driver.sendCommand(tabId, "Runtime.evaluate", {
+      expression:
+        "new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))",
+      awaitPromise: true,
+      returnByValue: true,
+      timeout: 1000,
+    });
+  } catch {
+    // Renderer was busy / debugger detached — don't block the click.
+  }
+}
+
+/**
+ * Snapshot of an element's actual visual position in the page, captured in
+ * a SINGLE round-trip alongside scroll and viewport size. Used both for
+ * dispatch (eliminates the document↔viewport conversion race that bit
+ * `tools/click-element.ts`) and for forensic logging that shows whether
+ * `getBoxModel`-based coords agree with `getBoundingClientRect`.
+ */
+export interface ElementGeometry {
+  /** Element bounding rect in VIEWPORT space (the same space CDP
+   *  `Input.dispatchMouseEvent` interprets). NaN if the read failed. */
+  vx: number;
+  vy: number;
+  vw: number;
+  vh: number;
+  /** Live page scroll AT THE INSTANT the rect was read. */
+  scrollX: number;
+  scrollY: number;
+  innerWidth: number;
+  innerHeight: number;
+  /** True iff the element resolved and the rect was read successfully. */
+  ok: boolean;
+  /** Free-text reason on failure. */
+  error?: string;
+}
+
+/**
+ * Read an element's `getBoundingClientRect()` plus scroll + viewport size in
+ * a single atomic `Runtime.callFunctionOn` call. The rect is in VIEWPORT
+ * coordinates by definition — no scroll subtraction needed, no race between
+ * separate `getBoxModel` / `Runtime.evaluate` reads.
+ *
+ * Strategy: resolve the backendNodeId to a Runtime objectId, then invoke a
+ * function on that object that returns the geometry as a plain JSON value.
+ *
+ * Returns an `{ ok: false, error: ... }` shape on any failure — callers
+ * should fall back to the legacy `getBoxModel` path and log a warning.
+ */
+export async function readElementGeometry(
+  driver: BrowserDriver,
+  tabId: TabId,
+  backendNodeId: number,
+): Promise<ElementGeometry> {
+  const empty: ElementGeometry = {
+    vx: NaN,
+    vy: NaN,
+    vw: NaN,
+    vh: NaN,
+    scrollX: 0,
+    scrollY: 0,
+    innerWidth: 0,
+    innerHeight: 0,
+    ok: false,
+  };
+  try {
+    const resolved = await driver.sendCommand<{
+      object?: { objectId?: string };
+    }>(tabId, "DOM.resolveNode", { backendNodeId });
+    const objectId = resolved.object?.objectId;
+    if (!objectId) return { ...empty, error: "DOM.resolveNode returned no objectId" };
+
+    const result = await driver.sendCommand<{
+      result?: {
+        value?: {
+          vx: number;
+          vy: number;
+          vw: number;
+          vh: number;
+          sx: number;
+          sy: number;
+          iw: number;
+          ih: number;
+        };
+      };
+    }>(tabId, "Runtime.callFunctionOn", {
+      objectId,
+      // Read everything in one frame: the rect is viewport-relative, scroll
+      // is the live scroll at the same instant, and innerWidth/Height
+      // bounds the off-viewport check.
+      functionDeclaration:
+        "function() { const r = this.getBoundingClientRect(); return { vx: r.x, vy: r.y, vw: r.width, vh: r.height, sx: window.scrollX, sy: window.scrollY, iw: window.innerWidth, ih: window.innerHeight }; }",
+      returnByValue: true,
+    });
+    const v = result.result?.value;
+    if (!v) return { ...empty, error: "callFunctionOn returned no value" };
+    return {
+      vx: v.vx,
+      vy: v.vy,
+      vw: v.vw,
+      vh: v.vh,
+      scrollX: v.sx,
+      scrollY: v.sy,
+      innerWidth: v.iw,
+      innerHeight: v.ih,
+      ok: true,
+    };
+  } catch (err) {
+    return {
+      ...empty,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+


### PR DESCRIPTION
## Why

Agent clicks were silently eaten by OpenBrowse's own "is working" overlay. Symptoms in the wild:
- FAQ accordions never expanded after `clickElement`
- Theme toggles reported success but didn't flip
- CUA subagent clicks landed on nothing

## Root cause

`.ob-cua-root` — the full-viewport (`position:fixed; inset:0`) shadow-DOM wrapper inside `openbrowse-cua-working-host` — had **implicit** `pointer-events: auto`. Trusted CDP `Input.dispatchMouseEvent` events climbed from the `pe:none` shield to its parent (the root, same size, default `pe:auto`) and were consumed there. Per CSS spec, `pe:none` on a parent doesn't disable descendants with explicit `pe:auto`, so adding `pe:none` to `.ob-cua-root` lets the shield and the Stop button keep working as hit-test targets while agent dispatches pass through to the page.

One CSS line is the functional fix. Everything else is forensics + cleanup that fell out of finding it.

## What's in here

**Click pipeline**
- `.ob-cua-root` → `pointer-events: none` (the fix)
- Atomic `getBoundingClientRect` via `Runtime.callFunctionOn` — eliminates the document↔viewport conversion race that was the original off-viewport bug
- `boxmodel-fallback` coord path now reads scroll/viewport via `readViewportMetrics` (was using zeroed sentinels — would dispatch at document coords on any non-top-of-page click when the atomic path failed)
- Off-viewport guard works in both code paths
- Pre + post-dispatch diagnostics inside the passthrough window with classifier tags (`ok` / `ok-retarget` / `OFF-VIEWPORT` / `OVERLAY-INTERCEPT`); all fields inlined into a single log line so you can read it without expanding the collapsed `Object`
- All forensic logs at `console.debug` — default DevTools shows only the genuinely-bad shapes

**Action-tool output shape**
- `clickElement` / `typeInElement` / `pressKey` now auto-attach a fresh viewport-scoped snapshot in the `snapshot` field (replaces the legacy `diff`)
- `snapshot` tool keeps its opt-in `diff: true` mode
- `interactiveCount` removed from `PageStateSignals` (mode-fragile and dead after the migration)
- System prompt + compaction map updated

**Click ripple visual**
- Themed by active space tint, doubles in size
- Layered "dithered shockwave" animation: halo + dithered disc + 2 parallax rings + center spark
- Cached space color forwarded via `CHAT_CUA_WORKING_STATE`
- `prefers-reduced-motion` collapses to a 350ms cross-fade

**Test coverage**
- `cua-overlay-pe.test.ts` — regression for the four CSS rules that make the fix work
- `click-diagnostic.test.ts` — 7 cases covering the classifier (incl. host-retargeted-benign and search-overlay-overrides-benign)
- `click-element-hit-test.test.ts` — boxmodel-fallback path with `failCallFunctionOn` mock
- Existing diff-based tests migrated to snapshot assertions
- 983/983 passing (was 950 before, +33 from new + migrated tests)

## Verification
- `pnpm -F openbrowse compile` ✅
- `pnpm -F openbrowse test` ✅ 983/983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced click ripple animation with improved visual appearance matching the interface theme
  * Added diagnostic tools to troubleshoot click interception issues

* **Bug Fixes**
  * Fixed overlay interaction blocking legitimate page clicks

* **Improvements**
  * Action tools now automatically return updated page state instead of requiring follow-up calls for context
  * Enhanced agent diagnostics and logging to better identify interaction failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->