### PR TITLE
fix(extension): tab identity continuity via LogicalTabId + TabRegistry

### DIFF
--- a/.changeset/tab-registry-logical-tab-ids.md
+++ b/.changeset/tab-registry-logical-tab-ids.md
@@ -1,0 +1,18 @@
+---
+"openbrowse": patch
+---
+
+Tab identity continuity via `LogicalTabId` and `TabRegistry`.
+
+The extension now keys agent-facing tab handles, conversation ownership, and persisted state on stable `LogicalTabId`s (UUIDs) instead of `chrome.tabs.id` (which Chrome silently renumbers on prerender activation, BFcache restore, and some discard/restore paths). A new `tab-registry` module owns the only `chrome.tabs.onReplaced` listener in the codebase and consolidates the trailing `onRemoved` Chrome fires for the replaced ctid (so consumers see exactly one event, not a replace-then-remove pair).
+
+Symptoms this fixes in production:
+
+- "Unknown tab handle" mid-flow on Speculation Rules sites (Attio settings, Notion, Vercel, Google Search, X) where prerender activation renumbers the underlying tab id.
+- "Cannot attach debugger to tab N: No tab with given id N" loops in the CUA computer-use subagent, which previously cached the chrome ctid at loop start and never refreshed it.
+- Stale `chrome.tabs.id` recycling across Chrome restarts that could resolve a persisted handle to an unrelated user tab.
+- `waitForTabLoad` timing out when the navigation completed on the post-replace ctid rather than the pre-replace one.
+
+chatDb schema bumps to v15. The migration walks each conversation's legacy `ownedTabIds: number[]`, probes `chrome.tabs.get(ctid)` to confirm liveness, and rewrites surviving entries through the registry to `ownedLtids: string[]`. Dead ctids are dropped silently; corrupt rows degrade to empty owned-state with a `console.warn` rather than aborting the upgrade. The `handleState.handles` map is rewritten in the same pass.
+
+The CUA loop subscribes to the registry's `onReplace` event and updates its cached ctid in place, keeping long-running computer-use sessions alive across prerender activations. The working-overlay glow re-routes to the new ctid automatically so the user sees continuous feedback.

--- a/apps/extension/src/components/cowork/__tests__/request-close-agent-tabs.test.ts
+++ b/apps/extension/src/components/cowork/__tests__/request-close-agent-tabs.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requestCloseAgentTabs } from "@/components/cowork/request-close-agent-tabs";
+import { tabRegistry } from "@/lib/agent/tab-registry";
 
 const sent: any[] = [];
+let ltid101: string;
+let ltid102: string;
 
 beforeEach(() => {
   sent.length = 0;
+  tabRegistry.__resetForTests!();
+  // Mint ltids for the synthetic ctids the test uses; requestCloseAgentTabs
+  // takes ctids (caller convenience) and translates internally to ltids.
+  ltid101 = tabRegistry.registerExisting(101);
+  ltid102 = tabRegistry.registerExisting(102);
   vi.stubGlobal("chrome", {
     runtime: {
       id: "test",
@@ -17,15 +25,18 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  tabRegistry.__resetForTests!();
+});
 
 describe("requestCloseAgentTabs", () => {
-  it("sends CLOSE_AGENT_TABS with conversationId + tabIds", async () => {
+  it("sends CLOSE_AGENT_TABS with conversationId + ltids (translated from ctids)", async () => {
     const res = await requestCloseAgentTabs("c1", [101, 102]);
     expect(sent[0]).toEqual({
       type: "CLOSE_AGENT_TABS",
       conversationId: "c1",
-      tabIds: [101, 102],
+      ltids: [ltid101, ltid102],
     });
     expect(res.ok).toBe(true);
   });

--- a/apps/extension/src/components/cowork/context-card.tsx
+++ b/apps/extension/src/components/cowork/context-card.tsx
@@ -3,6 +3,7 @@ import { ScrollText, Trash2, Bot } from "lucide-react";
 import { OPFS } from "@/lib/vfs/opfs";
 import { vfsEvents } from "@/lib/vfs/events";
 import { chatDb } from "@/lib/chat-db";
+import { tabRegistry } from "@/lib/agent/tab-registry";
 import { UPLOADS_DIR } from "@/lib/uploads-dir";
 import {
   Tooltip,
@@ -26,11 +27,12 @@ interface ContextTab {
   title: string;
   favicon: string;
   /**
-   * Conversation that owns this tab in `tab-scoping` (whose `ownedTabIds`
-   * the tab id lives in). For tabs created by the parent agent this is
-   * the parent's id; for tabs created by a subagent this is the child
-   * conversation's id. Cleanup must close tabs against their owner so
-   * the owner's `ownedTabIds` gets cleared (see `closeOwnedTabs`).
+   * Conversation that owns this tab in `tab-scoping` (whose `ownedLtids`
+   * the tab's LogicalTabId lives in). For tabs created by the parent
+   * agent this is the parent's id; for tabs created by a subagent this
+   * is the child conversation's id. Cleanup must close tabs against
+   * their owner so the owner's `ownedLtids` gets cleared (see
+   * `closeOwnedTabs`).
    */
   owningConversationId: string;
   /**
@@ -62,7 +64,7 @@ export function ContextCard({
   const [connectors, setConnectors] = useState<DerivedConnector[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
 
-  // Poll: tabs (from ownedTabIds) + connectors/skills (from message parts).
+  // Poll: tabs (from ownedLtids) + connectors/skills (from message parts).
   useEffect(() => {
     let isMounted = true;
 
@@ -86,17 +88,24 @@ export function ContextCard({
           subagent?: { label: string };
         };
         const ownedRefs: OwnedRef[] = [];
-        for (const id of conv?.ownedTabIds ?? []) {
-          ownedRefs.push({ tabId: id, owningConversationId: conversationId });
+        // ownedLtids holds LogicalTabIds (UUIDs); resolve to a live chrome
+        // ctid via the registry. Unresolvable ltids (the tab is gone or
+        // hasn't been re-discovered post-SW-restart) are dropped.
+        for (const ltid of conv?.ownedLtids ?? []) {
+          const ctid = tabRegistry.toChromeTabId(ltid);
+          if (ctid == null) continue;
+          ownedRefs.push({ tabId: ctid, owningConversationId: conversationId });
         }
         for (const child of children) {
           const label =
             child.subagentTraceTitle ??
             child.subagentSlug ??
             "Subagent";
-          for (const id of child.ownedTabIds ?? []) {
+          for (const ltid of child.ownedLtids ?? []) {
+            const ctid = tabRegistry.toChromeTabId(ltid);
+            if (ctid == null) continue;
             ownedRefs.push({
-              tabId: id,
+              tabId: ctid,
               owningConversationId: child.id,
               subagent: { label },
             });
@@ -203,7 +212,7 @@ export function ContextCard({
     setIsCleaningTabs(true);
     try {
       // Tabs owned by a subagent live in the *child* conversation's
-      // `ownedTabIds`; closing them against the parent id wouldn't
+      // `ownedLtids`; closing them against the parent id wouldn't
       // clear the child row. Group by owning conversation id so each
       // owner's list is cleaned up correctly. `closeOwnedTabs`
       // (background) closes the tabs, clears ownership, and broadcasts

--- a/apps/extension/src/components/cowork/request-close-agent-tabs.ts
+++ b/apps/extension/src/components/cowork/request-close-agent-tabs.ts
@@ -1,3 +1,5 @@
+import { tabRegistry } from "@/lib/agent/tab-registry";
+
 export interface RequestCloseAgentTabsResult {
   ok: boolean;
   error?: string;
@@ -8,6 +10,12 @@ export interface RequestCloseAgentTabsResult {
  * Sends the same `CLOSE_AGENT_TABS` background message the closeTabs tool
  * uses, so the background closes the tabs, clears ownership, and broadcasts
  * `AGENT_TABS_CLOSED` (which surfaces the Undo toast). No-ops on empty input.
+ *
+ * Takes chrome `tabId`s (numbers) for caller convenience — the Context
+ * card hydrates rows from `chrome.tabs.get` so it has live ctids in hand.
+ * Internally translates each ctid to a LogicalTabId via the registry
+ * before sending; ctids the registry doesn't know about (genuinely-gone
+ * tabs) are dropped silently.
  */
 export async function requestCloseAgentTabs(
   conversationId: string,
@@ -16,11 +24,17 @@ export async function requestCloseAgentTabs(
   if (!conversationId || tabIds.length === 0) {
     return { ok: false, error: "Nothing to close" };
   }
+  const ltids = tabIds
+    .map((ctid) => tabRegistry.toLogicalTabId(ctid))
+    .filter((ltid): ltid is string => ltid != null);
+  if (ltids.length === 0) {
+    return { ok: false, error: "Nothing to close" };
+  }
   try {
     const res = (await chrome.runtime.sendMessage({
       type: "CLOSE_AGENT_TABS",
       conversationId,
-      tabIds,
+      ltids,
     })) as { ok?: boolean; error?: string } | undefined;
     if (!res?.ok) {
       return { ok: false, error: res?.error ?? "Close failed" };

--- a/apps/extension/src/entrypoints/background/__tests__/cleanup-completed-agent-tabs.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/cleanup-completed-agent-tabs.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatDb } from "@/lib/chat-db";
+import { tabRegistry } from "@/lib/agent/tab-registry";
 
 const NOW = 10_000_000;
 
@@ -20,6 +21,7 @@ function installChromeStub(removed: number[], sent: any[] = []) {
       query: () => Promise.resolve([]),
       ungroup: () => Promise.reject(new Error("ungroup must not be called")),
       onRemoved: { addListener: () => {} },
+      onReplaced: { addListener: () => {} },
       onUpdated: { addListener: () => {} },
       onActivated: { addListener: () => {} },
     },
@@ -28,9 +30,18 @@ function installChromeStub(removed: number[], sent: any[] = []) {
   });
 }
 
+let ltid101: string;
+let ltid102: string;
+
 async function seed(id: string, fields: Record<string, unknown>) {
+  // Mint ltids for the fixture's two ctids in the registry so
+  // cleanupCompletedAgentTabs can resolve them via tabRegistry.
+  ltid101 = tabRegistry.registerExisting(101);
+  ltid102 = tabRegistry.registerExisting(102);
   await chatDb.createConversation({
-    id, title: id, spaceId: null, ownedGroupId: 1, ownedTabIds: [101, 102], createdAt: 0, updatedAt: 0,
+    id, title: id, spaceId: null, ownedGroupId: 1,
+    ownedLtids: [ltid101, ltid102],
+    createdAt: 0, updatedAt: 0,
   });
   await chatDb.updateConversation(id, fields);
 }
@@ -39,12 +50,14 @@ describe("cleanupCompletedAgentTabs", () => {
   beforeEach(() => {
     indexedDB = new IDBFactory();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
     vi.spyOn(Date, "now").mockReturnValue(NOW);
   });
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
   });
 
   it("closes tabs for a completed, idle conversation when enabled", async () => {

--- a/apps/extension/src/entrypoints/background/__tests__/close-agent-tabs-handler.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/close-agent-tabs-handler.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatDb } from "@/lib/chat-db";
+import { tabRegistry } from "@/lib/agent/tab-registry";
 
 function installChromeStub(removed: number[]) {
   vi.stubGlobal("chrome", {
@@ -14,6 +15,7 @@ function installChromeStub(removed: number[]) {
       },
       query: () => Promise.resolve([]),
       onRemoved: { addListener: () => {} },
+      onReplaced: { addListener: () => {} },
       onUpdated: { addListener: () => {} },
       onActivated: { addListener: () => {} },
     },
@@ -23,32 +25,41 @@ function installChromeStub(removed: number[]) {
 }
 
 describe("handleCloseAgentTabs", () => {
+  let ltid11: string;
+  let ltid22: string;
+
   beforeEach(async () => {
     indexedDB = new IDBFactory();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    ltid11 = tabRegistry.registerExisting(11);
+    ltid22 = tabRegistry.registerExisting(22);
     await chatDb.createConversation({
-      id: "c1", title: "t", spaceId: null, ownedGroupId: 3, ownedTabIds: [11, 22], createdAt: 0, updatedAt: 0,
+      id: "c1", title: "t", spaceId: null, ownedGroupId: 3,
+      ownedLtids: [ltid11, ltid22],
+      createdAt: 0, updatedAt: 0,
     });
   });
   afterEach(() => {
     vi.unstubAllGlobals();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
   });
 
   it("closes the group's tabs and returns undo", async () => {
     const removed: number[] = [];
     installChromeStub(removed);
     const { handleCloseAgentTabs } = await import("../close-agent-tabs");
-    const res = await handleCloseAgentTabs({ conversationId: "c1", tabIds: [11, 22] });
+    const res = await handleCloseAgentTabs({ conversationId: "c1", ltids: [ltid11, ltid22] });
     expect(res.ok).toBe(true);
     expect(removed.sort()).toEqual([11, 22]);
     expect(res.undo?.action).toBe("reopen");
   });
 
-  it("returns ok:false on empty tabIds", async () => {
+  it("returns ok:false on empty ltids", async () => {
     installChromeStub([]);
     const { handleCloseAgentTabs } = await import("../close-agent-tabs");
-    const res = await handleCloseAgentTabs({ conversationId: "c1", tabIds: [] });
+    const res = await handleCloseAgentTabs({ conversationId: "c1", ltids: [] });
     expect(res.ok).toBe(false);
   });
 });

--- a/apps/extension/src/entrypoints/background/__tests__/close-owned-tabs.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/close-owned-tabs.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatDb } from "@/lib/chat-db";
+import { tabRegistry } from "@/lib/agent/tab-registry";
 
 function installChromeStub(removed: number[]) {
   const tabsById: Record<number, chrome.tabs.Tab> = {
@@ -21,6 +22,7 @@ function installChromeStub(removed: number[]) {
       },
       query: () => Promise.resolve([]),
       onRemoved: { addListener: () => {}, removeListener: () => {} },
+      onReplaced: { addListener: () => {}, removeListener: () => {} },
       onUpdated: { addListener: () => {}, removeListener: () => {} },
       onActivated: { addListener: () => {}, removeListener: () => {} },
     },
@@ -30,15 +32,25 @@ function installChromeStub(removed: number[]) {
 }
 
 describe("closeOwnedTabs", () => {
+  let ltid101: string;
+  let ltid102: string;
+
   beforeEach(async () => {
     indexedDB = new IDBFactory();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    // Mint ltids for the fake ctids 101 and 102 so closeOwnedTabs can
+    // resolve them via the registry. In production the registry would
+    // have minted these via `bindTabsToConversation` (or the v15
+    // migration) before the conversation was persisted.
+    ltid101 = tabRegistry.registerExisting(101);
+    ltid102 = tabRegistry.registerExisting(102);
     await chatDb.createConversation({
       id: "conv-1",
       title: "t",
       spaceId: null,
       ownedGroupId: 7,
-      ownedTabIds: [101, 102],
+      ownedLtids: [ltid101, ltid102],
       createdAt: 0,
       updatedAt: 0,
     });
@@ -47,6 +59,7 @@ describe("closeOwnedTabs", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
   });
 
   it("removes the given tabs, returns an undo payload, and clears ownership", async () => {
@@ -54,7 +67,7 @@ describe("closeOwnedTabs", () => {
     installChromeStub(removed);
     const { closeOwnedTabs } = await import("../tab-scoping");
 
-    const undo = await closeOwnedTabs("conv-1", [101, 102]);
+    const undo = await closeOwnedTabs("conv-1", [ltid101, ltid102]);
 
     expect(removed.sort()).toEqual([101, 102]);
     expect(undo.action).toBe("reopen");
@@ -63,7 +76,7 @@ describe("closeOwnedTabs", () => {
       { url: "https://b.com/y", windowId: 1, pinned: false },
     ]);
     const conv = await chatDb.getConversation("conv-1");
-    expect(conv?.ownedTabIds).toEqual([]);
+    expect(conv?.ownedLtids).toEqual([]);
   });
 
   it("nulls ownedGroupId when all owned tabs are closed", async () => {
@@ -71,7 +84,7 @@ describe("closeOwnedTabs", () => {
     installChromeStub(removed);
     const { closeOwnedTabs } = await import("../tab-scoping");
 
-    await closeOwnedTabs("conv-1", [101, 102]);
+    await closeOwnedTabs("conv-1", [ltid101, ltid102]);
 
     const conv = await chatDb.getConversation("conv-1");
     expect(conv?.ownedGroupId).toBeNull();
@@ -82,10 +95,10 @@ describe("closeOwnedTabs", () => {
     installChromeStub(removed);
     const { closeOwnedTabs } = await import("../tab-scoping");
 
-    await closeOwnedTabs("conv-1", [101]);
+    await closeOwnedTabs("conv-1", [ltid101]);
 
     const conv = await chatDb.getConversation("conv-1");
-    expect(conv?.ownedTabIds).toEqual([102]);
+    expect(conv?.ownedLtids).toEqual([ltid102]);
     expect(conv?.ownedGroupId).toBe(7);
   });
 
@@ -95,9 +108,13 @@ describe("closeOwnedTabs", () => {
     const prev = chrome.tabs.get;
     (chrome.tabs as { get: typeof prev }).get = (id: number) =>
       id === 999 ? Promise.reject(new Error("no tab")) : prev(id);
+
+    // Synthesize an ltid that maps to ctid 999 in the registry, so the
+    // closeOwnedTabs resolution path actually attempts a chrome.tabs.get.
+    const ltid999 = tabRegistry.registerExisting(999);
     const { closeOwnedTabs } = await import("../tab-scoping");
 
-    const undo = await closeOwnedTabs("conv-1", [101, 999]);
+    const undo = await closeOwnedTabs("conv-1", [ltid101, ltid999]);
 
     expect(removed).toContain(101);
     expect(undo.tabs.map((t) => t.url)).toEqual(["https://a.com/x"]);

--- a/apps/extension/src/entrypoints/background/__tests__/close-owned-tabs.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/close-owned-tabs.test.ts
@@ -102,21 +102,46 @@ describe("closeOwnedTabs", () => {
     expect(conv?.ownedGroupId).toBe(7);
   });
 
-  it("tolerates a tab that is already gone", async () => {
+  it("silently skips ltids that are not owned by the conversation", async () => {
     const removed: number[] = [];
     installChromeStub(removed);
-    const prev = chrome.tabs.get;
-    (chrome.tabs as { get: typeof prev }).get = (id: number) =>
-      id === 999 ? Promise.reject(new Error("no tab")) : prev(id);
 
-    // Synthesize an ltid that maps to ctid 999 in the registry, so the
-    // closeOwnedTabs resolution path actually attempts a chrome.tabs.get.
+    // ltid999 is registered with the registry but NEVER added to
+    // conv-1's ownedLtids — closeOwnedTabs's defensive filter must
+    // skip it, leaving only the legitimately-owned ltid101 closed.
     const ltid999 = tabRegistry.registerExisting(999);
     const { closeOwnedTabs } = await import("../tab-scoping");
 
     const undo = await closeOwnedTabs("conv-1", [ltid101, ltid999]);
 
-    expect(removed).toContain(101);
+    expect(removed).toEqual([101]); // ONLY 101 closed; 999 was filtered
     expect(undo.tabs.map((t) => t.url)).toEqual(["https://a.com/x"]);
+    // 999 is NOT recorded as a closed tab in the conversation's owned
+    // list because it was never owned in the first place.
+    const conv = await chatDb.getConversation("conv-1");
+    expect(conv?.ownedLtids).toEqual([ltid102]);
+  });
+
+  it("tolerates an owned tab whose ctid is already gone in chrome", async () => {
+    const removed: number[] = [];
+    installChromeStub(removed);
+    // Override chrome.tabs.get for ctid 102 so it rejects (the tab is
+    // gone), but leave 101 alive. Both are owned by conv-1.
+    const prev = chrome.tabs.get;
+    (chrome.tabs as { get: typeof prev }).get = (id: number) =>
+      id === 102 ? Promise.reject(new Error("no tab")) : prev(id);
+
+    const { closeOwnedTabs } = await import("../tab-scoping");
+
+    const undo = await closeOwnedTabs("conv-1", [ltid101, ltid102]);
+
+    // 101 closed cleanly; 102 was owned but the chrome.tabs.get rejected
+    // so it's omitted from the undo (nothing to reopen) and chrome.tabs
+    // .remove never fires for it. Both ltids are still removed from the
+    // conversation's ownedLtids since they were both passed in.
+    expect(removed).toEqual([101]);
+    expect(undo.tabs.map((t) => t.url)).toEqual(["https://a.com/x"]);
+    const conv = await chatDb.getConversation("conv-1");
+    expect(conv?.ownedLtids).toEqual([]);
   });
 });

--- a/apps/extension/src/entrypoints/background/__tests__/tab-scoping-onreplaced.test.ts
+++ b/apps/extension/src/entrypoints/background/__tests__/tab-scoping-onreplaced.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for tab-scoping's registry integration: ownership keyed on
+ * LogicalTabId means `chrome.tabs.onReplaced` (Speculation Rules /
+ * prerender activation) leaves ownership intact, the side panel is
+ * re-registered against the new ctid, and the trailing `onRemoved` for
+ * the old ctid is suppressed by the registry's dedup window so ownership
+ * isn't accidentally cleared.
+ */
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "@/lib/chat-db";
+import { tabRegistry } from "@/lib/agent/tab-registry";
+
+describe("tab-scoping: registry integration", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    // We do NOT call vi.resetModules() here: tab-scoping imports
+    // tab-registry, and a reset would give tab-scoping a *different*
+    // registry instance from the one our test owns, breaking the link
+    // between our `__handleReplaceForTests` calls and tab-scoping's
+    // subscriptions. Module-level state is reset via the explicit
+    // helpers above.
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+  });
+
+  function installChromeStub() {
+    const sidePanelCalls: { tabId?: number; enabled?: boolean }[] = [];
+    vi.stubGlobal("chrome", {
+      runtime: {
+        id: "test",
+        sendMessage: () => Promise.resolve({ ok: true }),
+        lastError: undefined,
+      },
+      tabs: {
+        get: (id: number) =>
+          Promise.resolve({
+            id,
+            url: `https://x/${id}`,
+            title: "t",
+            windowId: 1,
+            pinned: false,
+          } as chrome.tabs.Tab),
+        remove: () => Promise.resolve(),
+        query: () => Promise.resolve([]),
+        sendMessage: () => Promise.resolve(undefined),
+        group: () => Promise.resolve(7),
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+      },
+      tabGroups: {
+        update: () => Promise.resolve(),
+        onRemoved: { addListener: () => {} },
+        TAB_GROUP_ID_NONE: -1,
+      },
+      sidePanel: {
+        setOptions: (opts: { tabId?: number; enabled?: boolean }) => {
+          sidePanelCalls.push(opts);
+          return Promise.resolve();
+        },
+      },
+      storage: {
+        session: {
+          get: () => Promise.resolve({}),
+          set: () => Promise.resolve(),
+        },
+      },
+    });
+    return { sidePanelCalls };
+  }
+
+  it("getConversationForTab survives onReplaced", async () => {
+    const { sidePanelCalls } = installChromeStub();
+    void sidePanelCalls;
+    const tabScoping = await import("../tab-scoping");
+
+    // Seed a conversation owning ctid 100 via the public API. This
+    // mints an ltid via the registry under the hood.
+    await chatDb.createConversation({
+      id: "c1",
+      title: "t",
+      spaceId: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await tabScoping.bindTabsToConversation("c1", [100]);
+
+    expect(tabScoping.getConversationForTab(100)).toBe("c1");
+
+    // Drive an onReplaced 100 → 200 through the registry.
+    tabRegistry.__handleReplaceForTests!(200, 100);
+
+    // Ownership survived the replace: the new ctid 200 resolves to c1.
+    expect(tabScoping.getConversationForTab(200)).toBe("c1");
+    // The OLD ctid 100 no longer resolves (registry re-keyed away from it).
+    expect(tabScoping.getConversationForTab(100)).toBeNull();
+  });
+
+  it("re-enables side panel on the new ctid post-onReplaced", async () => {
+    const { sidePanelCalls } = installChromeStub();
+    // Need to install the listeners so onReplace fires the
+    // setPanelEnabledForTab path. initTabScoping wires them.
+    const tabScoping = await import("../tab-scoping");
+    tabScoping.initTabScoping();
+
+    await chatDb.createConversation({
+      id: "c1",
+      title: "t",
+      spaceId: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await tabScoping.bindTabsToConversation("c1", [100]);
+
+    sidePanelCalls.length = 0;
+    tabRegistry.__handleReplaceForTests!(200, 100);
+
+    // Allow microtask drain for the async setPanelEnabledForTab.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const enableCalls = sidePanelCalls.filter((c) => c.tabId === 200 && c.enabled === true);
+    expect(enableCalls.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT clear ownership on the trailing onRemoved after onReplaced", async () => {
+    installChromeStub();
+    const tabScoping = await import("../tab-scoping");
+    tabScoping.initTabScoping();
+
+    await chatDb.createConversation({
+      id: "c1",
+      title: "t",
+      spaceId: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await tabScoping.bindTabsToConversation("c1", [100]);
+
+    // Sequence Chrome actually fires: onReplaced(200, 100) then
+    // onRemoved(100). The registry's dedup window must suppress the
+    // trailing onRemoved so consumers don't see it as a tab close.
+    tabRegistry.__handleReplaceForTests!(200, 100);
+    tabRegistry.__handleRemoveForTests!(100);
+
+    // Ownership intact on the new ctid.
+    expect(tabScoping.getConversationForTab(200)).toBe("c1");
+  });
+
+  it("clears ownership when the registry emits a real onRemove (no preceding replace)", async () => {
+    installChromeStub();
+    const tabScoping = await import("../tab-scoping");
+    tabScoping.initTabScoping();
+
+    await chatDb.createConversation({
+      id: "c1",
+      title: "t",
+      spaceId: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await tabScoping.bindTabsToConversation("c1", [100]);
+
+    tabRegistry.__handleRemoveForTests!(100);
+    // Allow the async clearTabOwnershipForLtid to drain.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tabScoping.getConversationForTab(100)).toBeNull();
+  });
+});

--- a/apps/extension/src/entrypoints/background/close-agent-tabs.ts
+++ b/apps/extension/src/entrypoints/background/close-agent-tabs.ts
@@ -2,7 +2,13 @@ import { closeOwnedTabs, type CloseTabsUndo } from "./tab-scoping";
 
 export interface CloseAgentTabsRequest {
   conversationId: string;
-  tabIds: number[];
+  /**
+   * LogicalTabIds to close. The background handler resolves each ltid
+   * back to a live `chrome.tabs.id` via `tab-registry` just before
+   * `chrome.tabs.remove`. ltids whose ctid is no longer resolvable are
+   * silently skipped (the underlying tab is already gone).
+   */
+  ltids: string[];
 }
 
 export interface CloseAgentTabsResponse {
@@ -18,11 +24,11 @@ export interface CloseAgentTabsResponse {
 export async function handleCloseAgentTabs(
   req: CloseAgentTabsRequest,
 ): Promise<CloseAgentTabsResponse> {
-  if (!req.conversationId || !Array.isArray(req.tabIds) || req.tabIds.length === 0) {
+  if (!req.conversationId || !Array.isArray(req.ltids) || req.ltids.length === 0) {
     return { ok: false, error: "No tabs to close" };
   }
   try {
-    const undo = await closeOwnedTabs(req.conversationId, req.tabIds);
+    const undo = await closeOwnedTabs(req.conversationId, req.ltids);
     return { ok: true, undo };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -2463,14 +2463,22 @@ export default defineBackground({
       }
     });
 
-    // Re-target the working overlay across `chrome.tabs.onReplaced`.
-    // Without this, prerender activation on the agent's working tab
-    // would leave the glow stranded on the old (now-dead) ctid until
-    // the next status update — visible flicker for the user. The
-    // tab-registry deduplicates replace vs. remove and exposes a
+    // Re-target the working overlay AND the per-window active-tab cache
+    // across `chrome.tabs.onReplaced`. Without this, prerender activation
+    // on the agent's working tab would leave the glow stranded on the old
+    // (now-dead) ctid until the next status update, AND
+    // `activeTabByWindow` would keep pointing at the dead ctid for any
+    // window-scoped lookups that read it before Chrome's next
+    // `onActivated` event (which is non-deterministic across replace).
+    // The tab-registry deduplicates replace vs. remove and exposes a
     // single `onReplace` event we hook here.
     import("@/lib/agent/tab-registry").then(({ tabRegistry }) => {
       tabRegistry.onReplace(({ oldCtid, newCtid }) => {
+        // Window-active-tab cache: rewrite any window whose active tab
+        // was the replaced ctid.
+        for (const [windowId, ctid] of activeTabByWindow) {
+          if (ctid === oldCtid) activeTabByWindow.set(windowId, newCtid);
+        }
         if (agentWorkingTabId === oldCtid) {
           agentWorkingTabId = newCtid;
           import("@/lib/agent/agent-transport")

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -1034,12 +1034,12 @@ export default defineBackground({
       if (message.type === "CLOSE_AGENT_TABS") {
         (async () => {
           const { handleCloseAgentTabs } = await import("./close-agent-tabs");
-          const { conversationId, tabIds } = message as {
+          const { conversationId, ltids } = message as {
             type: string;
             conversationId: string;
-            tabIds: number[];
+            ltids: string[];
           };
-          const res = await handleCloseAgentTabs({ conversationId, tabIds });
+          const res = await handleCloseAgentTabs({ conversationId, ltids });
           if (res.ok && res.undo && res.undo.tabs.length > 0) {
             chrome.runtime
               .sendMessage({ type: "AGENT_TABS_CLOSED", conversationId, undo: res.undo })
@@ -2462,6 +2462,25 @@ export default defineBackground({
         }).catch(() => {});
       }
     });
+
+    // Re-target the working overlay across `chrome.tabs.onReplaced`.
+    // Without this, prerender activation on the agent's working tab
+    // would leave the glow stranded on the old (now-dead) ctid until
+    // the next status update — visible flicker for the user. The
+    // tab-registry deduplicates replace vs. remove and exposes a
+    // single `onReplace` event we hook here.
+    import("@/lib/agent/tab-registry").then(({ tabRegistry }) => {
+      tabRegistry.onReplace(({ oldCtid, newCtid }) => {
+        if (agentWorkingTabId === oldCtid) {
+          agentWorkingTabId = newCtid;
+          import("@/lib/agent/agent-transport")
+            .then(({ notifyAgentStatus }) => {
+              notifyAgentStatus(true, agentWorkingColor, newCtid);
+            })
+            .catch(() => {});
+        }
+      });
+    }).catch(() => {});
 
     // Enforce the strip ordering invariant (pinned → favorites → regular)
     // when a tab is moved — whether dragged manually in Chrome's tab strip

--- a/apps/extension/src/entrypoints/background/tab-scoping.ts
+++ b/apps/extension/src/entrypoints/background/tab-scoping.ts
@@ -353,7 +353,20 @@ async function clearTabOwnershipForLtid(ltid: LogicalTabId): Promise<void> {
   const conv = await chatDb.getConversation(convId);
   if (!conv) return;
   const nextOwned = conv.ownedLtids.filter((l) => l !== ltid);
-  await chatDb.updateConversation(convId, { ownedLtids: nextOwned });
+  // When the last owned tab is dropped, the group is also empty; null
+  // `ownedGroupId` and clear the in-memory groupOwnership entry so a
+  // future `bindTabsToConversation` mints a fresh group rather than
+  // re-using a stale id. Without this, the conversation row could be
+  // left in an inconsistent state (`ownedGroupId: 7, ownedLtids: []`)
+  // until the next SW restart's reconciliation fixed it.
+  const updates: { ownedLtids: typeof nextOwned; ownedGroupId?: number | null } = {
+    ownedLtids: nextOwned,
+  };
+  if (nextOwned.length === 0 && conv.ownedGroupId != null) {
+    updates.ownedGroupId = null;
+    groupOwnership.delete(conv.ownedGroupId);
+  }
+  await chatDb.updateConversation(convId, updates);
 }
 
 async function clearGroupOwnership(groupId: number) {
@@ -589,6 +602,13 @@ export interface CloseTabsUndo {
  * resolved to a live ctid via the registry just before `chrome.tabs
  * .remove`. Unresolvable ltids (the underlying tab is already gone) are
  * silently skipped.
+ *
+ * Defensive ownership filter: each input ltid is validated against the
+ * conversation's persisted `ownedLtids` BEFORE any tab is removed. ltids
+ * that don't belong to this conversation are silently skipped — protects
+ * against a future caller passing the wrong ltid set, and also means a
+ * concurrent SW restart that wiped the conversation row degrades to a
+ * no-op rather than blindly removing tabs we no longer track.
  */
 export async function closeOwnedTabs(
   conversationId: string,
@@ -600,7 +620,14 @@ export async function closeOwnedTabs(
     tabs: [],
   };
 
+  // Validate ownership up front. If the conversation row is missing the
+  // function degrades to a no-op (returns the empty undo) — `ownedLtids`
+  // is the source of truth for what we're allowed to close.
+  const conv = await chatDb.getConversation(conversationId);
+  const ownedSet = new Set(conv?.ownedLtids ?? []);
+
   for (const ltid of ltids) {
+    if (!ownedSet.has(ltid)) continue; // not ours; skip silently
     const ctid = tabRegistry.toChromeTabId(ltid);
     if (ctid != null) {
       try {
@@ -620,9 +647,8 @@ export async function closeOwnedTabs(
     tabOwnership.delete(ltid);
   }
 
-  const conv = await chatDb.getConversation(conversationId);
   if (conv) {
-    const closed = new Set(ltids);
+    const closed = new Set(ltids.filter((l) => ownedSet.has(l)));
     const remaining = conv.ownedLtids.filter((l) => !closed.has(l));
     const updates: { ownedLtids: LogicalTabId[]; ownedGroupId?: number | null } = {
       ownedLtids: remaining,

--- a/apps/extension/src/entrypoints/background/tab-scoping.ts
+++ b/apps/extension/src/entrypoints/background/tab-scoping.ts
@@ -1,6 +1,23 @@
 import { chatDb } from "@/lib/chat-db";
+import { tabRegistry, type LogicalTabId } from "@/lib/agent/tab-registry";
 
-const tabOwnership = new Map<number, string>();
+/**
+ * In-memory ownership maps. As of the LogicalTabId migration:
+ *
+ *  - `tabOwnership` is keyed on `LogicalTabId` (UUID) so a `chrome.tabs
+ *    .onReplaced` (Speculation Rules / prerender activation) doesn't
+ *    silently corrupt ownership — the ltid stays the same across the
+ *    swap; only the underlying ctid changes (and that change is handled
+ *    by the registry itself).
+ *  - `groupOwnership` stays keyed on `groupId` — group ids ARE stable
+ *    across replacements (Chrome moves the new tab into the existing
+ *    group automatically).
+ *  - `userOpenedSidePanelTabs` and `agent_toast_dismissed_tabs` stay
+ *    keyed on chrome tab id: they represent UX gestures against a
+ *    specific tab right now ("the user just opened the side panel here"),
+ *    not logical agent identity.
+ */
+const tabOwnership = new Map<LogicalTabId, string>();
 const groupOwnership = new Map<number, string>();
 const sidePanelOpenByWindow = new Map<number, boolean>();
 
@@ -54,23 +71,27 @@ export async function clearToastDismissalForTab(tabId: number): Promise<void> {
 export async function clearToastDismissalForConversation(
   conversationId: string,
 ): Promise<void> {
-  const tabIds: number[] = [];
-  for (const [tabId, cid] of tabOwnership) {
-    if (cid === conversationId) tabIds.push(tabId);
+  // Resolve each owned ltid to its current ctid for the dismissal store
+  // (which is keyed on ctid by design — see tabOwnership comment above).
+  const ctids: number[] = [];
+  for (const [ltid, cid] of tabOwnership) {
+    if (cid !== conversationId) continue;
+    const ctid = tabRegistry.toChromeTabId(ltid);
+    if (ctid != null) ctids.push(ctid);
   }
-  if (tabIds.length === 0) return;
+  if (ctids.length === 0) return;
   const dismissed = await getDismissedTabs();
   let changed = false;
-  for (const tabId of tabIds) {
-    if (dismissed.delete(tabId)) changed = true;
+  for (const ctid of ctids) {
+    if (dismissed.delete(ctid)) changed = true;
   }
   if (changed) await setDismissedTabs(dismissed);
-  for (const tabId of tabIds) {
+  for (const ctid of ctids) {
     chrome.tabs
-      .get(tabId)
+      .get(ctid)
       .then((tab) => {
         if (tab.active && !isSidePanelOpenForWindow(tab.windowId!)) {
-          emitToast(tabId, true);
+          emitToast(ctid, true);
         }
       })
       .catch(() => {});
@@ -117,19 +138,34 @@ function emitFocus(windowId: number, conversationId: string | null) {
   }
 }
 
+/**
+ * Public lookup: which conversation owns the chrome tab id `tabId`?
+ *
+ * Keeps the legacy ctid-keyed signature so the dozen callers in
+ * `background/index.ts` don't have to change. Internally resolves
+ * ctid → ltid via the registry; returns `null` if the tab isn't tracked.
+ */
 export function getConversationForTab(tabId: number): string | null {
-  return tabOwnership.get(tabId) ?? null;
+  const ltid = tabRegistry.toLogicalTabId(tabId);
+  if (!ltid) return null;
+  return tabOwnership.get(ltid) ?? null;
 }
 
 /**
- * Reverse lookup: all tabIds currently owned by a conversation. Used to
- * resolve which browser window a conversation lives in (e.g. routing a
- * notification click to the correct space's side panel).
+ * Reverse lookup: all live chrome tab ids currently owned by a conversation.
+ * Used to resolve which browser window a conversation lives in (e.g.
+ * routing a notification click to the correct space's side panel).
+ *
+ * Resolves each owned ltid through the registry; ltids whose ctid the
+ * registry can't resolve are dropped (the underlying tab is gone or hasn't
+ * been re-discovered post-SW-restart).
  */
 export function getTabsForConversation(conversationId: string): number[] {
   const tabIds: number[] = [];
-  for (const [tabId, cid] of tabOwnership) {
-    if (cid === conversationId) tabIds.push(tabId);
+  for (const [ltid, cid] of tabOwnership) {
+    if (cid !== conversationId) continue;
+    const ctid = tabRegistry.toChromeTabId(ltid);
+    if (ctid != null) tabIds.push(ctid);
   }
   return tabIds;
 }
@@ -139,7 +175,9 @@ export function getConversationForGroup(groupId: number): string | null {
 }
 
 export function isTabOwned(tabId: number): boolean {
-  return tabOwnership.has(tabId);
+  const ltid = tabRegistry.toLogicalTabId(tabId);
+  if (!ltid) return false;
+  return tabOwnership.has(ltid);
 }
 
 export async function registerOwnership(
@@ -149,7 +187,8 @@ export async function registerOwnership(
 ): Promise<void> {
   groupOwnership.set(groupId, conversationId);
   for (const tabId of tabIds) {
-    tabOwnership.set(tabId, conversationId);
+    const ltid = tabRegistry.registerExisting(tabId);
+    tabOwnership.set(ltid, conversationId);
     setPanelEnabledForTab(tabId, true);
   }
 }
@@ -162,7 +201,7 @@ export function setSidePanelOpen(windowId: number, open: boolean) {
     });
   } else {
     chrome.tabs.query({ windowId, active: true }).then(([tab]) => {
-      if (tab?.id != null && tabOwnership.has(tab.id)) emitToast(tab.id, true);
+      if (tab?.id != null && isTabOwned(tab.id)) emitToast(tab.id, true);
     });
   }
 }
@@ -177,7 +216,7 @@ export function applyDesiredPanelState(tabId: number) {
   // opened it there. Otherwise, leave it unregistered so Chrome shows
   // nothing on that tab. The manifest declares no global side panel, so
   // there's no default fallback to fight against.
-  const owned = tabOwnership.has(tabId);
+  const owned = isTabOwned(tabId);
   const userOpened = userOpenedSidePanelTabs.has(tabId);
   chrome.sidePanel
     .setOptions({ tabId, path: "sidepanel.html", enabled: owned || userOpened })
@@ -200,6 +239,15 @@ async function setPanelEnabledForTab(tabId: number, enabled: boolean) {
   }
 }
 
+/**
+ * Bind a list of chrome tabs to a conversation. Mints (or recovers) a
+ * LogicalTabId for each ctid via the registry, then writes ltids to
+ * `tabOwnership` and persists them to chatDb's `ownedLtids` field.
+ *
+ * Public API keeps the ctid signature so the message-bus handlers in
+ * `background/index.ts` (which only know ctids when a tool calls
+ * `BIND_TABS_TO_CONVERSATION`) don't need to know about ltids.
+ */
 export async function bindTabsToConversation(
   conversationId: string,
   tabIds: number[],
@@ -262,33 +310,50 @@ export async function bindTabsToConversation(
   }
 
   groupOwnership.set(groupId, conversationId);
-  const newOwned = new Set(conv.ownedTabIds);
-  for (const id of ids) {
-    tabOwnership.set(id, conversationId);
-    newOwned.add(id);
-    setPanelEnabledForTab(id, true);
-    clearToastDismissalForTab(id);
+  // Mint or recover an ltid for each newly-bound ctid; merge with the
+  // conversation's existing ownedLtids set.
+  const newOwned = new Set<LogicalTabId>(conv.ownedLtids);
+  for (const ctid of ids) {
+    const ltid = tabRegistry.registerExisting(ctid);
+    tabOwnership.set(ltid, conversationId);
+    newOwned.add(ltid);
+    setPanelEnabledForTab(ctid, true);
+    clearToastDismissalForTab(ctid);
   }
 
   await chatDb.updateConversation(conversationId, {
     ownedGroupId: groupId,
-    ownedTabIds: Array.from(newOwned),
+    ownedLtids: Array.from(newOwned),
   });
 
   return { groupId, boundTabIds: ids };
 }
 
-async function clearTabOwnership(tabId: number) {
-  const convId = tabOwnership.get(tabId);
+/**
+ * Drop ownership for a single ltid. Called from the registry's `onRemove`
+ * subscription (the deduped stream — Chrome's trailing `onRemoved` after
+ * `onReplaced` is suppressed there) and from the in-process `chrome.tabs
+ * .onUpdated` group-change branch.
+ */
+async function clearTabOwnershipForLtid(ltid: LogicalTabId): Promise<void> {
+  const convId = tabOwnership.get(ltid);
   if (!convId) return;
-  tabOwnership.delete(tabId);
-  applyDesiredPanelState(tabId);
-  emitToast(tabId, false);
+  tabOwnership.delete(ltid);
+
+  // Best-effort: resolve the ltid back to its current ctid for the side-
+  // panel state and toast updates. If the registry no longer has the
+  // mapping (already dropped by `onRemove`), skip the UI updates — there's
+  // no live tab to update anyway.
+  const ctid = tabRegistry.toChromeTabId(ltid);
+  if (ctid != null) {
+    applyDesiredPanelState(ctid);
+    emitToast(ctid, false);
+  }
 
   const conv = await chatDb.getConversation(convId);
   if (!conv) return;
-  const nextOwned = conv.ownedTabIds.filter((t) => t !== tabId);
-  await chatDb.updateConversation(convId, { ownedTabIds: nextOwned });
+  const nextOwned = conv.ownedLtids.filter((l) => l !== ltid);
+  await chatDb.updateConversation(convId, { ownedLtids: nextOwned });
 }
 
 async function clearGroupOwnership(groupId: number) {
@@ -296,11 +361,13 @@ async function clearGroupOwnership(groupId: number) {
   if (!convId) return;
   groupOwnership.delete(groupId);
 
-  for (const [tabId, cid] of tabOwnership) {
-    if (cid === convId) {
-      tabOwnership.delete(tabId);
-      applyDesiredPanelState(tabId);
-      emitToast(tabId, false);
+  for (const [ltid, cid] of tabOwnership) {
+    if (cid !== convId) continue;
+    tabOwnership.delete(ltid);
+    const ctid = tabRegistry.toChromeTabId(ltid);
+    if (ctid != null) {
+      applyDesiredPanelState(ctid);
+      emitToast(ctid, false);
     }
   }
 
@@ -308,10 +375,18 @@ async function clearGroupOwnership(groupId: number) {
   if (!conv) return;
   await chatDb.updateConversation(convId, {
     ownedGroupId: null,
-    ownedTabIds: [],
+    ownedLtids: [],
   });
 }
 
+/**
+ * SW startup reconciliation. For each conversation with an `ownedGroupId`,
+ * query Chrome for the tabs in that group and re-mint ltids via the
+ * registry. Updates `chatDb.ownedLtids` to reflect the live set, dropping
+ * ltids whose ctid is gone and adding ltids minted for newly-discovered
+ * tabs. Mirrors the legacy "rebuild from group membership" semantics but
+ * keyed on ltid.
+ */
 async function rebuildIndexesFromStorage() {
   const convs = await chatDb.listConversations();
   tabOwnership.clear();
@@ -320,11 +395,11 @@ async function rebuildIndexesFromStorage() {
   for (const conv of convs) {
     if (conv.ownedGroupId == null) continue;
     let groupExists = false;
-    let liveTabIds: number[] = [];
+    let liveCtids: number[] = [];
     try {
       const tabs = await chrome.tabs.query({ groupId: conv.ownedGroupId });
-      liveTabIds = tabs.map((t) => t.id!).filter((id) => id != null);
-      groupExists = liveTabIds.length > 0;
+      liveCtids = tabs.map((t) => t.id!).filter((id) => id != null);
+      groupExists = liveCtids.length > 0;
     } catch {
       groupExists = false;
     }
@@ -332,18 +407,24 @@ async function rebuildIndexesFromStorage() {
     if (!groupExists) {
       await chatDb.updateConversation(conv.id, {
         ownedGroupId: null,
-        ownedTabIds: [],
+        ownedLtids: [],
       });
       continue;
     }
 
     groupOwnership.set(conv.ownedGroupId, conv.id);
-    for (const tabId of liveTabIds) {
-      tabOwnership.set(tabId, conv.id);
-      setPanelEnabledForTab(tabId, true);
+    const liveLtids: LogicalTabId[] = [];
+    for (const ctid of liveCtids) {
+      const ltid = tabRegistry.registerExisting(ctid);
+      liveLtids.push(ltid);
+      tabOwnership.set(ltid, conv.id);
+      setPanelEnabledForTab(ctid, true);
     }
-    if (liveTabIds.sort().join(",") !== [...conv.ownedTabIds].sort().join(",")) {
-      await chatDb.updateConversation(conv.id, { ownedTabIds: liveTabIds });
+    // Persist if the live set differs from what's stored.
+    const stored = [...conv.ownedLtids].sort().join(",");
+    const live = [...liveLtids].sort().join(",");
+    if (stored !== live) {
+      await chatDb.updateConversation(conv.id, { ownedLtids: liveLtids });
     }
   }
 }
@@ -351,8 +432,8 @@ async function rebuildIndexesFromStorage() {
 function installListeners() {
   chrome.tabs.onActivated.addListener(async (info) => {
     applyDesiredPanelState(info.tabId);
-    
-    const convId = tabOwnership.get(info.tabId);
+
+    const convId = getConversationForTab(info.tabId);
     if (convId) {
       if (sidePanelOpenByWindow.get(info.windowId)) {
         emitFocus(info.windowId, convId);
@@ -365,26 +446,47 @@ function installListeners() {
     }
   });
 
+  // Side-panel-only ctid bookkeeping: drop the user-opened-panel record
+  // when a tab closes. The ownership/handle drops happen via the
+  // registry's deduped `onRemove` subscription below.
   chrome.tabs.onRemoved.addListener((tabId) => {
     userOpenedSidePanelTabs.delete(tabId);
-    if (!tabOwnership.has(tabId)) return;
-    clearTabOwnership(tabId);
+  });
+
+  // Registry-driven ownership cleanup. Subscribing to the registry's
+  // `onRemove` (NOT `chrome.tabs.onRemoved`) means we get the deduped
+  // stream — the trailing `onRemoved` Chrome fires for the old ctid after
+  // an `onReplaced` is suppressed, so a prerender activation no longer
+  // looks like a tab close to ownership bookkeeping.
+  tabRegistry.onRemove(({ ltid }) => {
+    if (!tabOwnership.has(ltid)) return;
+    void clearTabOwnershipForLtid(ltid);
+  });
+
+  // On replace, the ltid is unchanged but the underlying ctid changed:
+  // re-register the side panel against the NEW ctid so the user can still
+  // open the panel from the (now-replaced) tab. Without this, prerender
+  // activation silently disables the side panel on agent-owned tabs.
+  tabRegistry.onReplace(({ ltid, newCtid }) => {
+    if (!tabOwnership.has(ltid)) return;
+    void setPanelEnabledForTab(newCtid, true);
   });
 
   chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-    if (changeInfo.pinned === true && tabOwnership.has(tabId)) {
-      await clearTabOwnership(tabId);
+    const ltid = tabRegistry.toLogicalTabId(tabId);
+    if (changeInfo.pinned === true && ltid && tabOwnership.has(ltid)) {
+      await clearTabOwnershipForLtid(ltid);
       return;
     }
-    if (changeInfo.groupId !== undefined && tabOwnership.has(tabId)) {
+    if (changeInfo.groupId !== undefined && ltid && tabOwnership.has(ltid)) {
       const newGroupId = changeInfo.groupId;
       if (newGroupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
-        await clearTabOwnership(tabId);
+        await clearTabOwnershipForLtid(ltid);
       } else {
         const ownerForNewGroup = groupOwnership.get(newGroupId);
-        const currentOwner = tabOwnership.get(tabId);
+        const currentOwner = tabOwnership.get(ltid);
         if (ownerForNewGroup !== currentOwner) {
-          await clearTabOwnership(tabId);
+          await clearTabOwnershipForLtid(ltid);
         }
       }
     }
@@ -437,10 +539,10 @@ export async function cleanupCompletedAgentTabs(opts: {
     if (!conv.lastCompletionApproved) continue;
     if (conv.taskCompletedAt == null) continue;
     if (now - conv.taskCompletedAt <= thresholdMs) continue;
-    if (conv.ownedTabIds.length === 0) continue;
+    if (conv.ownedLtids.length === 0) continue;
 
     try {
-      const undo = await closeOwnedTabs(conv.id, conv.ownedTabIds);
+      const undo = await closeOwnedTabs(conv.id, conv.ownedLtids);
       cleaned++;
       try {
         await chrome.runtime.sendMessage({
@@ -477,14 +579,20 @@ export interface CloseTabsUndo {
 /**
  * Close a set of agent-owned tabs for a conversation. Captures an undo
  * payload BEFORE removal, removes the tabs (tolerating already-closed
- * ones), then clears ownership: removes the closed ids from
- * `ownedTabIds`, and if no owned tabs remain, nulls `ownedGroupId`.
- * In-memory ownership maps are also cleared (onRemoved listeners do this
- * too, but we do it eagerly so callers see consistent state immediately).
+ * ones), then clears ownership: removes the closed ltids from
+ * `ownedLtids`, and if no owned ltids remain, nulls `ownedGroupId`.
+ * In-memory ownership maps are also cleared (the registry's `onRemove`
+ * subscription does this too, but we do it eagerly so callers see
+ * consistent state immediately).
+ *
+ * `ltids` is the conversation's `ownedLtids` array — each entry is
+ * resolved to a live ctid via the registry just before `chrome.tabs
+ * .remove`. Unresolvable ltids (the underlying tab is already gone) are
+ * silently skipped.
  */
 export async function closeOwnedTabs(
   conversationId: string,
-  tabIds: number[],
+  ltids: LogicalTabId[],
 ): Promise<CloseTabsUndo> {
   const undo: CloseTabsUndo = {
     action: "reopen",
@@ -492,29 +600,32 @@ export async function closeOwnedTabs(
     tabs: [],
   };
 
-  for (const tabId of tabIds) {
-    try {
-      const tab = await chrome.tabs.get(tabId);
-      if (tab.url) {
-        undo.tabs.push({
-          url: tab.url,
-          windowId: tab.windowId,
-          pinned: !!tab.pinned,
-        });
+  for (const ltid of ltids) {
+    const ctid = tabRegistry.toChromeTabId(ltid);
+    if (ctid != null) {
+      try {
+        const tab = await chrome.tabs.get(ctid);
+        if (tab.url) {
+          undo.tabs.push({
+            url: tab.url,
+            windowId: tab.windowId,
+            pinned: !!tab.pinned,
+          });
+        }
+        await chrome.tabs.remove(ctid);
+      } catch {
+        // Tab already gone; skip from undo and continue.
       }
-      await chrome.tabs.remove(tabId);
-    } catch {
-      // Tab already gone; skip from undo and continue.
     }
-    tabOwnership.delete(tabId);
+    tabOwnership.delete(ltid);
   }
 
   const conv = await chatDb.getConversation(conversationId);
   if (conv) {
-    const closed = new Set(tabIds);
-    const remaining = conv.ownedTabIds.filter((id) => !closed.has(id));
-    const updates: { ownedTabIds: number[]; ownedGroupId?: number | null } = {
-      ownedTabIds: remaining,
+    const closed = new Set(ltids);
+    const remaining = conv.ownedLtids.filter((l) => !closed.has(l));
+    const updates: { ownedLtids: LogicalTabId[]; ownedGroupId?: number | null } = {
+      ownedLtids: remaining,
     };
     if (remaining.length === 0) {
       updates.ownedGroupId = null;

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -1851,7 +1851,7 @@ export function useAgentChat({
       // tab-handle map is hydrated before tool calls run.
       // Bind the side panel's currently-shared active tab into the new
       // conversation BEFORE setAgentContext + onNewConversation. The
-      // legend block re-reads `ownedTabIds` from chatDb on every model
+      // legend block re-reads `ownedLtids` from chatDb on every model
       // call, so awaiting the bind here guarantees the auto-resume
       // sendMessage triggered by the message-load effect (after
       // `onNewConversation`) sees the shared tab in the very first

--- a/apps/extension/src/lib/__tests__/chat-db-completion-marker.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-completion-marker.test.ts
@@ -11,7 +11,7 @@ describe("chatDb completion marker fields", () => {
 
   it("persists lastCompletionApproved and taskCompletedAt", async () => {
     await chatDb.createConversation({
-      id: "c1", title: "t", spaceId: null, ownedTabIds: [], createdAt: 0, updatedAt: 0,
+      id: "c1", title: "t", spaceId: null, ownedLtids: [], createdAt: 0, updatedAt: 0,
     });
     await chatDb.updateConversation("c1", {
       lastCompletionApproved: true,
@@ -24,7 +24,7 @@ describe("chatDb completion marker fields", () => {
 
   it("defaults to undefined on fresh conversations", async () => {
     await chatDb.createConversation({
-      id: "c2", title: "t", spaceId: null, ownedTabIds: [], createdAt: 0, updatedAt: 0,
+      id: "c2", title: "t", spaceId: null, ownedLtids: [], createdAt: 0, updatedAt: 0,
     });
     const conv = await chatDb.getConversation("c2");
     expect(conv?.lastCompletionApproved).toBeUndefined();

--- a/apps/extension/src/lib/__tests__/chat-db-delete.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-delete.test.ts
@@ -9,7 +9,7 @@ async function seedConv(id: string = CONV) {
     id,
     title: id,
     spaceId: null,
-    ownedTabIds: [],
+    ownedLtids: [],
     createdAt: 0,
     updatedAt: 0,
   });
@@ -106,7 +106,7 @@ describe("chatDb.deleteMessagesFrom", () => {
       id: "other",
       title: "other",
       spaceId: null,
-      ownedTabIds: [],
+      ownedLtids: [],
       createdAt: 0,
       updatedAt: 0,
     });

--- a/apps/extension/src/lib/__tests__/chat-db-v15-migration.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-v15-migration.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the chat-db v15 upgrade hop, which renames
+ * `ownedTabIds: number[]` → `ownedLtids: string[]` and rewrites
+ * `handleState.handles` values from chrome.tabs.id (number) to LogicalTabId
+ * (UUID string).
+ *
+ * Uses fake-indexeddb to drive a real IndexedDB upgrade lifecycle so we can
+ * seed v14-shaped rows, open the db at v15, and assert the migration
+ * produced the expected v15 shape.
+ */
+
+import "fake-indexeddb/auto";
+import { openDB } from "idb";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { chatDb } from "../chat-db";
+import { tabRegistry } from "../agent/tab-registry";
+
+/**
+ * Seed a v14-shaped conversations object store. The columns we care about
+ * are `ownedTabIds: number[]` and `handleState.handles: Record<string, number>`.
+ * We don't need to faithfully simulate every prior schema bump — the v15 hop
+ * only reads `ownedTabIds` and `handleState`, plus calls `cursor.update` on
+ * the row in place.
+ */
+async function seedV14Row(row: {
+  id: string;
+  ownedTabIds: number[];
+  handleState?: { handles: Record<string, number>; counter: number };
+}): Promise<void> {
+  // Open at v14 with the minimum schema needed to write a row, mirroring
+  // what an existing user's IndexedDB looks like before the upgrade.
+  const db = await openDB("openbrowse-chat", 14, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains("conversations")) {
+        const s = db.createObjectStore("conversations", { keyPath: "id" });
+        s.createIndex("by-updated", "updatedAt");
+        s.createIndex("by-space", "spaceId");
+        s.createIndex("by-parent", "parentConversationId");
+      }
+      if (!db.objectStoreNames.contains("messages")) {
+        const m = db.createObjectStore("messages", { keyPath: "id" });
+        m.createIndex("by-conversation", "conversationId");
+      }
+      if (!db.objectStoreNames.contains("scheduledTasks")) {
+        const t = db.createObjectStore("scheduledTasks", { keyPath: "id" });
+        t.createIndex("by-next-run", "nextRunAt");
+      }
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const record: any = {
+    id: row.id,
+    title: "t",
+    spaceId: null,
+    ownedGroupId: null,
+    ownedTabIds: row.ownedTabIds,
+    parentConversationId: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+  if (row.handleState) {
+    record.handleState = row.handleState;
+  }
+  await db.put("conversations", record);
+  db.close();
+}
+
+/** Read the raw row past the typed chatDb wrapper to inspect post-migration shape. */
+async function readRowRaw(id: string): Promise<Record<string, unknown> | undefined> {
+  // chatDb.getDb is private; use the raw factory at v15.
+  const db = await openDB("openbrowse-chat", 15);
+  const v = await db.get("conversations", id);
+  db.close();
+  return v as unknown as Record<string, unknown> | undefined;
+}
+
+describe("chatDb v15 migration: ownedTabIds → ownedLtids", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+  });
+
+  afterEach(() => {
+    chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    vi.restoreAllMocks();
+  });
+
+  it("migrates a row with mixed live/dead ctids — drops dead, mints ltids for live", async () => {
+    // Stub chrome.tabs.get: ctid 42 is alive, 99 throws (dead).
+    vi.stubGlobal("chrome", {
+      ...((globalThis as { chrome?: unknown }).chrome ?? {}),
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        get: (id: number) => {
+          if (id === 42) return Promise.resolve({ id: 42, url: "https://x" });
+          return Promise.reject(new Error("no tab"));
+        },
+        query: () => Promise.resolve([]),
+        sendMessage: () => Promise.resolve(undefined),
+      },
+    });
+
+    await seedV14Row({
+      id: "c1",
+      ownedTabIds: [42, 99],
+      handleState: { handles: { t1: 42, t2: 99 }, counter: 3 },
+    });
+
+    // Trigger the upgrade by opening the db through chatDb's factory.
+    await chatDb.listConversations();
+
+    const row = await readRowRaw("c1");
+    expect(row).toBeDefined();
+    expect(row!.ownedTabIds).toBeUndefined(); // legacy field removed
+    const ownedLtids = row!.ownedLtids as string[];
+    expect(ownedLtids).toHaveLength(1);
+    const ltid42 = ownedLtids[0];
+    expect(typeof ltid42).toBe("string");
+    expect(ltid42.length).toBeGreaterThan(0);
+
+    // Handle map: t1 should rewrite to the ltid we minted for 42; t2 dropped.
+    const hs = row!.handleState as
+      | { handles: Record<string, string>; counter: number }
+      | undefined;
+    expect(hs).toBeDefined();
+    expect(hs!.handles).toEqual({ t1: ltid42 });
+    expect(hs!.counter).toBe(3);
+  });
+
+  it("degrades a corrupt row to empty owned-state and warns", async () => {
+    vi.stubGlobal("chrome", {
+      ...((globalThis as { chrome?: unknown }).chrome ?? {}),
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        // Make tabs.get throw synchronously (the registration loop awaits
+        // it). We don't want this to be the failure case though — that
+        // path is "tab dead, drop", not "throw and degrade". Instead we
+        // make ownedTabIds itself a getter that throws on read inside
+        // the try block.
+        get: () => Promise.resolve({ id: 0, url: "" }),
+        query: () => Promise.resolve([]),
+        sendMessage: () => Promise.resolve(undefined),
+      },
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Seed a normal-looking v14 row, then re-open the db at v14 and
+    // overwrite the row with a poison-pill payload whose `ownedTabIds`
+    // getter throws on read. fake-indexeddb's structured-clone path
+    // refuses to serialize getters, so instead we use a non-array,
+    // non-iterable ownedTabIds value that crashes the `for (const ctid
+    // of legacyTabIds)` loop's iterator after Array.isArray fails. We
+    // achieve this by making the migration's downstream `Object.entries`
+    // see a Proxy that throws on iteration.
+    //
+    // Simpler: directly check that an exception inside the inner loop
+    // routes to the catch by making `tabRegistry.registerExisting` throw.
+    const realRegister = tabRegistry.registerExisting;
+    let calls = 0;
+    tabRegistry.registerExisting = ((ctid: number) => {
+      calls += 1;
+      if (calls === 1) throw new Error("synthetic register failure");
+      return realRegister(ctid);
+    }) as typeof realRegister;
+
+    await seedV14Row({
+      id: "c-broken",
+      ownedTabIds: [42],
+    });
+
+    try {
+      await chatDb.listConversations();
+    } finally {
+      tabRegistry.registerExisting = realRegister;
+    }
+
+    const row = await readRowRaw("c-broken");
+    expect(row).toBeDefined();
+    expect(row!.ownedTabIds).toBeUndefined();
+    expect(row!.ownedLtids).toEqual([]);
+    expect(row!.handleState).toBeUndefined();
+
+    // The migration's catch path warns; multiple warns may fire (e.g.
+    // tab-registry's onReplaced telemetry may also have fired). Check that
+    // ours appears.
+    const v15warns = warn.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("[chat-db v15]"),
+    );
+    expect(v15warns.length).toBeGreaterThan(0);
+  });
+
+  it("migrates an empty row to ownedLtids: [] with no handleState", async () => {
+    vi.stubGlobal("chrome", {
+      ...((globalThis as { chrome?: unknown }).chrome ?? {}),
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        get: () => Promise.reject(new Error("none")),
+        query: () => Promise.resolve([]),
+        sendMessage: () => Promise.resolve(undefined),
+      },
+    });
+
+    await seedV14Row({ id: "empty", ownedTabIds: [] });
+
+    await chatDb.listConversations();
+
+    const row = await readRowRaw("empty");
+    expect(row!.ownedTabIds).toBeUndefined();
+    expect(row!.ownedLtids).toEqual([]);
+    expect(row!.handleState).toBeUndefined();
+  });
+
+  it("preserves the handle counter when handle map is empty post-migration", async () => {
+    vi.stubGlobal("chrome", {
+      ...((globalThis as { chrome?: unknown }).chrome ?? {}),
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        get: () => Promise.reject(new Error("dead")),
+        query: () => Promise.resolve([]),
+        sendMessage: () => Promise.resolve(undefined),
+      },
+    });
+
+    // All ctids are dead → all handles drop, but counter=7 should persist
+    // (so newly-minted handles continue from t7 and don't collide with
+    // earlier message text mentioning t1..t6).
+    await seedV14Row({
+      id: "c-counter",
+      ownedTabIds: [1, 2, 3],
+      handleState: { handles: { t1: 1, t2: 2, t3: 3 }, counter: 7 },
+    });
+
+    await chatDb.listConversations();
+
+    const row = await readRowRaw("c-counter");
+    expect(row!.ownedLtids).toEqual([]);
+    const hs = row!.handleState as
+      | { handles: Record<string, string>; counter: number }
+      | undefined;
+    expect(hs).toBeDefined();
+    expect(hs!.handles).toEqual({});
+    expect(hs!.counter).toBe(7);
+  });
+
+  it("is idempotent — re-opening at v15 doesn't re-migrate", async () => {
+    vi.stubGlobal("chrome", {
+      ...((globalThis as { chrome?: unknown }).chrome ?? {}),
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        get: (id: number) => Promise.resolve({ id, url: "https://x" }),
+        query: () => Promise.resolve([]),
+        sendMessage: () => Promise.resolve(undefined),
+      },
+    });
+
+    await seedV14Row({ id: "c1", ownedTabIds: [42] });
+
+    // First open triggers the v14 → v15 upgrade.
+    await chatDb.listConversations();
+    const row1 = await readRowRaw("c1");
+    const ltid1 = (row1!.ownedLtids as string[])[0];
+
+    // Reset chatDb's connection cache so the next call re-opens (which,
+    // because the schema is at v15, should run no upgrade hop and
+    // touch nothing).
+    chatDb._resetForTests();
+
+    await chatDb.listConversations();
+    const row2 = await readRowRaw("c1");
+    expect((row2!.ownedLtids as string[])[0]).toBe(ltid1);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/cdp-session-onreplaced.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/cdp-session-onreplaced.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Targeted tests for `cdp-session`'s registry integration: when the
+ * `tab-registry` emits `onReplace` / `onRemove`, the corresponding ctid's
+ * cached Session is dropped so the next `sendCommand` re-attaches against
+ * the live tab.
+ *
+ * These tests do NOT exercise the full `sendCommand` path (which would
+ * require a much heavier `chrome.debugger` mock) — they assert on the
+ * exported sessions map's emptiness via the indirect signal of a fresh
+ * attach call.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("cdp-session: registry-driven invalidation", () => {
+  // We dynamic-import inside each test so the module's top-level chrome
+  // listener registrations re-run against a fresh stubbed `chrome`.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("drops the cached session for oldCtid when the registry fires onReplace", async () => {
+    const attachCalls: number[] = [];
+    const sendCommandCalls: { tabId: number; method: string }[] = [];
+    vi.stubGlobal("chrome", {
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        get: () => Promise.resolve({ id: 1, url: "https://x" }),
+      },
+      debugger: {
+        onDetach: { addListener: () => {}, removeListener: () => {} },
+        onEvent: { addListener: () => {}, removeListener: () => {} },
+        attach: vi.fn((target: { tabId: number }) => {
+          attachCalls.push(target.tabId);
+          return Promise.resolve();
+        }),
+        detach: vi.fn(() => Promise.resolve()),
+        sendCommand: vi.fn(
+          (target: { tabId: number }, method: string) => {
+            sendCommandCalls.push({ tabId: target.tabId, method });
+            return Promise.resolve({});
+          },
+        ),
+      },
+    });
+
+    const { sendCommand } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    // First call attaches against ctid 100.
+    await sendCommand(100, "Page.bringToFront");
+    expect(attachCalls).toContain(100);
+    const attachesBefore = attachCalls.length;
+
+    // Register ctid 100 with the registry, then fire onReplaced 100 → 200.
+    tabRegistry.registerExisting(100);
+    tabRegistry.__handleReplaceForTests!(200, 100);
+
+    // Next sendCommand against ctid 200 should attach freshly (because
+    // session for 100 was dropped, AND no session exists for 200 yet).
+    await sendCommand(200, "Page.bringToFront");
+    expect(attachCalls).toContain(200);
+    expect(attachCalls.length).toBeGreaterThan(attachesBefore);
+
+    // Subsequent sendCommand against the OLD ctid 100 would also attach
+    // (the session was dropped by onReplace), proving the cache was
+    // invalidated.
+    const attachesAfter200 = attachCalls.length;
+    await sendCommand(100, "Page.bringToFront");
+    expect(attachCalls.length).toBeGreaterThan(attachesAfter200);
+  });
+
+  it("drops the cached session for ctid when the registry fires onRemove", async () => {
+    const attachCalls: number[] = [];
+    vi.stubGlobal("chrome", {
+      tabs: {
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onUpdated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        get: () => Promise.resolve({ id: 1, url: "" }),
+      },
+      debugger: {
+        onDetach: { addListener: () => {}, removeListener: () => {} },
+        onEvent: { addListener: () => {}, removeListener: () => {} },
+        attach: vi.fn((target: { tabId: number }) => {
+          attachCalls.push(target.tabId);
+          return Promise.resolve();
+        }),
+        detach: vi.fn(() => Promise.resolve()),
+        sendCommand: vi.fn(() => Promise.resolve({})),
+      },
+    });
+
+    const { sendCommand } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    await sendCommand(42, "Page.bringToFront");
+    expect(attachCalls.filter((id) => id === 42).length).toBe(1);
+
+    tabRegistry.registerExisting(42);
+    tabRegistry.__handleRemoveForTests!(42);
+
+    // Fresh attach on next call.
+    await sendCommand(42, "Page.bringToFront");
+    expect(attachCalls.filter((id) => id === 42).length).toBe(2);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/close-tabs-allowlist.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/close-tabs-allowlist.test.ts
@@ -1,6 +1,7 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatDb } from "../../chat-db";
+import { tabRegistry } from "../tab-registry";
 
 const CID = "conv-close-allow";
 
@@ -18,8 +19,10 @@ function installChromeStub() {
     },
     tabs: {
       onRemoved: { addListener: () => {}, removeListener: () => {} },
+      onReplaced: { addListener: () => {}, removeListener: () => {} },
       onUpdated: { addListener: () => {}, removeListener: () => {} },
       onActivated: { addListener: () => {}, removeListener: () => {} },
+      onCreated: { addListener: () => {}, removeListener: () => {} },
       get: (id: number) => Promise.resolve({ id, url: `https://x/${id}` }),
       query: () => Promise.resolve([]),
       sendMessage: () => Promise.resolve(undefined),
@@ -49,17 +52,26 @@ function installChromeStub() {
 }
 
 describe("closeTabs ownership-scoped always-allow", () => {
+  let ltid101: string;
+  let ltid102: string;
+
   beforeEach(async () => {
     installChromeStub();
     indexedDB = new IDBFactory();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    ltid101 = tabRegistry.registerExisting(101);
+    ltid102 = tabRegistry.registerExisting(102);
     await chatDb.createConversation({
-      id: CID, title: "t", spaceId: null, ownedGroupId: 1, ownedTabIds: [101, 102], createdAt: 0, updatedAt: 0,
+      id: CID, title: "t", spaceId: null, ownedGroupId: 1,
+      ownedLtids: [ltid101, ltid102],
+      createdAt: 0, updatedAt: 0,
     });
   });
   afterEach(() => {
     vi.unstubAllGlobals();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
   });
 
   it("defaults to not-allowed (approval required)", async () => {
@@ -77,13 +89,19 @@ describe("closeTabs ownership-scoped always-allow", () => {
     const { setCloseTabsAlwaysAllowed, shouldAutoApproveCloseTabs } = await import("../agent-transport");
     await setCloseTabsAlwaysAllowed(true);
     expect(await shouldAutoApproveCloseTabs(CID, { target: "group" })).toBe(true);
-    expect(await shouldAutoApproveCloseTabs(CID, { target: "tabs", tabIds: [101] })).toBe(true);
+    expect(
+      await shouldAutoApproveCloseTabs(CID, { target: "tabs", ltids: [ltid101] }),
+    ).toBe(true);
   });
 
   it("does NOT auto-approve when a target is not owned, even with flag on", async () => {
     const { setCloseTabsAlwaysAllowed, shouldAutoApproveCloseTabs } = await import("../agent-transport");
     await setCloseTabsAlwaysAllowed(true);
-    expect(await shouldAutoApproveCloseTabs(CID, { target: "tabs", tabIds: [999] })).toBe(false);
+    // A synthetic ltid that the conversation doesn't own.
+    const ltid999 = tabRegistry.registerExisting(999);
+    expect(
+      await shouldAutoApproveCloseTabs(CID, { target: "tabs", ltids: [ltid999] }),
+    ).toBe(false);
   });
 
   it("does NOT auto-approve when flag is off", async () => {

--- a/apps/extension/src/lib/agent/__tests__/completion-marker-persist.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/completion-marker-persist.test.ts
@@ -8,7 +8,7 @@ describe("persistCompletionMarker", () => {
     indexedDB = new IDBFactory();
     chatDb._resetForTests();
     await chatDb.createConversation({
-      id: "c1", title: "t", spaceId: null, ownedTabIds: [], createdAt: 0, updatedAt: 0,
+      id: "c1", title: "t", spaceId: null, ownedLtids: [], createdAt: 0, updatedAt: 0,
     });
   });
   afterEach(() => chatDb._resetForTests());

--- a/apps/extension/src/lib/agent/__tests__/execute-on-page-allowlist.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/execute-on-page-allowlist.test.ts
@@ -90,10 +90,14 @@ describe("executeOnPage allowlist integration (Always allow repro)", () => {
       await import("@/lib/agent/agent-transport");
     const { executeOnPageTool } = await import("@/lib/agent/tools");
     const { getOrCreateHandle } = await import("@/lib/agent/tab-handles");
+    const { tabRegistry } = await import("@/lib/agent/tab-registry");
 
     // Bind the active conversation + a live tab handle, like a real run.
     setAgentContext(CID);
-    const handle = getOrCreateHandle(CID, TAB_ID);
+    // Mint an ltid for the test ctid via the registry; getOrCreateHandle
+    // takes ltids post-migration.
+    const ltid = tabRegistry.registerExisting(TAB_ID);
+    const handle = getOrCreateHandle(CID, ltid);
 
     // Simulate clicking "Always allow on bookface.ycombinator.com" on an
     // earlier call: persist the grant for the executeOnPage tool + origin.

--- a/apps/extension/src/lib/agent/__tests__/new-tab-window-targeting.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/new-tab-window-targeting.test.ts
@@ -13,6 +13,7 @@
  */
 
 import "fake-indexeddb/auto";
+import { tabRegistry } from "../tab-registry";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatDb } from "../../chat-db";
 import type { ToolContext } from "../driver";
@@ -161,29 +162,40 @@ function makeChromeStub(opts: {
 
 async function seedConv(
   id: string,
-  opts: { ownedTabIds?: number[]; spaceId?: string | null } = {},
+  opts: { ownedLtids?: string[]; spaceId?: string | null } = {},
 ) {
   await chatDb.createConversation({
     id,
     title: id,
     spaceId: opts.spaceId ?? null,
     ownedGroupId: null,
-    ownedTabIds: opts.ownedTabIds ?? [],
+    ownedLtids: opts.ownedLtids ?? [],
     createdAt: 0,
     updatedAt: 0,
   });
+}
+
+/**
+ * Mint an ltid via the registry for a fake ctid; used by tests below
+ * that drive `resolveNewTabWindowId`, which now resolves `ownedLtids`
+ * through the registry to live ctids before consulting `chrome.tabs.get`.
+ */
+function ltidFor(ctid: number): string {
+  return tabRegistry.registerExisting(ctid);
 }
 
 describe("buildExtensionToolContext — resolveNewTabWindowId", () => {
   beforeEach(() => {
     indexedDB = new IDBFactory();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
   });
 
   it("returns the window of the first live owned tab", async () => {
@@ -191,7 +203,7 @@ describe("buildExtensionToolContext — resolveNewTabWindowId", () => {
       "chrome",
       makeChromeStub({ tabs: { 101: { windowId: 3 }, 102: { windowId: 9 } } }),
     );
-    await seedConv("c1", { ownedTabIds: [101, 102] });
+    await seedConv("c1", { ownedLtids: [ltidFor(101), ltidFor(102)] });
     const ctx = buildExtensionToolContext("c1");
     expect(await ctx.session?.resolveNewTabWindowId?.()).toBe(3);
   });
@@ -201,7 +213,10 @@ describe("buildExtensionToolContext — resolveNewTabWindowId", () => {
       "chrome",
       makeChromeStub({ tabs: { 102: { windowId: 9 } } }), // 101 is gone
     );
-    await seedConv("c1", { ownedTabIds: [101, 102] });
+    // Mint ltids for BOTH ctids in the registry — the registry maps
+    // ltid → ctid; whether the ctid is alive in chrome is checked via
+    // the chrome.tabs.get probe.
+    await seedConv("c1", { ownedLtids: [ltidFor(101), ltidFor(102)] });
     const ctx = buildExtensionToolContext("c1");
     expect(await ctx.session?.resolveNewTabWindowId?.()).toBe(9);
   });
@@ -215,7 +230,7 @@ describe("buildExtensionToolContext — resolveNewTabWindowId", () => {
         spaces: [{ id: "s1", name: "S", windowId: 8, favorites: [] }],
       }),
     );
-    await seedConv("c1", { ownedTabIds: [], spaceId: "s1" });
+    await seedConv("c1", { ownedLtids: [], spaceId: "s1" });
     const ctx = buildExtensionToolContext("c1");
     expect(await ctx.session?.resolveNewTabWindowId?.()).toBe(8);
   });
@@ -229,14 +244,14 @@ describe("buildExtensionToolContext — resolveNewTabWindowId", () => {
         spaces: [{ id: "s1", name: "S", windowId: 8, favorites: [] }],
       }),
     );
-    await seedConv("c1", { ownedTabIds: [], spaceId: "s1" });
+    await seedConv("c1", { ownedLtids: [], spaceId: "s1" });
     const ctx = buildExtensionToolContext("c1");
     expect(await ctx.session?.resolveNewTabWindowId?.()).toBeUndefined();
   });
 
   it("returns undefined when there are no owned tabs and no space", async () => {
     vi.stubGlobal("chrome", makeChromeStub({ tabs: {} }));
-    await seedConv("c1", { ownedTabIds: [], spaceId: null });
+    await seedConv("c1", { ownedLtids: [], spaceId: null });
     const ctx = buildExtensionToolContext("c1");
     expect(await ctx.session?.resolveNewTabWindowId?.()).toBeUndefined();
   });

--- a/apps/extension/src/lib/agent/__tests__/set-agent-context-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/set-agent-context-handles.test.ts
@@ -25,6 +25,7 @@ import {
   getOrCreateHandle,
   resolveHandle,
 } from "../tab-handles";
+import { tabRegistry, type LogicalTabId } from "../tab-registry";
 
 const CONV_A = "conv-a";
 const CONV_B = "conv-b";
@@ -34,10 +35,15 @@ async function seedConv(id: string) {
     id,
     title: id,
     spaceId: null,
-    ownedTabIds: [],
+    ownedLtids: [],
     createdAt: 0,
     updatedAt: 0,
   });
+}
+
+/** Mint an ltid for a fake ctid via the registry. */
+function ltidFor(ctid: number): LogicalTabId {
+  return tabRegistry.registerExisting(ctid);
 }
 
 describe("setAgentContext — handle-map preservation", () => {
@@ -47,6 +53,7 @@ describe("setAgentContext — handle-map preservation", () => {
     clearHandles(CONV_A);
     clearHandles(CONV_B);
     setAgentContext(null);
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
     // `loadHandlesForConversation` reads chrome.tabs.get during hydration;
     // stub it so the (fire-and-forget) hydration doesn't reject in tests.
@@ -59,6 +66,7 @@ describe("setAgentContext — handle-map preservation", () => {
     clearHandles(CONV_A);
     clearHandles(CONV_B);
     setAgentContext(null);
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
   });
 
@@ -67,40 +75,45 @@ describe("setAgentContext — handle-map preservation", () => {
     await seedConv(CONV_B);
 
     setAgentContext(CONV_A);
-    expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
-    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+    const ltid100 = ltidFor(100);
+    expect(getOrCreateHandle(CONV_A, ltid100)).toBe("t1");
+    expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
 
     // Switch to B mid-flight (as if user navigated). A's map must
     // survive — any tool call still in-flight for A needs to keep
     // resolving its handles.
     setAgentContext(CONV_B);
-    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+    expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
   });
 
   it("does not leak handles between conversations after a switch", async () => {
     await seedConv(CONV_A);
     await seedConv(CONV_B);
 
+    const ltid100 = ltidFor(100);
+    const ltid200 = ltidFor(200);
     setAgentContext(CONV_A);
-    getOrCreateHandle(CONV_A, 100); // A:t1 → 100
+    getOrCreateHandle(CONV_A, ltid100); // A:t1 → ltid100
 
     setAgentContext(CONV_B);
     // B's map starts empty regardless of A's contents.
     expect(resolveHandle(CONV_B, "t1")).toBeUndefined();
 
     // Mint a handle in B; it must not collide with A's mapping.
-    const bHandle = getOrCreateHandle(CONV_B, 200);
-    expect(resolveHandle(CONV_B, bHandle)).toBe(200);
-    expect(resolveHandle(CONV_A, "t1")).toBe(100); // A still intact.
+    const bHandle = getOrCreateHandle(CONV_B, ltid200);
+    expect(resolveHandle(CONV_B, bHandle)).toBe(ltid200);
+    expect(resolveHandle(CONV_A, "t1")).toBe(ltid100); // A still intact.
   });
 
   it("repeated switches are idempotent w.r.t. handle preservation", async () => {
     await seedConv(CONV_A);
     await seedConv(CONV_B);
 
+    const ltid100 = ltidFor(100);
+    const ltid200 = ltidFor(200);
     setAgentContext(CONV_A);
-    getOrCreateHandle(CONV_A, 100);
-    getOrCreateHandle(CONV_A, 200);
+    getOrCreateHandle(CONV_A, ltid100);
+    getOrCreateHandle(CONV_A, ltid200);
 
     setAgentContext(CONV_B);
     setAgentContext(CONV_A);
@@ -108,17 +121,18 @@ describe("setAgentContext — handle-map preservation", () => {
     setAgentContext(CONV_A);
 
     // After all the flipping, A's handles must still be there.
-    expect(resolveHandle(CONV_A, "t1")).toBe(100);
-    expect(resolveHandle(CONV_A, "t2")).toBe(200);
+    expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
+    expect(resolveHandle(CONV_A, "t2")).toBe(ltid200);
   });
 
   it("setting context to null also preserves prior maps", async () => {
     await seedConv(CONV_A);
 
     setAgentContext(CONV_A);
-    getOrCreateHandle(CONV_A, 100);
+    const ltid100 = ltidFor(100);
+    getOrCreateHandle(CONV_A, ltid100);
 
     setAgentContext(null);
-    expect(resolveHandle(CONV_A, "t1")).toBe(100);
+    expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
   });
 });

--- a/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-handles.test.ts
@@ -3,26 +3,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatDb } from "../../chat-db";
 import {
   clearHandles,
-  dropTab,
+  dropLtid,
   flushPersistsForTests,
   getOrCreateHandle,
   listHandles,
   loadHandlesForConversation,
   resolveHandle,
 } from "../tab-handles";
+import { tabRegistry, type LogicalTabId } from "../tab-registry";
 
 const CONV_A = "conv-a";
 const CONV_B = "conv-b";
 
-async function seedConv(id: string, ownedTabIds: number[] = []) {
+async function seedConv(id: string, ownedLtids: LogicalTabId[] = []) {
   await chatDb.createConversation({
     id,
     title: id,
     spaceId: null,
-    ownedTabIds,
+    ownedLtids,
     createdAt: 0,
     updatedAt: 0,
   });
+}
+
+/**
+ * Mint an ltid for a fake chrome tab id so tests can assert
+ * (handle → ltid → ctid) round-trips. The registry's `registerExisting`
+ * is idempotent, so duplicate calls return the same ltid.
+ */
+function ltidFor(ctid: number): LogicalTabId {
+  return tabRegistry.registerExisting(ctid);
 }
 
 /**
@@ -39,227 +49,235 @@ describe("tab-handles", () => {
     chatDb._resetForTests();
     clearHandles(CONV_A);
     clearHandles(CONV_B);
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
   });
 
   afterEach(() => {
     clearHandles(CONV_A);
     clearHandles(CONV_B);
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
   });
 
   describe("getOrCreateHandle", () => {
-    it("returns t1, t2, ... for new tabs and is stable per (conversation, tabId)", async () => {
+    it("returns t1, t2, ... for new ltids and is stable per (conversation, ltid)", async () => {
       await seedConv(CONV_A);
-      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
-      expect(getOrCreateHandle(CONV_A, 200)).toBe("t2");
-      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+      const ltid100 = ltidFor(100);
+      const ltid200 = ltidFor(200);
+      expect(getOrCreateHandle(CONV_A, ltid100)).toBe("t1");
+      expect(getOrCreateHandle(CONV_A, ltid200)).toBe("t2");
+      expect(getOrCreateHandle(CONV_A, ltid100)).toBe("t1");
     });
 
     it("scopes counter independently per conversation", async () => {
       await seedConv(CONV_A);
       await seedConv(CONV_B);
-      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
-      expect(getOrCreateHandle(CONV_B, 999)).toBe("t1");
-      expect(getOrCreateHandle(CONV_A, 200)).toBe("t2");
-      expect(getOrCreateHandle(CONV_B, 888)).toBe("t2");
+      expect(getOrCreateHandle(CONV_A, ltidFor(100))).toBe("t1");
+      expect(getOrCreateHandle(CONV_B, ltidFor(999))).toBe("t1");
+      expect(getOrCreateHandle(CONV_A, ltidFor(200))).toBe("t2");
+      expect(getOrCreateHandle(CONV_B, ltidFor(888))).toBe("t2");
     });
   });
 
   describe("resolveHandle", () => {
-    it("round-trips a handle to its tabId", async () => {
+    it("round-trips a handle to its ltid", async () => {
       await seedConv(CONV_A);
-      getOrCreateHandle(CONV_A, 42);
-      expect(resolveHandle(CONV_A, "t1")).toBe(42);
+      const ltid42 = ltidFor(42);
+      getOrCreateHandle(CONV_A, ltid42);
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid42);
     });
 
     it("returns undefined for unknown handle or unknown conversation", async () => {
       await seedConv(CONV_A);
-      getOrCreateHandle(CONV_A, 42);
+      getOrCreateHandle(CONV_A, ltidFor(42));
       expect(resolveHandle(CONV_A, "t99")).toBeUndefined();
       expect(resolveHandle("nope", "t1")).toBeUndefined();
     });
   });
 
   describe("listHandles", () => {
-    it("emits all live (handle, tabId) pairs", async () => {
+    it("emits all live (handle, ltid) pairs", async () => {
       await seedConv(CONV_A);
-      getOrCreateHandle(CONV_A, 10);
-      getOrCreateHandle(CONV_A, 20);
+      const ltid10 = ltidFor(10);
+      const ltid20 = ltidFor(20);
+      getOrCreateHandle(CONV_A, ltid10);
+      getOrCreateHandle(CONV_A, ltid20);
       const list = listHandles(CONV_A).sort((a, b) =>
         a.handle.localeCompare(b.handle),
       );
       expect(list).toEqual([
-        { handle: "t1", tabId: 10 },
-        { handle: "t2", tabId: 20 },
+        { handle: "t1", ltid: ltid10 },
+        { handle: "t2", ltid: ltid20 },
       ]);
     });
   });
 
-  describe("dropTab", () => {
+  describe("dropLtid", () => {
     it("removes the handle from every conversation that knew it", async () => {
       await seedConv(CONV_A);
       await seedConv(CONV_B);
-      getOrCreateHandle(CONV_A, 555);
-      getOrCreateHandle(CONV_B, 555);
+      const ltid555 = ltidFor(555);
+      getOrCreateHandle(CONV_A, ltid555);
+      getOrCreateHandle(CONV_B, ltid555);
 
-      dropTab(555);
+      dropLtid(ltid555);
 
       expect(resolveHandle(CONV_A, "t1")).toBeUndefined();
       expect(resolveHandle(CONV_B, "t1")).toBeUndefined();
     });
 
-    it("is a no-op for unknown tab", async () => {
+    it("is a no-op for unknown ltid", async () => {
       await seedConv(CONV_A);
-      getOrCreateHandle(CONV_A, 100);
-      expect(() => dropTab(99999)).not.toThrow();
-      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+      const ltid100 = ltidFor(100);
+      getOrCreateHandle(CONV_A, ltid100);
+      expect(() => dropLtid("nonexistent-ltid")).not.toThrow();
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
     });
   });
 
   describe("clearHandles", () => {
     it("drops the in-memory map but leaves persisted state intact", async () => {
-      await seedConv(CONV_A, [100]);
-      getOrCreateHandle(CONV_A, 100);
+      const ltid100 = ltidFor(100);
+      await seedConv(CONV_A, [ltid100]);
+      getOrCreateHandle(CONV_A, ltid100);
       await flushPersist();
 
       clearHandles(CONV_A);
       expect(resolveHandle(CONV_A, "t1")).toBeUndefined();
 
-      // Hydration restores it. Stub chrome so the tab is reported live.
-      vi.stubGlobal("chrome", {
-        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
-      });
+      // Hydration restores it. The registry still has ltid100 → 100, so
+      // the persisted handle is resolvable.
       await loadHandlesForConversation(CONV_A);
-      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
     });
   });
 
   describe("persistence + hydration", () => {
-    it("only persists handles for tabs in ownedTabIds", async () => {
-      // Seed with 100 owned, 999 unowned.
-      await seedConv(CONV_A, [100]);
-      getOrCreateHandle(CONV_A, 100);
-      getOrCreateHandle(CONV_A, 999); // ephemeral (e.g. a listTabs preview)
+    it("only persists handles for ltids in ownedLtids", async () => {
+      const ltid100 = ltidFor(100);
+      const ltid999 = ltidFor(999);
+      await seedConv(CONV_A, [ltid100]);
+      getOrCreateHandle(CONV_A, ltid100);
+      getOrCreateHandle(CONV_A, ltid999); // ephemeral (e.g. a listTabs preview)
       await flushPersist();
 
       const conv = await chatDb.getConversation(CONV_A);
-      expect(conv?.handleState?.handles).toEqual({ t1: 100 });
+      expect(conv?.handleState?.handles).toEqual({ t1: ltid100 });
       // counter still advances even for ephemeral handles
       expect(conv?.handleState?.counter).toBe(3);
     });
 
-    it("re-persists when an ephemeral handle's tab gets bound (selectTab flow)", async () => {
-      // Mint an ephemeral handle while ownedTabIds is empty.
+    it("re-persists when an ephemeral handle's ltid gets bound (selectTab flow)", async () => {
+      const ltid555 = ltidFor(555);
+      // Mint an ephemeral handle while ownedLtids is empty.
       await seedConv(CONV_A, []);
-      getOrCreateHandle(CONV_A, 555);
+      getOrCreateHandle(CONV_A, ltid555);
       await flushPersist();
 
       // chatDb should not contain the unowned handle yet.
       let conv = await chatDb.getConversation(CONV_A);
       expect(conv?.handleState?.handles).toEqual({});
 
-      // Simulate selectTab binding 555 into ownedTabIds.
-      await chatDb.updateConversation(CONV_A, { ownedTabIds: [555] });
+      // Simulate selectTab binding ltid555 into ownedLtids.
+      await chatDb.updateConversation(CONV_A, { ownedLtids: [ltid555] });
 
-      // Re-call getOrCreateHandle for the same tabId. The function returns
+      // Re-call getOrCreateHandle for the same ltid. The function returns
       // the existing handle BUT must also schedule a fresh persist so the
       // now-owned handle lands in chatDb.
-      const handle = getOrCreateHandle(CONV_A, 555);
+      const handle = getOrCreateHandle(CONV_A, ltid555);
       expect(handle).toBe("t1");
       await flushPersist();
 
       conv = await chatDb.getConversation(CONV_A);
-      expect(conv?.handleState?.handles).toEqual({ t1: 555 });
+      expect(conv?.handleState?.handles).toEqual({ t1: ltid555 });
     });
 
     it("persists newly-minted handles to chatDb (owned tabs)", async () => {
-      await seedConv(CONV_A, [100, 200]);
-      getOrCreateHandle(CONV_A, 100);
-      getOrCreateHandle(CONV_A, 200);
+      const ltid100 = ltidFor(100);
+      const ltid200 = ltidFor(200);
+      await seedConv(CONV_A, [ltid100, ltid200]);
+      getOrCreateHandle(CONV_A, ltid100);
+      getOrCreateHandle(CONV_A, ltid200);
       await flushPersist();
 
       const conv = await chatDb.getConversation(CONV_A);
       expect(conv?.handleState).toBeDefined();
-      expect(conv?.handleState?.handles).toEqual({ t1: 100, t2: 200 });
+      expect(conv?.handleState?.handles).toEqual({ t1: ltid100, t2: ltid200 });
       expect(conv?.handleState?.counter).toBe(3);
     });
 
     it("restores counter so new handles don't collide with persisted ones", async () => {
-      await seedConv(CONV_A, [100, 200]);
-      getOrCreateHandle(CONV_A, 100);
-      getOrCreateHandle(CONV_A, 200);
+      const ltid100 = ltidFor(100);
+      const ltid200 = ltidFor(200);
+      await seedConv(CONV_A, [ltid100, ltid200]);
+      getOrCreateHandle(CONV_A, ltid100);
+      getOrCreateHandle(CONV_A, ltid200);
       await flushPersist();
 
       // Simulate SW restart: in-memory map is cleared but chatDb survives.
+      // Crucially we DO NOT reset the registry — in real life the v15
+      // migration / SW startup pass would have re-registered the ctids
+      // under the same ltids before tab-handles loads them.
       clearHandles(CONV_A);
-
-      // `chrome.tabs.get` available → all persisted tabs are reported live.
-      vi.stubGlobal("chrome", {
-        tabs: {
-          get: vi.fn(async () => ({} as chrome.tabs.Tab)),
-        },
-      });
 
       await loadHandlesForConversation(CONV_A);
 
       // Existing handles still resolve.
-      expect(resolveHandle(CONV_A, "t1")).toBe(100);
-      expect(resolveHandle(CONV_A, "t2")).toBe(200);
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
+      expect(resolveHandle(CONV_A, "t2")).toBe(ltid200);
 
-      // New tab gets t3 (counter advanced past stored max).
-      expect(getOrCreateHandle(CONV_A, 300)).toBe("t3");
+      // New ltid gets t3 (counter advanced past stored max).
+      expect(getOrCreateHandle(CONV_A, ltidFor(300))).toBe("t3");
     });
 
-    it("prunes dead tabs during hydration", async () => {
-      await seedConv(CONV_A, [100, 200, 300]);
-      getOrCreateHandle(CONV_A, 100);
-      getOrCreateHandle(CONV_A, 200);
-      getOrCreateHandle(CONV_A, 300);
+    it("prunes ltids the registry can't resolve during hydration", async () => {
+      const ltid100 = ltidFor(100);
+      const ltid200 = ltidFor(200);
+      const ltid300 = ltidFor(300);
+      await seedConv(CONV_A, [ltid100, ltid200, ltid300]);
+      getOrCreateHandle(CONV_A, ltid100);
+      getOrCreateHandle(CONV_A, ltid200);
+      getOrCreateHandle(CONV_A, ltid300);
       await flushPersist();
 
       clearHandles(CONV_A);
 
-      // Tab 200 is dead.
-      vi.stubGlobal("chrome", {
-        tabs: {
-          get: vi.fn(async (id: number) => {
-            if (id === 200) throw new Error("No tab with id 200");
-            return {} as chrome.tabs.Tab;
-          }),
-        },
-      });
+      // Tab 200 is dead — simulate by unregistering its ltid from the
+      // registry. (In the real SW startup flow, only ctids that actually
+      // resolved via chrome.tabs.query would have been re-registered.)
+      tabRegistry.unregister(ltid200);
 
       await loadHandlesForConversation(CONV_A);
 
-      expect(resolveHandle(CONV_A, "t1")).toBe(100);
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
       expect(resolveHandle(CONV_A, "t2")).toBeUndefined();
-      expect(resolveHandle(CONV_A, "t3")).toBe(300);
+      expect(resolveHandle(CONV_A, "t3")).toBe(ltid300);
 
       // Pruned snapshot is written back.
       await flushPersist();
       const conv = await chatDb.getConversation(CONV_A);
-      expect(conv?.handleState?.handles).toEqual({ t1: 100, t3: 300 });
+      expect(conv?.handleState?.handles).toEqual({
+        t1: ltid100,
+        t3: ltid300,
+      });
     });
 
     it("repairs counter if chatDb stored an inconsistent (low) counter", async () => {
-      await seedConv(CONV_A, [999]);
+      const ltid999 = ltidFor(999);
+      await seedConv(CONV_A, [ltid999]);
       // Manually corrupt: stored counter is 1 but max suffix is t5.
       await chatDb.updateConversation(CONV_A, {
         handleState: {
-          handles: { t5: 999 },
+          handles: { t5: ltid999 },
           counter: 1,
         },
-      });
-
-      vi.stubGlobal("chrome", {
-        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
       });
 
       await loadHandlesForConversation(CONV_A);
 
       // Counter should advance past max seen suffix (5) → next handle is t6.
-      expect(getOrCreateHandle(CONV_A, 1000)).toBe("t6");
+      expect(getOrCreateHandle(CONV_A, ltidFor(1000))).toBe("t6");
     });
 
     it("repairs counter if chatDb stored a non-finite value", async () => {
@@ -270,62 +288,85 @@ describe("tab-handles", () => {
           counter: Number.NaN,
         },
       });
-      vi.stubGlobal("chrome", {
-        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
-      });
       await loadHandlesForConversation(CONV_A);
       // Falls back to 1 (defensive), not NaN.
-      expect(getOrCreateHandle(CONV_A, 100)).toBe("t1");
+      expect(getOrCreateHandle(CONV_A, ltidFor(100))).toBe("t1");
     });
 
     it("treats a missing handleState as a fresh map", async () => {
       await seedConv(CONV_A);
       // No handleState written.
       await loadHandlesForConversation(CONV_A);
-      expect(getOrCreateHandle(CONV_A, 42)).toBe("t1");
+      expect(getOrCreateHandle(CONV_A, ltidFor(42))).toBe("t1");
     });
 
     it("hydration's merge keeps live handles when a name collision happens", async () => {
-      // Pre-populate chatDb as if a previous session had t1→100 owned.
-      await seedConv(CONV_A, [100]);
+      const ltid100 = ltidFor(100);
+      // Pre-populate chatDb as if a previous session had t1→ltid100 owned.
+      await seedConv(CONV_A, [ltid100]);
       await chatDb.updateConversation(CONV_A, {
-        handleState: { handles: { t1: 100 }, counter: 2 },
+        handleState: { handles: { t1: ltid100 }, counter: 2 },
       });
 
-      // Stub chrome so hydration's liveness check passes for any id.
-      vi.stubGlobal("chrome", {
-        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
-      });
-
-      // Simulate the agent racing ahead and minting a handle BEFORE hydration
-      // lands. The fresh map starts at counter=1, so the freshly-minted
-      // handle for tabId=200 will also be "t1" — colliding with the
-      // persisted t1→100. The merge must keep the live binding (live wins),
-      // not silently overwrite it with the stale persisted value.
-      const freshHandle = getOrCreateHandle(CONV_A, 200);
+      // Simulate the agent racing ahead and minting a handle for a
+      // DIFFERENT ltid BEFORE hydration lands. The fresh map starts at
+      // counter=1, so the freshly-minted handle for ltid200 will also be
+      // "t1" — colliding with the persisted t1→ltid100. The merge must
+      // keep the live binding (live wins), not silently overwrite it
+      // with the stale persisted value.
+      const ltid200 = ltidFor(200);
+      const freshHandle = getOrCreateHandle(CONV_A, ltid200);
       expect(freshHandle).toBe("t1");
 
       await loadHandlesForConversation(CONV_A);
 
-      // t1 still resolves to the live tab the agent already minted (200),
+      // t1 still resolves to the live ltid the agent already minted (200),
       // not the stale persisted 100. The persisted entry is dropped on
       // collision because the live map's claim is authoritative.
-      expect(resolveHandle(CONV_A, "t1")).toBe(200);
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid200);
     });
 
     it("hydration's merge restores persisted handles when there's no live conflict", async () => {
-      await seedConv(CONV_A, [100]);
+      const ltid100 = ltidFor(100);
+      await seedConv(CONV_A, [ltid100]);
       await chatDb.updateConversation(CONV_A, {
-        handleState: { handles: { t1: 100 }, counter: 2 },
-      });
-      vi.stubGlobal("chrome", {
-        tabs: { get: vi.fn(async () => ({} as chrome.tabs.Tab)) },
+        handleState: { handles: { t1: ltid100 }, counter: 2 },
       });
       // Realistic flow: hydration completes BEFORE any handles are minted.
       await loadHandlesForConversation(CONV_A);
-      expect(resolveHandle(CONV_A, "t1")).toBe(100);
-      // Counter advanced; new tab gets t2.
-      expect(getOrCreateHandle(CONV_A, 200)).toBe("t2");
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
+      // Counter advanced; new ltid gets t2.
+      expect(getOrCreateHandle(CONV_A, ltidFor(200))).toBe("t2");
+    });
+  });
+
+  describe("registry integration", () => {
+    it("dropLtid fires when the registry emits onRemove", async () => {
+      const ltid100 = ltidFor(100);
+      await seedConv(CONV_A, [ltid100]);
+      getOrCreateHandle(CONV_A, ltid100);
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
+
+      // Drive the registry's onRemove via its test seam.
+      tabRegistry.__handleRemoveForTests!(100);
+
+      expect(resolveHandle(CONV_A, "t1")).toBeUndefined();
+    });
+
+    it("does NOT mutate the handle map on registry onReplace (ltid is stable)", async () => {
+      const ltid100 = ltidFor(100);
+      await seedConv(CONV_A, [ltid100]);
+      getOrCreateHandle(CONV_A, ltid100);
+      const beforeT1 = resolveHandle(CONV_A, "t1");
+      expect(beforeT1).toBe(ltid100);
+
+      // Drive an onReplace: ctid 100 → 200. Same ltid, different ctid.
+      tabRegistry.__handleReplaceForTests!(200, 100);
+
+      // Handle map is unchanged: t1 still resolves to the same ltid.
+      expect(resolveHandle(CONV_A, "t1")).toBe(ltid100);
+      // And the ltid now resolves to ctid 200 in the registry.
+      expect(tabRegistry.toChromeTabId(ltid100)).toBe(200);
     });
   });
 });

--- a/apps/extension/src/lib/agent/__tests__/tab-identity-e2e.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-identity-e2e.test.ts
@@ -1,0 +1,121 @@
+/**
+ * End-to-end identity-continuity test mirroring the prod scenario that
+ * motivated the LogicalTabId migration:
+ *
+ *   1. Agent navigates to an Attio settings page (sets up an owned tab).
+ *   2. Speculation Rules / prerender activation fires
+ *      `chrome.tabs.onReplaced(addedCtid, removedCtid)`.
+ *   3. Chrome ALSO fires `chrome.tabs.onRemoved(removedCtid)` (the
+ *      documented event order; the registry must dedup it).
+ *   4. The agent's next tool call against the same handle should land on
+ *      the new ctid — not fail with "Unknown tab handle" or
+ *      "No tab with given id".
+ *
+ * Asserts the integrated behavior across the registry, the handle map,
+ * the cdp-session cache, and the tab-scoping layer:
+ *
+ *   - Handle resolves to the same ltid pre/post-replace.
+ *   - The ltid resolves to the new ctid in the registry.
+ *   - Conversation ownership is intact (still keyed on the same ltid).
+ *   - The trailing `onRemoved` is suppressed (no consumer reacts).
+ *   - Subsequent CDP commands attach to the new ctid.
+ */
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatDb } from "@/lib/chat-db";
+import { tabRegistry } from "@/lib/agent/tab-registry";
+import {
+  clearHandles,
+  getOrCreateHandle,
+  resolveHandle,
+} from "@/lib/agent/tab-handles";
+
+const CONV_ID = "e2e-conv";
+
+describe("tab identity end-to-end (Attio-style prerender activation)", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    clearHandles(CONV_ID);
+    tabRegistry.__resetForTests!();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    chatDb._resetForTests();
+    clearHandles(CONV_ID);
+    tabRegistry.__resetForTests!();
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves handle, ownership, and cdp-session continuity across an onReplaced + trailing onRemoved", async () => {
+    // 1. Bootstrap: navigate creates ctid 100 and binds it to the
+    //    conversation. We simulate the side of that flow that matters:
+    //    the registry mints an ltid, tab-handles records the handle,
+    //    chatDb records the ownership. (The full navigate tool path is
+    //    covered by separate tool-level tests.)
+    const ltid = tabRegistry.registerExisting(100);
+    await chatDb.createConversation({
+      id: CONV_ID,
+      title: "Attio settings",
+      spaceId: null,
+      ownedLtids: [ltid],
+      ownedGroupId: 7,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const handle = getOrCreateHandle(CONV_ID, ltid);
+    expect(handle).toBe("t1");
+    expect(resolveHandle(CONV_ID, "t1")).toBe(ltid);
+    expect(tabRegistry.toChromeTabId(ltid)).toBe(100);
+
+    // 2. Prerender activation. Chrome fires onReplaced(addedCtid=200,
+    //    removedCtid=100) followed synchronously by onRemoved(100).
+    tabRegistry.__handleReplaceForTests!(200, 100);
+
+    // The handle is unchanged. Same ltid. New ctid.
+    expect(resolveHandle(CONV_ID, "t1")).toBe(ltid);
+    expect(tabRegistry.toChromeTabId(ltid)).toBe(200);
+    expect(tabRegistry.toLogicalTabId(100)).toBeUndefined();
+    expect(tabRegistry.toLogicalTabId(200)).toBe(ltid);
+
+    // Conversation ownership is intact (chatDb stores ltid, which didn't
+    // change; no need for tab-scoping to write).
+    const convAfterReplace = await chatDb.getConversation(CONV_ID);
+    expect(convAfterReplace?.ownedLtids).toEqual([ltid]);
+
+    // 3. Chrome's trailing onRemoved for the OLD ctid. Without dedup,
+    //    every consumer would treat this as a tab close and drop the
+    //    handle. The registry's dedup window suppresses it.
+    tabRegistry.__handleRemoveForTests!(100);
+
+    // Handle is STILL there.
+    expect(resolveHandle(CONV_ID, "t1")).toBe(ltid);
+    // ltid still resolves.
+    expect(tabRegistry.toChromeTabId(ltid)).toBe(200);
+  });
+
+  it("a real tab close (no preceding replace) DOES propagate through the deduper", async () => {
+    const ltid = tabRegistry.registerExisting(42);
+    await chatDb.createConversation({
+      id: CONV_ID,
+      title: "x",
+      spaceId: null,
+      ownedLtids: [ltid],
+      ownedGroupId: 1,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    getOrCreateHandle(CONV_ID, ltid);
+    expect(resolveHandle(CONV_ID, "t1")).toBe(ltid);
+
+    tabRegistry.__handleRemoveForTests!(42);
+
+    // Handle is dropped (the registry's onRemove fires through to
+    // tab-handles' subscriber).
+    expect(resolveHandle(CONV_ID, "t1")).toBeUndefined();
+    // Registry no longer knows the ctid.
+    expect(tabRegistry.toLogicalTabId(42)).toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tab-legend.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-legend.test.ts
@@ -42,7 +42,7 @@ describe("buildTabLegendEntries", () => {
     }));
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [1, 2, 3],
+      ownedLtids: [1, 2, 3],
       getTab,
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: null,
@@ -61,7 +61,7 @@ describe("buildTabLegendEntries", () => {
     });
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [10, 20],
+      ownedLtids: [10, 20],
       getTab,
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: 20,
@@ -77,7 +77,7 @@ describe("buildTabLegendEntries", () => {
     };
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [1, 99, 2],
+      ownedLtids: [1, 99, 2],
       getTab,
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: null,
@@ -97,7 +97,7 @@ describe("buildTabLegendEntries", () => {
     };
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [1, 5, 2],
+      ownedLtids: [1, 5, 2],
       getTab,
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: null,
@@ -112,7 +112,7 @@ describe("buildTabLegendEntries", () => {
     });
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [1],
+      ownedLtids: [1],
       getTab,
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: null,
@@ -120,10 +120,10 @@ describe("buildTabLegendEntries", () => {
     expect(entries[0].title).toBe("(untitled)");
   });
 
-  it("returns [] when ownedTabIds is empty", async () => {
+  it("returns [] when ownedLtids is empty", async () => {
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [],
+      ownedLtids: [],
       getTab: async () => ({ url: "x", title: "x" }),
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: null,
@@ -166,7 +166,7 @@ describe("buildOpenTabsAwarenessEntries", () => {
   it("returns an empty list when no open tabs are unowned", () => {
     const { entries, truncated } = buildOpenTabsAwarenessEntries({
       conversationId: CONV,
-      ownedTabIds: [1, 2],
+      ownedLtids: [1, 2],
       openTabs: [
         { id: 1, url: "https://a.test", title: "A", active: false },
         { id: 2, url: "https://b.test", title: "B", active: true },
@@ -180,7 +180,7 @@ describe("buildOpenTabsAwarenessEntries", () => {
   it("excludes owned tabs and internal/extension URLs", () => {
     const { entries } = buildOpenTabsAwarenessEntries({
       conversationId: CONV,
-      ownedTabIds: [1],
+      ownedLtids: [1],
       openTabs: [
         { id: 1, url: "https://owned.test", title: "Owned", active: false },
         { id: 2, url: "https://news.test", title: "News", active: true },
@@ -203,7 +203,7 @@ describe("buildOpenTabsAwarenessEntries", () => {
   it("falls back to '(untitled)' for blank titles", () => {
     const { entries } = buildOpenTabsAwarenessEntries({
       conversationId: CONV,
-      ownedTabIds: [],
+      ownedLtids: [],
       openTabs: [
         { id: 7, url: "https://x.test", title: "   ", active: false },
       ],
@@ -221,7 +221,7 @@ describe("buildOpenTabsAwarenessEntries", () => {
     }));
     const { entries, truncated } = buildOpenTabsAwarenessEntries({
       conversationId: CONV,
-      ownedTabIds: [],
+      ownedLtids: [],
       openTabs,
       getOrCreateHandle: fakeGetOrCreateHandle,
     });
@@ -237,7 +237,7 @@ describe("buildOpenTabsAwarenessEntries", () => {
     ];
     const { entries, truncated } = buildOpenTabsAwarenessEntries({
       conversationId: CONV,
-      ownedTabIds: [],
+      ownedLtids: [],
       openTabs,
       getOrCreateHandle: fakeGetOrCreateHandle,
       maxEntries: 2,
@@ -289,7 +289,7 @@ describe("prompt-injection & privacy hardening", () => {
   ): Promise<TabLegendEntry | undefined> {
     const entries = await buildTabLegendEntries({
       conversationId: CONV,
-      ownedTabIds: [1],
+      ownedLtids: [1],
       getTab: async () => ({ url, title }),
       getOrCreateHandle: fakeGetOrCreateHandle,
       activeTabId: null,
@@ -354,7 +354,7 @@ describe("prompt-injection & privacy hardening", () => {
   it("awareness block also sanitizes titles and filters by http(s) allowlist", () => {
     const { entries } = buildOpenTabsAwarenessEntries({
       conversationId: CONV,
-      ownedTabIds: [],
+      ownedLtids: [],
       openTabs: [
         { id: 1, url: "https://ok.test", title: "Line1\nLine2", active: false },
         { id: 2, url: "file:///etc/passwd", title: "leak", active: false },

--- a/apps/extension/src/lib/agent/__tests__/tab-registry.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tab-registry.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for `tab-registry`. Drives the registry via its `__*ForTests`
+ * seams to avoid coupling tests to vitest's chrome-mock listener wiring
+ * (which would make order-of-import sensitive).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tabRegistry } from "../tab-registry";
+
+describe("tab-registry", () => {
+  beforeEach(() => {
+    tabRegistry.__resetForTests!();
+    tabRegistry.__clearListenersForTests!();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("registerExisting", () => {
+    it("mints a fresh ltid for a new ctid", () => {
+      const ltid = tabRegistry.registerExisting(100);
+      expect(typeof ltid).toBe("string");
+      expect(ltid.length).toBeGreaterThan(0);
+      expect(tabRegistry.toChromeTabId(ltid)).toBe(100);
+      expect(tabRegistry.toLogicalTabId(100)).toBe(ltid);
+    });
+
+    it("is idempotent for the same ctid", () => {
+      const ltid1 = tabRegistry.registerExisting(100);
+      const ltid2 = tabRegistry.registerExisting(100);
+      expect(ltid1).toBe(ltid2);
+    });
+  });
+
+  describe("onReplaced", () => {
+    it("re-keys the ltid to the new ctid", () => {
+      const ltid = tabRegistry.registerExisting(100);
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      expect(tabRegistry.toChromeTabId(ltid)).toBe(200);
+      expect(tabRegistry.toLogicalTabId(200)).toBe(ltid);
+      expect(tabRegistry.toLogicalTabId(100)).toBeUndefined();
+    });
+
+    it("fires onReplace subscribers", () => {
+      const ltid = tabRegistry.registerExisting(100);
+      const seen: unknown[] = [];
+      tabRegistry.onReplace((ev) => seen.push(ev));
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      expect(seen).toEqual([
+        expect.objectContaining({ ltid, oldCtid: 100, newCtid: 200 }),
+      ]);
+    });
+
+    it("mints a fresh ltid when the removed ctid was never tracked", () => {
+      // No prior registration of 100.
+      const seen: unknown[] = [];
+      tabRegistry.onReplace((ev) => seen.push(ev));
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      expect(seen).toEqual([]); // no event for untracked replace
+      // But 200 IS now registered so future tools can find it.
+      const ltid = tabRegistry.toLogicalTabId(200);
+      expect(ltid).toBeTruthy();
+    });
+
+    it("logs a console.warn with url + ltid", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      tabRegistry.registerExisting(100);
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      // chrome.tabs.get in the test stub rejects; the catch path still
+      // logs (with url=undefined). Allow the microtask to drain.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(warn).toHaveBeenCalledWith(
+        "[tab-registry] onReplaced",
+        expect.objectContaining({ ltid: expect.any(String), oldCtid: 100, newCtid: 200 }),
+      );
+    });
+  });
+
+  describe("onRemoved dedup", () => {
+    it("suppresses onRemoved within the dedup window after onReplaced", () => {
+      tabRegistry.registerExisting(100);
+      const removed: unknown[] = [];
+      tabRegistry.onRemove((ev) => removed.push(ev));
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      tabRegistry.__handleRemoveForTests!(100); // trailing remove
+      expect(removed).toEqual([]); // suppressed
+    });
+
+    it("fires onRemove for a non-replaced ctid", () => {
+      const ltid = tabRegistry.registerExisting(100);
+      const removed: unknown[] = [];
+      tabRegistry.onRemove((ev) => removed.push(ev));
+      tabRegistry.__handleRemoveForTests!(100);
+      expect(removed).toEqual([{ ltid, ctid: 100 }]);
+      expect(tabRegistry.toLogicalTabId(100)).toBeUndefined();
+    });
+
+    it("fires onRemove after the dedup window expires", () => {
+      const initialNow = Date.now();
+      const dateSpy = vi.spyOn(Date, "now").mockReturnValue(initialNow);
+      tabRegistry.registerExisting(100);
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      // Advance past the 5s dedup window.
+      dateSpy.mockReturnValue(initialNow + 6_000);
+      // A late onRemoved for the OLD ctid (100). It's no longer in the
+      // ltid map (the replace re-keyed to 200), so emit semantics: nothing
+      // happens. We're really asserting "no crash" + dedup didn't suppress.
+      const removed: unknown[] = [];
+      tabRegistry.onRemove((ev) => removed.push(ev));
+      tabRegistry.__handleRemoveForTests!(100);
+      expect(removed).toEqual([]); // 100 isn't tracked anymore
+      // Simulate also a real removal of the new ctid 200 — should fire.
+      tabRegistry.__handleRemoveForTests!(200);
+      expect(removed.length).toBe(1);
+    });
+
+    it("is a no-op for never-registered ctids", () => {
+      const removed: unknown[] = [];
+      tabRegistry.onRemove((ev) => removed.push(ev));
+      expect(() => tabRegistry.__handleRemoveForTests!(999)).not.toThrow();
+      expect(removed).toEqual([]);
+    });
+  });
+
+  describe("subscriber semantics", () => {
+    it("fires multiple subscribers in registration order on replace", () => {
+      tabRegistry.registerExisting(100);
+      const order: string[] = [];
+      tabRegistry.onReplace(() => order.push("a"));
+      tabRegistry.onReplace(() => order.push("b"));
+      tabRegistry.onReplace(() => order.push("c"));
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      expect(order).toEqual(["a", "b", "c"]);
+    });
+
+    it("a throwing subscriber doesn't break later subscribers", () => {
+      tabRegistry.registerExisting(100);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const order: string[] = [];
+      tabRegistry.onReplace(() => {
+        throw new Error("boom");
+      });
+      tabRegistry.onReplace(() => order.push("survived"));
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      expect(order).toEqual(["survived"]);
+      expect(warn).toHaveBeenCalledWith(
+        "[tab-registry] onReplace subscriber threw",
+        expect.any(Error),
+      );
+    });
+
+    it("returns an unsubscribe function from onReplace", () => {
+      tabRegistry.registerExisting(100);
+      const seen: unknown[] = [];
+      const off = tabRegistry.onReplace((ev) => seen.push(ev));
+      off();
+      tabRegistry.__handleReplaceForTests!(200, 100);
+      expect(seen).toEqual([]);
+    });
+  });
+
+  describe("unregister", () => {
+    it("forgets both directions and is idempotent", () => {
+      const ltid = tabRegistry.registerExisting(100);
+      tabRegistry.unregister(ltid);
+      expect(tabRegistry.toChromeTabId(ltid)).toBeUndefined();
+      expect(tabRegistry.toLogicalTabId(100)).toBeUndefined();
+      expect(() => tabRegistry.unregister(ltid)).not.toThrow();
+    });
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tool-context-pinning.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-context-pinning.test.ts
@@ -26,6 +26,7 @@ import {
   clearHandles,
   getOrCreateHandle,
 } from "../tab-handles";
+import { tabRegistry, type LogicalTabId } from "../tab-registry";
 import { todoWriteTool } from "../tools/todowrite";
 
 const CONV_A = "conv-a";
@@ -34,7 +35,7 @@ const CONV_B = "conv-b";
 async function seedConv(
   id: string,
   opts: {
-    ownedTabIds?: number[];
+    ownedLtids?: LogicalTabId[];
     ownedGroupId?: number | null;
     todos?: import("../../types").TodoItem[];
   } = {},
@@ -43,12 +44,17 @@ async function seedConv(
     id,
     title: id,
     spaceId: null,
-    ownedTabIds: opts.ownedTabIds ?? [],
+    ownedLtids: opts.ownedLtids ?? [],
     ownedGroupId: opts.ownedGroupId ?? null,
     todos: opts.todos ?? [],
     createdAt: 0,
     updatedAt: 0,
   });
+}
+
+/** Mint an ltid for a fake ctid via the registry. */
+function ltidFor(ctid: number): LogicalTabId {
+  return tabRegistry.registerExisting(ctid);
 }
 
 describe("buildExtensionToolContext (per-call cid pinning)", () => {
@@ -58,6 +64,7 @@ describe("buildExtensionToolContext (per-call cid pinning)", () => {
     clearHandles(CONV_A);
     clearHandles(CONV_B);
     setAgentContext(null);
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
     // Tests that touch tab-binding helpers need a chrome stub so the
     // helper's `chrome.runtime.sendMessage` doesn't blow up.
@@ -70,6 +77,7 @@ describe("buildExtensionToolContext (per-call cid pinning)", () => {
     clearHandles(CONV_A);
     clearHandles(CONV_B);
     setAgentContext(null);
+    tabRegistry.__resetForTests!();
     vi.unstubAllGlobals();
   });
 
@@ -220,8 +228,15 @@ describe("buildExtensionToolContext (per-call cid pinning)", () => {
 
   describe("isAgentOwnedTab / hasOwnedTabGroup", () => {
     it("isAgentOwnedTab targets pinned cid", async () => {
-      await seedConv(CONV_A, { ownedTabIds: [42] });
-      await seedConv(CONV_B, { ownedTabIds: [99] });
+      // Mint ltids for two synthetic ctids and seed each conversation
+      // with its own ltid. isAgentOwnedTab takes a chrome ctid (the
+      // session API surface predates the migration); internally it
+      // resolves ctid → ltid via the registry to test the conversation's
+      // ownedLtids set.
+      const ltid42 = ltidFor(42);
+      const ltid99 = ltidFor(99);
+      await seedConv(CONV_A, { ownedLtids: [ltid42] });
+      await seedConv(CONV_B, { ownedLtids: [ltid99] });
 
       const ctxA = buildExtensionToolContext(CONV_A);
       setAgentContext(CONV_B);
@@ -256,15 +271,19 @@ describe("buildExtensionToolContext (per-call cid pinning)", () => {
       await seedConv(CONV_A);
       await seedConv(CONV_B);
 
-      // Pre-populate B's handle map; A's is empty.
-      getOrCreateHandle(CONV_B, 500);
+      // Pre-populate B's handle map; A's is empty. The direct
+      // tab-handles `getOrCreateHandle` takes an ltid (string), so we
+      // mint one for the synthetic ctid 500 first.
+      getOrCreateHandle(CONV_B, ltidFor(500));
 
       const ctxA = buildExtensionToolContext(CONV_A);
       // Even with global flipped to B, ctxA's helper must mint into A.
       setAgentContext(CONV_B);
+      // The session helper accepts a ctid (number) and routes through
+      // the registry to mint/recover an ltid.
       const aHandle = ctxA.session!.getOrCreateHandle!(123);
       expect(aHandle).toBe("t1");
-      // B's map is unchanged for tabId 123.
+      // B's map is unchanged for tab 123.
       const ctxB = buildExtensionToolContext(CONV_B);
       const bHandle = ctxB.session!.getOrCreateHandle!(123);
       // tab 123 is new for B → first available counter slot.
@@ -274,13 +293,16 @@ describe("buildExtensionToolContext (per-call cid pinning)", () => {
     it("resolveHandle uses pinned cid's handle map", async () => {
       await seedConv(CONV_A);
       await seedConv(CONV_B);
-      getOrCreateHandle(CONV_A, 100); // A:t1 → 100
-      getOrCreateHandle(CONV_B, 200); // B:t1 → 200
+      const ltid100 = ltidFor(100);
+      const ltid200 = ltidFor(200);
+      getOrCreateHandle(CONV_A, ltid100); // A:t1 → ltid100
+      getOrCreateHandle(CONV_B, ltid200); // B:t1 → ltid200
 
       const ctxA = buildExtensionToolContext(CONV_A);
       setAgentContext(CONV_B);
 
-      expect(ctxA.session!.resolveHandle!("t1")).toBe(100);
+      // resolveHandle returns the LogicalTabId, not the ctid.
+      expect(ctxA.session!.resolveHandle!("t1")).toBe(ltid100);
     });
 
     it("falls back to t<id> when pinned cid is null", () => {

--- a/apps/extension/src/lib/agent/__tests__/wait-for-tab-load-onreplaced.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/wait-for-tab-load-onreplaced.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for `waitForTabLoad`'s ltid-aware behavior: it resolves when the
+ * `chrome.tabs.id` corresponding to the passed ltid fires a `complete`
+ * status update, AND it follows `onReplaced` mid-wait so a Speculation
+ * Rules / prerender activation that swaps the ctid doesn't time out.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tabRegistry } from "../tab-registry";
+import { waitForTabLoad } from "../active-tab";
+
+type UpdateListener = (
+  tabId: number,
+  changeInfo: { status?: string },
+) => void;
+
+describe("waitForTabLoad: ltid-aware", () => {
+  let updateListeners: UpdateListener[];
+
+  beforeEach(() => {
+    tabRegistry.__resetForTests!();
+    updateListeners = [];
+    vi.stubGlobal("chrome", {
+      tabs: {
+        onUpdated: {
+          addListener: (fn: UpdateListener) => {
+            updateListeners.push(fn);
+          },
+          removeListener: (fn: UpdateListener) => {
+            const i = updateListeners.indexOf(fn);
+            if (i >= 0) updateListeners.splice(i, 1);
+          },
+        },
+        onReplaced: { addListener: () => {}, removeListener: () => {} },
+        onRemoved: { addListener: () => {}, removeListener: () => {} },
+        onCreated: { addListener: () => {}, removeListener: () => {} },
+        onActivated: { addListener: () => {}, removeListener: () => {} },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    tabRegistry.__resetForTests!();
+    tabRegistry.__clearListenersForTests!();
+  });
+
+  function fireUpdate(ctid: number, status: string) {
+    for (const fn of [...updateListeners]) {
+      fn(ctid, { status });
+    }
+  }
+
+  it("resolves when the underlying ctid fires complete", async () => {
+    const ltid = tabRegistry.registerExisting(100);
+
+    // Use real-but-short timers; the resolver waits 500ms after `complete`
+    // before resolving. We just need a longer timeout.
+    const p = waitForTabLoad(ltid, 5000);
+    fireUpdate(100, "complete");
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it("ignores updates for unrelated ctids", async () => {
+    const ltid = tabRegistry.registerExisting(100);
+    const p = waitForTabLoad(ltid, 1500);
+    fireUpdate(999, "complete"); // wrong ctid
+    fireUpdate(100, "complete");
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it("follows onReplaced: complete on NEW ctid still resolves", async () => {
+    const ltid = tabRegistry.registerExisting(100);
+
+    const p = waitForTabLoad(ltid, 5000);
+
+    // Mid-wait, fire onReplaced to swap ctid 100 → 200.
+    tabRegistry.__handleReplaceForTests!(200, 100);
+
+    // The complete event lands on 200, the new ctid. Without the ltid-aware
+    // listener swap this would have been ignored.
+    fireUpdate(200, "complete");
+
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it("ignores complete on the OLD ctid after onReplaced", async () => {
+    const ltid = tabRegistry.registerExisting(100);
+
+    const p = waitForTabLoad(ltid, 1200);
+    tabRegistry.__handleReplaceForTests!(200, 100);
+
+    // A spurious late event for the OLD ctid should NOT resolve.
+    fireUpdate(100, "complete");
+    // Then real completion on the new ctid.
+    fireUpdate(200, "complete");
+
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it("times out if no complete event fires", async () => {
+    const ltid = tabRegistry.registerExisting(100);
+    await expect(waitForTabLoad(ltid, 50)).rejects.toThrow(/timed out/i);
+  });
+
+  it("removes its listeners on resolve", async () => {
+    const ltid = tabRegistry.registerExisting(100);
+    expect(updateListeners.length).toBe(0);
+    const p = waitForTabLoad(ltid, 5000);
+    expect(updateListeners.length).toBe(1);
+    fireUpdate(100, "complete");
+    await p;
+    expect(updateListeners.length).toBe(0);
+  });
+});

--- a/apps/extension/src/lib/agent/active-tab.ts
+++ b/apps/extension/src/lib/agent/active-tab.ts
@@ -1,17 +1,52 @@
-let targetTabId: number | null = null;
+import { tabRegistry, type LogicalTabId } from "./tab-registry";
 
 /**
- * Get the current target tab ID (set via selectTab).
+ * The agent's pinned target ltid. Resolved to a live `chrome.tabs.id` via
+ * `tab-registry` immediately before any chrome.tabs / debugger call.
+ *
+ * Keying on ltid (not ctid) makes the target survive `chrome.tabs
+ * .onReplaced` (Speculation Rules / prerender activation): the registry
+ * re-keys the ltid → newCtid mapping atomically, so the next
+ * `getActiveUserTab()` resolves to the new ctid without any code here
+ * needing to react.
+ */
+let targetLtid: LogicalTabId | null = null;
+
+/**
+ * Get the current target chrome tab id. Compatibility shim for the
+ * extension-driver / tools that still want a ctid; resolves the pinned
+ * ltid through the registry. Returns null if no target is set or the
+ * pinned ltid no longer resolves to a live tab.
  */
 export function getTargetTabId(): number | null {
-  return targetTabId;
+  if (targetLtid == null) return null;
+  return tabRegistry.toChromeTabId(targetLtid) ?? null;
+}
+
+/** Get the current target LogicalTabId (or null when unset). */
+export function getTargetLtid(): LogicalTabId | null {
+  return targetLtid;
 }
 
 /**
- * Set a specific tab as the target for tool operations.
+ * Set a specific tab as the target for tool operations. Takes a chrome
+ * tab id for caller convenience; minted/recovered to an ltid via the
+ * registry so subsequent operations key on the stable identifier.
+ *
+ * Pass `null` to clear.
  */
 export function setTargetTabId(tabId: number | null) {
-  targetTabId = tabId;
+  if (tabId == null) {
+    targetLtid = null;
+    return;
+  }
+  targetLtid = tabRegistry.registerExisting(tabId);
+}
+
+/** Set a specific LogicalTabId as the target. Used by callers that
+ *  already have an ltid (e.g. handle-resolver paths). */
+export function setTargetLtid(ltid: LogicalTabId | null) {
+  targetLtid = ltid;
 }
 
 /**
@@ -33,23 +68,32 @@ function isInternalChromeUrl(url: string | undefined): boolean {
  * Get the tab the agent should operate on.
  *
  * Resolution order:
- *  1. Explicit tracked target (set by navigate/selectTab).
+ *  1. Explicit tracked target (the pinned ltid, resolved through the
+ *     registry).
  *  2. First-call bootstrap: the user's active tab in the current window,
  *     but ONLY if it's a real web page (not an extension page or chrome://).
- *     Once bootstrapped, the target is pinned and never silently replaced.
+ *     The bootstrap result is registered with the registry to mint an
+ *     ltid that's then pinned.
  *
  * We never fall back to `{active: true}` once a target exists — that was the
  * root cause of tool calls executing against the user's pinned home.html view
  * instead of the agent's tracked tab.
  */
 export async function getActiveUserTab(): Promise<chrome.tabs.Tab> {
-  if (targetTabId !== null) {
-    try {
-      const tab = await chrome.tabs.get(targetTabId);
-      if (tab) return tab;
-    } catch {
-      // Tracked tab no longer exists; clear and fall through to bootstrap.
-      targetTabId = null;
+  if (targetLtid !== null) {
+    const ctid = tabRegistry.toChromeTabId(targetLtid);
+    if (ctid != null) {
+      try {
+        const tab = await chrome.tabs.get(ctid);
+        if (tab) return tab;
+      } catch {
+        // Tracked tab no longer exists; clear and fall through to bootstrap.
+        targetLtid = null;
+      }
+    } else {
+      // Registry can't resolve the pinned ltid (e.g. SW restart hasn't
+      // re-registered it yet). Clear and bootstrap.
+      targetLtid = null;
     }
   }
 
@@ -58,7 +102,7 @@ export async function getActiveUserTab(): Promise<chrome.tabs.Tab> {
   const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
   for (const tab of tabs) {
     if (tab.id && !isInternalChromeUrl(tab.url)) {
-      targetTabId = tab.id;
+      targetLtid = tabRegistry.registerExisting(tab.id);
       return tab;
     }
   }
@@ -69,27 +113,54 @@ export async function getActiveUserTab(): Promise<chrome.tabs.Tab> {
 }
 
 /**
- * Wait for a tab to finish loading after a navigation was triggered.
- * Always waits for the onUpdated "complete" event (never trusts current status
- * since navigation may not have started yet).
+ * Wait for a logical tab to finish loading after a navigation was
+ * triggered. Resolves on the first `complete` event for whatever
+ * `chrome.tabs.id` the ltid currently maps to — including across an
+ * `onReplaced` mid-wait (the registry's `onReplace` event re-targets
+ * which ctid the listener watches for).
+ *
+ * The `tabId` parameter is named that way for backward-compat with the
+ * many call sites, but it's a LogicalTabId post-migration. The legacy
+ * ctid-number signature is gone; if you need to wait on a raw ctid, mint
+ * an ltid via `tabRegistry.registerExisting(ctid)` first.
  */
-export function waitForTabLoad(tabId: number, timeoutMs = 15000): Promise<void> {
+export function waitForTabLoad(
+  ltid: LogicalTabId,
+  timeoutMs = 15000,
+): Promise<void> {
   return new Promise((resolve, reject) => {
+    let currentCtid = tabRegistry.toChromeTabId(ltid) ?? null;
+
     const timeout = setTimeout(() => {
-      chrome.tabs.onUpdated.removeListener(listener);
+      cleanup();
       reject(new Error("Tab load timed out"));
     }, timeoutMs);
+
+    function cleanup() {
+      clearTimeout(timeout);
+      chrome.tabs.onUpdated.removeListener(listener);
+      offReplace();
+    }
 
     function listener(
       updatedTabId: number,
       changeInfo: { status?: string },
     ) {
-      if (updatedTabId === tabId && changeInfo.status === "complete") {
-        clearTimeout(timeout);
-        chrome.tabs.onUpdated.removeListener(listener);
+      if (currentCtid != null && updatedTabId === currentCtid && changeInfo.status === "complete") {
+        cleanup();
+        // Tiny settle delay matches the legacy 500ms tail; gives Chrome
+        // a chance to flush layout before tools run.
         setTimeout(resolve, 500);
       }
     }
+
+    // If onReplaced fires mid-wait, switch the ctid we're watching for so
+    // the resolver doesn't hang forever on the dead old id.
+    const offReplace = tabRegistry.onReplace((ev) => {
+      if (ev.ltid === ltid) {
+        currentCtid = ev.newCtid;
+      }
+    });
 
     chrome.tabs.onUpdated.addListener(listener);
   });

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -37,6 +37,7 @@ import {
   loadHandlesForConversation,
   resolveHandle as resolveTabHandle,
 } from "./tab-handles";
+import { tabRegistry } from "./tab-registry";
 import { persistCompletionMarker } from "./persist-completion-marker";
 import {
   buildTabLegendEntries,
@@ -319,33 +320,33 @@ export async function setCloseTabsAlwaysAllowed(
 }
 
 /**
- * Resolve the target tab ids for a closeTabs input against the
+ * Resolve the target ltids for a closeTabs auto-approve check against the
  * conversation's owned tabs.
  */
 async function resolveCloseTabsTargetIds(
   conversationId: string,
-  input: { target: "group" } | { target: "tabs"; tabIds: number[] },
-): Promise<number[]> {
+  input: { target: "group" } | { target: "tabs"; ltids: string[] },
+): Promise<string[]> {
   if (input.target === "group") {
     const conv = await chatDb.getConversation(conversationId);
-    return conv?.ownedTabIds ?? [];
+    return conv?.ownedLtids ?? [];
   }
-  return input.tabIds;
+  return input.ltids;
 }
 
 /**
  * True when a closeTabs call may skip approval: the global flag is on AND
- * every target tab is in the conversation's ownedTabIds. Any non-owned
+ * every target tab is in the conversation's ownedLtids. Any non-owned
  * target forces manual approval regardless of the flag.
  */
 export async function shouldAutoApproveCloseTabs(
   conversationId: string,
-  input: { target: "group" } | { target: "tabs"; tabIds: number[] },
+  input: { target: "group" } | { target: "tabs"; ltids: string[] },
 ): Promise<boolean> {
   if (!(await isCloseTabsAlwaysAllowed())) return false;
   const conv = await chatDb.getConversation(conversationId);
   if (!conv) return false;
-  const owned = new Set(conv.ownedTabIds);
+  const owned = new Set<string>(conv.ownedLtids);
   const targets = await resolveCloseTabsTargetIds(conversationId, input);
   if (targets.length === 0) return false;
   return targets.every((id) => owned.has(id));
@@ -461,9 +462,20 @@ export function buildExtensionToolContext(
         }
       },
       getOrCreateHandle: (tabId) => {
-        return pinnedConversationId
-          ? getOrCreateTabHandle(pinnedConversationId, Number(tabId))
-          : `t${Number(tabId)}`;
+        // The session API surface accepts a `TabId` (string|number) for
+        // historical reasons; post-migration the value is a LogicalTabId
+        // (string). On the extension we only ever receive strings here
+        // — tools call this with `tabRegistry.registerExisting(ctid)` for
+        // newly-discovered tabs, or with an existing ltid retrieved from
+        // a previous lookup. Defensive numeric coercion below routes a
+        // raw ctid through the registry to mint/recover an ltid; this
+        // keeps the older bench-harness call sites working unchanged.
+        if (!pinnedConversationId) return `t${tabId}`;
+        const ltid =
+          typeof tabId === "number"
+            ? tabRegistry.registerExisting(tabId)
+            : tabId;
+        return getOrCreateTabHandle(pinnedConversationId, ltid);
       },
       resolveHandle: (handle) => {
         return pinnedConversationId
@@ -473,7 +485,12 @@ export function buildExtensionToolContext(
       isAgentOwnedTab: async (tabId) => {
         if (!pinnedConversationId) return false;
         const conv = await chatDb.getConversation(pinnedConversationId);
-        return !!conv?.ownedTabIds.includes(Number(tabId));
+        // `tabId` here is the chrome.tabs.id (number) the caller has in
+        // hand. Translate to ltid via the registry to test against the
+        // conversation's ownedLtids list.
+        const ltid = tabRegistry.toLogicalTabId(Number(tabId));
+        if (ltid == null) return false;
+        return !!conv?.ownedLtids.includes(ltid);
       },
       hasOwnedTabGroup: async () => {
         if (!pinnedConversationId) return false;
@@ -498,10 +515,14 @@ export function buildExtensionToolContext(
         if (!conv) return undefined;
         // 1) Prefer the window of an existing owned tab so new tabs join
         //    the conversation's tab group rather than splitting across
-        //    windows. Probe in order and take the first live tab.
-        for (const tabId of conv.ownedTabIds ?? []) {
+        //    windows. Probe in order and take the first live tab. Each
+        //    `ownedLtids` entry is a LogicalTabId (string); resolve to a
+        //    chrome ctid via the registry before calling chrome.tabs.get.
+        for (const ltid of conv.ownedLtids ?? []) {
+          const ctid = tabRegistry.toChromeTabId(ltid);
+          if (ctid == null) continue;
           try {
-            const tab = await chrome.tabs.get(tabId);
+            const tab = await chrome.tabs.get(ctid);
             if (typeof tab.windowId === "number") return tab.windowId;
           } catch {
             // Tab gone; try the next owned id.
@@ -571,7 +592,12 @@ export function toSDKTool<TInput, TOutput>(
     if (!cid) return null;
     const handle = (input as { tab?: unknown })?.tab;
     if (typeof handle !== "string" || handle.length === 0) return null;
-    const tabId = resolveTabHandle(cid, handle);
+    const ltid = resolveTabHandle(cid, handle);
+    if (ltid == null) return null;
+    // resolveTabHandle returns a LogicalTabId; translate to a chrome ctid
+    // via the registry. Unresolvable ltids (the underlying tab is gone)
+    // bail to null so the caller falls back to "require approval".
+    const tabId = tabRegistry.toChromeTabId(ltid);
     if (tabId == null) return null;
     try {
       const tab = await chrome.tabs.get(tabId);
@@ -599,12 +625,17 @@ export function toSDKTool<TInput, TOutput>(
             | { target: "tabs"; handles?: string[] };
           let resolved:
             | { target: "group" }
-            | { target: "tabs"; tabIds: number[] };
+            | { target: "tabs"; ltids: string[] };
           if (typed?.target === "tabs") {
-            const tabIds = (typed.handles ?? [])
+            // Tool handles → ltids via the per-conversation handle map.
+            // resolveTabHandle returns LogicalTabId post-migration; drop
+            // unresolvable handles silently (the tool itself surfaces the
+            // error message; this path only decides whether approval is
+            // required, and a missing handle defaults to "require approval").
+            const ltids = (typed.handles ?? [])
               .map((h) => resolveTabHandle(cid, h))
-              .filter((id): id is number => id != null);
-            resolved = { target: "tabs", tabIds };
+              .filter((id): id is string => typeof id === "string");
+            resolved = { target: "tabs", ltids };
           } else {
             resolved = { target: "group" };
           }
@@ -1292,7 +1323,7 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
   }
 
   // The tab legend is intentionally NOT appended to `instructions` here.
-  // ownedTabIds and tab URLs change mid-conversation (navigate adds a tab,
+  // ownedLtids and tab URLs change mid-conversation (navigate adds a tab,
   // user closes a tab, etc.); a static legend baked at transport-construction
   // time would go stale. Instead we build it just-in-time inside `prepareCall`
   // below so every model call sees the live state.
@@ -1454,11 +1485,23 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
       cfg.agentDef.custom?.kind === "cua"
     ) {
       // The attached isolation seeded the parent tab handle into this
-      // session's handle map. Resolve it to the real tab id.
+      // session's handle map. Resolve it through the registry to a live
+      // chrome tab id; the CUA loop's CDP commands take ctids.
+      //
+      // Even after the resolution here, the loop calls
+      // `tabRegistry.toChromeTabId(ltid)` immediately before each action
+      // so a `chrome.tabs.onReplaced` mid-loop is followed transparently
+      // (the ltid is stable across replacements; only the ctid changes).
       const handle = firstSeededHandle(cfg.toolContext);
-      const tabId = handle
+      const ltid = handle
         ? cfg.toolContext.session?.resolveHandle?.(handle)
         : undefined;
+      // resolveHandle returns LogicalTabId (string) post-migration. The
+      // bench harness has no session at all here.
+      const tabId =
+        typeof ltid === "string"
+          ? tabRegistry.toChromeTabId(ltid) ?? null
+          : ltid ?? null;
       if (tabId == null) {
         // Strict: never silently guess a tab. Return an actionable
         // instruction to the PARENT agent (this finalText flows back as the
@@ -1735,7 +1778,7 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
   /**
    * Build the dynamic "## Tabs in this conversation" block plus an
    * awareness-only "## Other open tabs" block from live state. Re-reads
-   * ownedTabIds from chatDb and queries chrome.tabs each call so the
+   * ownedLtids from chatDb and queries chrome.tabs each call so the
    * agent sees the current tab set on every turn (not the snapshot
    * baked at transport-construction time).
    *
@@ -1748,16 +1791,41 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
     const cid = agentConversationId;
     if (!cid) return "";
     const liveConv = await chatDb.getConversation(cid);
-    const ownedTabIds = liveConv?.ownedTabIds ?? [];
+    const ownedLtids = liveConv?.ownedLtids ?? [];
     const entries = await buildTabLegendEntries({
       conversationId: cid,
-      ownedTabIds,
-      getTab: async (tabId) => {
-        const tab = await chrome.tabs.get(Number(tabId));
+      ownedLtids,
+      // The legend keys on LogicalTabIds. Resolve each ltid to a live
+      // chrome tab id via the registry just before fetching the tab info;
+      // unresolvable ltids (the underlying tab is gone) trigger the
+      // legend renderer's "drop this entry" branch via the rejected
+      // promise.
+      getTab: async (ltid) => {
+        const ctid =
+          typeof ltid === "string" ? tabRegistry.toChromeTabId(ltid) : Number(ltid);
+        if (ctid == null) {
+          throw new Error(
+            `LogicalTabId ${String(ltid)} no longer maps to a live chrome tab`,
+          );
+        }
+        const tab = await chrome.tabs.get(ctid);
         return { url: tab.url, title: tab.title };
       },
-      getOrCreateHandle: (c, tabId) => getOrCreateTabHandle(c, Number(tabId)),
-      activeTabId: getTargetTabId(),
+      getOrCreateHandle: (c, ltid) =>
+        // ltid is already a string; pass through. Defensive Number() for
+        // the bench harness path where ids may be numeric.
+        getOrCreateTabHandle(
+          c,
+          typeof ltid === "string" ? ltid : tabRegistry.registerExisting(Number(ltid)),
+        ),
+      // `getTargetTabId` returns a live ctid; map back to the matching
+      // ltid so the legend's `active` comparison (which is `ltid === ltid`)
+      // works correctly.
+      activeTabId: (() => {
+        const activeCtid = getTargetTabId();
+        if (activeCtid == null) return null;
+        return tabRegistry.toLogicalTabId(activeCtid) ?? null;
+      })(),
     });
     const ownedBlock = renderTabLegend(entries);
 
@@ -1771,15 +1839,24 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
       const { entries: awarenessEntries, truncated } =
         buildOpenTabsAwarenessEntries({
           conversationId: cid,
-          ownedTabIds,
+          ownedLtids,
+          // Convert each open tab's chrome ctid into an ltid via the
+          // registry so the awareness block keys on the same identifier
+          // namespace as the owned block. New tabs the agent hasn't
+          // bound yet get a freshly-minted ltid here (idempotent).
           openTabs: openTabs.map((t) => ({
-            id: t.id,
+            id: tabRegistry.registerExisting(Number(t.id)),
             url: t.url,
             title: t.title,
             active: !!t.active,
           })),
-          getOrCreateHandle: (c, tabId) =>
-            getOrCreateTabHandle(c, Number(tabId)),
+          getOrCreateHandle: (c, ltid) =>
+            getOrCreateTabHandle(
+              c,
+              typeof ltid === "string"
+                ? ltid
+                : tabRegistry.registerExisting(Number(ltid)),
+            ),
         });
       awarenessBlock = renderOpenTabsAwareness(awarenessEntries, truncated);
     } catch {

--- a/apps/extension/src/lib/agent/cdp-session.ts
+++ b/apps/extension/src/lib/agent/cdp-session.ts
@@ -13,6 +13,7 @@ const NO_ENABLE_DOMAINS = new Set(["Input", "Page", "DOMSnapshot", "Runtime"]);
 
 export { isDetachError } from "./cdp-errors";
 import { isDetachError } from "./cdp-errors";
+import { tabRegistry } from "./tab-registry";
 
 /**
  * Track Chrome's own detach events. Chrome auto-detaches the debugger on
@@ -177,4 +178,23 @@ export function releaseAll(): void {
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   sessions.delete(tabId);
+});
+
+// Registry-driven invalidation: when a tab is replaced (Speculation Rules /
+// prerender activation), Chrome silently detaches the debugger session
+// attached to the OLD tabId. Without dropping our cached `Session` for the
+// old id, the next `sendCommand` would hit a "No tab with given id" loop.
+// Subscribing to the registry's deduped `onReplace` means we drop the old
+// session immediately; the next CDP call against the new ctid will lazy-
+// attach via the existing `attach()` path. We also subscribe to `onRemove`
+// (which the registry only emits AFTER its dedup window confirms the tab
+// truly closed, not as part of a replace) for symmetry — it strictly
+// covers cases the existing `chrome.tabs.onRemoved` listener above does
+// not, but in practice Chrome fires both for removals so this is just
+// defense-in-depth.
+tabRegistry.onReplace(({ oldCtid }) => {
+  sessions.delete(oldCtid);
+});
+tabRegistry.onRemove(({ ctid }) => {
+  sessions.delete(ctid);
 });

--- a/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserDriver } from "../../driver";
 import { cuaToModelOutput, detectNoChange, executeAndShoot, runCuaToolLoop } from "../cua-loop";
 import type { CuaRunConfig } from "../provider";
+import type { CanonicalAction } from "../actions";
 
 // Controls how the mocked ToolLoopAgent behaves per test.
 let mockSteps = 0;
 let mockFinalText = "";
+
+// Bridge for the new "follows onReplaced mid-loop" test: when the
+// FakeToolLoopAgent runs each step it invokes `capturedRunAction` (set
+// by `fakeBuildCapturing`) with a default no-op-ish CanonicalAction.
+// `mockBetweenSteps` lets the test inject a side effect between steps,
+// e.g. firing `tabRegistry.__handleReplaceForTests` to swap the ctid.
+let capturedRunAction:
+  | ((action: CanonicalAction) => Promise<unknown>)
+  | null = null;
+let mockBetweenSteps: ((stepIndex: number) => void | Promise<void>) | null =
+  null;
 
 // Mock the `ai` module so we can drive `onStepFinish` and the streamed
 // UIMessages without a live model. `runCuaToolLoop` constructs
@@ -18,7 +30,22 @@ vi.mock("ai", () => {
       this.onStepFinish = config.onStepFinish;
     }
     async stream() {
-      for (let i = 0; i < mockSteps; i++) this.onStepFinish?.();
+      for (let i = 0; i < mockSteps; i++) {
+        // If a test wired a captured runAction (via fakeBuildCapturing),
+        // invoke it once per step with a `wait`-kind action. `wait` is
+        // the cheapest action: it only `setTimeout`s in
+        // `executeCanonicalAction` and then funnels into the screenshot
+        // + getTab calls, all of which the test driver mocks. The `tabId`
+        // passed into those driver calls is the loop's `currentCtid`,
+        // which the test asserts against.
+        if (capturedRunAction) {
+          await capturedRunAction({ kind: "wait", ms: 0 });
+        }
+        if (mockBetweenSteps) {
+          await mockBetweenSteps(i);
+        }
+        this.onStepFinish?.();
+      }
       return {
         toUIMessageStream: () => ({}) as never,
       };
@@ -80,6 +107,16 @@ function fakeRunConfig(maxSteps: number): CuaRunConfig {
 function fakeBuild() {
   return () => ({ tools: {} as Record<string, unknown> });
 }
+
+// Reset the per-test mock state between cases so a test that captures
+// `runAction` / wires `mockBetweenSteps` can't leak its hooks into a
+// later test that doesn't expect them to fire.
+beforeEach(() => {
+  mockSteps = 0;
+  mockFinalText = "";
+  capturedRunAction = null;
+  mockBetweenSteps = null;
+});
 
 describe("executeAndShoot", () => {
   it("runs the action and returns { imageDataUrl, currentUrl } OUTPUT", async () => {
@@ -301,24 +338,104 @@ describe("runCuaToolLoop — onReplaced retargeting", () => {
     tabRegistry.__resetForTests!();
     mockSteps = 0;
     mockFinalText = "ok";
+    capturedRunAction = null;
+    mockBetweenSteps = null;
     await runCuaToolLoop(fakeRunConfig(3), fakeBuild());
     // After registerExisting(1), the registry should have a mapping.
     expect(tabRegistry.toLogicalTabId(1)).toBeTruthy();
   });
 
   it("follows onReplaced mid-loop: subsequent actions land on the new ctid", async () => {
-    // We can't easily intercept the loop's internal closure tracking
-    // post-stream, so instead we directly test the documented behavior
-    // via the registry: register the tab, fire onReplaced, then verify
-    // the registry exposes the new ctid for the same ltid.
     const { tabRegistry } = await import("../../tab-registry");
     tabRegistry.__resetForTests!();
-    const ltid = tabRegistry.registerExisting(1);
 
-    tabRegistry.__handleReplaceForTests!(2, 1);
+    // Build a config whose driver records every (method, tabId) call.
+    // The cua loop's per-step `executeAndShoot` funnels through this
+    // driver; the `tabId` argument of every call is the loop's live
+    // `currentCtid`. By asserting on these args before and after an
+    // injected onReplaced we validate that the loop actually retargets,
+    // not just that the registry stores the right mapping.
+    const cdpCalls: { method: string; tabId: unknown }[] = [];
+    const getTabCalls: unknown[] = [];
+    const driver = {
+      sendCommand: vi.fn(async (tabId: unknown, method: string) => {
+        cdpCalls.push({ method, tabId });
+        if (method === "Page.captureScreenshot") return { data: "QUJD" };
+        if (method === "Runtime.evaluate") {
+          return { result: { value: { w: 800, h: 600, dpr: 1 } } };
+        }
+        return {};
+      }),
+      sendToContentScript: vi.fn(async () => ({})),
+      getTab: vi.fn(async (tabId: unknown) => {
+        getTabCalls.push(tabId);
+        return { id: 1, url: "https://example.com", title: "" };
+      }),
+      updateTabUrl: vi.fn(async () => {}),
+      waitForLoad: vi.fn(async () => {}),
+    } as unknown as BrowserDriver;
 
-    expect(tabRegistry.toChromeTabId(ltid)).toBe(2);
-    expect(tabRegistry.toLogicalTabId(1)).toBeUndefined();
-    expect(tabRegistry.toLogicalTabId(2)).toBe(ltid);
+    const cfg: CuaRunConfig = {
+      model: {} as never,
+      driver,
+      tabId: 100 as never,
+      modelId: "claude-sonnet-4-6",
+      task: "do a thing",
+      systemPrompt: "be helpful",
+      maxSteps: 3,
+    };
+
+    // Capture runAction so the FakeToolLoopAgent can fire one action
+    // per step. We use `fakeBuildCapturing` to bridge.
+    mockSteps = 2;
+    mockFinalText = "ok";
+    capturedRunAction = null;
+    mockBetweenSteps = async (stepIndex) => {
+      // Between step 0 and step 1, fire onReplaced(200, 100) so the
+      // loop's currentCtid swaps from 100 to 200.
+      if (stepIndex === 0) {
+        tabRegistry.__handleReplaceForTests!(200, 100);
+      }
+    };
+
+    await runCuaToolLoop(cfg, fakeBuildCapturing());
+
+    // The first step's screenshot must have hit ctid 100; the second
+    // step's screenshot must have hit ctid 200. (Other tabIds may
+    // appear too — readViewport runs at startup, getTab fires for
+    // currentUrl per step — but the tabIds we care about are the
+    // captureScreenshot calls inside executeAndShoot.)
+    const screenshotTabs = cdpCalls
+      .filter((c) => c.method === "Page.captureScreenshot")
+      .map((c) => c.tabId);
+    expect(screenshotTabs.length).toBeGreaterThanOrEqual(2);
+    expect(screenshotTabs[0]).toBe(100);
+    expect(screenshotTabs[screenshotTabs.length - 1]).toBe(200);
+
+    // Same shape via getTab (per-step currentUrl probe): first call on
+    // 100, last on 200.
+    expect(getTabCalls[0]).toBe(100);
+    expect(getTabCalls[getTabCalls.length - 1]).toBe(200);
+
+    // Registry agrees: the ltid now resolves to 200.
+    const ltid = tabRegistry.toLogicalTabId(200);
+    expect(ltid).toBeTruthy();
+    expect(tabRegistry.toLogicalTabId(100)).toBeUndefined();
   });
 });
+
+/**
+ * Like `fakeBuild` but stashes the loop's `runAction` so the
+ * FakeToolLoopAgent.stream() above can invoke it once per step. Used
+ * only by the onReplaced retargeting test below.
+ */
+function fakeBuildCapturing() {
+  return ({
+    runAction,
+  }: {
+    runAction: (action: CanonicalAction) => Promise<unknown>;
+  }) => {
+    capturedRunAction = runAction;
+    return { tools: {} as Record<string, unknown> };
+  };
+}

--- a/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
@@ -292,3 +292,33 @@ describe("cuaToModelOutput", () => {
     });
   });
 });
+
+describe("runCuaToolLoop — onReplaced retargeting", () => {
+  it("registers cfg.tabId with the registry on entry and unsubscribes on exit", async () => {
+    // Use the dynamic import for tabRegistry so the singleton matches the
+    // one cua-loop's static import resolves to.
+    const { tabRegistry } = await import("../../tab-registry");
+    tabRegistry.__resetForTests!();
+    mockSteps = 0;
+    mockFinalText = "ok";
+    await runCuaToolLoop(fakeRunConfig(3), fakeBuild());
+    // After registerExisting(1), the registry should have a mapping.
+    expect(tabRegistry.toLogicalTabId(1)).toBeTruthy();
+  });
+
+  it("follows onReplaced mid-loop: subsequent actions land on the new ctid", async () => {
+    // We can't easily intercept the loop's internal closure tracking
+    // post-stream, so instead we directly test the documented behavior
+    // via the registry: register the tab, fire onReplaced, then verify
+    // the registry exposes the new ctid for the same ltid.
+    const { tabRegistry } = await import("../../tab-registry");
+    tabRegistry.__resetForTests!();
+    const ltid = tabRegistry.registerExisting(1);
+
+    tabRegistry.__handleReplaceForTests!(2, 1);
+
+    expect(tabRegistry.toChromeTabId(ltid)).toBe(2);
+    expect(tabRegistry.toLogicalTabId(1)).toBeUndefined();
+    expect(tabRegistry.toLogicalTabId(2)).toBe(ltid);
+  });
+});

--- a/apps/extension/src/lib/agent/cua/cua-loop.ts
+++ b/apps/extension/src/lib/agent/cua/cua-loop.ts
@@ -6,6 +6,7 @@ import { executeCanonicalAction } from "./executor";
 import { captureNormalizedShot, captureRegionShot } from "./screenshot";
 import type { CuaRunConfig, CuaRunResult } from "./provider";
 import { notifyAgentStatus } from "../agent-indicator";
+import { tabRegistry } from "../tab-registry";
 import {
   runClickDiagnostic,
   setShieldPassthrough,
@@ -259,7 +260,29 @@ export async function runCuaToolLoop(
     runAction: (action: CanonicalAction) => Promise<CuaActionOutput>;
   }) => { tools: Record<string, unknown>; providerOptions?: Record<string, unknown> },
 ): Promise<CuaRunResult> {
-  const vp = await readViewport(cfg.driver, cfg.tabId);
+  // Track the chrome tab id we're driving across the lifetime of this
+  // run. The CUA loop is long-lived (~minutes); a `chrome.tabs
+  // .onReplaced` mid-loop (Speculation Rules / prerender activation)
+  // would otherwise leave us hammering CDP commands at a dead ctid.
+  // Register the initial ctid with the registry to mint or recover an
+  // ltid, then subscribe to onReplace to swap our cached ctid in place.
+  let currentCtid: TabId = cfg.tabId;
+  let cuaLtid: string | null = null;
+  if (typeof cfg.tabId === "number") {
+    cuaLtid = tabRegistry.registerExisting(cfg.tabId);
+  }
+  const offReplace = cuaLtid
+    ? tabRegistry.onReplace((ev) => {
+        if (ev.ltid === cuaLtid) {
+          currentCtid = ev.newCtid;
+          // Refresh the working-overlay glow on the new ctid so the user
+          // gets continuous feedback across the swap.
+          notifyAgentStatus(true, undefined, ev.newCtid);
+        }
+      })
+    : () => {};
+
+  const vp = await readViewport(cfg.driver, currentCtid);
   const display = computeDisplay({
     cssWidth: vp.cssWidth,
     cssHeight: vp.cssHeight,
@@ -279,7 +302,7 @@ export async function runCuaToolLoop(
 
       executeAndShoot(
         cfg.driver,
-        cfg.tabId,
+        currentCtid,
         action,
         display.displayWidth,
         display.displayHeight,
@@ -299,7 +322,7 @@ export async function runCuaToolLoop(
   // indicator so it gets the same space-color tint + robust delivery as the
   // main agent. Best-effort; removed in the finally below so it never lingers
   // after completion/error/abort.
-  notifyAgentStatus(true, undefined, cfg.tabId as number);
+  notifyAgentStatus(true, undefined, currentCtid as number);
 
   let stepCount = 0;
 
@@ -361,7 +384,9 @@ export async function runCuaToolLoop(
   } finally {
     // Always tear down the "working on this page" overlay so it never lingers
     // after the run ends (completion, error, or abort).
-    notifyAgentStatus(false, undefined, cfg.tabId as number);
+    notifyAgentStatus(false, undefined, currentCtid as number);
+    // Unsubscribe the registry listener so the loop's closure can be GC'd.
+    offReplace();
   }
 }
 

--- a/apps/extension/src/lib/agent/driver/extension-driver.ts
+++ b/apps/extension/src/lib/agent/driver/extension-driver.ts
@@ -22,6 +22,7 @@ import {
   waitForTabLoad,
 } from "../active-tab";
 import { sendCommand as sendCdpCommand } from "../cdp-session";
+import { tabRegistry } from "../tab-registry";
 import type {
   BrowserDriver,
   BrowserTabInfo,
@@ -102,7 +103,12 @@ export class ExtensionDriver implements BrowserDriver {
   }
 
   async waitForLoad(tabId: TabId, timeoutMs?: number): Promise<void> {
-    await waitForTabLoad(tabId as number, timeoutMs);
+    // The driver receives a chrome ctid (number) from the tool layer's
+    // `resolveTabIdOrThrow` path. `waitForTabLoad` is ltid-aware
+    // post-migration so it can follow `chrome.tabs.onReplaced` mid-wait;
+    // translate ctid → ltid here (registering if not yet known).
+    const ltid = tabRegistry.registerExisting(tabId as number);
+    await waitForTabLoad(ltid, timeoutMs);
   }
 
   async closeTab(tabId: TabId): Promise<void> {

--- a/apps/extension/src/lib/agent/driver/tool-context.ts
+++ b/apps/extension/src/lib/agent/driver/tool-context.ts
@@ -13,10 +13,24 @@
  * Tools that need extras beyond browser primitives + conversation state
  * should NOT extend this type. Extras belong in the extension wrapper layer
  * (`agent-transport.ts`), not in the portable tool surface.
+ *
+ * Logical tab ids
+ * ===============
+ * As of the LogicalTabId migration, the session's `resolveHandle` returns
+ * a `LogicalTabId` (a UUID), not a `chrome.tabs.id` (a number). Tools that
+ * call `resolveTabIdOrThrow` get a logical id back and must translate to
+ * a chrome ctid via `tabRegistry.toChromeTabId(ltid)` before any driver
+ * call (the driver's CDP / chrome.tabs methods take ctids).
+ *
+ * `TabId` (the driver-facing type) stays `number | string` so the bench
+ * harness's Playwright driver — which uses opaque string ids — keeps
+ * working unchanged. The extension's `ExtensionDriver` always sees
+ * numbers; the tool layer is responsible for the translation.
  */
 
 import type { BrowserDriver, BrowserTabInfo, TabId } from "./browser-driver";
 import type { TodoItem } from "../../types";
+import { tabRegistry } from "../tab-registry";
 
 export interface ToolSession {
   /** The active conversation id, or null when running outside a conversation. */
@@ -124,13 +138,33 @@ export interface ToolContext {
 /**
  * Convenience: derive a stable handle for a tab id, falling back to the
  * default `t<id>` format when no session-level handle map is available.
+ *
+ * `tabId` here is the driver's `TabId` — for the extension this is the
+ * `chrome.tabs.id` (number), which we register/lookup in the registry to
+ * get the LogicalTabId the session's `getOrCreateHandle` then maps to a
+ * stable `t<n>` handle. For the bench harness's PlaywrightDriver, `TabId`
+ * is a string and the session is undefined, so we just stringify.
  */
 export function handleForTab(ctx: ToolContext, tabId: TabId): string {
-  return ctx.session?.getOrCreateHandle?.(tabId) ?? `t${tabId}`;
+  if (!ctx.session?.getOrCreateHandle) return `t${tabId}`;
+  // Extension path: ctid (number) → ltid (via registry) → handle.
+  // Bench path: TabId is already a string; pass through.
+  if (typeof tabId === "number") {
+    const ltid = tabRegistry.registerExisting(tabId);
+    return ctx.session.getOrCreateHandle(ltid);
+  }
+  return ctx.session.getOrCreateHandle(tabId);
 }
 
 /**
- * Resolve a `tab` arg (a stable handle like `t1`) to a concrete tab id.
+ * Resolve a `tab` arg (a stable handle like `t1`) to a driver-addressable
+ * tab id (a `chrome.tabs.id` number on the extension; an opaque string in
+ * the bench harness).
+ *
+ * The session's `resolveHandle` returns a LogicalTabId (string) on the
+ * extension; we translate to ctid via the registry. Returns whatever the
+ * session returned otherwise (bench harness path, where the session is
+ * undefined or returns the driver's native id).
  *
  * This is the canonical entry point for every tab-interacting tool's
  * execute(): tools never pick a tab via the driver's "active" notion any
@@ -150,13 +184,29 @@ export function resolveTabIdOrThrow(
   ctx: ToolContext,
   handle: string,
 ): TabId {
-  const tabId = ctx.session?.resolveHandle?.(handle);
-  if (tabId == null) {
+  const sessionResult = ctx.session?.resolveHandle?.(handle);
+  if (sessionResult == null) {
     throw new ToolTabResolutionError(
       `Unknown tab handle "${handle}". Call listTabs to see available handles, or navigate to open a new tab.`,
     );
   }
-  return tabId;
+  // Extension path: session returns LogicalTabId (string); translate via
+  // the registry to a ctid (number) for the driver.
+  if (typeof sessionResult === "string") {
+    const ctid = tabRegistry.toChromeTabId(sessionResult);
+    if (ctid == null) {
+      // ltid is in the handle map but the registry can't resolve to a
+      // live ctid — the underlying tab is gone (closed) but the handle
+      // map's `dropLtid` cleanup hasn't fired yet, OR an SW restart
+      // hasn't re-registered the ltid. Treat as resolution failure.
+      throw new ToolTabResolutionError(
+        `Tab handle "${handle}" no longer points to an open tab. Call listTabs to refresh handles, or navigate to open a new one.`,
+      );
+    }
+    return ctid;
+  }
+  // Bench harness path: pass through whatever the session returned.
+  return sessionResult;
 }
 
 export async function resolveTabOrThrow(
@@ -180,13 +230,15 @@ export async function resolveTabOrThrow(
  * appears in the tab legend and can be addressed by subsequent tool calls.
  *
  * Resolution order mirrors `selectTab`:
- *   1. The session handle map (`resolveHandle`).
+ *   1. The session handle map (`resolveHandle`) — returns a LogicalTabId
+ *      (string) on the extension; the registry then resolves to a ctid.
  *   2. A numeric fallback — the raw `chrome.tabs` id, for tabs the agent
  *      hasn't bound yet (e.g. user-opened tabs surfaced by `listTabs`).
  * The tab is verified to exist via `driver.listTabs()` before binding.
  *
- * Returns the bound tab id, or `null` if the handle could not be resolved
- * to a live tab. Does NOT change the user's visible tab.
+ * Returns the driver-addressable tab id (a ctid number on the extension),
+ * or `null` if the handle could not be resolved to a live tab. Does NOT
+ * change the user's visible tab.
  *
  * Shared by the `selectTab` tool and the `delegate` tool's auto-bind path
  * for `attached` (CUA) subagents.
@@ -195,7 +247,16 @@ export async function bindTabByHandle(
   ctx: ToolContext,
   handle: string,
 ): Promise<TabId | null> {
-  let tabId = ctx.session?.resolveHandle?.(handle);
+  const sessionResult = ctx.session?.resolveHandle?.(handle);
+  let tabId: TabId | null = null;
+
+  if (typeof sessionResult === "string") {
+    // Extension path: ltid → ctid via registry.
+    const ctid = tabRegistry.toChromeTabId(sessionResult);
+    tabId = ctid ?? null;
+  } else if (sessionResult != null) {
+    tabId = sessionResult;
+  }
 
   // Fallback: a user-opened tab may appear in listTabs under its numeric
   // chrome id before it is bound to the conversation. Only accept a strictly

--- a/apps/extension/src/lib/agent/subagents/__tests__/child-conversation.test.ts
+++ b/apps/extension/src/lib/agent/subagents/__tests__/child-conversation.test.ts
@@ -45,7 +45,7 @@ describe("child-conversation helpers", () => {
       subagentStatus: "running",
       // Inherits parent's space.
       spaceId: "space-A",
-      ownedTabIds: [],
+      ownedLtids: [],
       ownedGroupId: null,
     });
   });

--- a/apps/extension/src/lib/agent/subagents/runner.ts
+++ b/apps/extension/src/lib/agent/subagents/runner.ts
@@ -19,6 +19,7 @@
 import { chatDb } from "../../chat-db";
 import type { ToolContext } from "../driver";
 import type { TabId } from "../driver/browser-driver";
+import { tabRegistry } from "../tab-registry";
 import {
   closeIncognitoWindow,
   openIncognitoWindow,
@@ -381,7 +382,14 @@ function buildChildToolContext(args: {
       ),
       isAgentOwnedTab: async (tabId: TabId) => {
         const conv = await chatDb.getConversation(childConvId);
-        return !!conv?.ownedTabIds.includes(Number(tabId));
+        // Translate ctid → ltid via the registry; the conversation row
+        // stores ownedLtids (strings), not chrome.tabs.id (numbers).
+        const ltid =
+          typeof tabId === "string"
+            ? tabId
+            : tabRegistry.toLogicalTabId(Number(tabId));
+        if (ltid == null) return false;
+        return !!conv?.ownedLtids.includes(ltid);
       },
       hasOwnedTabGroup: async () => {
         const conv = await chatDb.getConversation(childConvId);

--- a/apps/extension/src/lib/agent/subagents/runner.ts
+++ b/apps/extension/src/lib/agent/subagents/runner.ts
@@ -384,10 +384,12 @@ function buildChildToolContext(args: {
         const conv = await chatDb.getConversation(childConvId);
         // Translate ctid → ltid via the registry; the conversation row
         // stores ownedLtids (strings), not chrome.tabs.id (numbers).
-        const ltid =
-          typeof tabId === "string"
-            ? tabId
-            : tabRegistry.toLogicalTabId(Number(tabId));
+        // Mirrors the parent's `isAgentOwnedTab` (agent-transport.ts) so
+        // both paths handle a ctid argument identically: coerce through
+        // Number() and look up via the registry. Stringified-numeric
+        // arguments like "42" go through the same code path; non-numeric
+        // strings fail closed (toLogicalTabId returns undefined for NaN).
+        const ltid = tabRegistry.toLogicalTabId(Number(tabId));
         if (ltid == null) return false;
         return !!conv?.ownedLtids.includes(ltid);
       },

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -111,7 +111,7 @@ The biggest failure mode is giving up too early. Default to trying one more thin
 - A click, type, or key press returned a snapshot identical to what you saw before (no visible change): re-snapshot for fresh refs, then try a different element, scroll the target into view, or check for an overlay.
 - The page is still loading: scroll or screenshot to wait, don't bail.
 - A tool errored: if the error looks transient, retry; if structural, change approach.
-- An "Unknown tab handle" error means the legend has changed — call \`listTabs\` to refresh and pick a valid handle.
+- An "Unknown tab handle" error means the tab the handle pointed to was closed — call \`listTabs\` to refresh the legend and pick a valid handle, or \`navigate\` to open a new one. Page refreshes, prerender activations, and other in-place navigations preserve handles automatically.
 - Don't retry the same exact tool call with the same input more than 2-3 times.
 
 ## Delegation (subagents)

--- a/apps/extension/src/lib/agent/tab-handles.ts
+++ b/apps/extension/src/lib/agent/tab-handles.ts
@@ -1,7 +1,14 @@
 /**
  * Per-conversation handle map. Handles (`t1`, `t2`, ...) are stable agent-
- * facing identifiers that map to chrome tab ids. Tools take a handle in
- * their `tab` arg; the session resolves it back to a real tab id.
+ * facing identifiers that map to LogicalTabIds (UUIDs). Tools take a handle
+ * in their `tab` arg; the session resolves it to an ltid, and the
+ * `tab-registry` resolves the ltid to a live chrome tab id at the very last
+ * moment (immediately before each CDP call).
+ *
+ * Keying on ltid rather than chrome.tabs.id is what makes handles survive
+ * `chrome.tabs.onReplaced` (Speculation Rules / prerender activation), which
+ * would otherwise silently renumber the tab id mid-flow and break the
+ * agent's grip on the page.
  *
  * State is split:
  *   - In-memory (`maps`): fast sync access used by the tools' execute path
@@ -20,15 +27,16 @@
  */
 
 import { chatDb, type PersistedHandleState } from "@/lib/chat-db";
+import { tabRegistry, type LogicalTabId } from "./tab-registry";
 
 export interface TabHandle {
   handle: string;
-  chromeTabId: number;
+  ltid: LogicalTabId;
 }
 
 interface HandleMap {
-  handleToTab: Map<string, number>;
-  tabToHandle: Map<number, string>;
+  handleToLtid: Map<string, LogicalTabId>;
+  ltidToHandle: Map<LogicalTabId, string>;
   counter: number;
 }
 
@@ -54,7 +62,7 @@ const persistChains = new Map<string, Promise<void>>();
 const persistDirty = new Set<string>();
 
 function emptyMap(): HandleMap {
-  return { handleToTab: new Map(), tabToHandle: new Map(), counter: 1 };
+  return { handleToLtid: new Map(), ltidToHandle: new Map(), counter: 1 };
 }
 
 function getMap(conversationId: string): HandleMap {
@@ -68,17 +76,17 @@ function getMap(conversationId: string): HandleMap {
 
 /**
  * Project the in-memory map to a chatDb-shaped record, including only
- * handles whose tabId is in `ownedSet`. Non-owned handles (e.g. minted
+ * handles whose ltid is in `ownedSet`. Non-owned handles (e.g. minted
  * while enumerating `listTabs` for the user's other tabs) stay in memory
  * but don't bloat chatDb across SW lifetimes.
  */
 function snapshotOwned(
   map: HandleMap,
-  ownedSet: Set<number>,
+  ownedSet: Set<LogicalTabId>,
 ): PersistedHandleState {
-  const handles: Record<string, number> = {};
-  for (const [h, id] of map.handleToTab) {
-    if (ownedSet.has(id)) handles[h] = id;
+  const handles: Record<string, LogicalTabId> = {};
+  for (const [h, ltid] of map.handleToLtid) {
+    if (ownedSet.has(ltid)) handles[h] = ltid;
   }
   return { handles, counter: map.counter };
 }
@@ -86,16 +94,16 @@ function snapshotOwned(
 function restore(state: PersistedHandleState | undefined): HandleMap {
   if (!state) return emptyMap();
   const map = emptyMap();
-  for (const [h, id] of Object.entries(state.handles)) {
-    map.handleToTab.set(h, id);
-    map.tabToHandle.set(id, h);
+  for (const [h, ltid] of Object.entries(state.handles)) {
+    map.handleToLtid.set(h, ltid);
+    map.ltidToHandle.set(ltid, h);
   }
   // Defensive: clamp the stored counter to a finite positive integer (in
   // case chatDb was tampered with or partially written). If somehow lower
   // than the highest seen handle suffix, advance it so newly-minted
   // handles can't collide.
   let maxSeen = 0;
-  for (const h of map.handleToTab.keys()) {
+  for (const h of map.handleToLtid.keys()) {
     const m = h.match(/^t(\d+)$/);
     if (m) maxSeen = Math.max(maxSeen, Number(m[1]));
   }
@@ -110,7 +118,7 @@ function restore(state: PersistedHandleState | undefined): HandleMap {
  * Fire-and-forget; failures are swallowed. Writes are chained per
  * conversation so concurrent calls serialize (and so tests can
  * deterministically await `flushPersistsForTests`). Only handles whose
- * tabId is in the conversation's `ownedTabIds` are written; ephemeral
+ * ltid is in the conversation's `ownedLtids` are written; ephemeral
  * handles minted by `listTabs` for non-owned tabs stay in memory only.
  *
  * Calls are coalesced: if a write is already queued (pending), additional
@@ -141,7 +149,7 @@ function persist(conversationId: string): void {
       // while we were suspended.
       const liveMap = maps.get(conversationId);
       if (!liveMap) return;
-      const ownedSet = new Set(conv?.ownedTabIds ?? []);
+      const ownedSet = new Set<LogicalTabId>(conv?.ownedLtids ?? []);
       const state = snapshotOwned(liveMap, ownedSet);
       // Last guard before the write — chatDb may have been reset between
       // the read and the write (only happens in tests, but trivially safe
@@ -176,8 +184,9 @@ export function flushPersistsForTests(
 
 /**
  * Hydrate the in-memory handle map for a conversation from chatDb. Drops
- * any persisted handle whose tab no longer exists. Idempotent: subsequent
- * calls return the same in-flight promise until it settles.
+ * any persisted ltid the registry can't currently resolve to a chrome tab
+ * (the SW restart killed the tab). Idempotent: subsequent calls return
+ * the same in-flight promise until it settles.
  *
  * Merges restored state into any existing in-memory map for the
  * conversation rather than replacing it, so handles minted between
@@ -203,27 +212,15 @@ export function loadHandlesForConversation(
       const conv = await chatDb.getConversation(conversationId);
       const restored = restore(conv?.handleState);
 
-      // Prune dead tabs so a stale handle can't resolve to a closed tab.
-      const tabIds = Array.from(restored.tabToHandle.keys());
-      const liveness = await Promise.all(
-        tabIds.map((id) => {
-          // `chrome` is a free identifier on extension globals; in tests
-          // / non-extension contexts it may be undefined entirely. Use a
-          // typeof guard before any property access.
-          const chromeRef =
-            typeof chrome !== "undefined" ? chrome : undefined;
-          if (!chromeRef?.tabs?.get) {
-            // No chrome.tabs available (tests / non-extension context).
-            // Treat all persisted handles as live; tests can override
-            // per case via vi.stubGlobal.
-            return Promise.resolve(true);
-          }
-          return chromeRef.tabs
-            .get(id)
-            .then(() => true)
-            .catch(() => false);
-        }),
-      );
+      // Prune handles whose ltid the registry can't resolve. Resolution is
+      // a sync `Map.get` — far cheaper than the legacy `chrome.tabs.get`
+      // round-trip per handle. An ltid resolves only when the registry
+      // has either minted it in this SW lifetime (via `registerExisting`,
+      // typically during `rebuildIndexesFromStorage`) or migrated it from
+      // chatDb v15 at startup. Unresolvable ltids are treated as dead
+      // tabs — the upstream conversation reconciliation will already
+      // have removed them from `ownedLtids`.
+      const ltids = Array.from(restored.ltidToHandle.keys());
 
       // If we were cleared mid-flight, abort: the new state owns the
       // conversation now and we shouldn't repopulate maps with stale
@@ -236,23 +233,24 @@ export function loadHandlesForConversation(
       // promise settling.
       const live = getMap(conversationId);
       let pruned = false;
-      tabIds.forEach((id, i) => {
-        if (!liveness[i]) {
+      for (const ltid of ltids) {
+        const resolvable = tabRegistry.toChromeTabId(ltid) !== undefined;
+        if (!resolvable) {
           pruned = true;
-          return;
+          continue;
         }
-        const handle = restored.tabToHandle.get(id)!;
+        const handle = restored.ltidToHandle.get(ltid)!;
         // Only adopt the restored binding if neither side is already
         // claimed in-memory (the live map wins).
-        if (live.handleToTab.has(handle)) return;
-        if (live.tabToHandle.has(id)) return;
-        live.handleToTab.set(handle, id);
-        live.tabToHandle.set(id, handle);
-      });
+        if (live.handleToLtid.has(handle)) continue;
+        if (live.ltidToHandle.has(ltid)) continue;
+        live.handleToLtid.set(handle, ltid);
+        live.ltidToHandle.set(ltid, handle);
+      }
       live.counter = Math.max(live.counter, restored.counter);
 
       // If we pruned anything, write the pruned snapshot back so the
-      // next cold-start doesn't re-pay the liveness round-trip on dead ids.
+      // next cold-start doesn't re-pay the resolve work on dead ltids.
       if (pruned) persist(conversationId);
     } catch (err) {
       console.warn("[tab-handles] hydrate failed", err);
@@ -268,17 +266,26 @@ export function loadHandlesForConversation(
   return token;
 }
 
+/**
+ * Mint or retrieve the handle for a conversation+ltid pair. Returns the
+ * existing handle if one is already bound; otherwise mints `t<counter>`
+ * and increments. Either way, schedules a persist.
+ *
+ * `ltid` is the stable LogicalTabId from `tab-registry`. Tools that have a
+ * raw chrome tab id should resolve it via `tabRegistry.registerExisting(ctid)`
+ * (idempotent) before calling this.
+ */
 export function getOrCreateHandle(
   conversationId: string,
-  tabId: number,
+  ltid: LogicalTabId,
 ): string {
   const map = getMap(conversationId);
-  const existing = map.tabToHandle.get(tabId);
+  const existing = map.ltidToHandle.get(ltid);
   if (existing) {
     // Re-persist on every access. Cheap (the coalesce in `persist()`
     // collapses N calls in a tick to 1 chatDb write) and necessary: a
     // handle minted ephemerally — e.g. by `listTabs` for a tab that was
-    // not yet in `ownedTabIds` — gets filtered out by `snapshotOwned()`
+    // not yet in `ownedLtids` — gets filtered out by `snapshotOwned()`
     // at mint time. If `selectTab` later binds that tab into the
     // conversation, we need a chance to re-snapshot so the handle lands
     // in chatDb. Without this re-persist, that ephemeral handle would
@@ -288,8 +295,8 @@ export function getOrCreateHandle(
   }
 
   const handle = `t${map.counter++}`;
-  map.handleToTab.set(handle, tabId);
-  map.tabToHandle.set(tabId, handle);
+  map.handleToLtid.set(handle, ltid);
+  map.ltidToHandle.set(ltid, handle);
   persist(conversationId);
   return handle;
 }
@@ -297,8 +304,8 @@ export function getOrCreateHandle(
 export function resolveHandle(
   conversationId: string,
   handle: string,
-): number | undefined {
-  return maps.get(conversationId)?.handleToTab.get(handle);
+): LogicalTabId | undefined {
+  return maps.get(conversationId)?.handleToLtid.get(handle);
 }
 
 /**
@@ -314,36 +321,44 @@ export function clearHandles(conversationId: string): void {
 }
 
 /**
- * List the live `{handle, tabId}` pairs for a conversation. Used by the
+ * List the live `{handle, ltid}` pairs for a conversation. Used by the
  * system-prompt tab-legend renderer. Reads only from the in-memory map —
  * call `loadHandlesForConversation` first if you need post-restart state.
  */
 export function listHandles(
   conversationId: string,
-): { handle: string; tabId: number }[] {
+): { handle: string; ltid: LogicalTabId }[] {
   const map = maps.get(conversationId);
   if (!map) return [];
-  return Array.from(map.handleToTab, ([handle, tabId]) => ({ handle, tabId }));
+  return Array.from(map.handleToLtid, ([handle, ltid]) => ({ handle, ltid }));
 }
 
 /**
- * Drop a single handle (e.g. when its tab is closed). Idempotent.
+ * Drop a single handle (e.g. when its underlying tab is closed). Takes
+ * the ltid, not the chrome tab id — the registry is the only place that
+ * translates between them. Idempotent.
  */
-export function dropTab(tabId: number): void {
+export function dropLtid(ltid: LogicalTabId): void {
   for (const [conversationId, map] of maps) {
-    const handle = map.tabToHandle.get(tabId);
+    const handle = map.ltidToHandle.get(ltid);
     if (handle) {
-      map.handleToTab.delete(handle);
-      map.tabToHandle.delete(tabId);
+      map.handleToLtid.delete(handle);
+      map.ltidToHandle.delete(ltid);
       persist(conversationId);
     }
   }
 }
 
-// Auto-cleanup when chrome closes a tab. Best-effort; in non-extension
-// contexts (tests) `chrome.tabs` is undefined and we no-op.
-if (typeof chrome !== "undefined" && chrome.tabs?.onRemoved?.addListener) {
-  chrome.tabs.onRemoved.addListener((tabId) => {
-    dropTab(tabId);
-  });
-}
+// Subscribe to the registry's onRemove event (which is the deduped stream
+// — Chrome's trailing onRemoved after onReplaced is already filtered out).
+// Replaces the legacy `chrome.tabs.onRemoved` listener that keyed on ctid
+// directly (and silently dropped agent handles every time a Speculation
+// Rules site like Attio activated a prerender).
+//
+// `onReplace` is intentionally not subscribed: handles key on ltid, which
+// the registry does NOT change on replace. The new ctid is still
+// addressable through the same ltid; nothing in the handle map needs to
+// move.
+tabRegistry.onRemove(({ ltid }) => {
+  dropLtid(ltid);
+});

--- a/apps/extension/src/lib/agent/tab-legend.ts
+++ b/apps/extension/src/lib/agent/tab-legend.ts
@@ -17,7 +17,7 @@ import type { TabId } from "./driver";
 
 export interface TabLegendInput {
   conversationId: string;
-  ownedTabIds: TabId[];
+  ownedLtids: TabId[];
   /**
    * Per-tab info fetcher. Should resolve with the live tab info, or reject
    * if the tab no longer exists (the legend renderer treats rejection as
@@ -91,7 +91,7 @@ export async function buildTabLegendEntries(
   input: TabLegendInput,
 ): Promise<TabLegendEntry[]> {
   const entries: TabLegendEntry[] = [];
-  for (const tabId of input.ownedTabIds) {
+  for (const tabId of input.ownedLtids) {
     let url: string | undefined;
     let title: string | undefined;
     try {
@@ -149,7 +149,7 @@ export function renderTabLegend(entries: TabLegendEntry[]): string {
 export interface OpenTabsAwarenessInput {
   conversationId: string;
   /** Tab ids already in the conversation (omit from the awareness list). */
-  ownedTabIds: TabId[];
+  ownedLtids: TabId[];
   /** All open tabs in the current window. Internal/extension URLs filtered. */
   openTabs: { id: TabId; url: string; title: string; active: boolean }[];
   getOrCreateHandle: (conversationId: string, tabId: TabId) => string;
@@ -169,7 +169,7 @@ export interface OpenTabsAwarenessEntry {
 export function buildOpenTabsAwarenessEntries(
   input: OpenTabsAwarenessInput,
 ): { entries: OpenTabsAwarenessEntry[]; truncated: number } {
-  const owned = new Set<TabId>(input.ownedTabIds);
+  const owned = new Set<TabId>(input.ownedLtids);
   const cap = input.maxEntries ?? MAX_AWARENESS_ENTRIES;
   const result: OpenTabsAwarenessEntry[] = [];
   let truncated = 0;

--- a/apps/extension/src/lib/agent/tab-registry.ts
+++ b/apps/extension/src/lib/agent/tab-registry.ts
@@ -201,7 +201,12 @@ function handleReplace(addedCtid: ChromeTabId, removedCtid: ChromeTabId): void {
   // Best-effort URL for telemetry. Logged async so the synchronous emit
   // above never has to wait on a CDP round-trip; readers correlating logs
   // to events should match on `ltid`.
-  const tabsApi = (globalThis as { chrome?: { tabs?: { get?: (id: number) => Promise<chrome.tabs.Tab> } } })
+  //
+  // The chrome.tabs.get shape is inlined as a minimal `{ url?: string }`
+  // rather than `chrome.tabs.Tab` so this module typechecks in
+  // `packages/bench` (which imports from `apps/extension/src/lib` without
+  // pulling in `@types/chrome`).
+  const tabsApi = (globalThis as { chrome?: { tabs?: { get?: (id: number) => Promise<{ url?: string } | undefined> } } })
     .chrome?.tabs?.get;
   if (tabsApi) {
     Promise.resolve(tabsApi(addedCtid))
@@ -289,9 +294,26 @@ export const tabRegistry = {
 
 // Wire chrome's tab lifecycle events to the registry. This block runs at
 // module load. Guarded so non-extension contexts (vitest with the minimal
-// test-setup mock) don't crash on undefined APIs; tests drive the registry
-// via the `__handle*ForTests` seams instead.
-const chromeRef = (globalThis as { chrome?: typeof chrome }).chrome;
+// test-setup mock, or `packages/bench` imports) don't crash on undefined
+// APIs; tests drive the registry via the `__handle*ForTests` seams instead.
+//
+// The chrome global shape is inlined as a structural type rather than
+// `typeof chrome` so this module typechecks in `packages/bench` (no
+// `@types/chrome` there). The structural shape covers exactly the listeners
+// we need.
+interface ChromeTabsLifecycleShape {
+  tabs?: {
+    onReplaced?: {
+      addListener?: (
+        cb: (addedTabId: number, removedTabId: number) => void,
+      ) => void;
+    };
+    onRemoved?: {
+      addListener?: (cb: (tabId: number) => void) => void;
+    };
+  };
+}
+const chromeRef = (globalThis as { chrome?: ChromeTabsLifecycleShape }).chrome;
 if (chromeRef?.tabs?.onReplaced?.addListener) {
   chromeRef.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
     handleReplace(addedTabId, removedTabId);

--- a/apps/extension/src/lib/agent/tab-registry.ts
+++ b/apps/extension/src/lib/agent/tab-registry.ts
@@ -1,0 +1,304 @@
+/**
+ * Single source of truth for "which logical agent tab corresponds to which
+ * `chrome.tabs.id` right now?"
+ *
+ * Why this exists
+ * ===============
+ * `chrome.tabs.id` is *not* a stable identifier for the page the agent is
+ * working on. Chrome reassigns tab ids in at least three situations:
+ *
+ *   1. Speculation Rules / prerender activation. Many SPAs (Attio, Notion,
+ *      Vercel, Google Search, X) prerender the next route; on activation
+ *      Chrome fires `chrome.tabs.onReplaced(addedTabId, removedTabId)` and
+ *      *also* fires `onRemoved(removedTabId)`. The page is the same; the
+ *      integer id changes.
+ *   2. Chrome restart. Tab ids are not stable across browser restarts.
+ *   3. Tab discard + restore. Memory-pressure discarded tabs come back with
+ *      a new id.
+ *
+ * Without a layer of indirection, every map keyed on `chrome.tabs.id` —
+ * the agent's handle map (`tab-handles.ts`), the conversation ownership
+ * bookkeeping (`tab-scoping.ts`), the cdp-session cache (`cdp-session.ts`),
+ * and the persisted `Conversation.ownedLtids` array in chatDb (formerly
+ * `ownedTabIds: number[]`) — would
+ * silently corrupt on every replacement. The persistent symptom for the
+ * agent is "Unknown tab handle" + "No tab with given id" mid-flow.
+ *
+ * What this module does
+ * =====================
+ * Mints stable opaque `LogicalTabId`s (UUIDs). Owns the only listener for
+ * `chrome.tabs.onReplaced` in the codebase and consolidates the trailing
+ * `chrome.tabs.onRemoved` Chrome fires for the replaced ctid (the
+ * documented event order is `onReplaced` → `onRemoved(oldCtid)` — without
+ * dedup, every consumer treats a replace as a removal).
+ *
+ * Consumers (tab-handles, tab-scoping, cdp-session, active-tab, cua-loop,
+ * agent-transport) subscribe to the registry's `onReplace` and `onRemove`
+ * events instead of installing their own `chrome.tabs.onRemoved` listeners.
+ *
+ * What this module does NOT do
+ * ============================
+ *  - chatDb persistence (lives in `tab-handles.ts` per-conversation)
+ *  - tab ownership policy / side-panel UX (lives in `tab-scoping.ts`)
+ *  - debugger session lifecycle (lives in `cdp-session.ts`)
+ *
+ * The registry is a *resolver* and an *event source*. Persistence and
+ * policy stay in their existing homes; they just key on ltid now.
+ */
+
+export type LogicalTabId = string;
+export type ChromeTabId = number;
+
+export interface ReplaceEvent {
+  ltid: LogicalTabId;
+  oldCtid: ChromeTabId;
+  newCtid: ChromeTabId;
+}
+
+export interface RemoveEvent {
+  ltid: LogicalTabId;
+  ctid: ChromeTabId;
+}
+
+type ReplaceListener = (e: ReplaceEvent) => void;
+type RemoveListener = (e: RemoveEvent) => void;
+
+/**
+ * Window during which a trailing `onRemoved` for a just-replaced ctid is
+ * suppressed. Chrome fires `onReplaced` then `onRemoved` synchronously, so
+ * this only needs to be larger than 0; 5s is generous defense against
+ * scheduler oddities.
+ */
+const REPLACE_DEDUP_WINDOW_MS = 5_000;
+
+const ltidByCtid = new Map<ChromeTabId, LogicalTabId>();
+const ctidByLtid = new Map<LogicalTabId, ChromeTabId>();
+
+interface DedupEntry {
+  ltid: LogicalTabId;
+  expires: number;
+}
+const recentlyReplaced = new Map<ChromeTabId, DedupEntry>();
+
+const replaceListeners = new Set<ReplaceListener>();
+const removeListeners = new Set<RemoveListener>();
+
+function now(): number {
+  return Date.now();
+}
+
+function sweepExpired(): void {
+  const t = now();
+  for (const [ctid, entry] of recentlyReplaced) {
+    if (entry.expires <= t) recentlyReplaced.delete(ctid);
+  }
+}
+
+/**
+ * Mint a fresh ltid. Uses `crypto.randomUUID()` when available (extension
+ * runtime always has it; older test environments may not) and falls back
+ * to a counter-based id under test.
+ */
+let testCounter = 0;
+function mintLtid(): LogicalTabId {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  testCounter += 1;
+  return `ltid-test-${testCounter}`;
+}
+
+function emitReplace(ev: ReplaceEvent): void {
+  for (const fn of replaceListeners) {
+    try {
+      fn(ev);
+    } catch (err) {
+      console.warn("[tab-registry] onReplace subscriber threw", err);
+    }
+  }
+}
+
+function emitRemove(ev: RemoveEvent): void {
+  for (const fn of removeListeners) {
+    try {
+      fn(ev);
+    } catch (err) {
+      console.warn("[tab-registry] onRemove subscriber threw", err);
+    }
+  }
+}
+
+/**
+ * Mint or return the existing ltid for a chrome tab id. Idempotent: calling
+ * with the same ctid multiple times returns the same ltid.
+ */
+function registerExisting(ctid: ChromeTabId): LogicalTabId {
+  const existing = ltidByCtid.get(ctid);
+  if (existing) return existing;
+  const ltid = mintLtid();
+  ltidByCtid.set(ctid, ltid);
+  ctidByLtid.set(ltid, ctid);
+  return ltid;
+}
+
+/**
+ * Forget a logical tab. Idempotent.
+ */
+function unregister(ltid: LogicalTabId): void {
+  const ctid = ctidByLtid.get(ltid);
+  if (ctid != null) ltidByCtid.delete(ctid);
+  ctidByLtid.delete(ltid);
+}
+
+function toChromeTabId(ltid: LogicalTabId): ChromeTabId | undefined {
+  return ctidByLtid.get(ltid);
+}
+
+function toLogicalTabId(ctid: ChromeTabId): LogicalTabId | undefined {
+  return ltidByCtid.get(ctid);
+}
+
+function onReplace(fn: ReplaceListener): () => void {
+  replaceListeners.add(fn);
+  return () => replaceListeners.delete(fn);
+}
+
+function onRemove(fn: RemoveListener): () => void {
+  removeListeners.add(fn);
+  return () => removeListeners.delete(fn);
+}
+
+/**
+ * Internal: handle a `chrome.tabs.onReplaced(added, removed)` event.
+ * Exported only as `__handleReplaceForTests` for unit tests; production
+ * callers come from the chrome listener installed at module load.
+ */
+function handleReplace(addedCtid: ChromeTabId, removedCtid: ChromeTabId): void {
+  sweepExpired();
+  let ltid = ltidByCtid.get(removedCtid);
+  if (!ltid) {
+    // We weren't tracking the old ctid (e.g. replace fired for a tab the
+    // agent hadn't bound yet). Mint a fresh ltid for the new ctid so
+    // future tools can address it; emit no event (no consumers care about
+    // an untracked tab's identity).
+    registerExisting(addedCtid);
+    return;
+  }
+  // Atomic re-key.
+  ltidByCtid.delete(removedCtid);
+  ltidByCtid.set(addedCtid, ltid);
+  ctidByLtid.set(ltid, addedCtid);
+
+  recentlyReplaced.set(removedCtid, {
+    ltid,
+    expires: now() + REPLACE_DEDUP_WINDOW_MS,
+  });
+
+  // Emit synchronously so subscribers (cdp-session invalidation,
+  // tab-scoping side-panel re-registration, agent-transport working-glow
+  // re-target) run in deterministic order before any other code reacts.
+  emitReplace({ ltid, oldCtid: removedCtid, newCtid: addedCtid });
+
+  // Best-effort URL for telemetry. Logged async so the synchronous emit
+  // above never has to wait on a CDP round-trip; readers correlating logs
+  // to events should match on `ltid`.
+  const tabsApi = (globalThis as { chrome?: { tabs?: { get?: (id: number) => Promise<chrome.tabs.Tab> } } })
+    .chrome?.tabs?.get;
+  if (tabsApi) {
+    Promise.resolve(tabsApi(addedCtid))
+      .then((tab) => {
+        console.warn("[tab-registry] onReplaced", {
+          url: tab?.url,
+          ltid,
+          oldCtid: removedCtid,
+          newCtid: addedCtid,
+        });
+      })
+      .catch(() => {
+        console.warn("[tab-registry] onReplaced", {
+          url: undefined,
+          ltid,
+          oldCtid: removedCtid,
+          newCtid: addedCtid,
+        });
+      });
+  } else {
+    console.warn("[tab-registry] onReplaced", {
+      url: undefined,
+      ltid,
+      oldCtid: removedCtid,
+      newCtid: addedCtid,
+    });
+  }
+}
+
+/**
+ * Internal: handle a `chrome.tabs.onRemoved(ctid)` event. Suppresses the
+ * event when the ctid is in the recently-replaced dedup window.
+ */
+function handleRemove(ctid: ChromeTabId): void {
+  sweepExpired();
+  const dedup = recentlyReplaced.get(ctid);
+  if (dedup && dedup.expires > now()) {
+    // Trailing onRemoved that pairs with a recent onReplaced. Drop.
+    recentlyReplaced.delete(ctid);
+    return;
+  }
+  const ltid = ltidByCtid.get(ctid);
+  if (!ltid) return; // never tracked; nothing to emit
+  ltidByCtid.delete(ctid);
+  ctidByLtid.delete(ltid);
+  emitRemove({ ltid, ctid });
+}
+
+/** Reset internal *state* (handle maps, dedup window). Intended for tests
+ *  that need a clean ltid namespace between cases but expect the
+ *  application-level subscribers (tab-handles, tab-scoping, cdp-session)
+ *  to keep working.
+ *
+ *  Listener lists are NOT cleared by this — that would silently break any
+ *  module-level subscription that registered at import time. Tests that
+ *  want a totally clean registry (e.g. the registry's own unit tests)
+ *  call `__clearListenersForTests` in addition. */
+function __resetForTests(): void {
+  ltidByCtid.clear();
+  ctidByLtid.clear();
+  recentlyReplaced.clear();
+  testCounter = 0;
+}
+
+/** Clear all subscriber lists. Tests-only escape hatch for the registry's
+ *  own unit tests; production code should never call this. */
+function __clearListenersForTests(): void {
+  replaceListeners.clear();
+  removeListeners.clear();
+}
+
+export const tabRegistry = {
+  registerExisting,
+  unregister,
+  toChromeTabId,
+  toLogicalTabId,
+  onReplace,
+  onRemove,
+  // Test seams. Production callers come from chrome listeners.
+  __handleReplaceForTests: handleReplace,
+  __handleRemoveForTests: handleRemove,
+  __resetForTests,
+  __clearListenersForTests,
+};
+
+// Wire chrome's tab lifecycle events to the registry. This block runs at
+// module load. Guarded so non-extension contexts (vitest with the minimal
+// test-setup mock) don't crash on undefined APIs; tests drive the registry
+// via the `__handle*ForTests` seams instead.
+const chromeRef = (globalThis as { chrome?: typeof chrome }).chrome;
+if (chromeRef?.tabs?.onReplaced?.addListener) {
+  chromeRef.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+    handleReplace(addedTabId, removedTabId);
+  });
+}
+if (chromeRef?.tabs?.onRemoved?.addListener) {
+  chromeRef.tabs.onRemoved.addListener((tabId) => {
+    handleRemove(tabId);
+  });
+}

--- a/apps/extension/src/lib/agent/tools/__tests__/close-tabs.test.ts
+++ b/apps/extension/src/lib/agent/tools/__tests__/close-tabs.test.ts
@@ -6,12 +6,19 @@ import { closeTabsTool } from "../close-tabs";
 
 const sent: any[] = [];
 
+// Stable ltid strings for the test's two synthetic owned tabs. Real
+// production code would mint these via tabRegistry.registerExisting; for
+// this tool's tests we don't need the registry — closeTabs just passes
+// whatever resolveHandle returns through to the message bus.
+const LTID_T1 = "ltid-test-101";
+const LTID_T2 = "ltid-test-102";
+
 function ctx(overrides: Partial<NonNullable<ToolContext["session"]>> = {}): ToolContext {
   return {
     driver: {} as ToolContext["driver"],
     session: {
       conversationId: "c1",
-      resolveHandle: (h: string) => ({ t1: 101, t2: 102 } as Record<string, number>)[h],
+      resolveHandle: (h: string) => ({ t1: LTID_T1, t2: LTID_T2 } as Record<string, string>)[h],
       ...overrides,
     },
   };
@@ -22,7 +29,9 @@ beforeEach(async () => {
   indexedDB = new IDBFactory();
   chatDb._resetForTests();
   await chatDb.createConversation({
-    id: "c1", title: "t", spaceId: null, ownedGroupId: 5, ownedTabIds: [101, 102], createdAt: 0, updatedAt: 0,
+    id: "c1", title: "t", spaceId: null, ownedGroupId: 5,
+    ownedLtids: [LTID_T1, LTID_T2],
+    createdAt: 0, updatedAt: 0,
   });
   vi.stubGlobal("chrome", {
     runtime: {
@@ -33,7 +42,7 @@ beforeEach(async () => {
           ok: true,
           undo: {
             action: "reopen",
-            tabs: (msg.tabIds as number[]).map((_id, i) => ({
+            tabs: (msg.ltids as string[]).map((_id, i) => ({
               url: `https://tab-${i}`,
               windowId: 1,
               pinned: false,
@@ -52,17 +61,17 @@ afterEach(() => {
 });
 
 describe("closeTabs tool", () => {
-  it("target:'group' closes all owned tab ids", async () => {
+  it("target:'group' closes all owned ltids", async () => {
     const res = await closeTabsTool.execute({ target: "group" }, ctx());
     expect(sent[0].type).toBe("CLOSE_AGENT_TABS");
     expect(sent[0].conversationId).toBe("c1");
-    expect(sent[0].tabIds.sort()).toEqual([101, 102]);
+    expect(sent[0].ltids.sort()).toEqual([LTID_T1, LTID_T2].sort());
     expect(res.closed).toBe(2);
   });
 
-  it("target:'tabs' resolves handles to ids", async () => {
+  it("target:'tabs' resolves handles to ltids", async () => {
     const res = await closeTabsTool.execute({ target: "tabs", handles: ["t1"] }, ctx());
-    expect(sent[0].tabIds).toEqual([101]);
+    expect(sent[0].ltids).toEqual([LTID_T1]);
     expect(res.closed).toBe(1);
   });
 
@@ -73,7 +82,7 @@ describe("closeTabs tool", () => {
   });
 
   it("returns closed:0 with a note when group is empty", async () => {
-    await chatDb.updateConversation("c1", { ownedTabIds: [], ownedGroupId: null });
+    await chatDb.updateConversation("c1", { ownedLtids: [], ownedGroupId: null });
     const res = await closeTabsTool.execute({ target: "group" }, ctx());
     expect(res.closed).toBe(0);
     expect(sent.length).toBe(0);
@@ -100,7 +109,7 @@ describe("closeTabs tool", () => {
       },
     });
     const res = await closeTabsTool.execute({ target: "group" }, ctx());
-    expect(sent[0].tabIds.sort()).toEqual([101, 102]);
+    expect(sent[0].ltids.sort()).toEqual([LTID_T1, LTID_T2].sort());
     expect(res.closed).toBe(1);
   });
 

--- a/apps/extension/src/lib/agent/tools/close-tabs.ts
+++ b/apps/extension/src/lib/agent/tools/close-tabs.ts
@@ -48,10 +48,10 @@ export const closeTabsTool: BrowserTool<Input, Output> = {
       return { closed: 0, error: "No active conversation." };
     }
 
-    let tabIds: number[];
+    let ltidsToClose: string[];
     if (input.target === "group") {
       const conv = await chatDb.getConversation(cid);
-      tabIds = conv?.ownedTabIds ?? [];
+      ltidsToClose = conv?.ownedLtids ?? [];
     } else {
       // input.target === "tabs"
       if (!input.handles || input.handles.length === 0) {
@@ -60,19 +60,19 @@ export const closeTabsTool: BrowserTool<Input, Output> = {
           error: "target 'tabs' requires a non-empty 'handles' array.",
         };
       }
-      tabIds = [];
+      ltidsToClose = [];
       for (const handle of input.handles) {
-        const id = ctx.session?.resolveHandle?.(handle);
-        if (id == null) {
+        const ltid = ctx.session?.resolveHandle?.(handle);
+        if (ltid == null) {
           throw new Error(
             `Tab handle "${handle}" not found. Use listTabs to see available tabs.`,
           );
         }
-        tabIds.push(id as number);
+        ltidsToClose.push(ltid as string);
       }
     }
 
-    if (tabIds.length === 0) {
+    if (ltidsToClose.length === 0) {
       return {
         closed: 0,
         note: "No tabs to close — the conversation has no open owned tabs.",
@@ -83,12 +83,15 @@ export const closeTabsTool: BrowserTool<Input, Output> = {
       const res = (await chrome.runtime.sendMessage({
         type: "CLOSE_AGENT_TABS",
         conversationId: cid,
-        tabIds,
+        // Send ltids over the wire. The background handler resolves each
+        // ltid back to a live ctid via the registry just before
+        // `chrome.tabs.remove`.
+        ltids: ltidsToClose,
       })) as { ok: boolean; undo?: Output["undo"]; error?: string };
       if (!res?.ok) {
         return { closed: 0, error: res?.error ?? "Close failed." };
       }
-      return { closed: res.undo?.tabs.length ?? tabIds.length, undo: res.undo };
+      return { closed: res.undo?.tabs.length ?? ltidsToClose.length, undo: res.undo };
     } catch (err) {
       return { closed: 0, error: err instanceof Error ? err.message : String(err) };
     }

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -9,10 +9,19 @@ import { OPFS } from "./vfs/opfs";
  * stable identifiers the agent uses to address tabs in tool args. Backed
  * by a sync in-memory cache in `tab-handles.ts`; this field lets the cache
  * survive service-worker restarts and conversation switches.
+ *
+ * As of chat-db v15, the value type is `LogicalTabId` (a UUID minted by
+ * `tab-registry.ts`), not `chrome.tabs.id`. The registry holds the only
+ * `LogicalTabId → chrome.tabs.id` mapping in the system, and that mapping
+ * is in-memory and ephemeral by design (a chrome tab id is only meaningful
+ * within one Chrome process lifetime). Keying handles on the stable ltid
+ * makes them survive prerender activations (`chrome.tabs.onReplaced`),
+ * which silently renumber tab ids on Speculation Rules sites like Attio,
+ * Notion, and X.
  */
 export interface PersistedHandleState {
-  /** handle → chrome tab id */
-  handles: Record<string, number>;
+  /** handle → LogicalTabId (string UUID) */
+  handles: Record<string, string>;
   /** Next handle counter (1-based, monotonic per conversation). */
   counter: number;
 }
@@ -25,7 +34,17 @@ interface ChatDB extends DBSchema {
       title: string;
       spaceId: string | null;
       ownedGroupId: number | null;
-      ownedTabIds: number[];
+      /**
+       * Logical tab ids (UUIDs minted by `tab-registry.ts`) the conversation
+       * owns. As of v15, replaces the legacy `ownedTabIds: number[]` field
+       * which keyed on `chrome.tabs.id` and silently corrupted on
+       * `chrome.tabs.onReplaced` (prerender activation).
+       *
+       * The registry resolves each ltid to a live chrome tab id at SW
+       * boot via `rebuildIndexesFromStorage`; ltids whose ctid can't be
+       * recovered are dropped from this list during reconciliation.
+       */
+      ownedLtids: string[];
       todos?: TodoItem[];
       handleState?: PersistedHandleState;
       createdAt: number;
@@ -171,6 +190,11 @@ function emitConversationChange(conversationId: string): void {
 
 function getDb(): Promise<IDBPDatabase<ChatDB>> {
   if (!dbPromise) {
+    // Mutable flag the upgrade callback flips when a v15 migration is
+    // needed. Read inside the post-open `then` (which runs *after* the
+    // upgrade callback completes), so by then the flag reflects whether
+    // the synchronous upgrade actually ran the v15 hop.
+    const flags = { needsV15Fixup: false };
     // v7: migrates legacy `{ type: "compaction", auto, ... }` parts
     // to the AI SDK's DataUIPart contract:
     // `{ type: "data-compaction", data: { auto, ... } }`.
@@ -189,7 +213,14 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
     // v13: adds `lastCompletionApproved` + `taskCompletedAt` on
     //      conversations for agent tab-cleanup. Optional; no backfill.
     // v14: adds the scheduledTasks object store.
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 14, {
+    // v15: renames `ownedTabIds: number[]` → `ownedLtids: string[]` and
+    //      rewrites `handleState.handles` values from chrome.tabs.id
+    //      (number) to LogicalTabId (string UUID). The migration mints a
+    //      fresh ltid for each live ctid via the registry; ctids whose
+    //      `chrome.tabs.get` rejects (the tab is gone) are dropped.
+    //      Per-row try/catch — corrupt rows degrade to empty owned-state
+    //      with a console.warn rather than aborting the whole upgrade.
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 15, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -239,8 +270,12 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
             while (cursor) {
               const record = cursor.value as Record<string, unknown>;
               if (record.ownedGroupId === undefined) record.ownedGroupId = null;
+              // Legacy field name `ownedTabIds` (number[]); the v15 hop
+              // renames it to `ownedLtids: string[]` after migrating values
+              // through the registry.
               if (!Array.isArray(record.ownedTabIds)) record.ownedTabIds = [];
-              cursor.update(record as ChatDB["conversations"]["value"]);
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              cursor.update(record as any);
               cursor = await cursor.continue();
             }
           };
@@ -384,10 +419,149 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
           // small). The index is kept for future range queries.
           taskStore.createIndex("by-next-run", "nextRunAt");
         }
+
+        if (oldVersion < 15) {
+          // v15: rename `ownedTabIds: number[]` → `ownedLtids: string[]`
+          // and rewrite `handleState.handles` values from chrome.tabs.id
+          // (number) to LogicalTabId (UUID string).
+          //
+          // The actual ctid → ltid migration runs in `runV15Fixup` *outside*
+          // this upgrade transaction — IDB upgrade transactions auto-commit
+          // on the next microtask without an in-flight IDB request, so
+          // awaiting `chrome.tabs.get` (a non-IDB promise) or a dynamic
+          // `import` here would prematurely close the txn and crash the
+          // cursor loop. The synchronous part of the schema bump (the
+          // type-level rename) is a no-op at the IDB level because
+          // IndexedDB stores arbitrary values — we just need to bump the
+          // version number so the post-open fixup runs.
+          flags.needsV15Fixup = true;
+        }
       },
+    });
+    // Chain the v15 fixup pass into the open promise unconditionally; the
+    // chained handler reads `flags.needsV15Fixup` *after* the upgrade
+    // callback has finished, so it correctly reflects whether the hop ran.
+    // No-op when not needed; failures are logged but not propagated.
+    dbPromise = dbPromise.then(async (db) => {
+      if (flags.needsV15Fixup) {
+        try {
+          await runV15Fixup(db);
+        } catch (err) {
+          console.warn("[chat-db v15] fixup pass failed", err);
+        }
+      }
+      return db;
     });
   }
   return dbPromise;
+}
+
+/**
+ * Post-upgrade fixup for chat-db v15: rewrites each conversation's legacy
+ * `ownedTabIds: number[]` to `ownedLtids: string[]`, minting a LogicalTabId
+ * via `tab-registry` for each ctid that's still alive in `chrome.tabs`. Dead
+ * ctids and corrupt `handleState` values are dropped silently (with a
+ * console.warn per failed row). Per-row try/catch — a corrupt row degrades
+ * to empty owned-state rather than aborting the pass.
+ *
+ * Lives outside the upgrade transaction so we can `await` non-IDB promises
+ * (`chrome.tabs.get`, the dynamic `tab-registry` import) without IDB
+ * auto-committing the txn mid-iteration.
+ */
+async function runV15Fixup(db: IDBPDatabase<ChatDB>): Promise<void> {
+  const { tabRegistry } = await import("./agent/tab-registry");
+  const chromeRef = (globalThis as { chrome?: typeof chrome }).chrome;
+  const tabsGet = chromeRef?.tabs?.get;
+
+  // Read all conversations once, then process each in its own short
+  // readwrite transaction. Avoids long-running txn drift and keeps each
+  // row's failure isolated.
+  const all = await db.getAll("conversations");
+  for (const existing of all) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const record = existing as any;
+    // Skip already-migrated rows (defensive — the upgrade hop is the only
+    // signal but a partial previous run could leave us re-entering).
+    if (record.ownedTabIds === undefined && record.ownedLtids !== undefined) {
+      continue;
+    }
+    try {
+      const legacyTabIds: number[] = Array.isArray(record.ownedTabIds)
+        ? (record.ownedTabIds as number[])
+        : [];
+
+      const ownedLtids: string[] = [];
+      for (const ctid of legacyTabIds) {
+        if (typeof ctid !== "number") continue;
+        let alive = false;
+        if (tabsGet) {
+          try {
+            await tabsGet(ctid);
+            alive = true;
+          } catch {
+            alive = false;
+          }
+        }
+        if (alive) {
+          ownedLtids.push(tabRegistry.registerExisting(ctid));
+        }
+        // else: tab is gone since last session, drop silently
+      }
+
+      // Rewrite handle map: number values → ltid values.
+      const legacyHandleState = record.handleState as
+        | { handles?: unknown; counter?: number }
+        | undefined;
+      let newHandleState:
+        | { handles: Record<string, string>; counter: number }
+        | undefined = undefined;
+      if (
+        legacyHandleState &&
+        legacyHandleState.handles &&
+        typeof legacyHandleState.handles === "object"
+      ) {
+        const newHandles: Record<string, string> = {};
+        for (const [handle, ctid] of Object.entries(
+          legacyHandleState.handles as Record<string, unknown>,
+        )) {
+          if (typeof ctid !== "number") continue;
+          const ltid = tabRegistry.toLogicalTabId(ctid);
+          if (ltid) newHandles[handle] = ltid;
+          // else: the ctid wasn't alive when we probed above; drop the
+          // handle. The agent will re-mint as needed.
+        }
+        const counter =
+          typeof legacyHandleState.counter === "number" &&
+          legacyHandleState.counter > 0
+            ? legacyHandleState.counter
+            : 1;
+        if (Object.keys(newHandles).length > 0 || counter > 1) {
+          newHandleState = { handles: newHandles, counter };
+        }
+      }
+
+      delete record.ownedTabIds;
+      record.ownedLtids = ownedLtids;
+      if (newHandleState) {
+        record.handleState = newHandleState;
+      } else {
+        delete record.handleState;
+      }
+      await db.put("conversations", record);
+    } catch (err) {
+      console.warn("[chat-db v15] failed to migrate conversation row", err);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const degraded = existing as any;
+        delete degraded.ownedTabIds;
+        degraded.ownedLtids = [];
+        delete degraded.handleState;
+        await db.put("conversations", degraded);
+      } catch {
+        // Even the degrade write failed; leave the row alone.
+      }
+    }
+  }
 }
 
 export const chatDb = {
@@ -467,19 +641,19 @@ export const chatDb = {
   async createConversation(
     conv: Omit<
       ChatDB["conversations"]["value"],
-      "ownedGroupId" | "ownedTabIds" | "todos" | "handleState"
+      "ownedGroupId" | "ownedLtids" | "todos" | "handleState"
     > &
       Partial<
         Pick<
           ChatDB["conversations"]["value"],
-          "ownedGroupId" | "ownedTabIds" | "todos" | "handleState"
+          "ownedGroupId" | "ownedLtids" | "todos" | "handleState"
         >
       >,
   ): Promise<void> {
     const db = await getDb();
     await db.put("conversations", {
       ownedGroupId: null,
-      ownedTabIds: [],
+      ownedLtids: [],
       todos: [],
       ...conv,
     });
@@ -518,7 +692,7 @@ export const chatDb = {
     emitConversationChange(id);
     // Only broadcast for fields that materially affect conversation-list UIs.
     // Excludes high-frequency churn like `updatedAt` (per message turn),
-    // `ownedTabIds`/`ownedGroupId` (tab-scoping reconciliation), and `todos`
+    // `ownedLtids`/`ownedGroupId` (tab-scoping reconciliation), and `todos`
     // (per agent step). Same-window UIs don't refetch on those either, so
     // broadcasting them would make cross-window behavior more aggressive
     // than same-window — wrong direction.

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -112,7 +112,7 @@ export interface Conversation {
   ownedGroupId: number | null;
   /**
    * Logical tab ids (UUIDs minted by `tab-registry.ts`) the conversation
-   * owns. As of chat-db v15, replaces the legacy `ownedLtids: number[]`
+   * owns. As of chat-db v15, replaces the legacy `ownedTabIds: number[]`
    * field which keyed on `chrome.tabs.id` and silently corrupted on
    * `chrome.tabs.onReplaced` (prerender activation).
    */

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -110,7 +110,13 @@ export interface Conversation {
   title: string;
   spaceId: string | null;
   ownedGroupId: number | null;
-  ownedTabIds: number[];
+  /**
+   * Logical tab ids (UUIDs minted by `tab-registry.ts`) the conversation
+   * owns. As of chat-db v15, replaces the legacy `ownedLtids: number[]`
+   * field which keyed on `chrome.tabs.id` and silently corrupted on
+   * `chrome.tabs.onReplaced` (prerender activation).
+   */
+  ownedLtids: string[];
   todos?: TodoItem[];
   createdAt: number;
   updatedAt: number;

--- a/apps/extension/test-setup.ts
+++ b/apps/extension/test-setup.ts
@@ -27,8 +27,10 @@ if (typeof (globalThis as { chrome?: unknown }).chrome === "undefined") {
     },
     tabs: {
       onRemoved: { addListener: noop, removeListener: noop },
+      onReplaced: { addListener: noop, removeListener: noop },
       onUpdated: { addListener: noop, removeListener: noop },
       onActivated: { addListener: noop, removeListener: noop },
+      onCreated: { addListener: noop, removeListener: noop },
       get: () => Promise.reject(new Error("chrome.tabs.get not stubbed")),
       query: () => Promise.resolve([] as never[]),
       sendMessage: () => Promise.resolve(undefined),

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -436,7 +436,7 @@ async function runTrialInner(
     const driverForLegend = driver;
     const legendEntries = await buildTabLegendEntries({
       conversationId: "bench",
-      ownedTabIds: [initialTabId],
+      ownedLtids: [initialTabId],
       getTab: async (tabId) => {
         const info = await driverForLegend.getTab(tabId).catch(() => null);
         return { url: info?.url, title: info?.title };


### PR DESCRIPTION
## Problem

On Speculation Rules sites (Attio, Notion, Vercel, X, Google Search), Chrome silently renumbers `chrome.tabs.id` mid-flow when a prerendered page activates. The agent's tab handles, the cdp-session cache, conversation ownership, and `waitForTabLoad` were all keyed on the old ctid — so a single prerender activation broke all of them at once. Symptoms in prod: `Unknown tab handle`, `Cannot attach debugger to tab N: No tab with given id`, and `Tab load timed out` mid-navigate.

## Fix

Introduces `LogicalTabId` (UUID) as the stable identity for "the page the agent is working on" and a `tab-registry` module that owns the only `chrome.tabs.onReplaced` listener in the codebase. Every map that previously keyed on `chrome.tabs.id` for *agent identity* (handle map, ownership, CDP session cache, persisted state) now keys on ltid. UX-keyed maps (toast dismissal, user-opened side panel) stay on ctid as intended.

The registry deduplicates the trailing `onRemoved` Chrome fires for the replaced ctid (5s window), so consumers see exactly one event — not a replace-then-remove pair.

## Surface

- **chatDb v15 migration**: `Conversation.ownedTabIds: number[]` → `ownedLtids: string[]`; `handleState.handles` rewrites number values to ltid strings. Runs in a post-open fixup pass (NOT inside the upgrade transaction — IDB auto-commits on non-IDB awaits like `chrome.tabs.get` and dynamic imports). Per-row try/catch; corrupt rows degrade to empty owned-state with a `console.warn`.
- **CUA loop** subscribes to `onReplace` and updates its cached ctid in place. Working-overlay glow re-targets to the new ctid so the user gets continuous feedback.
- **`waitForTabLoad`** re-arms its `onUpdated` listener on the new ctid mid-wait.
- **Telemetry**: `console.warn(\"[tab-registry] onReplaced\", { url, ltid, oldCtid, newCtid })` fires on every detected replacement so prod DevTools logs confirm the fix and surface other sites that trigger it.

## Tests

- 8 new test files: registry semantics + dedup, v15 migration with corrupt rows, cdp-session invalidation, tab-scoping onReplaced, waitForTabLoad re-arming, CUA-loop retargeting, end-to-end Attio scenario.
- All existing tests updated to ltid contract: 120 files / 1020 tests pass on extension; 7 / 63 on bench.
- `tsc --noEmit` clean. `pnpm build` succeeds.

## Manual verification

Tested on Attio (Companies → Attributes → Funded by) — the original prod failure. Agent now keeps its grip on the same handle across prerender activations; `[tab-registry] onReplaced` fires as expected.

Closes the Attio detachment issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced stable tab identity tracking so conversation ownership stays consistent when Chrome replaces tabs (prerender, restore, discard/restore).

* **Bug Fixes**
  * Fixed conversation ownership loss after silent tab ID changes.
  * Improved overlay/working-tab feedback and side-panel availability after tab replacement.
  * Updated tab-close flows to target the correct tabs using stable identities.

* **Chores**
  * Migrated the conversation database to use stable logical tab identifiers for owned-tab and handle state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->