### PR TITLE
feat(extension): toolbar opens side panel + blue sparkle generating indicator

### DIFF
--- a/.changeset/sidepanel-blue-dot.md
+++ b/.changeset/sidepanel-blue-dot.md
@@ -1,0 +1,10 @@
+---
+"openbrowse": patch
+---
+
+**Sidebar polish + clearer "agent is working" indicator.**
+
+- Clicking the toolbar icon now toggles the side panel, replacing the previous spotlight overlay. Works on every page including `chrome://` URLs where the overlay couldn't inject.
+- Removed the redundant logo button from the side panel header — the sidebar already conveys the app context, and `Alt+H` still opens the home view.
+- The "Retry from this message" dialog now advertises and accepts `⌘⏎` (or `Ctrl+Enter`) as a confirmation shortcut, matching the rest of the app's keyboard conventions.
+- A pulsing blue pixel-art sparkle now marks the active assistant turn from the moment you hit Send through the end of streaming. It replaces the old gray bouncing-dots bubble during the "submitted" phase and stays visible at the end of the streaming text — gating on the local-stream signal so it doesn't disappear in the brief window between agent-start and first token (a regression caused by the cross-tab `isAgentActiveGlobally` flag flipping `isStreaming` on prematurely).

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -11,6 +11,7 @@ import { CompletionCheckRunningBlock } from "./CompletionCheckRunningBlock";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { ToolApprovalBlock } from "./ToolApprovalBlock";
 import { StepGroup } from "./StepGroup";
+import { GeneratingIndicator } from "./GeneratingIndicator";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 import { capturedToolOrigins, allowToolOnSite, setCloseTabsAlwaysAllowed } from "@/lib/agent/agent-transport";
 import { memo } from "react";
@@ -431,22 +432,7 @@ function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, di
             </StepGroup>
           );
         })}
-        {isStreaming && (
-          <div className="flex w-full items-start pt-3">
-            <svg viewBox="0 0 9 9" className="h-4 w-4 animate-scale-pulse" style={{ imageRendering: "pixelated" }} aria-label="Generating">
-              <rect x="4" y="2" width="1" height="5" fill="currentColor" className="text-blue-500 outward-core" />
-              <rect x="2" y="4" width="5" height="1" fill="currentColor" className="text-blue-500 outward-core" />
-              <rect x="2" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-              <rect x="6" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-              <rect x="2" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-              <rect x="6" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-              <rect x="4" y="0" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-              <rect x="4" y="8" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-              <rect x="0" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-              <rect x="8" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-            </svg>
-          </div>
-        )}
+        {isStreaming && <GeneratingIndicator />}
       </div>
       <MessageActions message={message} />
     </div>

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -431,6 +431,22 @@ function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, di
             </StepGroup>
           );
         })}
+        {isStreaming && (
+          <div className="flex w-full items-start pt-3">
+            <svg viewBox="0 0 9 9" className="h-4 w-4 animate-scale-pulse" style={{ imageRendering: "pixelated" }} aria-label="Generating">
+              <rect x="4" y="2" width="1" height="5" fill="currentColor" className="text-blue-500 outward-core" />
+              <rect x="2" y="4" width="5" height="1" fill="currentColor" className="text-blue-500 outward-core" />
+              <rect x="2" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+              <rect x="6" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+              <rect x="2" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+              <rect x="6" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+              <rect x="4" y="0" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+              <rect x="4" y="8" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+              <rect x="0" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+              <rect x="8" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+            </svg>
+          </div>
+        )}
       </div>
       <MessageActions message={message} />
     </div>

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -519,11 +519,14 @@ export function ChatView({
     void openSettingsTab();
   }
 
-  const showThinking =
-    isLoading &&
-    !isStreaming &&
-    messages.length > 0 &&
-    messages[messages.length - 1].role === "user";
+  // Use the hook's local streaming signal (not the cross-tab `isStreaming`
+  // that includes `isAgentActiveGlobally`). The global flag flips on as
+  // soon as the agent starts running anywhere, but our local `messages`
+  // array only contains a streaming assistant message once
+  // `hookIsStreaming` is true. Gating on the global flag would unmount
+  // <ThinkingIndicator> before the assistant message exists, leaving a
+  // gap with no dot visible.
+  const showThinking = isLoading && !hookIsStreaming;
 
   // Sent-message edits dim everything below the edited row. Queued
   // edits don't affect the transcript, so they don't dim anything.

--- a/apps/extension/src/components/chat/GeneratingIndicator.tsx
+++ b/apps/extension/src/components/chat/GeneratingIndicator.tsx
@@ -1,0 +1,35 @@
+/**
+ * Pulsing pixel-art sparkle that anchors the active assistant turn.
+ *
+ * Used by:
+ *   - <ThinkingIndicator> (MessageList) during the post-Send / pre-stream window
+ *   - <AssistantMessage> at the end of the streaming bubble
+ *
+ * Animation classes (`animate-scale-pulse`, `outward-core/mid/edge`) live in
+ * `entrypoints/sidepanel/app.css` and `entrypoints/_shared/home.css` so the
+ * indicator works on every surface that mounts a ChatView.
+ */
+export function GeneratingIndicator() {
+  return (
+    <div className="flex w-full items-start pt-3">
+      <svg
+        viewBox="0 0 9 9"
+        className="h-4 w-4 animate-scale-pulse"
+        style={{ imageRendering: "pixelated" }}
+        role="status"
+        aria-label="Generating"
+      >
+        <rect x="4" y="2" width="1" height="5" fill="currentColor" className="text-blue-500 outward-core" />
+        <rect x="2" y="4" width="5" height="1" fill="currentColor" className="text-blue-500 outward-core" />
+        <rect x="2" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="6" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="2" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="6" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="4" y="0" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+        <rect x="4" y="8" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+        <rect x="0" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+        <rect x="8" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+      </svg>
+    </div>
+  );
+}

--- a/apps/extension/src/components/chat/MessageList.tsx
+++ b/apps/extension/src/components/chat/MessageList.tsx
@@ -3,6 +3,7 @@ import type { AgentUIMessage } from "@/lib/types";
 import { ChatMessage } from "./ChatMessage";
 import { CompactionDivider } from "./CompactionDivider";
 import { ExpandableText } from "./tool-results/expandable-text";
+import { GeneratingIndicator as ThinkingIndicator } from "./GeneratingIndicator";
 import { AlertCircle, RefreshCw } from "lucide-react";
 
 interface MessageListProps {
@@ -123,25 +124,6 @@ function MessageListImpl({
 }
 
 export const MessageList = memo(MessageListImpl);
-
-function ThinkingIndicator() {
-  return (
-    <div className="flex w-full items-start pt-3">
-      <svg viewBox="0 0 9 9" className="h-4 w-4 animate-scale-pulse" style={{ imageRendering: "pixelated" }} aria-label="Generating">
-        <rect x="4" y="2" width="1" height="5" fill="currentColor" className="text-blue-500 outward-core" />
-        <rect x="2" y="4" width="5" height="1" fill="currentColor" className="text-blue-500 outward-core" />
-        <rect x="2" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-        <rect x="6" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-        <rect x="2" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-        <rect x="6" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
-        <rect x="4" y="0" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-        <rect x="4" y="8" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-        <rect x="0" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-        <rect x="8" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
-      </svg>
-    </div>
-  );
-}
 
 function ErrorMessage({
   error,

--- a/apps/extension/src/components/chat/MessageList.tsx
+++ b/apps/extension/src/components/chat/MessageList.tsx
@@ -126,14 +126,19 @@ export const MessageList = memo(MessageListImpl);
 
 function ThinkingIndicator() {
   return (
-    <div className="flex justify-start">
-      <div className="rounded-lg px-3 py-2 bg-muted">
-        <div className="flex items-center gap-1">
-          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse" />
-          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse [animation-delay:150ms]" />
-          <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse [animation-delay:300ms]" />
-        </div>
-      </div>
+    <div className="flex w-full items-start pt-3">
+      <svg viewBox="0 0 9 9" className="h-4 w-4 animate-scale-pulse" style={{ imageRendering: "pixelated" }} aria-label="Generating">
+        <rect x="4" y="2" width="1" height="5" fill="currentColor" className="text-blue-500 outward-core" />
+        <rect x="2" y="4" width="5" height="1" fill="currentColor" className="text-blue-500 outward-core" />
+        <rect x="2" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="6" y="2" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="2" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="6" y="6" width="1" height="1" fill="currentColor" className="text-blue-500 outward-mid" />
+        <rect x="4" y="0" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+        <rect x="4" y="8" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+        <rect x="0" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+        <rect x="8" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
+      </svg>
     </div>
   );
 }

--- a/apps/extension/src/components/chat/UserMessage.tsx
+++ b/apps/extension/src/components/chat/UserMessage.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { ZoomableImage } from "@/components/ui/zoomable-image";
 import { Check, Copy, Pencil, RefreshCw } from "lucide-react";
+import { Kbd } from "@/components/ui/kbd";
 import { useCallback, useMemo, useRef, useState, memo } from "react";
 import { parseAttachedFiles } from "@/lib/chat/parse-attached-files";
 import { classifyFile } from "@/lib/vfs/file-classify";
@@ -202,7 +203,15 @@ function UserMessageImpl({ message, onEdit, onRetry, dimmed }: UserMessageProps)
       )}
       {onRetry && (
         <AlertDialog open={confirmRetryOpen} onOpenChange={setConfirmRetryOpen}>
-          <AlertDialogContent>
+          <AlertDialogContent
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                setConfirmRetryOpen(false);
+                onRetry();
+              }
+            }}
+          >
             <AlertDialogHeader>
               <AlertDialogTitle>Retry from this message?</AlertDialogTitle>
               <AlertDialogDescription>
@@ -219,6 +228,7 @@ function UserMessageImpl({ message, onEdit, onRetry, dimmed }: UserMessageProps)
                 }}
               >
                 Retry
+                <Kbd className="ml-1.5">⌘⏎</Kbd>
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/apps/extension/src/entrypoints/_shared/home.css
+++ b/apps/extension/src/entrypoints/_shared/home.css
@@ -223,3 +223,18 @@ body {
   opacity: 0.6;
   user-select: none;
 }
+
+/* Option Y: Outward Ripple animation for generating chat indicator */
+@keyframes scalePulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.8; }
+}
+.animate-scale-pulse { animation: scalePulse 1.5s ease-in-out infinite; }
+
+@keyframes outwardPulse {
+  0%, 100% { fill-opacity: 0.2; }
+  50% { fill-opacity: 1; }
+}
+.outward-core { animation: outwardPulse 1.5s ease-in-out infinite; }
+.outward-mid { animation: outwardPulse 1.5s ease-in-out infinite 0.2s; }
+.outward-edge { animation: outwardPulse 1.5s ease-in-out infinite 0.4s; }

--- a/apps/extension/src/entrypoints/_shared/home.css
+++ b/apps/extension/src/entrypoints/_shared/home.css
@@ -225,16 +225,16 @@ body {
 }
 
 /* Option Y: Outward Ripple animation for generating chat indicator */
-@keyframes scalePulse {
+@keyframes scale-pulse {
   0%, 100% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.3); opacity: 0.8; }
 }
-.animate-scale-pulse { animation: scalePulse 1.5s ease-in-out infinite; }
+.animate-scale-pulse { animation: scale-pulse 1.5s ease-in-out infinite; }
 
-@keyframes outwardPulse {
+@keyframes outward-pulse {
   0%, 100% { fill-opacity: 0.2; }
   50% { fill-opacity: 1; }
 }
-.outward-core { animation: outwardPulse 1.5s ease-in-out infinite; }
-.outward-mid { animation: outwardPulse 1.5s ease-in-out infinite 0.2s; }
-.outward-edge { animation: outwardPulse 1.5s ease-in-out infinite 0.4s; }
+.outward-core { animation: outward-pulse 1.5s ease-in-out infinite; }
+.outward-mid { animation: outward-pulse 1.5s ease-in-out infinite 0.2s; }
+.outward-edge { animation: outward-pulse 1.5s ease-in-out infinite 0.4s; }

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -74,21 +74,25 @@ export default defineBackground({
       }
     })();
 
-    chrome.action.onClicked.addListener(async (tab) => {
+    chrome.action.onClicked.addListener((tab) => {
       if (!tab.id || !tab.windowId) return;
       const ownExtUrl = chrome.runtime.getURL("");
       if (tab.url?.startsWith(ownExtUrl)) {
         chrome.runtime.sendMessage({ type: "TOGGLE_HOME_OVERLAY", windowId: tab.windowId });
         return;
       }
-      if (tab.url?.startsWith("chrome://") || tab.url?.startsWith("chrome-extension://")) {
-        return;
-      }
-      const { sendToContentScript } = await import("@/lib/agent/active-tab");
-      try {
-        await sendToContentScript(tab.id, { type: "TOGGLE_OVERLAY" });
-      } catch {
-        // Cannot inject into this page
+
+      // Must be synchronous off the user gesture
+      const tabId = tab.id;
+      const opened = isUserOpenedSidePanel(tabId);
+      if (opened && chrome.sidePanel.close) {
+        markUserClosedSidePanel(tabId);
+        chrome.sidePanel.close({ tabId }).catch(() => {});
+        chrome.sidePanel
+          .setOptions({ tabId, path: "sidepanel.html", enabled: false })
+          .catch(() => {});
+      } else {
+        openSidePanelOnTab(tabId);
       }
     });
 

--- a/apps/extension/src/entrypoints/sidepanel/App.tsx
+++ b/apps/extension/src/entrypoints/sidepanel/App.tsx
@@ -7,7 +7,6 @@ import { useTheme } from "@/hooks/useTheme";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ChatView } from "@/components/chat/ChatView";
 import { ChatPicker } from "@/components/chat/ChatPicker";
-import { Logo } from "@/components/ui/logo";
 import { CopyIcon, Download, ExternalLink, FileDown, MessageSquarePlus, MoreVertical, Settings, PictureInPicture, PanelRight } from "lucide-react";
 import {
   Tooltip,
@@ -456,19 +455,6 @@ export default function App() {
     <FileSelectionContext.Provider value={handleSelectFile}>
       <div className="relative flex flex-col h-screen">
         <div className="relative flex items-center gap-1.5 border-b border-border px-2 py-1.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={handleOpenFullView}
-                className="rounded p-1 hover:bg-accent"
-                aria-label="Open OpenBrowse home"
-              >
-                <Logo className="size-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Open home</TooltipContent>
-          </Tooltip>
           {conversationTitle && (
             <>
               <span className="text-muted-foreground text-xs">/</span>

--- a/apps/extension/src/entrypoints/sidepanel/app.css
+++ b/apps/extension/src/entrypoints/sidepanel/app.css
@@ -197,3 +197,18 @@ body {
   -webkit-text-fill-color: transparent;
   animation: shimmer 1.5s ease-in-out infinite;
 }
+
+/* Option Y: Outward Ripple animation for generating chat indicator */
+@keyframes scalePulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.8; }
+}
+.animate-scale-pulse { animation: scalePulse 1.5s ease-in-out infinite; }
+
+@keyframes outwardPulse {
+  0%, 100% { fill-opacity: 0.2; }
+  50% { fill-opacity: 1; }
+}
+.outward-core { animation: outwardPulse 1.5s ease-in-out infinite; }
+.outward-mid { animation: outwardPulse 1.5s ease-in-out infinite 0.2s; }
+.outward-edge { animation: outwardPulse 1.5s ease-in-out infinite 0.4s; }

--- a/apps/extension/src/entrypoints/sidepanel/app.css
+++ b/apps/extension/src/entrypoints/sidepanel/app.css
@@ -199,16 +199,16 @@ body {
 }
 
 /* Option Y: Outward Ripple animation for generating chat indicator */
-@keyframes scalePulse {
+@keyframes scale-pulse {
   0%, 100% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.3); opacity: 0.8; }
 }
-.animate-scale-pulse { animation: scalePulse 1.5s ease-in-out infinite; }
+.animate-scale-pulse { animation: scale-pulse 1.5s ease-in-out infinite; }
 
-@keyframes outwardPulse {
+@keyframes outward-pulse {
   0%, 100% { fill-opacity: 0.2; }
   50% { fill-opacity: 1; }
 }
-.outward-core { animation: outwardPulse 1.5s ease-in-out infinite; }
-.outward-mid { animation: outwardPulse 1.5s ease-in-out infinite 0.2s; }
-.outward-edge { animation: outwardPulse 1.5s ease-in-out infinite 0.4s; }
+.outward-core { animation: outward-pulse 1.5s ease-in-out infinite; }
+.outward-mid { animation: outward-pulse 1.5s ease-in-out infinite 0.2s; }
+.outward-edge { animation: outward-pulse 1.5s ease-in-out infinite 0.4s; }


### PR DESCRIPTION
## Summary

- **Toolbar icon → side panel.** Clicking the extension icon now toggles the per-tab side panel instead of injecting the spotlight overlay. Works on every page including `chrome://` URLs (where the overlay couldn't inject before). Home pages keep their existing `TOGGLE_HOME_OVERLAY` behavior.
- **Removed the side panel's logo button.** It was a redundant entry point — `Alt+H` still opens the home view.
- **Retry dialog: `⌘⏎` shortcut.** The Retry-from-this-message dialog now advertises and accepts `Cmd/Ctrl+Enter` for confirmation, with a `<Kbd>⌘⏎</Kbd>` hint inside the action button.
- **Pulsing blue sparkle as the active-turn indicator.** Replaced the gray bouncing-dots `ThinkingIndicator` and the streamdown caret with a pulsing pixel-art sparkle (Option Y) that anchors the active assistant turn continuously from Send through end-of-stream.

## Why the dot stayed gone for 1-2s in earlier iterations

The combined `isStreaming = hookIsStreaming || isAgentActiveGlobally` flips true the moment the agent starts running anywhere (cross-tab signal from `chrome.storage.local`), but the local `messages` array doesn't yet contain the streaming assistant message at that instant. Gating `showThinking` on the combined flag unmounted `<ThinkingIndicator>` ~1s before `<AssistantMessage>` had a streaming bubble to host the new dot — leaving a gap.

Fix: gate `showThinking` on `hookIsStreaming` directly. The `<ThinkingIndicator>` stays visible until tokens actually start streaming locally; from there `<AssistantMessage>`'s end-of-message dot takes over.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Toolbar icon: regular pages → opens/closes side panel; `chrome://` pages → opens/closes side panel; extension's own home page → unchanged `TOGGLE_HOME_OVERLAY`
- [x] `Alt+I` (open-chat command) and `Alt+K` (open-search overlay) still work
- [x] Retry dialog: `Cmd+Enter` confirms; `Esc` cancels; `<Kbd>⌘⏎</Kbd>` visible on the Retry button
- [x] Side panel: no logo button in header; conversation title still renders flush left
- [x] Send a message: blue sparkle appears immediately, persists through the full `submitted` window, and continues at the end of the streaming response until completion

## Files

```
.changeset/sidepanel-blue-dot.md                                          | new
apps/extension/src/entrypoints/background/index.ts                        | +12 -10  toolbar handler
apps/extension/src/entrypoints/sidepanel/App.tsx                          | +0 -14   logo removed
apps/extension/src/components/chat/UserMessage.tsx                        | +11 -1   ⌘⏎ retry shortcut
apps/extension/src/components/chat/AssistantMessage.tsx                   | +16 -0   end-of-stream dot
apps/extension/src/components/chat/MessageList.tsx                        | +14 -7   ThinkingIndicator → sparkle
apps/extension/src/components/chat/ChatView.tsx                           | +8 -5    showThinking gating fix
apps/extension/src/entrypoints/sidepanel/app.css                          | +15      scalePulse + outwardPulse keyframes
apps/extension/src/entrypoints/_shared/home.css                           | +15      same, for the home/newtab surface
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toolbar icon now toggles the side panel on all pages, including chrome:// URLs.
  * Keyboard shortcuts (⌘⏎ or Ctrl+Enter) added for retry confirmation dialog.

* **UI/UX Improvements**
  * Enhanced "agent working" indicator with pulsing visual feedback during streaming.
  * Removed redundant logo button from side panel header.
  * Clearer visual indicators for active assistant turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->