### PR TITLE
fix(extension): cross-extension iframe resilience in CDP frame walks

### DIFF
--- a/.changeset/cross-extension-iframe-snapshot.md
+++ b/.changeset/cross-extension-iframe-snapshot.md
@@ -1,0 +1,24 @@
+---
+"openbrowse": patch
+---
+
+Make CDP frame-walking calls (`Accessibility.getFullAXTree`, `DOMSnapshot.captureSnapshot`) resilient to cross-extension iframes that the debugger isn't permitted to inspect.
+
+Symptoms this fixes:
+
+- "Cannot attach debugger to tab N: No tab with given id N" cascading across every action on http(s) pages where another installed Chrome extension (e.g. **1Password**, LastPass, Bitwarden, Honey, Grammarly) has injected a content-script iframe served from `chrome-extension://<otherExtId>/`. Chrome refuses cross-extension debugger access and detaches the whole session as collateral, which made every snapshot fatal until the page was closed.
+- Misleading `No tab with given id` errors that read like a prerender / Speculation Rules failure (handled separately by #139) but were actually caused by a hostile iframe.
+- Repeated "post-action snapshot failed" warnings on sites with many embedded forms where a password manager aggressively injects.
+
+What changed:
+
+- New `isCrossExtensionFrameError` classifier in `cdp-errors.ts`. The detach classifier (`isDetachError`) explicitly does NOT match this class, so the existing detach-and-retry path can never accidentally tear down a healthy session for a per-call iframe failure.
+- `cdp-session.ts` bails early on cross-extension errors at both catch sites (`<Domain>.enable` and the actual command). The session is left intact; the error bubbles to the caller.
+- `snapshot-capture.ts` runs a `Page.getFrameTree` pre-pass on every capture and walks each frame individually with `Accessibility.getFullAXTree({frameId})`. Frames whose URL starts with `chrome-extension://` and don't belong to this extension are skipped preemptively; per-frame races (an iframe injected mid-walk) are caught and logged. When `Page.getFrameTree` is unavailable (older Chrome / non-Page targets), the helper falls back to the legacy whole-tree call. `buildTree` now returns a synthetic empty root when given zero AX nodes (instead of dereferencing `nodes[0]`), so an all-frames-hostile page produces an empty snapshot rather than crashing.
+- New `note` field on `CaptureResult`, propagated through `snapshot`, `clickElement`, `typeInElement`, `pressKey`, and `navigate`. When frames were excluded the agent receives a short, agent-actionable message naming the offending extension hosts so it knows the snapshot represents the actionable parts of the page even though the walk wasn't whole-tree.
+
+Tests added:
+
+- `cdp-errors.test.ts` — classifier coverage on every Chrome error string we've seen in the wild + the mutual-exclusion invariant against `isDetachError`.
+- `cdp-session-cross-extension.test.ts` — confirms the session map is NOT mutated and no retry runs when a cross-extension error fires from either `<Domain>.enable` or the command itself.
+- `snapshot-capture-cross-extension.test.ts` — per-frame walking semantics: foreign frames preemptively skipped, race-injected frames caught, nested frames handled, legacy fallback when `Page.getFrameTree` is unavailable.

--- a/.changeset/cross-extension-iframe-snapshot.md
+++ b/.changeset/cross-extension-iframe-snapshot.md
@@ -14,11 +14,16 @@ What changed:
 
 - New `isCrossExtensionFrameError` classifier in `cdp-errors.ts`. The detach classifier (`isDetachError`) explicitly does NOT match this class, so the existing detach-and-retry path can never accidentally tear down a healthy session for a per-call iframe failure.
 - `cdp-session.ts` bails early on cross-extension errors at both catch sites (`<Domain>.enable` and the actual command). The session is left intact; the error bubbles to the caller.
-- `snapshot-capture.ts` runs a `Page.getFrameTree` pre-pass on every capture and walks each frame individually with `Accessibility.getFullAXTree({frameId})`. Frames whose URL starts with `chrome-extension://` and don't belong to this extension are skipped preemptively; per-frame races (an iframe injected mid-walk) are caught and logged. When `Page.getFrameTree` is unavailable (older Chrome / non-Page targets), the helper falls back to the legacy whole-tree call. `buildTree` now returns a synthetic empty root when given zero AX nodes (instead of dereferencing `nodes[0]`), so an all-frames-hostile page produces an empty snapshot rather than crashing.
-- New `note` field on `CaptureResult`, propagated through `snapshot`, `clickElement`, `typeInElement`, `pressKey`, and `navigate`. When frames were excluded the agent receives a short, agent-actionable message naming the offending extension hosts so it knows the snapshot represents the actionable parts of the page even though the walk wasn't whole-tree.
+- `snapshot-capture.ts` adopts a two-tier AX-walk strategy:
+  - **Tier 1 (primary)**: a single whole-tree `Accessibility.getFullAXTree()` call. Chrome stitches the AX tree across frames on its end, preserving legitimate iframe content (Stripe, YouTube, embedded forms, etc.). On benign pages and on most pages that have a foreign extension iframe loaded but not actively in the AX walk, this is the only CDP round-trip taken — no additional cost vs. the legacy code.
+  - **Tier 2 (fallback, only on cross-extension rejection)**: `Page.getFrameTree` to enumerate frames, then `Accessibility.getFullAXTree({frameId: <main>})` to walk just the main frame. Legitimate child-frame content is unavailable in this mode; the agent is told via `note`.
+- `buildTree` returns a synthetic empty root when given zero AX nodes (instead of dereferencing `nodes[0]`), so an all-frames-hostile page produces an empty snapshot rather than crashing.
+- New `note` field on `CaptureResult`, propagated through `snapshot`, `clickElement`, `typeInElement`, `pressKey`, and `navigate`. When frames were excluded the agent receives a short, agent-actionable message naming the offending extension hosts. The note language is split into two cases so attribution is honest:
+  - Foreign-only exclusions: lists the cross-extension hosts and confirms the main page is unaffected.
+  - Raced/main-frame failures: reports "frames errored mid-walk" without speculating about which extension owns them, and recommends a retry.
 
 Tests added:
 
 - `cdp-errors.test.ts` — classifier coverage on every Chrome error string we've seen in the wild + the mutual-exclusion invariant against `isDetachError`.
 - `cdp-session-cross-extension.test.ts` — confirms the session map is NOT mutated and no retry runs when a cross-extension error fires from either `<Domain>.enable` or the command itself.
-- `snapshot-capture-cross-extension.test.ts` — per-frame walking semantics: foreign frames preemptively skipped, race-injected frames caught, nested frames handled, legacy fallback when `Page.getFrameTree` is unavailable.
+- `snapshot-capture-cross-extension.test.ts` — Tier 1 happy path (no frame-tree round-trip), legitimate child-frame content preserved across the merge, Tier 2 fallback semantics (main-frame-only walk, no other safe frames walked, attribution note correct), soft language when the main frame itself races, and the generic note when `Page.getFrameTree` is unavailable post-rejection.

--- a/apps/extension/src/lib/agent/__tests__/cdp-errors.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/cdp-errors.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the side-effect-free CDP error classifiers.
+ *
+ * The classifiers gate two distinct recovery paths in `cdp-session` and
+ * `snapshot-capture`. Misclassification is dangerous in both directions:
+ *
+ *   - If a cross-extension frame error is treated as a detach, we tear
+ *     down a perfectly healthy session and retry the same whole-tree call,
+ *     which fails identically and burns the retry budget.
+ *   - If a real detach is treated as a cross-extension error, we keep
+ *     using a dead session and every subsequent call fails.
+ *
+ * Hence: explicit unit tests on every Chrome error string we've seen in
+ * the wild, and an assertion that the two predicates are mutually
+ * exclusive on the strings we care about.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isCrossExtensionFrameError, isDetachError } from "../cdp-errors";
+
+describe("isCrossExtensionFrameError", () => {
+  const positive = [
+    "Cannot access a chrome-extension:// URL of different extension",
+    'Cannot access contents of url "chrome-extension://abc/inject.html". Extension manifest must request permission to access this host.',
+    'Cannot access content of the url "chrome-extension://xyz/iframe.html"',
+    // Mixed-case shouldn't matter
+    "cannot access a chrome-extension:// url of different extension",
+  ];
+
+  for (const msg of positive) {
+    it(`matches: ${msg.slice(0, 60)}…`, () => {
+      expect(isCrossExtensionFrameError(new Error(msg))).toBe(true);
+      expect(isCrossExtensionFrameError(msg)).toBe(true);
+    });
+  }
+
+  const negative = [
+    "Detached while handling command.",
+    "No tab with given id 1234",
+    "Target closed",
+    "Debugger is not attached to the tab with id: 1234",
+    "Cannot find context with specified id",
+    "Some unrelated error",
+    "",
+  ];
+
+  for (const msg of negative) {
+    it(`does not match: ${msg.slice(0, 50)}`, () => {
+      expect(isCrossExtensionFrameError(new Error(msg))).toBe(false);
+    });
+  }
+});
+
+describe("isDetachError x cross-extension exclusion", () => {
+  it("does NOT classify the cross-extension error as a detach error", () => {
+    // This is the critical invariant: a cross-extension frame error must
+    // bypass the existing detach/retry path so the session isn't dropped.
+    const err = new Error(
+      "Cannot access a chrome-extension:// URL of different extension",
+    );
+    expect(isCrossExtensionFrameError(err)).toBe(true);
+    expect(isDetachError(err)).toBe(false);
+  });
+
+  it("still classifies real detach errors as detach errors", () => {
+    expect(isDetachError(new Error("Detached while handling command."))).toBe(
+      true,
+    );
+    expect(isDetachError(new Error("No tab with given id 5"))).toBe(true);
+    expect(isDetachError(new Error("Target closed"))).toBe(true);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/cdp-session-cross-extension.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/cdp-session-cross-extension.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Cross-extension iframe bail-early in `cdp-session`.
+ *
+ * The shared CDP session manager classifies errors into three buckets:
+ *
+ *   - Detach errors (e.g. "Detached while handling command", "No tab with
+ *     given id"): drop the cached Session and re-attach once.
+ *   - Cross-extension frame errors (e.g. "Cannot access a chrome-extension://
+ *     URL of different extension"): the session is HEALTHY — only this
+ *     specific call walked into a hostile iframe. Bubble unchanged; do NOT
+ *     drop the session and do NOT retry, so the caller (snapshot-capture)
+ *     can pick the per-frame fallback path.
+ *   - Anything else: pass through.
+ *
+ * Misclassifying a cross-ext error as a detach would burn the retry budget
+ * and thrash the attach state for nothing — the second whole-tree call
+ * would hit the same iframe and fail identically. These tests pin down the
+ * bail-early behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const CROSS_EXT_ERROR =
+  "Cannot access a chrome-extension:// URL of different extension";
+
+describe("cdp-session: cross-extension frame error", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT drop the session or retry on cross-extension error during sendCommand", async () => {
+    const attachCalls: number[] = [];
+    let sendCallCount = 0;
+    vi.stubGlobal("chrome", {
+      tabs: {
+        onRemoved: { addListener: () => {} },
+        onReplaced: { addListener: () => {} },
+        onUpdated: { addListener: () => {} },
+        onActivated: { addListener: () => {} },
+        onCreated: { addListener: () => {} },
+        get: () => Promise.resolve({ id: 1, url: "" }),
+      },
+      debugger: {
+        onDetach: { addListener: () => {} },
+        onEvent: { addListener: () => {} },
+        attach: vi.fn((target: { tabId: number }) => {
+          attachCalls.push(target.tabId);
+          return Promise.resolve();
+        }),
+        detach: vi.fn(() => Promise.resolve()),
+        sendCommand: vi.fn((_target, method: string) => {
+          sendCallCount++;
+          // The cross-ext error fires from the AX command, not from the
+          // domain.enable bookkeeping call. Reject only the AX one so the
+          // test pins the behavior of the post-enable catch branch.
+          if (method === "Accessibility.getFullAXTree") {
+            return Promise.reject(new Error(CROSS_EXT_ERROR));
+          }
+          return Promise.resolve({});
+        }),
+      },
+    });
+
+    const { sendCommand } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    // First a benign call to seed the cached session for ctid 7.
+    await sendCommand(7, "Page.bringToFront");
+    expect(attachCalls).toEqual([7]);
+
+    const attachesBefore = attachCalls.length;
+    const sendsBefore = sendCallCount;
+
+    // Now the AX call rejects with the cross-ext error.
+    let caught: Error | null = null;
+    try {
+      await sendCommand(7, "Accessibility.getFullAXTree");
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    // The error bubbles UNCHANGED.
+    expect(caught).not.toBeNull();
+    expect(caught?.message).toBe(CROSS_EXT_ERROR);
+
+    // No retry — sendCommand was called exactly once for the AX method, on
+    // top of any preceding domain.enable call. With NO_ENABLE_DOMAINS
+    // listing "Runtime"/"Page"/etc., Accessibility goes through .enable
+    // first then the AX call → 2 sends total for this round, NOT 4 (which
+    // would be 2 attempts × 2 sends).
+    const sendsThisRound = sendCallCount - sendsBefore;
+    expect(sendsThisRound).toBeLessThanOrEqual(2);
+
+    // No fresh attach (no session teardown).
+    expect(attachCalls.length).toBe(attachesBefore);
+
+    // Subsequent benign call should reuse the existing session — i.e. NO
+    // new attach. Proves the cross-ext error didn't tear down the cache.
+    await sendCommand(7, "Page.bringToFront");
+    expect(attachCalls.length).toBe(attachesBefore);
+  });
+
+  it("does NOT drop the session when the error fires from a domain.enable call", async () => {
+    // Some sites trigger the cross-ext rejection on the bookkeeping
+    // `<Domain>.enable` call rather than on the actual AX command. The
+    // bail-early branch must cover both catch sites.
+    const attachCalls: number[] = [];
+    vi.stubGlobal("chrome", {
+      tabs: {
+        onRemoved: { addListener: () => {} },
+        onReplaced: { addListener: () => {} },
+        onUpdated: { addListener: () => {} },
+        onActivated: { addListener: () => {} },
+        onCreated: { addListener: () => {} },
+        get: () => Promise.resolve({ id: 1, url: "" }),
+      },
+      debugger: {
+        onDetach: { addListener: () => {} },
+        onEvent: { addListener: () => {} },
+        attach: vi.fn((target: { tabId: number }) => {
+          attachCalls.push(target.tabId);
+          return Promise.resolve();
+        }),
+        detach: vi.fn(() => Promise.resolve()),
+        sendCommand: vi.fn((_target, method: string) => {
+          if (method === "Accessibility.enable") {
+            return Promise.reject(new Error(CROSS_EXT_ERROR));
+          }
+          return Promise.resolve({});
+        }),
+      },
+    });
+
+    const { sendCommand } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    const attachesBefore = attachCalls.length;
+    let caught: Error | null = null;
+    try {
+      await sendCommand(11, "Accessibility.getFullAXTree");
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught?.message).toBe(CROSS_EXT_ERROR);
+    // First attach happened (this is the seeding attach for ctid 11). We
+    // care that no SECOND attach was forced by retry teardown.
+    expect(attachCalls.filter((id) => id === 11).length).toBe(1);
+    // attachesBefore is 0 here; the assertion above is the meaningful one.
+    void attachesBefore;
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/snapshot-capture-cross-extension.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/snapshot-capture-cross-extension.test.ts
@@ -8,15 +8,21 @@
  * different extension — when `Accessibility.getFullAXTree` walks into
  * such an iframe, Chrome rejects the call and the capture path errors out.
  *
- * `snapshot-capture` runs a `Page.getFrameTree` pre-pass and walks each
- * non-foreign frame individually with `Accessibility.getFullAXTree({frameId})`.
- * Foreign frames are skipped preemptively; if the per-frame walk itself
- * trips a cross-extension reject (race: an iframe was injected between
- * the frame-tree pre-pass and the AX call), that frame is also skipped
- * and recorded in a `note` returned to the caller.
+ * Strategy is two-tier:
  *
- * These tests exercise the helper end-to-end through `captureSnapshot`,
- * stubbing `driver.sendCommand` per-method to mimic Chrome's responses.
+ *   - **Tier 1**: a single whole-tree `Accessibility.getFullAXTree()` (no
+ *     `frameId`). Chrome stitches the AX tree across frames on its end,
+ *     preserving legitimate iframe content (Stripe, YouTube, etc.). This
+ *     succeeds on benign pages AND on most pages that only have a foreign
+ *     extension iframe loaded but not actively in the AX walk.
+ *   - **Tier 2 (only on cross-extension rejection)**: enumerate frames
+ *     with `Page.getFrameTree`, then call
+ *     `Accessibility.getFullAXTree({frameId: <main>})` to walk just the
+ *     main frame. Legitimate child-frame content is unavailable in this
+ *     mode; the agent is told via `note`.
+ *
+ * These tests pin down both tiers by stubbing `driver.sendCommand`
+ * per-method.
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -28,21 +34,34 @@ const TAB_ID = 1 as TabId;
 
 beforeEach(() => invalidateRefs(TAB_ID));
 
+const CROSS_EXT_ERR =
+  "Cannot access a chrome-extension:// URL of different extension";
+
 interface FrameTreeNode {
   frame: { id: string; url?: string };
   childFrames?: FrameTreeNode[];
 }
 
 interface MockOpts {
-  frameTree: FrameTreeNode | undefined;
-  /** Per-frame AX nodes keyed by frameId. Undefined frameId → top-level. */
-  axNodesByFrame: Record<string, unknown[]>;
-  /** Frame ids that should reject with a cross-extension error. */
+  /** Result of the whole-tree (no-frameId) Accessibility.getFullAXTree call. */
+  wholeTree?: { nodes: unknown[] } | "cross-ext-error" | "throws";
+  /** Frame tree returned by Page.getFrameTree (Tier 2 only). Omit to simulate Page domain unavailable. */
+  frameTree?: FrameTreeNode;
+  /**
+   * Per-frame AX nodes keyed by frameId. Tier 2 only ever calls with the
+   * main frame's id; entries for other frames exist only to assert we
+   * don't accidentally walk them.
+   */
+  axNodesByFrame?: Record<string, unknown[]>;
+  /** Frame ids that should reject with cross-extension when walked individually. */
   crossExtRejectFrames?: string[];
   url?: string;
 }
 
-function makeMock(opts: MockOpts): { driver: BrowserDriver; calls: { method: string; params?: Record<string, unknown> }[] } {
+function makeMock(opts: MockOpts): {
+  driver: BrowserDriver;
+  calls: { method: string; params?: Record<string, unknown> }[];
+} {
   const calls: { method: string; params?: Record<string, unknown> }[] = [];
   const driver: BrowserDriver = {
     sendCommand: async (
@@ -56,18 +75,26 @@ function makeMock(opts: MockOpts): { driver: BrowserDriver; calls: { method: str
       }
       if (method === "Accessibility.getFullAXTree") {
         const frameId = params?.frameId as string | undefined;
-        if (frameId && opts.crossExtRejectFrames?.includes(frameId)) {
-          throw new Error(
-            "Cannot access a chrome-extension:// URL of different extension",
-          );
+        if (frameId == null) {
+          // Tier 1 whole-tree call.
+          if (opts.wholeTree === "cross-ext-error") {
+            throw new Error(CROSS_EXT_ERR);
+          }
+          if (opts.wholeTree === "throws") {
+            throw new Error("Some unrelated error");
+          }
+          return { nodes: opts.wholeTree?.nodes ?? [] };
         }
-        const key = frameId ?? "__top__";
-        return { nodes: opts.axNodesByFrame[key] ?? [] };
+        // Tier 2 per-frame (main-only) call.
+        if (opts.crossExtRejectFrames?.includes(frameId)) {
+          throw new Error(CROSS_EXT_ERR);
+        }
+        return { nodes: opts.axNodesByFrame?.[frameId] ?? [] };
       }
       if (method === "Target.getTargetInfo") {
         return { targetInfo: { url: opts.url ?? "https://example.com" } };
       }
-      // Visibility / cursor calls — return empty so the test focuses on AX walking.
+      // Visibility / cursor / etc. — return empty so tests focus on AX.
       return {};
     },
     getTab: async () => ({ id: TAB_ID, url: opts.url ?? "", title: "test" }),
@@ -95,137 +122,197 @@ function btn(nodeId: string, name: string, backendId: number) {
   };
 }
 
-describe("captureSnapshot: cross-extension iframe handling", () => {
-  it("excludes foreign chrome-extension:// frames and walks only safe ones", async () => {
-    const frameTree: FrameTreeNode = {
-      frame: { id: "MAIN", url: "https://example.com/" },
-      childFrames: [
-        {
-          frame: {
-            id: "ONEPW",
-            url: "chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/iframe.html",
-          },
-        },
-      ],
-    };
+describe("captureSnapshot: Tier 1 (whole-tree) — common case", () => {
+  it("returns the whole-tree AX walk on a benign page; never invokes Page.getFrameTree", async () => {
     const { driver, calls } = makeMock({
-      frameTree,
+      wholeTree: { nodes: [root(["b"]), btn("b", "Hello", 1)] },
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+
+    // Content from the whole-tree walk surfaces in the snapshot.
+    expect(result.snapshotText).toContain("Hello");
+
+    // No degraded note on the happy path.
+    expect(result.note).toBeUndefined();
+
+    // Crucially: no Page.getFrameTree round-trip. Tier 1 is the entire path.
+    const sawGetFrameTree = calls.some((c) => c.method === "Page.getFrameTree");
+    expect(sawGetFrameTree).toBe(false);
+
+    // Exactly one Accessibility.getFullAXTree call, with no frameId param.
+    const axCalls = calls.filter(
+      (c) => c.method === "Accessibility.getFullAXTree",
+    );
+    expect(axCalls).toHaveLength(1);
+    expect(axCalls[0].params?.frameId).toBeUndefined();
+  });
+
+  it("preserves legitimate child-frame content via Chrome's whole-tree stitching", async () => {
+    // Chrome's no-frameId getFullAXTree stitches main + legitimate iframes
+    // into one connected forest. We model that by having the mock return
+    // both frames' nodes in a single response with the main frame's
+    // RootWebArea as the only parentless node — the legitimate iframe
+    // descendants attach via parentId. This mirrors real Chrome output.
+    const { driver } = makeMock({
+      wholeTree: {
+        nodes: [
+          root(["main-btn", "embed-host"]),
+          btn("main-btn", "MainBtn", 1),
+          // The iframe-element wrapper in the main frame whose children
+          // are nodes from the embedded frame, tagged with frameId.
+          {
+            nodeId: "embed-host",
+            role: { value: "Iframe" },
+            name: { value: "" },
+            backendDOMNodeId: 100,
+            parentId: "root",
+            childIds: ["embed-btn"],
+          },
+          {
+            nodeId: "embed-btn",
+            role: { value: "button" },
+            name: { value: "EmbedBtn" },
+            backendDOMNodeId: 2,
+            parentId: "embed-host",
+            frameId: "EMBED",
+          },
+        ],
+      },
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+    // Both subtrees must appear in the rendered snapshot — this is the
+    // regression Finding #2 was about: per-frame walking would silently
+    // drop one of them.
+    expect(result.snapshotText).toContain("MainBtn");
+    expect(result.snapshotText).toContain("EmbedBtn");
+    expect(result.note).toBeUndefined();
+  });
+
+  it("rethrows non-cross-extension errors so the cdp-session retry path can handle them", async () => {
+    const { driver } = makeMock({ wholeTree: "throws" });
+    await expect(captureSnapshot(driver, TAB_ID)).rejects.toThrow(
+      /Some unrelated error/,
+    );
+  });
+});
+
+describe("captureSnapshot: Tier 2 (main-frame fallback) — hostile pages", () => {
+  it("falls back to main-frame-only walk on cross-extension error and surfaces an attribution note", async () => {
+    const { driver, calls } = makeMock({
+      wholeTree: "cross-ext-error",
+      frameTree: {
+        frame: { id: "MAIN", url: "https://example.com/" },
+        childFrames: [
+          {
+            frame: {
+              id: "ONEPW",
+              url: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/iframe.html",
+            },
+          },
+        ],
+      },
       axNodesByFrame: {
-        MAIN: [root(["click-me"]), btn("click-me", "Save", 5)],
+        MAIN: [root(["save"]), btn("save", "Save", 5)],
       },
     });
     const result = await captureSnapshot(driver, TAB_ID);
 
-    // Main frame walked; ONEPW frame must NOT be walked (preemptive skip).
-    const axCalls = calls.filter(
-      (c) => c.method === "Accessibility.getFullAXTree",
-    );
-    const walkedFrames = axCalls
-      .map((c) => c.params?.frameId)
-      .filter((id): id is string => typeof id === "string");
-    expect(walkedFrames).toContain("MAIN");
-    expect(walkedFrames).not.toContain("ONEPW");
-
-    // Snapshot text comes from main-frame nodes.
+    // Main-frame content rendered.
     expect(result.snapshotText).toContain("Save");
 
-    // Note tells the agent a frame was excluded.
+    // Note attributes the exclusion to a cross-extension iframe AND
+    // claims main-page interactivity is unaffected (true in this case —
+    // foreign-only, no raced frames).
     expect(result.note).toBeDefined();
     expect(result.note).toMatch(/excluded 1 frame/i);
     expect(result.note).toMatch(/chrome-extension/i);
-  });
+    expect(result.note).toMatch(/main page are unaffected/i);
 
-  it("falls back gracefully when a per-frame walk hits a race-injected cross-extension iframe", async () => {
-    // The frame tree LOOKS clean (only main), but the per-frame AX call
-    // for main throws the cross-extension error — simulating an iframe
-    // that was injected between the pre-pass and the AX call.
-    const frameTree: FrameTreeNode = {
-      frame: { id: "MAIN", url: "https://example.com/" },
-    };
-    const { driver } = makeMock({
-      frameTree,
-      axNodesByFrame: {},
-      crossExtRejectFrames: ["MAIN"],
-    });
-    // Should NOT throw — the helper catches the cross-ext error per-frame.
-    // With no safe frame succeeding, the result has no nodes; the wrapper
-    // falls into its empty-snapshot retry branch (which also catches and
-    // produces an empty result with the racedFrames note).
-    const result = await captureSnapshot(driver, TAB_ID);
-    expect(result.note).toBeDefined();
-    expect(result.note).toMatch(/excluded/i);
-  });
-
-  it("walks normally when no foreign frames are present (single main frame)", async () => {
-    const frameTree: FrameTreeNode = {
-      frame: { id: "MAIN", url: "https://example.com/" },
-    };
-    const { driver, calls } = makeMock({
-      frameTree,
-      axNodesByFrame: {
-        MAIN: [root(["b1"]), btn("b1", "Hello", 7)],
-      },
-    });
-    const result = await captureSnapshot(driver, TAB_ID);
-    expect(result.snapshotText).toContain("Hello");
-    // No cross-extension exclusion => no note.
-    expect(result.note).toBeUndefined();
-    // One getFullAXTree call per safe frame.
+    // Tier 2 issued exactly the right calls.
     const axCalls = calls.filter(
       (c) => c.method === "Accessibility.getFullAXTree",
     );
-    expect(axCalls.length).toBe(1);
-    expect(axCalls[0].params?.frameId).toBe("MAIN");
+    // First (failing) whole-tree call + second main-frame-only call.
+    expect(axCalls).toHaveLength(2);
+    expect(axCalls[0].params?.frameId).toBeUndefined();
+    expect(axCalls[1].params?.frameId).toBe("MAIN");
+
+    // The hostile frame is NOT walked individually. Tier 2 only walks
+    // the main frame.
+    const walkedFrameIds = axCalls
+      .map((c) => c.params?.frameId)
+      .filter((id): id is string => typeof id === "string");
+    expect(walkedFrameIds).not.toContain("ONEPW");
   });
 
-  it("falls back to legacy whole-tree when Page.getFrameTree is unavailable", async () => {
-    // Older Chrome / non-Page targets may not return a frameTree. The
-    // helper degrades to a single frame-id-less getFullAXTree.
-    const { driver, calls } = makeMock({
-      frameTree: undefined,
-      axNodesByFrame: { __top__: [root(["b"]), btn("b", "OK", 1)] },
+  it("softens the note language when the main frame itself races into a cross-extension reject", async () => {
+    // A pathological case: the foreign extension iframe is attached such
+    // that even main-frame-scoped getFullAXTree rejects. The note
+    // should NOT make the "main page unaffected" claim because we lost
+    // visibility into a frame that wasn't a foreign-extension URL.
+    const { driver } = makeMock({
+      wholeTree: "cross-ext-error",
+      frameTree: { frame: { id: "MAIN", url: "https://example.com/" } },
+      crossExtRejectFrames: ["MAIN"],
     });
     const result = await captureSnapshot(driver, TAB_ID);
-    expect(result.snapshotText).toContain("OK");
-    const axCall = calls.find(
-      (c) => c.method === "Accessibility.getFullAXTree",
-    );
-    expect(axCall).toBeDefined();
-    expect(axCall?.params?.frameId).toBeUndefined();
-    expect(result.note).toBeUndefined();
+    expect(result.note).toBeDefined();
+    // Raced-frame language present.
+    expect(result.note).toMatch(/errored mid-walk/i);
+    expect(result.note).toMatch(/retry if expected content is missing/i);
+    // Importantly: NO "main page are unaffected" claim — the reviewer's
+    // concern (Finding #1) was that this language was sometimes false.
+    expect(result.note).not.toMatch(/main page are unaffected/i);
   });
 
-  it("walks nested safe frames and skips nested foreign frames", async () => {
-    const frameTree: FrameTreeNode = {
-      frame: { id: "MAIN", url: "https://example.com/" },
-      childFrames: [
-        {
-          frame: { id: "EMBED", url: "https://embed.example.com/" },
-          childFrames: [
-            {
-              frame: {
-                id: "ONEPW-NESTED",
-                url: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/x.html",
-              },
-            },
-          ],
-        },
-      ],
-    };
+  it("emits a generic 'frame tree not enumerable' note when Page.getFrameTree is unavailable post-rejection", async () => {
+    const { driver } = makeMock({
+      wholeTree: "cross-ext-error",
+      frameTree: undefined, // Page domain unavailable in Tier 2
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+    expect(result.note).toBeDefined();
+    expect(result.note).toMatch(/blocked by a cross-extension iframe/i);
+    expect(result.note).toMatch(/could not be enumerated/i);
+  });
+
+  it("does NOT walk other safe frames — only the main frame — even when the frame tree contains nested non-extension iframes", async () => {
+    // Regression for Finding #2: under the old "always per-frame" design
+    // we'd have walked MAIN and EMBED individually and concatenated their
+    // RootWebAreas, which buildTree would then collapse to one. Tier 2
+    // must walk ONLY MAIN.
     const { driver, calls } = makeMock({
-      frameTree,
+      wholeTree: "cross-ext-error",
+      frameTree: {
+        frame: { id: "MAIN", url: "https://example.com/" },
+        childFrames: [
+          {
+            frame: { id: "EMBED", url: "https://embed.example.com/" },
+            childFrames: [
+              {
+                frame: {
+                  id: "ONEPW-NESTED",
+                  url: "chrome-extension://bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/x.html",
+                },
+              },
+            ],
+          },
+        ],
+      },
       axNodesByFrame: {
         MAIN: [root(["m"]), btn("m", "MainBtn", 1)],
         EMBED: [root(["e"]), btn("e", "EmbedBtn", 2)],
       },
     });
     const result = await captureSnapshot(driver, TAB_ID);
+    expect(result.snapshotText).toContain("MainBtn");
+    // EmbedBtn is unavailable in Tier 2 — that's the documented tradeoff.
+    expect(result.snapshotText).not.toContain("EmbedBtn");
+
     const walked = calls
       .filter((c) => c.method === "Accessibility.getFullAXTree")
       .map((c) => c.params?.frameId);
-    expect(walked).toContain("MAIN");
-    expect(walked).toContain("EMBED");
-    expect(walked).not.toContain("ONEPW-NESTED");
-    expect(result.note).toBeDefined();
+    // First entry is undefined (the failing whole-tree call), then MAIN.
+    expect(walked).toEqual([undefined, "MAIN"]);
   });
 });

--- a/apps/extension/src/lib/agent/__tests__/snapshot-capture-cross-extension.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/snapshot-capture-cross-extension.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Cross-extension iframe handling in `captureSnapshot`.
+ *
+ * Background: third-party Chrome extensions like 1Password, LastPass,
+ * Bitwarden, and Honey inject content-script iframes served from
+ * `chrome-extension://<otherExtId>/...` into normal http(s) tabs. The
+ * tab-attached debugger we use is NOT permitted to inspect URLs from a
+ * different extension — when `Accessibility.getFullAXTree` walks into
+ * such an iframe, Chrome rejects the call and the capture path errors out.
+ *
+ * `snapshot-capture` runs a `Page.getFrameTree` pre-pass and walks each
+ * non-foreign frame individually with `Accessibility.getFullAXTree({frameId})`.
+ * Foreign frames are skipped preemptively; if the per-frame walk itself
+ * trips a cross-extension reject (race: an iframe was injected between
+ * the frame-tree pre-pass and the AX call), that frame is also skipped
+ * and recorded in a `note` returned to the caller.
+ *
+ * These tests exercise the helper end-to-end through `captureSnapshot`,
+ * stubbing `driver.sendCommand` per-method to mimic Chrome's responses.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { captureSnapshot } from "../snapshot-capture";
+import { invalidateRefs } from "../ref-store";
+import type { BrowserDriver, TabId } from "../driver";
+
+const TAB_ID = 1 as TabId;
+
+beforeEach(() => invalidateRefs(TAB_ID));
+
+interface FrameTreeNode {
+  frame: { id: string; url?: string };
+  childFrames?: FrameTreeNode[];
+}
+
+interface MockOpts {
+  frameTree: FrameTreeNode | undefined;
+  /** Per-frame AX nodes keyed by frameId. Undefined frameId → top-level. */
+  axNodesByFrame: Record<string, unknown[]>;
+  /** Frame ids that should reject with a cross-extension error. */
+  crossExtRejectFrames?: string[];
+  url?: string;
+}
+
+function makeMock(opts: MockOpts): { driver: BrowserDriver; calls: { method: string; params?: Record<string, unknown> }[] } {
+  const calls: { method: string; params?: Record<string, unknown> }[] = [];
+  const driver: BrowserDriver = {
+    sendCommand: async (
+      _tabId: unknown,
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      calls.push({ method, params });
+      if (method === "Page.getFrameTree") {
+        return { frameTree: opts.frameTree };
+      }
+      if (method === "Accessibility.getFullAXTree") {
+        const frameId = params?.frameId as string | undefined;
+        if (frameId && opts.crossExtRejectFrames?.includes(frameId)) {
+          throw new Error(
+            "Cannot access a chrome-extension:// URL of different extension",
+          );
+        }
+        const key = frameId ?? "__top__";
+        return { nodes: opts.axNodesByFrame[key] ?? [] };
+      }
+      if (method === "Target.getTargetInfo") {
+        return { targetInfo: { url: opts.url ?? "https://example.com" } };
+      }
+      // Visibility / cursor calls — return empty so the test focuses on AX walking.
+      return {};
+    },
+    getTab: async () => ({ id: TAB_ID, url: opts.url ?? "", title: "test" }),
+    waitForLoad: async () => undefined,
+    sendToContentScript: async () => ({ success: true }),
+  } as unknown as BrowserDriver;
+  return { driver, calls };
+}
+
+function root(childIds: string[]) {
+  return {
+    nodeId: "root",
+    role: { value: "RootWebArea" },
+    name: { value: "" },
+    childIds,
+  };
+}
+function btn(nodeId: string, name: string, backendId: number) {
+  return {
+    nodeId,
+    role: { value: "button" },
+    name: { value: name },
+    backendDOMNodeId: backendId,
+    parentId: "root",
+  };
+}
+
+describe("captureSnapshot: cross-extension iframe handling", () => {
+  it("excludes foreign chrome-extension:// frames and walks only safe ones", async () => {
+    const frameTree: FrameTreeNode = {
+      frame: { id: "MAIN", url: "https://example.com/" },
+      childFrames: [
+        {
+          frame: {
+            id: "ONEPW",
+            url: "chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/iframe.html",
+          },
+        },
+      ],
+    };
+    const { driver, calls } = makeMock({
+      frameTree,
+      axNodesByFrame: {
+        MAIN: [root(["click-me"]), btn("click-me", "Save", 5)],
+      },
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+
+    // Main frame walked; ONEPW frame must NOT be walked (preemptive skip).
+    const axCalls = calls.filter(
+      (c) => c.method === "Accessibility.getFullAXTree",
+    );
+    const walkedFrames = axCalls
+      .map((c) => c.params?.frameId)
+      .filter((id): id is string => typeof id === "string");
+    expect(walkedFrames).toContain("MAIN");
+    expect(walkedFrames).not.toContain("ONEPW");
+
+    // Snapshot text comes from main-frame nodes.
+    expect(result.snapshotText).toContain("Save");
+
+    // Note tells the agent a frame was excluded.
+    expect(result.note).toBeDefined();
+    expect(result.note).toMatch(/excluded 1 frame/i);
+    expect(result.note).toMatch(/chrome-extension/i);
+  });
+
+  it("falls back gracefully when a per-frame walk hits a race-injected cross-extension iframe", async () => {
+    // The frame tree LOOKS clean (only main), but the per-frame AX call
+    // for main throws the cross-extension error — simulating an iframe
+    // that was injected between the pre-pass and the AX call.
+    const frameTree: FrameTreeNode = {
+      frame: { id: "MAIN", url: "https://example.com/" },
+    };
+    const { driver } = makeMock({
+      frameTree,
+      axNodesByFrame: {},
+      crossExtRejectFrames: ["MAIN"],
+    });
+    // Should NOT throw — the helper catches the cross-ext error per-frame.
+    // With no safe frame succeeding, the result has no nodes; the wrapper
+    // falls into its empty-snapshot retry branch (which also catches and
+    // produces an empty result with the racedFrames note).
+    const result = await captureSnapshot(driver, TAB_ID);
+    expect(result.note).toBeDefined();
+    expect(result.note).toMatch(/excluded/i);
+  });
+
+  it("walks normally when no foreign frames are present (single main frame)", async () => {
+    const frameTree: FrameTreeNode = {
+      frame: { id: "MAIN", url: "https://example.com/" },
+    };
+    const { driver, calls } = makeMock({
+      frameTree,
+      axNodesByFrame: {
+        MAIN: [root(["b1"]), btn("b1", "Hello", 7)],
+      },
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+    expect(result.snapshotText).toContain("Hello");
+    // No cross-extension exclusion => no note.
+    expect(result.note).toBeUndefined();
+    // One getFullAXTree call per safe frame.
+    const axCalls = calls.filter(
+      (c) => c.method === "Accessibility.getFullAXTree",
+    );
+    expect(axCalls.length).toBe(1);
+    expect(axCalls[0].params?.frameId).toBe("MAIN");
+  });
+
+  it("falls back to legacy whole-tree when Page.getFrameTree is unavailable", async () => {
+    // Older Chrome / non-Page targets may not return a frameTree. The
+    // helper degrades to a single frame-id-less getFullAXTree.
+    const { driver, calls } = makeMock({
+      frameTree: undefined,
+      axNodesByFrame: { __top__: [root(["b"]), btn("b", "OK", 1)] },
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+    expect(result.snapshotText).toContain("OK");
+    const axCall = calls.find(
+      (c) => c.method === "Accessibility.getFullAXTree",
+    );
+    expect(axCall).toBeDefined();
+    expect(axCall?.params?.frameId).toBeUndefined();
+    expect(result.note).toBeUndefined();
+  });
+
+  it("walks nested safe frames and skips nested foreign frames", async () => {
+    const frameTree: FrameTreeNode = {
+      frame: { id: "MAIN", url: "https://example.com/" },
+      childFrames: [
+        {
+          frame: { id: "EMBED", url: "https://embed.example.com/" },
+          childFrames: [
+            {
+              frame: {
+                id: "ONEPW-NESTED",
+                url: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/x.html",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const { driver, calls } = makeMock({
+      frameTree,
+      axNodesByFrame: {
+        MAIN: [root(["m"]), btn("m", "MainBtn", 1)],
+        EMBED: [root(["e"]), btn("e", "EmbedBtn", 2)],
+      },
+    });
+    const result = await captureSnapshot(driver, TAB_ID);
+    const walked = calls
+      .filter((c) => c.method === "Accessibility.getFullAXTree")
+      .map((c) => c.params?.frameId);
+    expect(walked).toContain("MAIN");
+    expect(walked).toContain("EMBED");
+    expect(walked).not.toContain("ONEPW-NESTED");
+    expect(result.note).toBeDefined();
+  });
+});

--- a/apps/extension/src/lib/agent/cdp-errors.ts
+++ b/apps/extension/src/lib/agent/cdp-errors.ts
@@ -20,7 +20,46 @@ const DETACH_ERROR_PATTERNS = [
   /No tab with given id/i,
 ];
 
+/**
+ * Patterns matching Chrome debugger errors that fire when a CDP frame-walking
+ * call (e.g. `Accessibility.getFullAXTree`, `DOM.getDocument`) crosses into a
+ * frame served from a `chrome-extension://` URL belonging to a DIFFERENT
+ * extension than ours. Common in the wild: 1Password, LastPass, Bitwarden,
+ * Honey, Grammarly all inject content-script iframes that our debugger isn't
+ * allowed to inspect. Chrome surfaces this as e.g.
+ *
+ *   "Cannot access a chrome-extension:// URL of different extension"
+ *
+ * The session is NOT actually torn down by this — the specific call fails,
+ * but the debugger remains attached. So we want to BAIL EARLY rather than
+ * trigger the detach-and-retry recovery path (which would (a) thrash the
+ * attach state for nothing and (b) try the same whole-frame-tree call again
+ * and fail identically). Snapshot capture catches this and falls back to a
+ * per-frame walk that excludes the offending frame.
+ */
+const CROSS_EXTENSION_FRAME_ERROR_PATTERNS = [
+  /Cannot access a chrome-extension:\/\/ URL of different extension/i,
+  /Cannot access (?:a )?contents? of (?:the )?(?:url|page) "chrome-extension:\/\//i,
+];
+
 export function isDetachError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
+  // A cross-extension frame error is NOT a detach — classify it explicitly so
+  // a future addition to the detach pattern list can't accidentally
+  // re-enable the destructive retry path for this class.
+  if (CROSS_EXTENSION_FRAME_ERROR_PATTERNS.some((re) => re.test(msg))) {
+    return false;
+  }
   return DETACH_ERROR_PATTERNS.some((re) => re.test(msg));
+}
+
+/**
+ * True when `err` is the cross-extension frame access rejection. Callers
+ * (snapshot-capture's per-frame walk, cdp-session's bail-early branch) use
+ * this to switch to a degraded path that excludes the offending frame from
+ * the AX walk, instead of treating it as a session-level failure.
+ */
+export function isCrossExtensionFrameError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return CROSS_EXTENSION_FRAME_ERROR_PATTERNS.some((re) => re.test(msg));
 }

--- a/apps/extension/src/lib/agent/cdp-session.ts
+++ b/apps/extension/src/lib/agent/cdp-session.ts
@@ -12,7 +12,7 @@ const pendingAttach = new Map<number, Promise<Session>>();
 const NO_ENABLE_DOMAINS = new Set(["Input", "Page", "DOMSnapshot", "Runtime"]);
 
 export { isDetachError } from "./cdp-errors";
-import { isDetachError } from "./cdp-errors";
+import { isCrossExtensionFrameError, isDetachError } from "./cdp-errors";
 import { tabRegistry } from "./tab-registry";
 
 /**
@@ -115,6 +115,15 @@ async function sendCommandWithRetry<T>(
       await chrome.debugger.sendCommand({ tabId }, `${domain}.enable`);
       session.enabledDomains.add(domain);
     } catch (err) {
+      // Cross-extension frame access errors do not mean the session is dead
+      // — the debugger is still attached, only the specific call walked into
+      // a chrome-extension:// frame from a different extension (commonly a
+      // password manager iframe). Bail without touching the session map; the
+      // caller (snapshot-capture) catches via isCrossExtensionFrameError and
+      // falls back to a per-frame walk that excludes the offending frame.
+      if (isCrossExtensionFrameError(err)) {
+        throw err;
+      }
       if (allowRetry && isDetachError(err)) {
         // Stale session — drop and retry once with a fresh attach.
         // Logged at debug; transient and self-healing, so most engineers
@@ -140,6 +149,12 @@ async function sendCommandWithRetry<T>(
     );
     return result as T;
   } catch (err) {
+    // Same bail-early rationale as the .enable branch above: cross-extension
+    // frame access is a per-call failure, not a session failure. Don't drop
+    // the session, don't retry — let the caller pick a degraded path.
+    if (isCrossExtensionFrameError(err)) {
+      throw err;
+    }
     if (allowRetry && isDetachError(err)) {
       // The debugger detached between attach() and sendCommand (or the
       // command itself fell off the wire mid-flight). Drop our stale session

--- a/apps/extension/src/lib/agent/snapshot-capture.ts
+++ b/apps/extension/src/lib/agent/snapshot-capture.ts
@@ -767,13 +767,15 @@ function collectRefs(root: TreeNode): Map<string, RefEntry> {
 }
 
 /**
- * Result of a frame-aware AX-tree fetch. Concatenates `getFullAXTree` nodes
- * from every frame the debugger could safely walk, and surfaces a `note`
- * naming any frames we excluded (currently only cross-extension iframes —
- * 1Password, LastPass, etc. — which Chrome refuses to expose to a
- * cross-extension debugger). Snapshots are still actionable on the
- * remaining frames; the note is propagated up to the agent so it knows
- * the snapshot isn't whole-tree.
+ * Result of a frame-aware AX-tree fetch. The fetch follows a two-tier
+ * strategy (see `fetchAxNodesAvoidingForeignFrames` for details):
+ *   - Tier 1: a single `Accessibility.getFullAXTree()` whole-tree call.
+ *   - Tier 2 (only on cross-extension rejection): main-frame-only walk
+ *     after a `Page.getFrameTree` pre-pass.
+ *
+ * On the Tier 2 path, an optional `note` names the cross-extension frames
+ * we couldn't see (1Password, LastPass, etc.) so the agent knows the
+ * snapshot doesn't cover the whole frame tree.
  */
 interface AxFetchResult {
   nodes: AXNode[];
@@ -805,56 +807,130 @@ function getOwnExtensionUrlPrefix(): string | undefined {
 }
 
 /**
- * Walk a `Page.getFrameTree` result and bucket frames into "safe to AX-walk"
- * vs "foreign chrome-extension://". The bench harness and tests omit the
- * own-extension prefix, in which case all `chrome-extension://` frames are
- * conservatively bucketed as foreign.
+ * Walk a `Page.getFrameTree` result and collect the URLs of frames served
+ * from a `chrome-extension://` URL belonging to a DIFFERENT extension.
+ * Used purely to populate the descriptive `note` on the Tier 2 fallback —
+ * the actual AX walk in Tier 2 only ever runs on the main frame.
  */
-function classifyFrames(
+function collectForeignExtensionUrls(
   root: FrameNode,
   ownPrefix: string | undefined,
-): { safe: { id: string; url: string | undefined }[]; foreignUrls: string[] } {
-  const safe: { id: string; url: string | undefined }[] = [];
-  const foreignUrls: string[] = [];
+): string[] {
+  const out: string[] = [];
   function visit(node: FrameNode): void {
     const url = node.frame.url;
-    const isExtUrl = !!url && url.startsWith("chrome-extension://");
-    const isOurOwn = !!url && !!ownPrefix && url.startsWith(ownPrefix);
-    if (isExtUrl && !isOurOwn) {
-      foreignUrls.push(url ?? "(unknown)");
-    } else {
-      safe.push({ id: node.frame.id, url });
+    if (url && url.startsWith("chrome-extension://")) {
+      if (!ownPrefix || !url.startsWith(ownPrefix)) {
+        out.push(url);
+      }
     }
     for (const child of node.childFrames ?? []) visit(child);
   }
   visit(root);
-  return { safe, foreignUrls };
+  return out;
 }
 
 /**
- * Fetch the page's AX nodes in a way that doesn't blow up on cross-extension
- * iframes (e.g. password-manager content scripts). Strategy:
+ * Format the agent-facing note for the Tier 2 fallback. `foreignUrls` are
+ * frames the pre-pass identified as belonging to a different extension —
+ * those are reliably attributable. `racedFrameIds` are frames whose AX
+ * walk threw cross-extension after the pre-pass — we can't tell whether
+ * Chrome's classifier is rejecting THAT frame or some descendant, so we
+ * surface only opaque frame ids and don't make claims about which
+ * extension owns them.
  *
- *   1. Pre-pass `Page.getFrameTree` to enumerate frames.
- *   2. Bucket frames by URL: foreign `chrome-extension://` frames are skipped
- *      preemptively, all others are walked individually with
- *      `Accessibility.getFullAXTree({frameId})` and concatenated.
- *   3. If a per-frame walk *itself* raises `isCrossExtensionFrameError`
- *      (race: an iframe was injected between the frameTree pre-pass and the
- *      AX call), skip that frame too and add it to the note.
- *   4. If `Page.getFrameTree` itself fails (older Chrome, or a target type
- *      that doesn't enable Page domain), fall back to the legacy whole-tree
- *      `getFullAXTree()` call so the snapshot still works on benign pages.
+ * Soft language: when only foreign frames are excluded, the main page is
+ * actionable as expected. When raced frames are also present (the page
+ * mutated mid-walk and we couldn't enumerate cleanly), some frames are
+ * missing and the agent should be prepared to retry.
+ */
+function buildExclusionNote(
+  foreignUrls: string[],
+  racedFrameIds: string[],
+): string | undefined {
+  if (foreignUrls.length === 0 && racedFrameIds.length === 0) return undefined;
+
+  const parts: string[] = [];
+  if (foreignUrls.length > 0) {
+    const sample = foreignUrls
+      .slice(0, 3)
+      .map((u) => {
+        const m = u.match(/^chrome-extension:\/\/([a-p]+)\//i);
+        return m ? `chrome-extension://${m[1]}/…` : u.slice(0, 80);
+      })
+      .join(", ");
+    const more =
+      foreignUrls.length > 3 ? ` (+${foreignUrls.length - 3} more)` : "";
+    parts.push(
+      `Snapshot excluded ${foreignUrls.length} frame${foreignUrls.length === 1 ? "" : "s"} ` +
+        `belonging to other Chrome extensions (e.g. password managers): ${sample}${more}.`,
+    );
+  }
+  if (racedFrameIds.length > 0) {
+    parts.push(
+      `${racedFrameIds.length} additional frame${racedFrameIds.length === 1 ? "" : "s"} ` +
+        `errored mid-walk and ${racedFrameIds.length === 1 ? "is" : "are"} missing from this snapshot — ` +
+        `retry if expected content is missing.`,
+    );
+  }
+  if (foreignUrls.length > 0 && racedFrameIds.length === 0) {
+    parts.push("Interactive elements in the main page are unaffected.");
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Fetch the page's AX nodes resiliently to cross-extension iframes (e.g.
+ * password-manager content scripts). Two-tier strategy:
  *
- * Returns the concatenated AX nodes plus an optional note describing any
- * excluded frames. Throws only if EVERY safe frame's AX walk fails for a
- * non-cross-extension reason — callers can then decide whether to retry,
- * surface the error, or degrade to no AX tree at all.
+ *   - **Tier 1 (primary)**: a single `Accessibility.getFullAXTree()` with
+ *     no `frameId`. Chrome stitches the whole frame tree on its end and
+ *     returns one connected AX forest with each child-frame node tagged
+ *     with `frameId`. On benign pages and on most pages with foreign
+ *     extension iframes that aren't actively *attached* to the page,
+ *     this succeeds and we return the legacy whole-tree result with no
+ *     additional CDP round-trips.
+ *
+ *   - **Tier 2 (fallback)**: triggered only when Tier 1 throws
+ *     `isCrossExtensionFrameError`. We then run `Page.getFrameTree` to
+ *     enumerate frames (so we can attribute the failure in the agent
+ *     note) and call `Accessibility.getFullAXTree({frameId: <main>})` to
+ *     get just the main frame's tree. Legitimate child-frame content
+ *     (Stripe, YouTube, etc.) is unavailable in this mode; the agent is
+ *     informed via `note`.
+ *
+ * Why not "always per-frame"? Per-frame walks return one RootWebArea per
+ * frame with no parent linkage between them. Concatenating produces
+ * multiple parentless roots and `buildTree` would silently drop all but
+ * one — turning legitimate iframe content into hidden content. Tier 1
+ * preserves Chrome's frame-stitching exactly, paying only a single
+ * extra CDP call's worth of latency on the rare hostile-frame path.
+ *
+ * Returns the AX nodes plus an optional `note`. Re-throws non-cross-ext
+ * errors from Tier 1 unchanged so the existing detach/retry path in
+ * `cdp-session` can handle them.
  */
 async function fetchAxNodesAvoidingForeignFrames(
   driver: BrowserDriver,
   tabId: TabId,
 ): Promise<AxFetchResult> {
+  // Tier 1: whole-tree walk. The common case on every page — benign and
+  // hostile alike — when the cross-extension iframe isn't being actively
+  // included in the AX walk. Re-throws non-cross-ext errors so the cdp-
+  // session retry path keeps its semantics.
+  try {
+    const tree = await driver.sendCommand<{ nodes: AXNode[] }>(
+      tabId,
+      "Accessibility.getFullAXTree",
+    );
+    return { nodes: tree.nodes ?? [] };
+  } catch (err) {
+    if (!isCrossExtensionFrameError(err)) throw err;
+    // Fall through to Tier 2.
+  }
+
+  // Tier 2: enumerate frames (best-effort, for the note), then walk only
+  // the main frame.
   let frameTree: FrameNode | undefined;
   try {
     const result = await driver.sendCommand<{ frameTree?: FrameNode }>(
@@ -863,76 +939,49 @@ async function fetchAxNodesAvoidingForeignFrames(
     );
     frameTree = result.frameTree;
   } catch {
-    // Page domain unavailable (rare). Fall through to legacy whole-tree.
+    // Page domain unavailable (rare). We have no main-frame id to walk
+    // by — return empty with a generic note.
   }
 
   if (!frameTree) {
-    const tree = await driver.sendCommand<{ nodes: AXNode[] }>(
-      tabId,
-      "Accessibility.getFullAXTree",
-    );
-    return { nodes: tree.nodes ?? [] };
+    return {
+      nodes: [],
+      note:
+        "Snapshot blocked by a cross-extension iframe and the frame tree " +
+        "could not be enumerated. Retry, or interact with elements you can " +
+        "see via screenshot.",
+    };
   }
 
   const ownPrefix = getOwnExtensionUrlPrefix();
-  const { safe, foreignUrls } = classifyFrames(frameTree, ownPrefix);
+  const foreignUrls = collectForeignExtensionUrls(frameTree, ownPrefix);
+  const mainFrameId = frameTree.frame.id;
 
-  const allNodes: AXNode[] = [];
-  const racedFrames: string[] = [];
-  let lastNonClassifiedError: unknown = null;
-  let anySucceeded = false;
-
-  for (const frame of safe) {
-    try {
-      const tree = await driver.sendCommand<{ nodes: AXNode[] }>(
-        tabId,
-        "Accessibility.getFullAXTree",
-        { frameId: frame.id },
-      );
-      if (tree.nodes && tree.nodes.length > 0) {
-        for (const n of tree.nodes) allNodes.push(n);
-      }
-      anySucceeded = true;
-    } catch (err) {
-      if (isCrossExtensionFrameError(err)) {
-        // Race: a cross-extension iframe was injected between getFrameTree
-        // and the per-frame AX call. Record and continue.
-        racedFrames.push(frame.url ?? frame.id);
-        continue;
-      }
-      // Real error from this frame. Keep going so a single broken frame
-      // can't kill the whole snapshot, but remember the last error in case
-      // every frame fails (then we re-throw at the end).
-      lastNonClassifiedError = err;
+  const racedFrameIds: string[] = [];
+  let mainNodes: AXNode[] = [];
+  try {
+    const tree = await driver.sendCommand<{ nodes: AXNode[] }>(
+      tabId,
+      "Accessibility.getFullAXTree",
+      { frameId: mainFrameId },
+    );
+    mainNodes = tree.nodes ?? [];
+  } catch (err) {
+    if (isCrossExtensionFrameError(err)) {
+      // Even the main frame's walk failed (e.g. an extension iframe is
+      // attached to <body> and Chrome considers it part of the main
+      // frame's AX scope). Surface as a raced frame so the note
+      // describes it accurately.
+      racedFrameIds.push(mainFrameId);
+    } else {
+      throw err;
     }
   }
 
-  if (!anySucceeded && lastNonClassifiedError) {
-    throw lastNonClassifiedError;
-  }
-
-  const excluded = [...foreignUrls, ...racedFrames];
-  if (excluded.length === 0) {
-    return { nodes: allNodes };
-  }
-
-  // Compact, agent-actionable note. Truncate URLs because chrome-extension
-  // ones can be very long; the host id is the useful part.
-  const sample = excluded
-    .slice(0, 3)
-    .map((u) => {
-      const m = u.match(/^chrome-extension:\/\/([a-z]+)\//i);
-      return m ? `chrome-extension://${m[1]}/…` : u.slice(0, 80);
-    })
-    .join(", ");
-  const more =
-    excluded.length > 3 ? ` (+${excluded.length - 3} more)` : "";
-  const note =
-    `Snapshot excluded ${excluded.length} frame${excluded.length === 1 ? "" : "s"} ` +
-    `belonging to other Chrome extensions (e.g. password managers): ${sample}${more}. ` +
-    `Interactive elements in the main page are unaffected.`;
-
-  return { nodes: allNodes, note };
+  return {
+    nodes: mainNodes,
+    note: buildExclusionNote(foreignUrls, racedFrameIds),
+  };
 }
 
 /**

--- a/apps/extension/src/lib/agent/snapshot-capture.ts
+++ b/apps/extension/src/lib/agent/snapshot-capture.ts
@@ -11,6 +11,7 @@
  * session. No `chrome.*` references in here.
  */
 
+import { isCrossExtensionFrameError } from "./cdp-errors";
 import type { BrowserDriver, TabId } from "./driver";
 import {
   setRefs,
@@ -86,6 +87,15 @@ export interface CaptureResult {
    * whether there's more to see.
    */
   belowFoldCount: number;
+  /**
+   * Set when the snapshot ran in a degraded mode — currently only when one
+   * or more frames had to be excluded because they belong to another
+   * Chrome extension (commonly password-manager iframes like 1Password).
+   * Tools surface this verbatim to the agent so it knows the snapshot
+   * still represents the actionable parts of the page even though the
+   * walk wasn't whole-tree.
+   */
+  note?: string;
 }
 
 export interface PageStateSignals {
@@ -194,17 +204,15 @@ export async function captureSnapshot(
     }
   }
 
-  let axTree = await driver.sendCommand<{ nodes: AXNode[] }>(
-    tabId,
-    "Accessibility.getFullAXTree",
-  );
+  let axFetch = await fetchAxNodesAvoidingForeignFrames(driver, tabId);
+  let axTree: { nodes: AXNode[] } = { nodes: axFetch.nodes };
+  let frameNote = axFetch.note;
 
   if (!axTree.nodes || axTree.nodes.length === 0) {
     await new Promise((r) => setTimeout(r, 300));
-    axTree = await driver.sendCommand<{ nodes: AXNode[] }>(
-      tabId,
-      "Accessibility.getFullAXTree",
-    );
+    axFetch = await fetchAxNodesAvoidingForeignFrames(driver, tabId);
+    axTree = { nodes: axFetch.nodes };
+    frameNote = axFetch.note ?? frameNote;
   }
 
   // Gather visibility info. We always fetch bounds (needed both for hidden
@@ -235,10 +243,7 @@ export async function captureSnapshot(
 
   if (snapshotText.length === 0 && axTree.nodes.length > 0) {
     await new Promise((r) => setTimeout(r, 400));
-    const retry = await driver.sendCommand<{ nodes: AXNode[] }>(
-      tabId,
-      "Accessibility.getFullAXTree",
-    );
+    const retry = await fetchAxNodesAvoidingForeignFrames(driver, tabId);
     const retryVis = await getVisibilityInfo(driver, tabId, viewport);
     const retryCursor = await detectCursorInteractive(driver, tabId);
     tree = buildTree(
@@ -250,7 +255,8 @@ export async function captureSnapshot(
     assignStableRefs(tree);
     snapshotText = renderTree(tree, isInteractive);
     refs = collectRefs(tree);
-    axTree = retry; // keep axTree in sync for downstream signal + belowFoldCount derivation.
+    axTree = { nodes: retry.nodes }; // keep axTree in sync for downstream signal + belowFoldCount derivation.
+    frameNote = retry.note ?? frameNote;
   }
 
   // Fetch current URL for the URL signal. Cheap CDP call.
@@ -302,6 +308,7 @@ export async function captureSnapshot(
     signals,
     previousSignals,
     belowFoldCount,
+    ...(frameNote ? { note: frameNote } : {}),
   };
 }
 
@@ -491,16 +498,21 @@ function buildTree(
   }
 
   if (scopeRoot) return scopeRoot;
-  return (
-    root ?? {
-      axNode: nodes[0],
-      children: [],
-      ref: null,
-      interactive: false,
-      nth: 0,
-      visible: true,
-    }
-  );
+  if (root) return root;
+  // No root and no scoped root — common when every frame's AX call failed
+  // (e.g. a hostile cross-extension iframe was the ONLY frame the helper
+  // could see). Return a synthetic empty tree rather than dereferencing
+  // `nodes[0]` (which is undefined and crashes downstream `walk()`).
+  // Synthetic root mirrors the shape `walk()` and `renderTree()` expect:
+  // an AXNode with empty role/name and no children, treated as visible.
+  return {
+    axNode: { nodeId: "__empty__", role: { value: "" }, name: { value: "" } },
+    children: [],
+    ref: null,
+    interactive: false,
+    nth: 0,
+    visible: true,
+  };
 }
 
 function renderTree(
@@ -752,6 +764,175 @@ function collectRefs(root: TreeNode): Map<string, RefEntry> {
 
   walk(root);
   return refs;
+}
+
+/**
+ * Result of a frame-aware AX-tree fetch. Concatenates `getFullAXTree` nodes
+ * from every frame the debugger could safely walk, and surfaces a `note`
+ * naming any frames we excluded (currently only cross-extension iframes —
+ * 1Password, LastPass, etc. — which Chrome refuses to expose to a
+ * cross-extension debugger). Snapshots are still actionable on the
+ * remaining frames; the note is propagated up to the agent so it knows
+ * the snapshot isn't whole-tree.
+ */
+interface AxFetchResult {
+  nodes: AXNode[];
+  note?: string;
+}
+
+interface FrameNode {
+  frame: { id: string; url?: string };
+  childFrames?: FrameNode[];
+}
+
+/**
+ * Best-effort lookup of OUR extension's `chrome-extension://<id>/` prefix.
+ * Used to distinguish frames from this extension (always safe to walk —
+ * the debugger can inspect its own surfaces) from frames belonging to a
+ * DIFFERENT extension (Chrome refuses access). Returns undefined in
+ * non-extension runtimes (tests, bench harness), in which case we
+ * conservatively treat all `chrome-extension://` frames as foreign.
+ *
+ * Indirected through `globalThis` so this module typechecks in
+ * `packages/bench` without `@types/chrome` and runs cleanly in the
+ * Node-side test runner.
+ */
+function getOwnExtensionUrlPrefix(): string | undefined {
+  const c = (globalThis as { chrome?: { runtime?: { id?: string } } })
+    .chrome;
+  const id = c?.runtime?.id;
+  return id ? `chrome-extension://${id}/` : undefined;
+}
+
+/**
+ * Walk a `Page.getFrameTree` result and bucket frames into "safe to AX-walk"
+ * vs "foreign chrome-extension://". The bench harness and tests omit the
+ * own-extension prefix, in which case all `chrome-extension://` frames are
+ * conservatively bucketed as foreign.
+ */
+function classifyFrames(
+  root: FrameNode,
+  ownPrefix: string | undefined,
+): { safe: { id: string; url: string | undefined }[]; foreignUrls: string[] } {
+  const safe: { id: string; url: string | undefined }[] = [];
+  const foreignUrls: string[] = [];
+  function visit(node: FrameNode): void {
+    const url = node.frame.url;
+    const isExtUrl = !!url && url.startsWith("chrome-extension://");
+    const isOurOwn = !!url && !!ownPrefix && url.startsWith(ownPrefix);
+    if (isExtUrl && !isOurOwn) {
+      foreignUrls.push(url ?? "(unknown)");
+    } else {
+      safe.push({ id: node.frame.id, url });
+    }
+    for (const child of node.childFrames ?? []) visit(child);
+  }
+  visit(root);
+  return { safe, foreignUrls };
+}
+
+/**
+ * Fetch the page's AX nodes in a way that doesn't blow up on cross-extension
+ * iframes (e.g. password-manager content scripts). Strategy:
+ *
+ *   1. Pre-pass `Page.getFrameTree` to enumerate frames.
+ *   2. Bucket frames by URL: foreign `chrome-extension://` frames are skipped
+ *      preemptively, all others are walked individually with
+ *      `Accessibility.getFullAXTree({frameId})` and concatenated.
+ *   3. If a per-frame walk *itself* raises `isCrossExtensionFrameError`
+ *      (race: an iframe was injected between the frameTree pre-pass and the
+ *      AX call), skip that frame too and add it to the note.
+ *   4. If `Page.getFrameTree` itself fails (older Chrome, or a target type
+ *      that doesn't enable Page domain), fall back to the legacy whole-tree
+ *      `getFullAXTree()` call so the snapshot still works on benign pages.
+ *
+ * Returns the concatenated AX nodes plus an optional note describing any
+ * excluded frames. Throws only if EVERY safe frame's AX walk fails for a
+ * non-cross-extension reason — callers can then decide whether to retry,
+ * surface the error, or degrade to no AX tree at all.
+ */
+async function fetchAxNodesAvoidingForeignFrames(
+  driver: BrowserDriver,
+  tabId: TabId,
+): Promise<AxFetchResult> {
+  let frameTree: FrameNode | undefined;
+  try {
+    const result = await driver.sendCommand<{ frameTree?: FrameNode }>(
+      tabId,
+      "Page.getFrameTree",
+    );
+    frameTree = result.frameTree;
+  } catch {
+    // Page domain unavailable (rare). Fall through to legacy whole-tree.
+  }
+
+  if (!frameTree) {
+    const tree = await driver.sendCommand<{ nodes: AXNode[] }>(
+      tabId,
+      "Accessibility.getFullAXTree",
+    );
+    return { nodes: tree.nodes ?? [] };
+  }
+
+  const ownPrefix = getOwnExtensionUrlPrefix();
+  const { safe, foreignUrls } = classifyFrames(frameTree, ownPrefix);
+
+  const allNodes: AXNode[] = [];
+  const racedFrames: string[] = [];
+  let lastNonClassifiedError: unknown = null;
+  let anySucceeded = false;
+
+  for (const frame of safe) {
+    try {
+      const tree = await driver.sendCommand<{ nodes: AXNode[] }>(
+        tabId,
+        "Accessibility.getFullAXTree",
+        { frameId: frame.id },
+      );
+      if (tree.nodes && tree.nodes.length > 0) {
+        for (const n of tree.nodes) allNodes.push(n);
+      }
+      anySucceeded = true;
+    } catch (err) {
+      if (isCrossExtensionFrameError(err)) {
+        // Race: a cross-extension iframe was injected between getFrameTree
+        // and the per-frame AX call. Record and continue.
+        racedFrames.push(frame.url ?? frame.id);
+        continue;
+      }
+      // Real error from this frame. Keep going so a single broken frame
+      // can't kill the whole snapshot, but remember the last error in case
+      // every frame fails (then we re-throw at the end).
+      lastNonClassifiedError = err;
+    }
+  }
+
+  if (!anySucceeded && lastNonClassifiedError) {
+    throw lastNonClassifiedError;
+  }
+
+  const excluded = [...foreignUrls, ...racedFrames];
+  if (excluded.length === 0) {
+    return { nodes: allNodes };
+  }
+
+  // Compact, agent-actionable note. Truncate URLs because chrome-extension
+  // ones can be very long; the host id is the useful part.
+  const sample = excluded
+    .slice(0, 3)
+    .map((u) => {
+      const m = u.match(/^chrome-extension:\/\/([a-z]+)\//i);
+      return m ? `chrome-extension://${m[1]}/…` : u.slice(0, 80);
+    })
+    .join(", ");
+  const more =
+    excluded.length > 3 ? ` (+${excluded.length - 3} more)` : "";
+  const note =
+    `Snapshot excluded ${excluded.length} frame${excluded.length === 1 ? "" : "s"} ` +
+    `belonging to other Chrome extensions (e.g. password managers): ${sample}${more}. ` +
+    `Interactive elements in the main page are unaffected.`;
+
+  return { nodes: allNodes, note };
 }
 
 /**
@@ -1119,21 +1300,21 @@ export async function captureSnapshotWithUrlIds(
     }
   }
 
-  // Parallelize the three independent CDP collections.
-  const [axTreeRaw, visibility, cursorInteractive, hrefs] = await Promise.all([
-    driver.sendCommand<{ nodes: AXNode[] }>(tabId, "Accessibility.getFullAXTree"),
+  // Parallelize the three independent CDP collections. The AX walk uses
+  // the frame-aware path so a cross-extension iframe (e.g. password manager)
+  // can't kill the whole snapshot; foreign frames are silently excluded.
+  const [axFetch, visibility, cursorInteractive, hrefs] = await Promise.all([
+    fetchAxNodesAvoidingForeignFrames(driver, tabId),
     getVisibilityInfo(driver, tabId, null),
     detectCursorInteractive(driver, tabId),
     collectLinkHrefs(driver, tabId),
   ]);
 
-  let axTree = axTreeRaw;
+  let axTree: { nodes: AXNode[] } = { nodes: axFetch.nodes };
   if (!axTree.nodes || axTree.nodes.length === 0) {
     await new Promise((r) => setTimeout(r, 300));
-    axTree = await driver.sendCommand<{ nodes: AXNode[] }>(
-      tabId,
-      "Accessibility.getFullAXTree",
-    );
+    const retry = await fetchAxNodesAvoidingForeignFrames(driver, tabId);
+    axTree = { nodes: retry.nodes };
   }
 
   const tree = buildTree(

--- a/apps/extension/src/lib/agent/tools/click-element.ts
+++ b/apps/extension/src/lib/agent/tools/click-element.ts
@@ -124,7 +124,11 @@ export const clickElementTool: BrowserTool<Input, Output> = {
         result.belowFoldCount = cap.belowFoldCount;
         result.hint = `${cap.belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`;
       }
-      if (hitWarning) result.note = hitWarning;
+      // Merge per-call notes. `hitWarning` (overlay-intercept) and `cap.note`
+      // (cross-extension frames excluded from the snapshot) are both
+      // information the agent benefits from; concatenate when both fire.
+      const notes = [hitWarning, cap.note].filter(Boolean);
+      if (notes.length > 0) result.note = notes.join(" ");
       return result;
     } catch (err) {
       return {

--- a/apps/extension/src/lib/agent/tools/navigate.ts
+++ b/apps/extension/src/lib/agent/tools/navigate.ts
@@ -100,13 +100,16 @@ export const navigateTool: BrowserTool<Input, Output> = {
     // Auto-attach initial snapshot so the agent can act on the new page
     // without a follow-up snapshot call.
     try {
-      const { snapshotText, refs } = await captureSnapshot(ctx.driver, tabId);
+      const cap = await captureSnapshot(ctx.driver, tabId);
       return {
         navigated: true,
         url,
         tab: resolvedHandle,
-        snapshot: snapshotText,
-        refCount: refs.size,
+        snapshot: cap.snapshotText,
+        refCount: cap.refs.size,
+        // Surface cross-extension frame exclusion (e.g. password-manager
+        // iframes) so the agent knows the snapshot isn't whole-tree.
+        ...(cap.note ? { note: cap.note } : {}),
       };
     } catch (err) {
       return {

--- a/apps/extension/src/lib/agent/tools/press-key.ts
+++ b/apps/extension/src/lib/agent/tools/press-key.ts
@@ -123,6 +123,9 @@ export const pressKeyTool: BrowserTool<Input, Output> = {
         result.belowFoldCount = cap.belowFoldCount;
         result.hint = `${cap.belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`;
       }
+      // Surface cross-extension frame exclusion (e.g. password-manager
+      // iframes) so the agent knows the snapshot isn't whole-tree.
+      if (cap.note) result.note = cap.note;
       return result;
     } catch (err) {
       return {

--- a/apps/extension/src/lib/agent/tools/snapshot.ts
+++ b/apps/extension/src/lib/agent/tools/snapshot.ts
@@ -35,6 +35,7 @@ const outputSchema = z.object({
   url: z.string(),
   belowFoldCount: z.number().optional(),
   hint: z.string().optional(),
+  note: z.string().optional(),
 });
 type Output = z.infer<typeof outputSchema>;
 
@@ -52,12 +53,19 @@ export const snapshotTool: BrowserTool<Input, Output> = {
     const viewportOnly = mode === "viewport";
     const captureMode = mode === "viewport" ? "interactive" : mode;
 
-    const { snapshotText, refs, previous, signals, previousSignals, belowFoldCount } =
-      await captureSnapshot(ctx.driver, tabId, {
-        mode: captureMode,
-        selector,
-        viewportOnly,
-      });
+    const {
+      snapshotText,
+      refs,
+      previous,
+      signals,
+      previousSignals,
+      belowFoldCount,
+      note,
+    } = await captureSnapshot(ctx.driver, tabId, {
+      mode: captureMode,
+      selector,
+      viewportOnly,
+    });
 
     const baseResult: Output = {
       tab: handle,
@@ -78,6 +86,7 @@ export const snapshotTool: BrowserTool<Input, Output> = {
         ? `${belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`
         : `${belowFoldCount} of the returned refs are below the fold — scrolling may reveal additional interactive elements beyond the current tree.`;
     }
+    if (note) baseResult.note = note;
 
     return baseResult;
   },

--- a/apps/extension/src/lib/agent/tools/type-in-element.ts
+++ b/apps/extension/src/lib/agent/tools/type-in-element.ts
@@ -176,6 +176,9 @@ export const typeInElementTool: BrowserTool<Input, Output> = {
         baseResult.belowFoldCount = cap.belowFoldCount;
         baseResult.hint = `${cap.belowFoldCount} more interactive element(s) are below the fold. Use scrollPage + snapshot to see them.`;
       }
+      // Surface cross-extension frame exclusion (e.g. password-manager
+      // iframes) so the agent knows the snapshot isn't whole-tree.
+      if (cap.note) baseResult.note = cap.note;
       return baseResult;
     } catch (err) {
       return {


### PR DESCRIPTION
## Problem

On http(s) pages where another installed Chrome extension (1Password, LastPass, Bitwarden, Honey, Grammarly) injects a content-script iframe served from `chrome-extension://<otherExtId>/`, every snapshot fails: the tab-attached debugger isn't permitted to inspect cross-extension URLs, so `Accessibility.getFullAXTree` rejects with "Cannot access a chrome-extension:// URL of different extension" and Chrome detaches the whole session as collateral.

Symptoms in prod: "Cannot attach debugger to tab N: No tab with given id" cascading across every action; "post-action snapshot failed" warnings on form-heavy SaaS pages where password managers aggressively inject. Looks identical to the prerender failure class fixed in #139 but is unrelated.

## Fix

Frame-aware AX walking. Every `captureSnapshot` runs a `Page.getFrameTree` pre-pass and walks each safe frame individually with `Accessibility.getFullAXTree({frameId})`. Frames whose URL belongs to another extension are skipped preemptively; per-frame races (iframe injected mid-walk) are caught and recorded.

Cross-extension errors are now classified separately from detach errors, so `cdp-session` bails without tearing down the healthy session — the existing detach/retry path can never accidentally retry the same whole-tree call and fail identically.

When frames are excluded, a short `note` propagates through the action tools so the agent knows the snapshot still represents the actionable parts of the page even though the walk wasn't whole-tree.

## Surface

- `cdp-errors.ts`: new `isCrossExtensionFrameError`. `isDetachError` explicitly excludes this class.
- `cdp-session.ts`: bail-early at both catch sites (`<Domain>.enable` and the command).
- `snapshot-capture.ts`: `fetchAxNodesAvoidingForeignFrames` helper + per-frame walk. `buildTree` returns a synthetic empty root for zero AX nodes (was dereferencing `nodes[0]` and crashing).
- `note?: string` added to `CaptureResult` and threaded through `snapshot`, `clickElement`, `typeInElement`, `pressKey`, `navigate`. `clickElement` merges `cap.note` with the existing `hitWarning` instead of overwriting.

## Tests

- `cdp-errors.test.ts` — classifier coverage + mutual-exclusion invariant.
- `cdp-session-cross-extension.test.ts` — session map untouched, no retry, on cross-ext error from either catch site.
- `snapshot-capture-cross-extension.test.ts` — preemptive skip, race-injected frame, benign single-frame, legacy whole-tree fallback, nested frame walking.
- All existing tests pass: 1041 extension + 63 bench. `tsc --noEmit` clean.

## Manual verification

Not yet run on the live failure (would need 1Password installed + Attio settings → "Funded by"). The unit tests stub Chrome's exact error strings — the regex/classification path is covered, but the end-to-end behavior in the actual offending environment hasn't been confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of iframes from other extensions (such as password managers) during snapshot capture operations
  * Prevented unnecessary retry loops when unable to access cross-extension frames

* **New Features**
  * Snapshot results now include informational notes indicating when frames have been excluded from capture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->