### PR TITLE
fix(extension): make Anthropic tool_use.input 400 structurally impossible

### DIFF
--- a/.changeset/fix-tool-input-normalization.md
+++ b/.changeset/fix-tool-input-normalization.md
@@ -1,0 +1,19 @@
+---
+"openbrowse": patch
+---
+
+Make the Anthropic `tool_use.input: Input should be a valid dictionary` error structurally impossible.
+
+The bug: Opus (and any provider) sometimes emits a non-object `input` for a tool call — most commonly `input: ""` for a no-arg MCP tool like Attio's `list-attribute-definitions`. The Anthropic API rejects it with HTTP 400; Gemini coerces it silently, which is why the same conversation 400'd on Opus but worked when retried on Gemini. Once the bad shape was persisted to chat-db, every subsequent send failed until the row was manually purged.
+
+This change closes the failure path at five layers — any one of which would have prevented the bug, and all five together make it impossible to recur from any direction:
+
+1. **`tool-input-normalize.ts`** — new module with a recovery ladder applied at every outbound and persisted boundary. Recovers a stringified-JSON object input (Opus quirk), falls back to `rawInput`, and rescues no-arg MCP tools by coercing `""` / `null` / `42` / `[]` to `{}` when the tool's schema accepts an empty object. Irrecoverable values (e.g. `""` for a tool with required fields) are dropped rather than producing a malformed `tool_use` on the wire.
+2. **`mcp/schema-to-zod.ts`** — tightened so every MCP tool's resolved Zod schema is a top-level `z.object({...})`. A non-object input now fails `validateUIMessages` structurally instead of slipping through the previous `z.any()` / `z.record(...)` fallthroughs. Property-level `passthrough()` keeps MCP-server schema drift forward-compatible. Adds support for `additionalProperties`, n-ary `oneOf` / `anyOf`, `allOf`, `format` (uuid / email / url / date-time), `const`, multi-type `type`, and tuple-form `items`.
+3. **Persistence sanitization** — `serializeParts` and `deserializeToolPart` route every tool part's `input` through the normalizer, so a non-object value never reaches chat-db (or, for legacy rows, never reaches the live UIMessage list).
+4. **chat-db v16 migration** — sweeps every persisted message's parts on first open and either recovers (stringified-JSON / rawInput → object) or excises any tool part with a malformed input. Fixes already-broken conversations without user action.
+5. **Last-mile assertion** — `assertModelMessageToolInputs` runs immediately before `agent.stream(...)` (both fast-path and rejection-loop). If a non-object `tool_use.input` somehow slips through layers 1–4, it's coerced to `{}` in place and a `console.error` logs the model-message index, content-block index, tool name, and offending value — converting "the agent mysteriously 400'd on Opus once last week" into a one-look DevTools entry.
+
+Bench harness (`packages/bench/src/agent/headless-chat.ts`) gets the same normalization on its `tool-call` chunk path so future regressions surface in `pnpm bench`.
+
+109 new tests, 6 in a dedicated end-to-end regression suite (`opus-input-bug-regression.test.ts`) that exercises the full pipeline with real-world Attio-style MCP tool schemas. All 1496 tests pass; type checking clean.

--- a/apps/extension/src/hooks/__tests__/persistence-input-sanitize.test.ts
+++ b/apps/extension/src/hooks/__tests__/persistence-input-sanitize.test.ts
@@ -192,6 +192,28 @@ describe("serializeParts — tool input sanitization", () => {
       url: "https://example.com",
     });
   });
+
+  it("preserves a tool-<name> part that has no input field (intentionally absent)", () => {
+    // Pre-fix the fallback branch had `"input" in p` in its guard, so a
+    // tool-<name> part without an input field was silently dropped at
+    // serialize time. The dynamic-tool branch above had no such gate,
+    // creating an asymmetry. Now both branches let absent-input parts
+    // through to the sanitizer, which preserves them as input:undefined
+    // (legitimate persisted shape for terminal states).
+    const parts: AgentMessageParts = [
+      {
+        type: "tool-navigate",
+        toolCallId: "c1",
+        state: "output-error",
+        errorText: "interrupted",
+        // no input key
+      } as never,
+    ];
+    const out = serializeParts(parts);
+    expect(out).toHaveLength(1);
+    expect((out[0] as SerializedToolPart).input).toBeUndefined();
+    expect((out[0] as SerializedToolPart).errorText).toBe("interrupted");
+  });
 });
 
 describe("deserializePart — tool input sanitization", () => {
@@ -276,5 +298,42 @@ describe("deserializePart — tool input sanitization", () => {
     const out = deserializePart(p);
     expect(out).not.toBeNull();
     expect((out as { input: unknown }).input).toBeUndefined();
+  });
+
+  it("recovers a legacy persisted part via rawInput when input is absent", () => {
+    // Pre-fix serialize never wrote rawInput, but legacy IDB rows from
+    // older code paths may carry it (IDB stores whole objects). The
+    // deserializer threads rawInput through the normalizer so a row
+    // like `{ input: undefined, rawInput: { url: "x" } }` recovers
+    // cleanly instead of being treated as input-less.
+    const p = {
+      type: "dynamic-tool",
+      toolName: "navigate",
+      toolCallId: "c1",
+      state: "output-error",
+      errorText: "interrupted",
+      rawInput: { url: "https://example.com" },
+    } as unknown as SerializedUIPart;
+    const out = deserializePart(p);
+    expect(out).not.toBeNull();
+    expect((out as { input: unknown }).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("recovers a legacy persisted part via stringified-JSON rawInput", () => {
+    const p = {
+      type: "dynamic-tool",
+      toolName: "navigate",
+      toolCallId: "c1",
+      state: "output-error",
+      errorText: "interrupted",
+      rawInput: '{"url":"https://example.com"}',
+    } as unknown as SerializedUIPart;
+    const out = deserializePart(p);
+    expect(out).not.toBeNull();
+    expect((out as { input: unknown }).input).toEqual({
+      url: "https://example.com",
+    });
   });
 });

--- a/apps/extension/src/hooks/__tests__/persistence-input-sanitize.test.ts
+++ b/apps/extension/src/hooks/__tests__/persistence-input-sanitize.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from "vitest";
+import { serializeParts, deserializePart } from "../useAgentChat";
+import type {
+  AgentDataParts,
+  SerializedToolPart,
+  SerializedUIPart,
+} from "@/lib/agent/message-types";
+import type { UIMessage } from "ai";
+
+type AgentMessageParts = UIMessage<unknown, AgentDataParts>["parts"];
+
+/**
+ * End-to-end coverage of the input-shape contract on the persistence
+ * boundary. The contract:
+ *   - serialize never writes a non-object `input` to chat-db. A
+ *     stringified-JSON object is parsed; an irrecoverable non-object
+ *     drops the entire tool part.
+ *   - deserialize never re-introduces a non-object `input` into the
+ *     live UIMessage list. A stringified-JSON object on disk is parsed;
+ *     an irrecoverable non-object drops the part (null return).
+ *
+ * The two pillars together close the chat-db re-poisoning path that made
+ * the Opus bug stick across reloads.
+ */
+
+describe("serializeParts — tool input sanitization", () => {
+  it("preserves a plain-object input verbatim", () => {
+    const parts: AgentMessageParts = [
+      {
+        type: "dynamic-tool",
+        toolName: "navigate",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { url: "https://example.com" },
+        output: { ok: true },
+      } as never,
+    ];
+    const out = serializeParts(parts);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      type: "dynamic-tool",
+      input: { url: "https://example.com" },
+    });
+  });
+
+  it("recovers a stringified-JSON-object input", () => {
+    const parts: AgentMessageParts = [
+      {
+        type: "dynamic-tool",
+        toolName: "navigate",
+        toolCallId: "c1",
+        state: "output-available",
+        input: '{"url":"https://example.com"}',
+        output: { ok: true },
+      } as never,
+    ];
+    const out = serializeParts(parts);
+    expect(out).toHaveLength(1);
+    expect((out[0] as SerializedToolPart).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("DROPS the part when input is '' (the Opus no-arg-tool quirk)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const parts: AgentMessageParts = [
+        {
+          type: "dynamic-tool",
+          toolName: "list-attribute-definitions",
+          toolCallId: "c1",
+          state: "output-error",
+          errorText: "boom",
+          input: "",
+        } as never,
+      ];
+      const out = serializeParts(parts);
+      expect(out).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("DROPS the part when input is null", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const parts: AgentMessageParts = [
+        {
+          type: "dynamic-tool",
+          toolName: "x",
+          toolCallId: "c1",
+          state: "output-error",
+          errorText: "boom",
+          input: null,
+        } as never,
+      ];
+      const out = serializeParts(parts);
+      expect(out).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("DROPS the part when input is an array", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const parts: AgentMessageParts = [
+        {
+          type: "dynamic-tool",
+          toolName: "x",
+          toolCallId: "c1",
+          state: "output-error",
+          errorText: "boom",
+          input: [1, 2, 3],
+        } as never,
+      ];
+      expect(serializeParts(parts)).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preserves a part whose input is intentionally absent (terminal state)", () => {
+    // input:undefined is a legitimate persisted shape — the SDK skips
+    // schema validation for output-error parts when input is undefined.
+    // The transport's runtime normalizer decides at send time whether to
+    // drop or coerce.
+    const parts: AgentMessageParts = [
+      {
+        type: "dynamic-tool",
+        toolName: "x",
+        toolCallId: "c1",
+        state: "output-error",
+        errorText: "boom",
+      } as never,
+    ];
+    const out = serializeParts(parts);
+    expect(out).toHaveLength(1);
+    expect((out[0] as SerializedToolPart).input).toBeUndefined();
+  });
+
+  it("recovers via rawInput when input is missing but rawInput is an object", () => {
+    const parts: AgentMessageParts = [
+      {
+        type: "dynamic-tool",
+        toolName: "navigate",
+        toolCallId: "c1",
+        state: "output-error",
+        errorText: "boom",
+        rawInput: { url: "https://example.com" },
+      } as never,
+    ];
+    const out = serializeParts(parts);
+    expect(out).toHaveLength(1);
+    expect((out[0] as SerializedToolPart).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("applies the same sanitization to tool-<name> fallback parts (built-in tools)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const parts: AgentMessageParts = [
+        {
+          type: "tool-navigate",
+          toolCallId: "c1",
+          state: "output-error",
+          errorText: "boom",
+          input: "", // malformed
+        } as never,
+      ];
+      expect(serializeParts(parts)).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preserves a tool-<name> part with a valid object input", () => {
+    const parts: AgentMessageParts = [
+      {
+        type: "tool-navigate",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { url: "https://example.com" },
+        output: { ok: true },
+      } as never,
+    ];
+    const out = serializeParts(parts);
+    expect(out).toHaveLength(1);
+    expect((out[0] as SerializedToolPart).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+});
+
+describe("deserializePart — tool input sanitization", () => {
+  it("preserves a plain-object input verbatim", () => {
+    const p: SerializedUIPart = {
+      type: "dynamic-tool",
+      toolName: "navigate",
+      toolCallId: "c1",
+      state: "output-available",
+      input: { url: "https://example.com" },
+      output: { ok: true },
+    };
+    const out = deserializePart(p);
+    expect(out).not.toBeNull();
+    expect((out as { input: unknown }).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("recovers a stringified-JSON-object input from a legacy chat-db row", () => {
+    const p: SerializedUIPart = {
+      type: "dynamic-tool",
+      toolName: "navigate",
+      toolCallId: "c1",
+      state: "output-available",
+      // Pre-fix chat-db row: input was persisted as a stringified blob.
+      input: '{"url":"https://example.com"}' as never,
+      output: { ok: true },
+    };
+    const out = deserializePart(p);
+    expect(out).not.toBeNull();
+    expect((out as { input: unknown }).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("DROPS a tool part whose input is `\"\"` (legacy Opus persistence)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const p: SerializedUIPart = {
+        type: "dynamic-tool",
+        toolName: "list-attribute-definitions",
+        toolCallId: "c1",
+        state: "output-error",
+        errorText: "boom",
+        input: "" as never,
+      };
+      const out = deserializePart(p);
+      expect(out).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("DROPS a tool part whose input is `null`", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const p: SerializedUIPart = {
+        type: "dynamic-tool",
+        toolName: "x",
+        toolCallId: "c1",
+        state: "output-error",
+        errorText: "boom",
+        input: null as never,
+      };
+      expect(deserializePart(p)).toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preserves a part with intentionally-absent input (terminal state)", () => {
+    const p: SerializedUIPart = {
+      type: "dynamic-tool",
+      toolName: "x",
+      toolCallId: "c1",
+      state: "output-error",
+      errorText: "boom",
+      // No `input` key — intentional absence.
+    };
+    const out = deserializePart(p);
+    expect(out).not.toBeNull();
+    expect((out as { input: unknown }).input).toBeUndefined();
+  });
+});

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -13,6 +13,7 @@ import {
 import { setTargetTabId } from "@/lib/agent/active-tab";
 import { healPendingTools } from "@/lib/agent/heal-pending-tools";
 import { bindSharedTab } from "@/lib/agent/bind-shared-tab";
+import { normalizeToolInputForPersistence } from "@/lib/agent/tool-input-normalize";
 import { setAgentActive, setAgentInactive } from "@/lib/active-agents";
 import { runOwnership, HEARTBEAT_MS, STALE_OWNER_MS } from "@/lib/agent/run-ownership";
 import {
@@ -277,25 +278,84 @@ export function deserializePart(
   }
 }
 
-function deserializeToolPart(p: SerializedToolPart): DynamicToolUIPart {
+function deserializeToolPart(p: SerializedToolPart): DynamicToolUIPart | null {
+  // Sanitize the persisted input on the way back into a live UIMessage.
+  // chat-db rows from before the input-normalization fix may carry a
+  // non-object `input` (Opus emitted `""` / `null` for no-arg MCP tool
+  // calls and the persistence layer wrote it verbatim). Re-introducing
+  // such a part to the live message list would carry the bad shape into
+  // every subsequent send. The normalizer recovers stringified-JSON and
+  // rawInput-style inputs; truly irrecoverable values are dropped here
+  // (return null) so the live UI never sees them. The transport's
+  // send-time normalizer is the eventual backstop, but dropping at
+  // deserialization keeps the runtime UIMessage list clean.
+  const inputResult = normalizeToolInputForPersistence({ value: p.input });
+  // Distinguish "input intentionally absent" (legitimate persisted shape
+  // for a terminal output-error/output-denied) from "input was a
+  // malformed non-object" (must be dropped). The persistence-side
+  // normalizer collapses both to `drop`, so we re-check here.
+  const inputWasIntentionallyAbsent = p.input === undefined;
+  let recoveredInput: unknown;
+  if (inputResult.kind === "object") {
+    recoveredInput = inputResult.value;
+  } else if (inputWasIntentionallyAbsent) {
+    recoveredInput = undefined;
+  } else {
+    // Present-but-malformed and non-recoverable. Drop the part so it
+    // never reaches the live message list.
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        `[useAgentChat] dropping persisted tool part with ` +
+          `non-object input on deserialize ` +
+          `(toolName=${p.toolName}, state=${p.state}, ` +
+          `inputType=${typeof p.input}); see tool-input-normalize.ts.`,
+      );
+    }
+    return null;
+  }
+
   const base = {
     type: "dynamic-tool" as const,
     toolName: p.toolName,
     toolCallId: p.toolCallId,
   };
   if (p.state === "output-available") {
-    return { ...base, state: "output-available", input: p.input, output: p.output };
+    return {
+      ...base,
+      state: "output-available",
+      input: recoveredInput,
+      output: p.output,
+    };
   }
   if (p.state === "output-error") {
-    return { ...base, state: "output-error", input: p.input, errorText: p.errorText ?? "" };
+    return {
+      ...base,
+      state: "output-error",
+      input: recoveredInput,
+      errorText: p.errorText ?? "",
+    };
   }
   if (p.state === "approval-requested" && p.approval) {
-    return { ...base, state: "approval-requested", input: p.input, approval: { id: p.approval.id } } as DynamicToolUIPart;
+    return {
+      ...base,
+      state: "approval-requested",
+      input: recoveredInput,
+      approval: { id: p.approval.id },
+    } as DynamicToolUIPart;
   }
   if (p.state === "approval-responded" && p.approval) {
-    return { ...base, state: "approval-responded", input: p.input, approval: p.approval as { id: string; approved: boolean; reason?: string } } as DynamicToolUIPart;
+    return {
+      ...base,
+      state: "approval-responded",
+      input: recoveredInput,
+      approval: p.approval as {
+        id: string;
+        approved: boolean;
+        reason?: string;
+      },
+    } as DynamicToolUIPart;
   }
-  return { ...base, state: "input-available", input: p.input };
+  return { ...base, state: "input-available", input: recoveredInput };
 }
 
 function dbMessageToUIMessage(m: {

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -289,12 +289,29 @@ function deserializeToolPart(p: SerializedToolPart): DynamicToolUIPart | null {
   // (return null) so the live UI never sees them. The transport's
   // send-time normalizer is the eventual backstop, but dropping at
   // deserialization keeps the runtime UIMessage list clean.
-  const inputResult = normalizeToolInputForPersistence({ value: p.input });
+  //
+  // Legacy rows may also carry a `rawInput` field even though
+  // `SerializedToolPart` doesn't declare it (IDB stores whole objects;
+  // older versions of `serializeParts` may have written rawInput
+  // through). Surface it to the normalizer so a part with
+  // `{ input: undefined, rawInput: { url: "x" } }` recovers cleanly
+  // instead of being treated as input-less and bypassing the rescue.
+  const persistedRaw = p as unknown as Record<string, unknown>;
+  const rawInput = persistedRaw.rawInput;
+  const inputResult = normalizeToolInputForPersistence({
+    value: p.input,
+    rawValue: rawInput,
+  });
   // Distinguish "input intentionally absent" (legitimate persisted shape
   // for a terminal output-error/output-denied) from "input was a
   // malformed non-object" (must be dropped). The persistence-side
   // normalizer collapses both to `drop`, so we re-check here.
-  const inputWasIntentionallyAbsent = p.input === undefined;
+  // A part with `rawInput` data is NOT intentionally absent — the writer
+  // had something to record but it didn't make it into `input`. Such a
+  // part falls through to the drop path only when rawInput also fails
+  // recovery (covered by the normalizer).
+  const inputWasIntentionallyAbsent =
+    p.input === undefined && rawInput === undefined;
   let recoveredInput: unknown;
   if (inputResult.kind === "object") {
     recoveredInput = inputResult.value;

--- a/apps/extension/src/lib/__tests__/chat-db-v15-migration.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-v15-migration.test.ts
@@ -75,8 +75,11 @@ async function seedV14Row(row: {
 
 /** Read the raw row past the typed chatDb wrapper to inspect post-migration shape. */
 async function readRowRaw(id: string): Promise<Record<string, unknown> | undefined> {
-  // chatDb.getDb is private; use the raw factory at v15.
-  const db = await openDB("openbrowse-chat", 15);
+  // chatDb.getDb is private; use the raw factory at the current schema
+  // version. Must be ≥ the current chat-db version (the v15 migration
+  // shipped at v15; subsequent bumps mean we re-open here at the latest
+  // version to read the post-migration shape).
+  const db = await openDB("openbrowse-chat", 16);
   const v = await db.get("conversations", id);
   db.close();
   return v as unknown as Record<string, unknown> | undefined;

--- a/apps/extension/src/lib/__tests__/chat-db-v16-migration.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-v16-migration.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for the chat-db v16 upgrade hop, which sweeps every persisted
+ * message's `parts` array and either recovers (stringified-JSON object,
+ * rawInput object) or drops any tool part with a non-object `input`.
+ *
+ * Targets the specific Anthropic-only failure mode that motivated this
+ * migration: the model (notably Opus) sometimes emits `input: ""` for a
+ * no-arg MCP tool call, the persistence layer wrote it verbatim, and
+ * every subsequent send 400'd with `tool_use.input: Input should be a
+ * valid dictionary`. Gemini coerced the same shape silently, which is
+ * why retrying on Gemini "just worked" — but the chat-db row stayed
+ * broken on Anthropic until manually purged.
+ *
+ * Uses fake-indexeddb to drive a real IndexedDB upgrade lifecycle.
+ */
+
+import "fake-indexeddb/auto";
+import { openDB } from "idb";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { chatDb } from "../chat-db";
+import { tabRegistry } from "../agent/tab-registry";
+import type { SerializedUIPart } from "../types";
+
+/**
+ * Seed a v15-shaped messages object store with a row whose `parts` carry
+ * malformed tool inputs. The v15 hop's conversation columns aren't
+ * relevant to v16, so we pass `ownedLtids: []` and skip handleState.
+ */
+async function seedV15MessageRow(row: {
+  id: string;
+  conversationId: string;
+  parts: unknown[];
+}): Promise<void> {
+  const db = await openDB("openbrowse-chat", 15, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains("conversations")) {
+        const s = db.createObjectStore("conversations", { keyPath: "id" });
+        s.createIndex("by-updated", "updatedAt");
+        s.createIndex("by-space", "spaceId");
+        s.createIndex("by-parent", "parentConversationId");
+      }
+      if (!db.objectStoreNames.contains("messages")) {
+        const m = db.createObjectStore("messages", { keyPath: "id" });
+        m.createIndex("by-conversation", "conversationId");
+      }
+      if (!db.objectStoreNames.contains("scheduledTasks")) {
+        const t = db.createObjectStore("scheduledTasks", { keyPath: "id" });
+        t.createIndex("by-next-run", "nextRunAt");
+      }
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const record: any = {
+    id: row.id,
+    conversationId: row.conversationId,
+    role: "assistant",
+    content: "",
+    parts: row.parts,
+    createdAt: 0,
+  };
+  await db.put("messages", record);
+  // Also seed the conversation so by-conversation queries work.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const conv: any = {
+    id: row.conversationId,
+    title: "t",
+    spaceId: null,
+    ownedGroupId: null,
+    ownedLtids: [],
+    parentConversationId: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+  await db.put("conversations", conv);
+  db.close();
+}
+
+/** Read raw message past the typed wrapper. */
+async function readMessageRaw(
+  id: string,
+): Promise<Record<string, unknown> | undefined> {
+  const db = await openDB("openbrowse-chat", 16);
+  const v = await db.get("messages", id);
+  db.close();
+  return v as unknown as Record<string, unknown> | undefined;
+}
+
+describe("chatDb v16 migration: tool-input shape sweep", () => {
+  beforeEach(() => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    // Stub chrome (the v15 hop reads chrome.tabs.get).
+    vi.stubGlobal("chrome", {
+      tabs: { get: vi.fn().mockRejectedValue(new Error("no tabs")) },
+    });
+  });
+
+  afterEach(() => {
+    chatDb._resetForTests();
+    tabRegistry.__resetForTests!();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("drops a tool part whose input is `\"\"` (the actual Opus bug shape)", async () => {
+    await seedV15MessageRow({
+      id: "m1",
+      conversationId: "c1",
+      parts: [
+        { type: "text", text: "let me check" },
+        {
+          type: "dynamic-tool",
+          toolName: "list-attribute-definitions",
+          toolCallId: "toolu_1",
+          state: "output-error",
+          errorText: "boom",
+          input: "", // ← malformed
+        },
+      ],
+    });
+
+    // Triggers the v15→v16 upgrade.
+    await chatDb.getMessages("c1");
+
+    const row = (await readMessageRaw("m1"))!;
+    const parts = row.parts as SerializedUIPart[];
+    // The text part survives; the malformed tool part is dropped.
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({ type: "text", text: "let me check" });
+  });
+
+  it("recovers a tool part whose input is a stringified JSON object", async () => {
+    await seedV15MessageRow({
+      id: "m2",
+      conversationId: "c2",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "navigate",
+          toolCallId: "toolu_2",
+          state: "output-available",
+          input: '{"url":"https://example.com"}',
+          output: { ok: true },
+        },
+      ],
+    });
+    await chatDb.getMessages("c2");
+    const row = (await readMessageRaw("m2"))!;
+    const parts = row.parts as SerializedUIPart[];
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({
+      type: "dynamic-tool",
+      input: { url: "https://example.com" },
+    });
+  });
+
+  it("recovers a tool part using rawInput when input is a non-object", async () => {
+    await seedV15MessageRow({
+      id: "m3",
+      conversationId: "c3",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "navigate",
+          toolCallId: "toolu_3",
+          state: "output-error",
+          errorText: "boom",
+          input: "",
+          rawInput: { url: "https://example.com" },
+        } as unknown as SerializedUIPart,
+      ],
+    });
+    await chatDb.getMessages("c3");
+    const row = (await readMessageRaw("m3"))!;
+    const parts = row.parts as SerializedUIPart[];
+    expect(parts).toHaveLength(1);
+    expect((parts[0] as { input: unknown }).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("preserves a tool part with a valid object input verbatim", async () => {
+    await seedV15MessageRow({
+      id: "m4",
+      conversationId: "c4",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "navigate",
+          toolCallId: "toolu_4",
+          state: "output-available",
+          input: { url: "https://example.com" },
+          output: { ok: true },
+        },
+      ],
+    });
+    await chatDb.getMessages("c4");
+    const row = (await readMessageRaw("m4"))!;
+    const parts = row.parts as SerializedUIPart[];
+    expect(parts).toHaveLength(1);
+    expect((parts[0] as { input: unknown }).input).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("preserves a tool part with intentionally absent input (terminal state)", async () => {
+    await seedV15MessageRow({
+      id: "m5",
+      conversationId: "c5",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "x",
+          toolCallId: "toolu_5",
+          state: "output-error",
+          errorText: "interrupted",
+          // no `input` key at all — legitimate persisted shape
+        } as unknown as SerializedUIPart,
+      ],
+    });
+    await chatDb.getMessages("c5");
+    const row = (await readMessageRaw("m5"))!;
+    const parts = row.parts as SerializedUIPart[];
+    expect(parts).toHaveLength(1);
+    expect("input" in (parts[0] as object)).toBe(false);
+  });
+
+  it("drops only the malformed tool part, leaving siblings intact", async () => {
+    await seedV15MessageRow({
+      id: "m6",
+      conversationId: "c6",
+      parts: [
+        { type: "text", text: "step 1" },
+        {
+          type: "dynamic-tool",
+          toolName: "good",
+          toolCallId: "toolu_good",
+          state: "output-available",
+          input: { ok: 1 },
+          output: { ok: true },
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "bad",
+          toolCallId: "toolu_bad",
+          state: "output-error",
+          errorText: "boom",
+          input: null,
+        },
+        { type: "text", text: "step 2" },
+      ],
+    });
+    await chatDb.getMessages("c6");
+    const row = (await readMessageRaw("m6"))!;
+    const parts = row.parts as SerializedUIPart[];
+    // text + good tool + text. The bad tool part is excised.
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toMatchObject({ type: "text", text: "step 1" });
+    expect((parts[1] as { toolCallId?: string }).toolCallId).toBe("toolu_good");
+    expect(parts[2]).toMatchObject({ type: "text", text: "step 2" });
+  });
+
+  it("is idempotent — re-running on already-clean rows is a no-op", async () => {
+    await seedV15MessageRow({
+      id: "m7",
+      conversationId: "c7",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "navigate",
+          toolCallId: "toolu_7",
+          state: "output-available",
+          input: { url: "https://example.com" },
+          output: { ok: true },
+        },
+      ],
+    });
+    await chatDb.getMessages("c7");
+    const before = await readMessageRaw("m7");
+    // Reset the in-memory cache; reopen to re-execute the upgrade chain.
+    // (Re-opening at v16 should be a no-op since flags.needsV16Fixup
+    // is only set when oldVersion < 16.)
+    chatDb._resetForTests();
+    await chatDb.getMessages("c7");
+    const after = await readMessageRaw("m7");
+    expect(after).toEqual(before);
+  });
+
+  it("logs a summary when at least one part was rewritten or dropped", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await seedV15MessageRow({
+        id: "m8",
+        conversationId: "c8",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "x",
+            toolCallId: "toolu_8",
+            state: "output-error",
+            errorText: "boom",
+            input: "",
+          } as unknown as SerializedUIPart,
+        ],
+      });
+      await chatDb.getMessages("c8");
+      // Find an info call mentioning the v16 sweep.
+      const calls = infoSpy.mock.calls.flat();
+      const hasSummary = calls.some(
+        (c) =>
+          typeof c === "string" &&
+          c.includes("v16") &&
+          c.includes("dropped"),
+      );
+      expect(hasSummary).toBe(true);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/apps/extension/src/lib/__tests__/chat-db-v16-migration.test.ts
+++ b/apps/extension/src/lib/__tests__/chat-db-v16-migration.test.ts
@@ -188,6 +188,64 @@ describe("chatDb v16 migration: tool-input shape sweep", () => {
     });
   });
 
+  it("recovers a tool part using rawInput when input is INTENTIONALLY ABSENT", async () => {
+    // Pre-fix the migration short-circuited `input === undefined` and
+    // skipped recovery entirely, so a legacy row with
+    // `{ input: undefined, rawInput: { url: "x" } }` stayed unmigrated
+    // and the runtime normalizer rescued it on every send. The
+    // migration now attempts recovery via rawInput in this case too.
+    await seedV15MessageRow({
+      id: "m3b",
+      conversationId: "c3b",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "navigate",
+          toolCallId: "toolu_3b",
+          state: "output-error",
+          errorText: "interrupted",
+          rawInput: { url: "https://recovered.example.com" },
+          // input deliberately missing
+        } as unknown as SerializedUIPart,
+      ],
+    });
+    await chatDb.getMessages("c3b");
+    const row = (await readMessageRaw("m3b"))!;
+    const parts = row.parts as SerializedUIPart[];
+    expect(parts).toHaveLength(1);
+    expect((parts[0] as { input: unknown }).input).toEqual({
+      url: "https://recovered.example.com",
+    });
+  });
+
+  it("preserves an input-undefined part when rawInput is also unrecoverable", async () => {
+    // The migration only drops irrecoverable parts that had a
+    // present-but-malformed input. An input-undefined part is the
+    // legitimate "Interrupted" persisted shape — even if rawInput
+    // failed recovery, we keep the part so the UI badge still renders.
+    // The runtime normalizer drops it at send time if it's truly
+    // unsendable.
+    await seedV15MessageRow({
+      id: "m3c",
+      conversationId: "c3c",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "x",
+          toolCallId: "toolu_3c",
+          state: "output-error",
+          errorText: "interrupted",
+          rawInput: '{"url":"https://incomplete', // ← unparseable
+        } as unknown as SerializedUIPart,
+      ],
+    });
+    await chatDb.getMessages("c3c");
+    const row = (await readMessageRaw("m3c"))!;
+    const parts = row.parts as SerializedUIPart[];
+    expect(parts).toHaveLength(1);
+    expect("input" in (parts[0] as object)).toBe(false);
+  });
+
   it("preserves a tool part with a valid object input verbatim", async () => {
     await seedV15MessageRow({
       id: "m4",

--- a/apps/extension/src/lib/agent/__tests__/assert-model-message-tool-inputs.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/assert-model-message-tool-inputs.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest";
+import { assertModelMessageToolInputs } from "../compacting-transport";
+
+/**
+ * Tests for the last-mile assertion that runs after `convertToModelMessages`
+ * and before `agent.stream(...)`. The assertion's contract:
+ *   - Plain-object `input` on a tool-call: untouched.
+ *   - Non-object `input`: in-place coercion to `{}` + console.error log.
+ *   - Non-tool-call content: untouched.
+ *
+ * This is the "if the upstream layers all failed, we still don't 400 the
+ * provider" backstop. It SHOULD never fire in production after Fix 1+2+3,
+ * but if it does we get a self-diagnosing log line and the user's turn
+ * still completes (matching Gemini's adapter behavior).
+ */
+
+type ModelMessage = {
+  role: "user" | "assistant" | "system" | "tool";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any;
+};
+
+describe("assertModelMessageToolInputs", () => {
+  it("leaves a tool-call with an object input untouched", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "navigate",
+              toolCallId: "c1",
+              input: { url: "https://example.com" },
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({
+        url: "https://example.com",
+      });
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("coerces an empty-string input to {} and logs an error", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "list-attribute-definitions",
+              toolCallId: "c1",
+              input: "", // ← the Opus bug
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({});
+      expect(errSpy).toHaveBeenCalled();
+      // The error log should mention the tool name and the typeof.
+      const args = errSpy.mock.calls[0]
+        .map((a) => (typeof a === "string" ? a : ""))
+        .join(" ");
+      expect(args).toContain("list-attribute-definitions");
+      expect(args).toContain("typeof=string");
+      expect(args).toContain("Coercing to {}");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("coerces a null input to {}", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "x",
+              toolCallId: "c1",
+              input: null,
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({});
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("coerces an array input to {}", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "x",
+              toolCallId: "c1",
+              input: [1, 2, 3],
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({});
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("leaves non-tool-call content alone", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "hi" },
+            { type: "reasoning", text: "thinking" },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "c1",
+              toolName: "navigate",
+              output: { ok: true },
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(errSpy).not.toHaveBeenCalled();
+      expect(messages[0].content[0]).toMatchObject({ type: "text" });
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("processes multiple offending blocks across multiple messages", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "a",
+              toolCallId: "c1",
+              input: "",
+            },
+            {
+              type: "tool-call",
+              toolName: "b",
+              toolCallId: "c2",
+              input: { ok: 1 },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "c",
+              toolCallId: "c3",
+              input: 42,
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({});
+      expect(messages[0].content[1].input).toEqual({ ok: 1 });
+      expect(messages[1].content[0].input).toEqual({});
+      // 2 offending blocks → 2 error logs.
+      expect(errSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("handles a string-content message without crashing", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        { role: "user", content: "hello" }, // string content, not array
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("truncates large input values in the log to keep DevTools usable", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const huge = "x".repeat(2000);
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "x",
+              toolCallId: "c1",
+              input: huge, // ← non-object, will be coerced
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(errSpy).toHaveBeenCalled();
+      const logged = errSpy.mock.calls[0]
+        .map((a) => (typeof a === "string" ? a : ""))
+        .join(" ");
+      // The log shouldn't contain 2000 chars of x.
+      expect(logged.length).toBeLessThan(2000);
+      // Should contain the truncation indicator.
+      expect(logged).toContain("…");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/assert-model-message-tool-inputs.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/assert-model-message-tool-inputs.test.ts
@@ -126,6 +126,62 @@ describe("assertModelMessageToolInputs", () => {
     }
   });
 
+  it("coerces a Date instance to {} (non-plain object — would JSON-serialize to non-conforming shape)", () => {
+    // Anthropic requires tool_use.input to be a plain JSON object.
+    // A Date / Map / Set / class instance JSON-serializes to either
+    // an empty `{}` or a non-conforming string — silently losing data
+    // or tripping a downstream provider error. The strict plain-object
+    // check rejects these.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "x",
+              toolCallId: "c1",
+              input: new Date(), // ← non-plain object
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({});
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("coerces a class instance to {}", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      class Custom {
+        x = 1;
+      }
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "x",
+              toolCallId: "c1",
+              input: new Custom(),
+            },
+          ],
+        },
+      ];
+      assertModelMessageToolInputs(messages as never, "test");
+      expect(messages[0].content[0].input).toEqual({});
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
   it("leaves non-tool-call content alone", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {

--- a/apps/extension/src/lib/agent/__tests__/opus-input-bug-regression.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/opus-input-bug-regression.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateUIMessages,
+  convertToModelMessages,
+  tool,
+} from "ai";
+import {
+  rewriteForLLM,
+  assertModelMessageToolInputs,
+} from "../compacting-transport";
+import { jsonSchemaToZod } from "@/lib/mcp/schema-to-zod";
+import type { AgentUIMessage } from "@/lib/types";
+
+/**
+ * End-to-end regression for THE Opus bug:
+ *
+ *   Anthropic 400: messages.<i>.content.<j>.tool_use.input:
+ *   Input should be a valid dictionary
+ *
+ * The exact failure mode: Opus calls a no-arg MCP tool (e.g. Attio's
+ * `list-attribute-definitions`) and emits `input: ""` instead of
+ * `input: {}`. The pre-fix loose schema accepted it, the persistence
+ * layer wrote it, every subsequent send 400'd Anthropic. Gemini coerced
+ * the same shape silently, so retrying on Gemini "just worked" — which
+ * is the smoking-gun symptom this regression test guards against.
+ *
+ * The full pipeline this test exercises:
+ *   1. MCP tool surface comes from `jsonSchemaToZod` over a real-world
+ *      Attio-style schema.
+ *   2. A persisted UIMessage carrying `input: ""` (the actual bug shape)
+ *      is run through `rewriteForLLM`.
+ *   3. The result is `validateUIMessages`-checked against the tools.
+ *   4. Converted via `convertToModelMessages`.
+ *   5. The final `ModelMessage[]` is asserted to contain ONLY object
+ *      `tool_use.input` values via `assertModelMessageToolInputs` — the
+ *      shape Anthropic accepts.
+ *
+ * If any layer regresses, this test fails the way the production bug
+ * presented (validation throw or non-object input on the wire).
+ */
+
+const ATTIO_LIST_ATTR_DEFS_SCHEMA = {
+  type: "object",
+  properties: {
+    object: { type: "string", description: "Object whose attributes to list" },
+    query: { type: "string" },
+    offset: { type: "number" },
+    limit: { type: "number" },
+  },
+};
+
+const ATTIO_LIST_RECORDS_SCHEMA = {
+  type: "object",
+  properties: {
+    list: { type: "string" },
+    filter: { type: "object" },
+    limit: { type: "number" },
+  },
+  required: ["list"],
+};
+
+function buildMcpTools() {
+  // Mirrors what mcp/registry.ts does at runtime: jsonSchemaToZod over
+  // each MCP tool's inputSchema, then wrap with `tool()`. The SDK's tool
+  // map expects Tool<unknown, unknown>; tool() narrows the output type
+  // from `execute`'s return, so we widen via `as any` for these helper
+  // calls (matches the pattern in heal-validate-integration.test.ts).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return {
+    "mcp_attio_list-attribute-definitions": tool({
+      description: "Attio: list attribute definitions",
+      inputSchema: jsonSchemaToZod(ATTIO_LIST_ATTR_DEFS_SCHEMA),
+      execute: async () => "ok",
+    }),
+    "mcp_attio_list-records-in-list": tool({
+      description: "Attio: list records in a list",
+      inputSchema: jsonSchemaToZod(ATTIO_LIST_RECORDS_SCHEMA),
+      execute: async () => "ok",
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function userMsg(text: string): AgentUIMessage {
+  return {
+    id: `u-${Math.random()}`,
+    role: "user",
+    parts: [{ type: "text", text }],
+  } as AgentUIMessage;
+}
+
+describe("Opus bug regression — full pipeline", () => {
+  it("a no-arg MCP tool call with input:'' is RESCUED to {} and lands cleanly on the wire", async () => {
+    // The exact production sequence that broke on Opus: the user asks the
+    // agent to do something Attio-related, the model emits a tool_use with
+    // input:"" for the no-required-args tool, and the next send 400s.
+    const tools = buildMcpTools();
+    const conversation: AgentUIMessage[] = [
+      userMsg("list attio attribute definitions for People"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Looking up the list..." },
+          {
+            // Opus emits this shape for a no-arg call. Pre-fix:
+            // jsonSchemaToZod returned an over-loose schema that accepted
+            // "" and the persistence layer wrote it verbatim.
+            type: "tool-mcp_attio_list-attribute-definitions",
+            toolCallId: "toolu_no_arg",
+            state: "output-error",
+            errorText: "interrupted",
+            input: "",
+          },
+        ],
+      } as unknown as AgentUIMessage,
+      userMsg("retry"),
+    ];
+
+    // Step 1: rewriteForLLM with tools threaded in (rule-5 rescue path).
+    const rewritten = rewriteForLLM(conversation, tools);
+
+    // Step 2: validate against tools. With the tightened schema this
+    // now structurally enforces object inputs — but the rescue happened
+    // upstream so input is already {}.
+    const validated = await validateUIMessages({
+      messages: rewritten as never,
+      tools,
+    });
+
+    // Step 3: convert to ModelMessage[].
+    const modelMessages = await convertToModelMessages(validated, { tools });
+
+    // Step 4: last-mile assertion. Should be a no-op (everything is already
+    // an object), but proves the contract.
+    assertModelMessageToolInputs(modelMessages, "regression-test");
+
+    // Final check: every tool-call on the wire has an OBJECT input.
+    let toolCallsSeen = 0;
+    for (const m of modelMessages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const c of m.content as Array<{ type: string; input?: unknown }>) {
+        if (c.type === "tool-call") {
+          toolCallsSeen++;
+          expect(typeof c.input).toBe("object");
+          expect(c.input).not.toBeNull();
+          expect(Array.isArray(c.input)).toBe(false);
+        }
+      }
+    }
+    expect(toolCallsSeen).toBeGreaterThan(0);
+  });
+
+  it("a required-args MCP tool call with input:'' is DROPPED (no rescue available)", async () => {
+    // For tools with required fields, "" cannot be coerced to {} (would
+    // fail required-fields validation). The transport drops the part
+    // instead of producing a malformed tool_use.
+    const tools = buildMcpTools();
+    const conversation: AgentUIMessage[] = [
+      userMsg("list records in the People list"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Looking up the list..." },
+          {
+            type: "tool-mcp_attio_list-records-in-list",
+            toolCallId: "toolu_required",
+            state: "output-error",
+            errorText: "interrupted",
+            input: "",
+          },
+        ],
+      } as unknown as AgentUIMessage,
+      userMsg("retry"),
+    ];
+
+    const rewritten = rewriteForLLM(conversation, tools);
+    const validated = await validateUIMessages({
+      messages: rewritten as never,
+      tools,
+    });
+    const modelMessages = await convertToModelMessages(validated, { tools });
+    assertModelMessageToolInputs(modelMessages, "regression-test");
+
+    // The dropped tool call shouldn't appear on the wire.
+    const toolCalls: Array<{ toolCallId?: string }> = [];
+    for (const m of modelMessages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const c of m.content as Array<{
+        type: string;
+        toolCallId?: string;
+      }>) {
+        if (c.type === "tool-call") toolCalls.push(c);
+      }
+    }
+    expect(
+      toolCalls.some((tc) => tc.toolCallId === "toolu_required"),
+    ).toBe(false);
+  });
+
+  it("a mix of valid and bad tool calls produces a fully-clean wire payload", async () => {
+    const tools = buildMcpTools();
+    const conversation: AgentUIMessage[] = [
+      userMsg("do a few things"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "step 1" },
+          {
+            type: "tool-mcp_attio_list-attribute-definitions",
+            toolCallId: "toolu_good",
+            state: "output-available",
+            input: { object: "people" },
+            output: { ok: true },
+          },
+          {
+            type: "tool-mcp_attio_list-attribute-definitions",
+            toolCallId: "toolu_opus_bug",
+            state: "output-error",
+            errorText: "interrupted",
+            input: "", // ← Opus emission, rescuable to {}
+          },
+          {
+            type: "tool-mcp_attio_list-records-in-list",
+            toolCallId: "toolu_required_bad",
+            state: "output-error",
+            errorText: "interrupted",
+            input: null, // ← non-rescuable, dropped
+          },
+        ],
+      } as unknown as AgentUIMessage,
+      userMsg("continue"),
+    ];
+
+    const rewritten = rewriteForLLM(conversation, tools);
+    const validated = await validateUIMessages({
+      messages: rewritten as never,
+      tools,
+    });
+    const modelMessages = await convertToModelMessages(validated, { tools });
+    assertModelMessageToolInputs(modelMessages, "regression-test");
+
+    // Every tool-call on the wire is an object.
+    const wireToolCalls: Array<{ toolCallId: string; input: unknown }> = [];
+    for (const m of modelMessages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const c of m.content as Array<{
+        type: string;
+        toolCallId?: string;
+        input?: unknown;
+      }>) {
+        if (c.type === "tool-call" && typeof c.toolCallId === "string") {
+          wireToolCalls.push({ toolCallId: c.toolCallId, input: c.input });
+        }
+      }
+    }
+
+    // toolu_good: object input preserved.
+    const good = wireToolCalls.find((tc) => tc.toolCallId === "toolu_good");
+    expect(good?.input).toEqual({ object: "people" });
+
+    // toolu_opus_bug: rescued to {} via rule 5.
+    const opus = wireToolCalls.find((tc) => tc.toolCallId === "toolu_opus_bug");
+    expect(opus?.input).toEqual({});
+
+    // toolu_required_bad: dropped — must not appear on the wire.
+    const bad = wireToolCalls.find(
+      (tc) => tc.toolCallId === "toolu_required_bad",
+    );
+    expect(bad).toBeUndefined();
+
+    // Sanity: every tool-call's input is an object.
+    for (const tc of wireToolCalls) {
+      expect(typeof tc.input).toBe("object");
+      expect(tc.input).not.toBeNull();
+      expect(Array.isArray(tc.input)).toBe(false);
+    }
+  });
+
+  it("does not regress: a tool whose input has unexpected fields (server schema drift) passes through", async () => {
+    // The tightened schema uses passthrough() at the property level so
+    // an MCP server adding a new optional field between releases doesn't
+    // cause client-side validation to strip the model's input. This
+    // matters because a stripped field on the wire would silently
+    // change tool semantics.
+    const tools = {
+      "mcp_some_tool": tool({
+        description: "tool",
+        inputSchema: jsonSchemaToZod({
+          type: "object",
+          properties: { known: { type: "string" } },
+          required: ["known"],
+        }),
+        execute: async () => "ok",
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const conversation: AgentUIMessage[] = [
+      userMsg("call it"),
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-mcp_some_tool",
+            toolCallId: "toolu_drift",
+            state: "output-available",
+            input: { known: "x", new_optional: "kept" },
+            output: { ok: true },
+          },
+        ],
+      } as unknown as AgentUIMessage,
+    ];
+
+    const rewritten = rewriteForLLM(conversation, tools);
+    const validated = await validateUIMessages({
+      messages: rewritten as never,
+      tools,
+    });
+    const modelMessages = await convertToModelMessages(validated, { tools });
+
+    let inputOnWire: unknown;
+    for (const m of modelMessages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const c of m.content as Array<{ type: string; input?: unknown }>) {
+        if (c.type === "tool-call") inputOnWire = c.input;
+      }
+    }
+    expect(inputOnWire).toMatchObject({ known: "x", new_optional: "kept" });
+  });
+
+  it("uses a non-strict object schema by default (validateUIMessages doesn't strip extras)", () => {
+    // Direct schema check (independent of the full pipeline): the schema
+    // converter's default is passthrough, not strict.
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { known: { type: "string" } },
+    });
+    const result = schema.safeParse({ known: "x", extra: "kept" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.known).toBe("x");
+      expect(data.extra).toBe("kept");
+    }
+  });
+
+  it("explicit additionalProperties:false IS enforced when the server opts in", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { known: { type: "string" } },
+      additionalProperties: false,
+    });
+    expect(schema.safeParse({ known: "x" }).success).toBe(true);
+    expect(schema.safeParse({ known: "x", extra: "rejected" }).success).toBe(
+      false,
+    );
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tool-input-normalize.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-input-normalize.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { tool } from "ai";
+import {
+  isPlainObject,
+  normalizeToolInput,
+  normalizeToolInputForPersistence,
+  schemaAcceptsEmptyObject,
+} from "../tool-input-normalize";
+
+describe("isPlainObject", () => {
+  it.each([
+    ["{}", {}, true],
+    ["object", { a: 1 }, true],
+    ["null", null, false],
+    ["undefined", undefined, false],
+    ["array", [1, 2, 3], false],
+    ["empty array", [], false],
+    ["string", "hello", false],
+    ["empty string", "", false],
+    ["number", 42, false],
+    ["zero", 0, false],
+    ["boolean true", true, false],
+    ["boolean false", false, false],
+  ])("%s -> %s", (_label, value, expected) => {
+    expect(isPlainObject(value)).toBe(expected);
+  });
+});
+
+describe("schemaAcceptsEmptyObject", () => {
+  it("accepts a Zod object schema with all-optional properties", () => {
+    const schema = z.object({ q: z.string().optional() });
+    expect(schemaAcceptsEmptyObject(schema)).toBe(true);
+  });
+
+  it("accepts an empty Zod object schema", () => {
+    expect(schemaAcceptsEmptyObject(z.object({}))).toBe(true);
+  });
+
+  it("rejects a Zod object schema with a required property", () => {
+    const schema = z.object({ list: z.string() });
+    expect(schemaAcceptsEmptyObject(schema)).toBe(false);
+  });
+
+  it("rejects a non-schema value", () => {
+    expect(schemaAcceptsEmptyObject(undefined)).toBe(false);
+    expect(schemaAcceptsEmptyObject(null)).toBe(false);
+    expect(schemaAcceptsEmptyObject({})).toBe(false);
+    expect(schemaAcceptsEmptyObject("nope")).toBe(false);
+  });
+
+  it("returns false rather than throwing on a buggy schema", () => {
+    const buggy = {
+      safeParse: () => {
+        throw new Error("boom");
+      },
+    };
+    expect(schemaAcceptsEmptyObject(buggy)).toBe(false);
+  });
+});
+
+// Rule 5 (`{}` rescue) needs a real Tool whose inputSchema accepts {}.
+// `tool({...})` is the AI SDK's helper; it returns a structurally-correct
+// Tool with the Zod schema attached to `inputSchema`.
+const noArgTool = tool({
+  description: "no args",
+  inputSchema: z.object({ q: z.string().optional() }),
+  execute: async () => "ok",
+});
+const requiredArgTool = tool({
+  description: "needs list",
+  inputSchema: z.object({ list: z.string() }),
+  execute: async () => "ok",
+});
+
+describe("normalizeToolInput — rule 1 (plain object passes through)", () => {
+  it("keeps an object value verbatim", () => {
+    const value = { a: 1, b: "x" };
+    const out = normalizeToolInput({
+      value,
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-anything",
+      toolName: undefined,
+    });
+    expect(out).toEqual({ kind: "object", value });
+  });
+
+  it("keeps an empty object", () => {
+    const out = normalizeToolInput({
+      value: {},
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-anything",
+      toolName: undefined,
+    });
+    expect(out).toEqual({ kind: "object", value: {} });
+  });
+});
+
+describe("normalizeToolInput — rule 2 (string-encoded JSON object)", () => {
+  it("parses a stringified JSON object", () => {
+    const out = normalizeToolInput({
+      value: '{"url":"https://example.com"}',
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-navigate",
+      toolName: undefined,
+    });
+    expect(out).toEqual({
+      kind: "object",
+      value: { url: "https://example.com" },
+    });
+  });
+
+  it("does NOT use a stringified non-object (string -> array, falls through)", () => {
+    const out = normalizeToolInput({
+      value: "[1,2,3]",
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-x",
+      toolName: undefined,
+    });
+    expect(out.kind).toBe("drop");
+  });
+
+  it("does NOT use a stringified scalar", () => {
+    const out = normalizeToolInput({
+      value: '"hello"',
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-x",
+      toolName: undefined,
+    });
+    expect(out.kind).toBe("drop");
+  });
+});
+
+describe("normalizeToolInput — rule 3/4 (rawValue rescue)", () => {
+  it("uses rawValue if it's a plain object and value is empty string", () => {
+    const out = normalizeToolInput({
+      value: "",
+      rawValue: { url: "https://example.com" },
+      tools: undefined,
+      partType: "tool-navigate",
+      toolName: undefined,
+    });
+    expect(out).toEqual({
+      kind: "object",
+      value: { url: "https://example.com" },
+    });
+  });
+
+  it("parses rawValue from a stringified JSON object (partial-stream stash)", () => {
+    const out = normalizeToolInput({
+      value: undefined,
+      rawValue: '{"url":"https://example.com"}',
+      tools: undefined,
+      partType: "tool-navigate",
+      toolName: undefined,
+    });
+    expect(out).toEqual({
+      kind: "object",
+      value: { url: "https://example.com" },
+    });
+  });
+
+  it("ignores a malformed rawValue string (incomplete JSON)", () => {
+    const out = normalizeToolInput({
+      value: undefined,
+      rawValue: '{"url":"https://incomp',
+      tools: undefined,
+      partType: "tool-navigate",
+      toolName: undefined,
+    });
+    // Without rule 5 rescue, drops.
+    expect(out.kind).toBe("drop");
+  });
+});
+
+describe("normalizeToolInput — rule 5 ({} rescue for empty-args tools)", () => {
+  it("coerces `\"\"` to `{}` when the tool has all-optional schema (THE OPUS BUG)", () => {
+    const out = normalizeToolInput({
+      value: "",
+      rawValue: undefined,
+      tools: { "list-attribute-definitions": noArgTool },
+      partType: "dynamic-tool",
+      toolName: "list-attribute-definitions",
+    });
+    expect(out).toEqual({ kind: "object", value: {} });
+  });
+
+  it("coerces `null` to `{}` for empty-args tools", () => {
+    const out = normalizeToolInput({
+      value: null,
+      rawValue: undefined,
+      tools: { foo: noArgTool },
+      partType: "dynamic-tool",
+      toolName: "foo",
+    });
+    expect(out).toEqual({ kind: "object", value: {} });
+  });
+
+  it("coerces `42` to `{}` for empty-args tools", () => {
+    const out = normalizeToolInput({
+      value: 42,
+      rawValue: undefined,
+      tools: { foo: noArgTool },
+      partType: "dynamic-tool",
+      toolName: "foo",
+    });
+    expect(out).toEqual({ kind: "object", value: {} });
+  });
+
+  it("coerces `[]` to `{}` for empty-args tools (arrays are not objects)", () => {
+    const out = normalizeToolInput({
+      value: [],
+      rawValue: undefined,
+      tools: { foo: noArgTool },
+      partType: "dynamic-tool",
+      toolName: "foo",
+    });
+    expect(out).toEqual({ kind: "object", value: {} });
+  });
+
+  it("DROPS instead of coercing when the tool requires a property", () => {
+    const out = normalizeToolInput({
+      value: "",
+      rawValue: undefined,
+      tools: { "list-records-in-list": requiredArgTool },
+      partType: "dynamic-tool",
+      toolName: "list-records-in-list",
+    });
+    expect(out.kind).toBe("drop");
+  });
+
+  it("works with the tool-<name> part-type convention (built-in tools)", () => {
+    const out = normalizeToolInput({
+      value: "",
+      rawValue: undefined,
+      tools: { foo: noArgTool },
+      partType: "tool-foo",
+      toolName: undefined,
+    });
+    expect(out).toEqual({ kind: "object", value: {} });
+  });
+
+  it("does NOT coerce when tools is undefined (persistence layer)", () => {
+    const out = normalizeToolInput({
+      value: "",
+      rawValue: undefined,
+      tools: undefined,
+      partType: "dynamic-tool",
+      toolName: "foo",
+    });
+    expect(out.kind).toBe("drop");
+  });
+});
+
+describe("normalizeToolInput — drop reasons report value type", () => {
+  it("reports 'string' for a non-JSON string", () => {
+    const out = normalizeToolInput({
+      value: "hello",
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-x",
+      toolName: undefined,
+    });
+    expect(out.kind).toBe("drop");
+    if (out.kind === "drop") expect(out.reason).toMatch(/string/);
+  });
+
+  it("reports 'array' for an array", () => {
+    const out = normalizeToolInput({
+      value: [1, 2, 3],
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-x",
+      toolName: undefined,
+    });
+    expect(out.kind).toBe("drop");
+    if (out.kind === "drop") expect(out.reason).toMatch(/array/);
+  });
+
+  it("reports 'undefined' for missing", () => {
+    const out = normalizeToolInput({
+      value: undefined,
+      rawValue: undefined,
+      tools: undefined,
+      partType: "tool-x",
+      toolName: undefined,
+    });
+    expect(out.kind).toBe("drop");
+    if (out.kind === "drop") expect(out.reason).toMatch(/undefined/);
+  });
+});
+
+describe("normalizeToolInputForPersistence", () => {
+  it("keeps a plain object", () => {
+    const out = normalizeToolInputForPersistence({ value: { a: 1 } });
+    expect(out).toEqual({ kind: "object", value: { a: 1 } });
+  });
+
+  it("recovers a stringified JSON object", () => {
+    const out = normalizeToolInputForPersistence({ value: '{"a":1}' });
+    expect(out).toEqual({ kind: "object", value: { a: 1 } });
+  });
+
+  it("does NOT coerce empty strings to {} (no schema available)", () => {
+    const out = normalizeToolInputForPersistence({ value: "" });
+    expect(out.kind).toBe("drop");
+  });
+
+  it("uses rawValue when present", () => {
+    const out = normalizeToolInputForPersistence({
+      value: "",
+      rawValue: { a: 1 },
+    });
+    expect(out).toEqual({ kind: "object", value: { a: 1 } });
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/tool-input-normalize.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-input-normalize.test.ts
@@ -25,6 +25,37 @@ describe("isPlainObject", () => {
   ])("%s -> %s", (_label, value, expected) => {
     expect(isPlainObject(value)).toBe(expected);
   });
+
+  // Strict plain-object check: only literal {} and Object.create(null)
+  // pass. Class instances, Date, Map, Set, RegExp etc. fail — they
+  // would JSON-serialize to a non-conforming shape (or empty {}) and
+  // bypass the Anthropic `tool_use.input` validation downstream.
+  it("rejects Date instances", () => {
+    expect(isPlainObject(new Date())).toBe(false);
+  });
+
+  it("rejects Map instances", () => {
+    expect(isPlainObject(new Map())).toBe(false);
+  });
+
+  it("rejects Set instances", () => {
+    expect(isPlainObject(new Set())).toBe(false);
+  });
+
+  it("rejects RegExp instances", () => {
+    expect(isPlainObject(/foo/)).toBe(false);
+  });
+
+  it("rejects class instances", () => {
+    class Foo {
+      x = 1;
+    }
+    expect(isPlainObject(new Foo())).toBe(false);
+  });
+
+  it("accepts Object.create(null) (no prototype)", () => {
+    expect(isPlainObject(Object.create(null))).toBe(true);
+  });
 });
 
 describe("schemaAcceptsEmptyObject", () => {

--- a/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts
@@ -192,10 +192,36 @@ describe("rewriteForLLM tool-state heal", () => {
     expect(part.input).toEqual({ url: "https://example.com" });
   });
 
-  it("falls back to rawInput when input is absent (does not drop)", () => {
+  it("falls back to rawInput when input is absent and rawInput parses to an object", () => {
+    // The SDK stashes complete-but-not-yet-promoted args as a stringified
+    // JSON blob in rawInput. The normalizer parses it and uses the result
+    // as the part's input.
     const part = {
       type: "tool-navigate",
       toolCallId: "raw-input-only",
+      state: "input-streaming",
+      rawInput: '{"url":"https://example.com"}',
+    } as unknown as AgentUIMessage["parts"][number];
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart(part),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const healed = out[1].parts[0] as { state: string; input: unknown };
+    expect(healed.state).toBe("output-error");
+    expect(healed.input).toEqual({ url: "https://example.com" });
+  });
+
+  it("DROPS a part whose rawInput is a malformed (truncated) JSON string", () => {
+    // Pre-fix behavior accepted any non-null rawInput including a truncated
+    // string like '{"url":"https://partial'. convertToModelMessages would
+    // forward it verbatim on the wire, which the provider then rejects with
+    // `tool_use.input: Input should be a valid dictionary`. The normalizer
+    // now requires rawInput to actually parse to an object before keeping it.
+    const part = {
+      type: "tool-navigate",
+      toolCallId: "raw-input-malformed",
       state: "input-streaming",
       rawInput: '{"url":"https://partial',
     } as unknown as AgentUIMessage["parts"][number];
@@ -204,9 +230,9 @@ describe("rewriteForLLM tool-state heal", () => {
       assistantWithPart(part),
     ];
     const out = rewriteForLLM(msgs);
-    expect(out).toHaveLength(2);
-    const healed = out[1].parts[0] as { state: string };
-    expect(healed.state).toBe("output-error");
+    // The lone tool part is dropped → assistant message becomes empty → removed.
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
   });
 
   it("heals output-streaming parts to output-error", () => {
@@ -317,7 +343,14 @@ describe("rewriteForLLM tool-state heal", () => {
     });
   });
 
-  it("leaves missing input undefined on an approved approval-responded part (no {} synthesis)", () => {
+  it("DROPS an approved approval-responded part with no input (no {} synthesis, no provider 400)", () => {
+    // Pre-fix this preserved the part as approval-responded/input:undefined,
+    // and convertToModelMessages then forwarded a tool_use with no input to
+    // Anthropic on the auto-resume turn → 400. The normalizer drops the
+    // part instead. Synthesizing {} would make validateUIMessages run the
+    // tool's (possibly strict) schema against an empty object and fail.
+    // (In practice this state never occurs: a user can't approve a call
+    // they have no args for. The test exercises the defensive drop path.)
     const part = {
       type: "dynamic-tool",
       toolCallId: "install-no-input",
@@ -328,15 +361,17 @@ describe("rewriteForLLM tool-state heal", () => {
     } as unknown as AgentUIMessage["parts"][number];
     const msgs: AgentUIMessage[] = [
       userMsg("install"),
-      assistantWithPart(part),
+      // Keep a text part so the message itself survives.
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "approving" }, part],
+      } as AgentUIMessage,
     ];
     const out = rewriteForLLM(msgs);
-    const healed = out[1].parts[0] as { state: string; input: unknown };
-    expect(healed.state).toBe("approval-responded");
-    // Synthesizing {} here would make validateUIMessages run the tool's
-    // (possibly strict) schema against an empty object and fail. Absent
-    // input must stay absent.
-    expect(healed.input).toBeUndefined();
+    expect(out).toHaveLength(2);
+    expect(out[1].parts).toHaveLength(1);
+    expect(out[1].parts[0]).toMatchObject({ type: "text", text: "approving" });
   });
 
   it("heals an approval-responded part with malformed approval to output-error", () => {
@@ -468,23 +503,48 @@ describe("rewriteForLLM tool-state heal", () => {
     expect(part.errorText).toBe("boom");
   });
 
-  it("KEEPS a terminal output-error part with no input but a rawInput", () => {
-    // convertToModelMessages fills the emitted input from rawInput, producing
-    // a defined value the provider accepts — so we must not drop these.
+  it("KEEPS a terminal output-error part with no input but a rawInput that parses to an object", () => {
+    // The SDK fills the emitted input from rawInput when input is absent.
+    // The normalizer accepts rawInput only when it actually parses to an
+    // object, so the resulting tool_use is structurally valid for the
+    // provider.
     const msgs: AgentUIMessage[] = [
       userMsg("hi"),
       assistantWithPart({
         type: "tool-navigate",
-        toolCallId: "err-raw-input",
+        toolCallId: "err-raw-input-ok",
+        state: "output-error",
+        errorText: "boom",
+        rawInput: '{"url":"https://example.com"}',
+      } as unknown as AgentUIMessage["parts"][number]),
+    ];
+    const out = rewriteForLLM(msgs);
+    expect(out).toHaveLength(2);
+    const part = out[1].parts[0] as { state: string; input: unknown };
+    expect(part.state).toBe("output-error");
+    expect(part.input).toEqual({ url: "https://example.com" });
+  });
+
+  it("DROPS a terminal output-error part whose rawInput is a malformed (truncated) JSON string", () => {
+    // Pre-fix accepted any non-null rawInput, including a truncated string
+    // like '{"url":"https://partial'. convertToModelMessages forwards the
+    // value verbatim → the provider sees a non-object input and 400s
+    // (Anthropic: `tool_use.input: Input should be a valid dictionary`).
+    // The normalizer requires rawInput to actually parse before keeping it;
+    // an unparseable rawInput is irrecoverable, so drop the part.
+    const msgs: AgentUIMessage[] = [
+      userMsg("hi"),
+      assistantWithPart({
+        type: "tool-navigate",
+        toolCallId: "err-raw-input-malformed",
         state: "output-error",
         errorText: "boom",
         rawInput: '{"url":"https://partial',
       } as unknown as AgentUIMessage["parts"][number]),
     ];
     const out = rewriteForLLM(msgs);
-    expect(out).toHaveLength(2);
-    const part = out[1].parts[0] as { state: string };
-    expect(part.state).toBe("output-error");
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
   });
 
   it("DROPS a terminal output-denied part with no usable input", () => {

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -18,6 +18,7 @@ import {
   prunePartsAtSendTime,
   stripScreenshotsFromParts,
 } from "./compaction";
+import { normalizeToolInput } from "./tool-input-normalize";
 import {
   runCompletionCheck,
   shouldGate,
@@ -197,7 +198,7 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
     const buildCompletionCheckInput = this.buildCompletionCheckInput;
     const onCompletionCheckApproved = this.onCompletionCheckApproved;
     const pinnedConversationId = this.getActiveConversationId?.() ?? null;
-    let rewritten = rewriteForLLM(messages);
+    let rewritten = rewriteForLLM(messages, this.agent.tools);
     if (this.keepOnlyLatestImage) {
       rewritten = keepOnlyLatestScreenshot(rewritten, this.screenshotToolNames);
     }
@@ -232,6 +233,7 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
         this.agent.tools,
         "transport.fast-path",
       );
+      assertModelMessageToolInputs(modelMessages, "transport.fast-path");
       try {
         const result = await this.agent.stream({
           prompt: modelMessages,
@@ -377,8 +379,19 @@ function extractCausedByPath(err: unknown): number | null {
  * Operates on `AgentUIMessage` directly — its `DATA_PARTS = AgentDataParts`
  * gives us a real `data-compaction` variant in the parts union, so all the
  * helpers below narrow on `p.type === "data-compaction"` without casts.
+ *
+ * The optional `tools` argument is threaded into `repairToolPart` so the
+ * input-normalizer can rescue no-arg tool calls (Opus emits `input: ""`)
+ * by coercing them to `{}` when the tool's schema accepts an empty object.
+ * Tests that call `rewriteForLLM` without a ToolSet still work — the
+ * normalizer just falls through to its drop path for non-object inputs,
+ * which is the pre-fix behavior for tests that didn't depend on the
+ * rescue.
  */
-export function rewriteForLLM(messages: AgentUIMessage[]): AgentUIMessage[] {
+export function rewriteForLLM(
+  messages: AgentUIMessage[],
+  tools?: ToolSet,
+): AgentUIMessage[] {
   // Step 1: repair legacy broken compaction events. An earlier version of
   // `runCompaction` had a "prune-only fast path" that wrote a compaction
   // event with an empty summary assistant. Sending that message fails the
@@ -460,7 +473,7 @@ export function rewriteForLLM(messages: AgentUIMessage[]): AgentUIMessage[] {
   // part must be removed too — an empty assistant message would otherwise
   // reach `convertToModelMessages`.
   return filtered
-    .map(healNonTerminalToolParts)
+    .map((m) => healNonTerminalToolParts(m, tools))
     .filter((m) => m.parts.length > 0);
 }
 
@@ -493,27 +506,26 @@ const DROP_TOOL_PART = Symbol("drop-tool-part");
  *
  * The healer enforces these invariants:
  *
- *  1. A tool part must carry a usable `input`. A real `input` is preserved;
- *     a MISSING input is left `undefined` (never `{}` — that re-triggers the
- *     tool's strict, e.g. MCP, schema validation in validateUIMessages and
- *     fails its required fields). Critically, ANY tool call with no usable
- *     input at all (no real `input` and no partial `rawInput`) is DROPPED —
- *     returned as `DROP_TOOL_PART`. This covers an interrupted call aborted
- *     mid-`input-streaming` AND an already-terminal `output-error` /
- *     `output-denied` part whose input was never captured (e.g. a tool whose
- *     arguments failed to parse, or a part healed from a non-terminal state on
- *     a prior pass). Such a part would otherwise reach
- *     `convertToModelMessages`, which emits a `tool-call` block whose `input`
- *     is missing. validateUIMessages skips that (input is undefined), but the
- *     PROVIDER rejects it: Anthropic/Bedrock with
- *     `tool_use.input: Field required` (HTTP 400) and Gemini/Vertex with a
- *     silent `Malformed function call ... Function call is empty` error
- *     finish (Gemini also coerces some of these, which is why the terminal
- *     `output-error` case reproduced only on Anthropic). A `tool_use` with no
- *     input carries no information for the model, and each UI tool part
- *     expands to a self-contained `tool-call` + paired `tool-result`, so
- *     dropping the whole part removes both sides cleanly (no orphaned
- *     `tool_result`).
+ *  1. A tool part must carry a usable `input` THAT IS A JSON OBJECT.
+ *     `normalizeToolInput` runs the recovery ladder:
+ *       - plain object → keep
+ *       - stringified-JSON object (Opus quirk) → parse and use
+ *       - rawInput (object or stringified) → use it
+ *       - tool's schema accepts `{}` → coerce no-arg call to `{}`
+ *       - else → DROP. Substituting `{}` here would re-trigger the
+ *         tool's strict required-fields schema in validateUIMessages
+ *         and crash the whole turn instead of just dropping one call.
+ *     A non-object input (e.g. `""`, `null`, an array, a non-JSON
+ *     string) reaches the provider as-is otherwise:
+ *       - Anthropic/Bedrock 400 with
+ *         `tool_use.input: Input should be a valid dictionary` /
+ *         `tool_use.input: Field required`.
+ *       - Gemini/Vertex coerces silently (which is why Gemini retries
+ *         "just work" on a conversation that 400s on Opus).
+ *     A `tool_use` with no recoverable input carries no information for
+ *     the model, and each UI tool part expands to a self-contained
+ *     `tool-call` + paired `tool-result`, so dropping the whole part
+ *     removes both sides cleanly (no orphaned `tool_result`).
  *
  *  2. State is terminal. Any non-terminal state collapses to
  *     `output-error` with `errorText: TRANSPORT_HEAL_TEXT` and the
@@ -529,6 +541,7 @@ const DROP_TOOL_PART = Symbol("drop-tool-part");
  */
 function repairToolPart(
   part: AgentUIMessage["parts"][number],
+  tools?: ToolSet,
 ): AgentUIMessage["parts"][number] | typeof DROP_TOOL_PART {
   const p = part as { type?: unknown; state?: unknown };
   const isTool =
@@ -538,22 +551,26 @@ function repairToolPart(
 
   const raw = part as Record<string, unknown>;
   const state = typeof raw.state === "string" ? raw.state : undefined;
+  const partType = typeof raw.type === "string" ? raw.type : "";
+  const toolName =
+    typeof raw.toolName === "string" ? raw.toolName : undefined;
 
-  // Preserve a real `input`; otherwise set it to `undefined` (key present,
-  // value undefined) — never `{}`. The structural UIMessage schema requires
-  // the `input` key to be present on tool parts, but validateUIMessages
-  // schema-checks an output-error part's input only when it is !== undefined.
-  // Substituting `{}` makes it validate against the tool's (possibly strict,
-  // e.g. MCP) schema and fail required fields; `undefined` is skipped, and
-  // convertToModelMessages tolerates undefined input on errored/denied calls.
-  const hasInput = raw.input !== undefined && raw.input !== null;
-  // Fall back to a captured `rawInput` (some SDK paths stash the partial /
-  // raw argument string here) before giving up on input entirely.
-  const rawInput = raw.rawInput;
-  const hasRawInput = rawInput !== undefined && rawInput !== null;
-  const input: unknown = hasInput ? raw.input : undefined;
-  // The structural schema rejects a tool part missing the `input` key, so a
-  // terminal part that lacks it must still be rewritten to add it.
+  // Normalize `input` against the strict provider contract: must be a JSON
+  // object. The normalizer applies the recovery ladder (parse stringified
+  // JSON, fall back to rawInput, rescue no-arg tools by coercing to `{}`)
+  // and signals `drop` for irrecoverable non-object inputs. See
+  // `normalizeToolInput` for the full ladder.
+  const normalized = normalizeToolInput({
+    value: raw.input,
+    rawValue: raw.rawInput,
+    tools,
+    partType,
+    toolName,
+  });
+  // The structural schema rejects a tool part missing the `input` key,
+  // so a part that's keeping its existing input still needs the key
+  // re-added if it was absent. `inputKeyMissing` covers that case for
+  // the few branches where we'd otherwise return the part verbatim.
   const inputKeyMissing = !("input" in raw);
 
   // `approval-responded` is NOT a terminal state, but it is a
@@ -569,7 +586,8 @@ function repairToolPart(
   // generic non-terminal branch below would), the tool NEVER runs and
   // the user sees "Interrupted" the instant they approve. So:
   //   - approved (approved === true), no output yet → pass through so
-  //     the SDK runs `execute`.
+  //     the SDK runs `execute`. Drop if the input couldn't be normalized
+  //     (the call would 400 the provider on the auto-resume turn).
   //   - explicitly denied (approved === false) → fold to output-denied,
   //     the canonical terminal shape for a denial.
   //   - malformed approval (no id / approved not boolean) → fall through
@@ -580,20 +598,24 @@ function repairToolPart(
       | undefined;
     if (approval && typeof approval.id === "string") {
       if (approval.approved === true) {
-        // Awaiting execution — preserve verbatim. This path serves the
-        // legitimate auto-resume: when the approved call is still the last
-        // message, the SDK re-executes it. (The client-side healPendingTools
-        // terminalizes approved calls instead, because by the time IT runs a
-        // user message has been appended and resume is impossible.)
-        if (raw.input !== input) {
-          return { ...raw, input } as typeof part;
+        // Awaiting execution — preserve verbatim. Without a normalized
+        // input the SDK would emit a `tool_use` the provider rejects on
+        // auto-resume, so drop irrecoverable parts here too.
+        if (normalized.kind === "drop") {
+          return DROP_TOOL_PART;
+        }
+        if (raw.input !== normalized.value) {
+          return { ...raw, input: normalized.value } as typeof part;
         }
         return part;
       }
       if (approval.approved === false) {
+        if (normalized.kind === "drop") {
+          return DROP_TOOL_PART;
+        }
         return {
           ...raw,
-          input,
+          input: normalized.value,
           state: "output-denied",
           approval: {
             id: approval.id,
@@ -612,20 +634,15 @@ function repairToolPart(
   // Non-terminal state → collapse to output-error. Drop any partial
   // output so the part is unambiguous.
   if (!state || !TERMINAL_TOOL_STATES.has(state)) {
-    // An interrupted call that never received ANY input (aborted mid
-    // `input-streaming`, no `rawInput` either) cannot be emitted as a valid
-    // `tool_use`: convertToModelMessages would produce a `tool-call` with no
-    // `input` field, which the provider rejects (Anthropic/Bedrock
-    // `tool_use.input: Field required`; Gemini silent malformed-call error).
-    // Such a part carries no information — drop it entirely. The paired
-    // `tool-result` is emitted from the same UI part, so dropping the whole
-    // part leaves no orphan.
-    if (!hasInput && !hasRawInput) {
+    // An interrupted call whose input cannot be normalized to an object
+    // (no real `input`, no `rawInput`, schema doesn't accept `{}`)
+    // cannot be emitted as a valid `tool_use`. Drop it entirely.
+    if (normalized.kind === "drop") {
       return DROP_TOOL_PART;
     }
     return {
       ...raw,
-      input,
+      input: normalized.value,
       state: "output-error",
       errorText: TRANSPORT_HEAL_TEXT,
       output: undefined,
@@ -638,49 +655,52 @@ function repairToolPart(
   // converter.
   if (state === "output-available") {
     if (raw.output === undefined || raw.output === null) {
-      // Downgrading to output-error; same input-less guard as the
-      // non-terminal branch — a resulting `tool-call` with no input is
-      // rejected by the provider, so drop it instead.
-      if (!hasInput && !hasRawInput) {
+      // Downgrading to output-error; same drop guard as above.
+      if (normalized.kind === "drop") {
         return DROP_TOOL_PART;
       }
       return {
         ...raw,
-        input,
+        input: normalized.value,
         state: "output-error",
         errorText: TRANSPORT_HEAL_TEXT,
         output: undefined,
       } as typeof part;
     }
-    if (raw.input === undefined || raw.input === null) {
-      return { ...raw, input } as typeof part;
+    if (normalized.kind === "drop") {
+      // A successful tool call (it has output!) whose input we cannot
+      // normalize. This shouldn't happen in practice because the SDK
+      // wouldn't have called execute() with a bad input, but if a stale
+      // chat-db row has it, drop rather than send a malformed tool_use.
+      return DROP_TOOL_PART;
+    }
+    if (raw.input !== normalized.value || inputKeyMissing) {
+      return { ...raw, input: normalized.value } as typeof part;
     }
     return part;
   }
 
   if (state === "output-error") {
-    // A terminal errored call with NO usable input (neither a real `input`
-    // nor a partial `rawInput`) cannot be emitted as a valid `tool_use`:
-    // convertToModelMessages forwards `input: undefined`, which Anthropic
-    // rejects (`tool_use.input: Field required`). Gemini tolerates it, which
-    // is why the bug only reproduced on Anthropic/Opus. Such a part carries
-    // no information — drop it (its paired tool-result comes from the same
-    // part, so nothing is orphaned). When `rawInput` is present the SDK fills
-    // the emitted input from it (a defined value the provider accepts), so we
-    // keep those. This complements the non-terminal/`output-available` drop
-    // above; an `output-error` reached here either streamed in that way or was
-    // healed from a non-terminal state on a prior pass.
-    if (!hasInput && !hasRawInput) {
+    // A terminal errored call whose input cannot be normalized cannot be
+    // emitted as a valid `tool_use`. Drop it. (Pre-fix this was the
+    // exact Opus reproduction: a failed MCP call whose input was never
+    // captured persisted as output-error with no input → 400 from
+    // Anthropic on every subsequent send.)
+    if (normalized.kind === "drop") {
       return DROP_TOOL_PART;
     }
     const errorText =
       typeof raw.errorText === "string" && raw.errorText.length > 0
         ? raw.errorText
         : TRANSPORT_HEAL_TEXT;
-    if (raw.input !== input || inputKeyMissing || raw.errorText !== errorText) {
+    if (
+      raw.input !== normalized.value ||
+      inputKeyMissing ||
+      raw.errorText !== errorText
+    ) {
       return {
         ...raw,
-        input,
+        input: normalized.value,
         state: "output-error",
         errorText,
       } as typeof part;
@@ -692,9 +712,8 @@ function repairToolPart(
     const approval = raw.approval as
       | { id?: unknown; approved?: unknown; reason?: unknown }
       | undefined;
-    // Same input-less guard as output-error: a denied call with no usable
-    // input also emits a provider-rejected `tool_use`. Drop it.
-    if (!hasInput && !hasRawInput) {
+    // Same drop guard as output-error.
+    if (normalized.kind === "drop") {
       return DROP_TOOL_PART;
     }
     // Strict denial shape: state=output-denied REQUIRES `approved: false`.
@@ -707,14 +726,14 @@ function repairToolPart(
     if (!hasValidApproval) {
       return {
         ...raw,
-        input,
+        input: normalized.value,
         state: "output-error",
         errorText: TRANSPORT_HEAL_TEXT,
         output: undefined,
       } as typeof part;
     }
-    if (raw.input !== input || inputKeyMissing) {
-      return { ...raw, input } as typeof part;
+    if (raw.input !== normalized.value || inputKeyMissing) {
+      return { ...raw, input: normalized.value } as typeof part;
     }
     return part;
   }
@@ -723,11 +742,14 @@ function repairToolPart(
   return part;
 }
 
-function healNonTerminalToolParts(message: AgentUIMessage): AgentUIMessage {
+function healNonTerminalToolParts(
+  message: AgentUIMessage,
+  tools?: ToolSet,
+): AgentUIMessage {
   let changed = false;
   const newParts: AgentUIMessage["parts"] = [];
   for (const part of message.parts) {
-    const repaired = repairToolPart(part);
+    const repaired = repairToolPart(part, tools);
     if (repaired === DROP_TOOL_PART) {
       // Input-less interrupted tool call — omit it entirely (see
       // repairToolPart). Its paired tool-result comes from the same part,
@@ -932,6 +954,10 @@ export function runWithRejectionLoop(args: {
           const modelMessages = await convertModelMessagesWithDiag(
             messages,
             agent.tools,
+            `rejection-loop.iter-${i}`,
+          );
+          assertModelMessageToolInputs(
+            modelMessages,
             `rejection-loop.iter-${i}`,
           );
           let result;
@@ -1153,6 +1179,77 @@ export function runWithRejectionLoop(args: {
     },
   });
 }
+
+/**
+ * Last-mile defense before `agent.stream(...)`: walks the converted
+ * `ModelMessage[]` and asserts every `tool-call` block carries a
+ * plain-object `input`. A non-object input would 400 the Anthropic API
+ * (`tool_use.input: Input should be a valid dictionary`) — the exact
+ * failure mode this whole module is built to prevent. By the time we
+ * reach this function, repairToolPart, the persistence sanitizer, and
+ * the v16 chat-db migration should all have caught any malformed
+ * shape; this is the assertion that proves they did.
+ *
+ * On detection:
+ *   1. Coerces the bad input to `{}` IN PLACE (mutates the
+ *      ModelMessage array). Coercion matches the Gemini adapter's
+ *      lenient behavior — the user's request still completes — and
+ *      avoids a hard failure on what should be unreachable.
+ *   2. Logs a `console.error` with the message index, content-block
+ *      index, tool name, the offending value's typeof, and a truncated
+ *      JSON string. This is the diagnostic that turns "the agent
+ *      mysteriously 400'd on Opus once last week" into a one-look
+ *      DevTools entry.
+ *
+ * Why coerce instead of throw: throwing here aborts the user's turn even
+ * though the upstream layers should have caught the error. Coercing to
+ * `{}` matches what Gemini does silently and what the user expects when
+ * an empty-args tool is called. The log makes it easy to find and fix
+ * the root cause if this ever fires.
+ */
+export function assertModelMessageToolInputs(
+  modelMessages: Awaited<ReturnType<typeof convertToModelMessages>>,
+  label: string,
+): void {
+  for (let i = 0; i < modelMessages.length; i++) {
+    const m = modelMessages[i];
+    if (!Array.isArray(m.content)) continue;
+    for (let j = 0; j < m.content.length; j++) {
+      const c = m.content[j] as { type?: string; input?: unknown; toolName?: string; toolCallId?: string };
+      if (c.type !== "tool-call") continue;
+      const input = c.input;
+      const isObject =
+        typeof input === "object" && input !== null && !Array.isArray(input);
+      if (isObject) continue;
+
+      // Truncate the JSON-stringified value for the log so a giant blob
+      // doesn't blow up the DevTools console. Catch in case the value
+      // is a circular structure.
+      let valueRepr: string;
+      try {
+        const s = JSON.stringify(input);
+        valueRepr = s == null ? String(input) : s.length > 120 ? s.slice(0, 120) + "…" : s;
+      } catch {
+        valueRepr = "<unstringifiable>";
+      }
+      console.error(
+        `[transport] ${label}: tool-call at modelMessages[${i}].content[${j}] ` +
+          `(toolName=${c.toolName ?? "?"}, toolCallId=${c.toolCallId ?? "?"}) ` +
+          `has non-object input (typeof=${typeof input}, value=${valueRepr}). ` +
+          `Coercing to {}. ` +
+          `This is unreachable if compacting-transport's repairToolPart, ` +
+          `serialize-parts' sanitizer, and the chat-db v16 migration all ` +
+          `ran — please file a bug if you see this in production.`,
+      );
+
+      // Coerce in place. The ModelMessage array is locally owned at
+      // this call site (we just produced it via convertToModelMessages),
+      // so mutating it has no observable side-effect outside this turn.
+      (m.content[j] as { input: unknown }).input = {};
+    }
+  }
+}
+
 
 /**
  * Mutates the observer state for one streaming chunk. Extracted from the

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -18,7 +18,7 @@ import {
   prunePartsAtSendTime,
   stripScreenshotsFromParts,
 } from "./compaction";
-import { normalizeToolInput } from "./tool-input-normalize";
+import { isPlainObject, normalizeToolInput } from "./tool-input-normalize";
 import {
   runCompletionCheck,
   shouldGate,
@@ -1218,9 +1218,13 @@ export function assertModelMessageToolInputs(
       const c = m.content[j] as { type?: string; input?: unknown; toolName?: string; toolCallId?: string };
       if (c.type !== "tool-call") continue;
       const input = c.input;
-      const isObject =
-        typeof input === "object" && input !== null && !Array.isArray(input);
-      if (isObject) continue;
+      // Anthropic requires tool_use.input to be a PLAIN JSON object —
+      // not a Date, Map, Set, RegExp, or class instance. Use the strict
+      // plain-object predicate so a non-serializable object can't slip
+      // through the assertion (it would JSON.stringify to either an
+      // empty `{}` or a non-conforming shape and either silently lose
+      // information or trip a downstream validation error).
+      if (isPlainObject(input)) continue;
 
       // Truncate the JSON-stringified value for the log so a giant blob
       // doesn't blow up the DevTools console. Catch in case the value

--- a/apps/extension/src/lib/agent/serialize-parts.ts
+++ b/apps/extension/src/lib/agent/serialize-parts.ts
@@ -162,13 +162,20 @@ export function serializeParts(parts: AgentMessageParts): SerializedUIPart[] {
           typeof part.type === "string" &&
           part.type.startsWith("tool-") &&
           "toolCallId" in p &&
-          "state" in p &&
-          "input" in p
+          "state" in p
         ) {
           // Same input-sanitization contract as the dynamic-tool branch
           // above. The fallback path is hit by the SDK's `tool-<name>`
           // shape (built-in browser tools) — a non-object input here is
           // just as fatal at send time as in the dynamic-tool case.
+          //
+          // Note: we do NOT gate on `"input" in p`. A tool-<name> part
+          // can legitimately reach this branch with no input field set
+          // (e.g. an aborted call mid input-streaming). The sanitizer
+          // returns `keep-undefined` for that case, matching the
+          // dynamic-tool branch above; gating on `"input" in p` here
+          // would silently drop those parts and lose the "Interrupted"
+          // UI badge.
           const rawInput = "rawInput" in p ? p.rawInput : undefined;
           const sanitized = sanitizeToolInputForPersistence(p.input, rawInput);
           if (sanitized.kind === "drop") {

--- a/apps/extension/src/lib/agent/serialize-parts.ts
+++ b/apps/extension/src/lib/agent/serialize-parts.ts
@@ -10,12 +10,61 @@
  * If you add a new `SerializedUIPart` variant, update both `serializeParts`
  * (forward conversion from SDK parts) and `hasMeaningfulContent`
  * (predicate that decides whether a streamed turn is worth saving).
+ *
+ * Tool-input shape contract: every persisted tool part's `input` MUST be
+ * a JSON object (or `undefined`). A non-object `input` (e.g. `""` from
+ * Opus's no-arg-tool quirk) is rejected by Anthropic with
+ * `tool_use.input: Input should be a valid dictionary` and silently
+ * coerced by Gemini — so persisting it would re-poison every subsequent
+ * Anthropic send. The `normalizeToolInputForPersistence` runs the same
+ * recovery ladder as the transport's send-time normalizer (parse
+ * stringified JSON, fall back to rawInput) before persisting; if the
+ * value is still irrecoverable, the entire tool part is dropped from
+ * the saved parts array. The transport's send-time pass would have
+ * dropped it too, but doing it here keeps chat-db clean.
  */
 
 import type { UIMessage } from "ai";
 import type { AgentDataParts, SerializedUIPart } from "./message-types";
+import { normalizeToolInputForPersistence } from "./tool-input-normalize";
 
 type AgentMessageParts = UIMessage<unknown, AgentDataParts>["parts"];
+
+/**
+ * Persistence-time tool-input sanitizer. Returns:
+ *   - `keep-undefined` when the input was never assigned (truly absent —
+ *     the SDK and runtime normalizer both tolerate this on terminal
+ *     states, and the user sees an "Interrupted" badge in the UI),
+ *   - `object` with a recovered plain-object value (input was already
+ *     an object, or rawInput / a stringified-JSON input parsed to one),
+ *   - `drop` when the input was present-and-malformed and no recovery
+ *     was possible. The whole tool part must be dropped from
+ *     persistence — saving it would re-poison every subsequent send.
+ */
+function sanitizeToolInputForPersistence(
+  input: unknown,
+  rawInput: unknown,
+):
+  | { kind: "object"; value: Record<string, unknown> }
+  | { kind: "keep-undefined" }
+  | { kind: "drop" } {
+  // Truly absent: persist with input:undefined; the runtime normalizer at
+  // send time will decide whether to drop the part (no rescue available)
+  // or coerce to {} (tool accepts empty object). Keeping the persisted
+  // copy lets the UI render the part as "Interrupted" until the user's
+  // next send.
+  if (input === undefined && rawInput === undefined) {
+    return { kind: "keep-undefined" };
+  }
+  const result = normalizeToolInputForPersistence({
+    value: input,
+    rawValue: rawInput,
+  });
+  if (result.kind === "object") {
+    return { kind: "object", value: result.value };
+  }
+  return { kind: "drop" };
+}
 
 /**
  * Convert AI SDK `UIMessage.parts` into the `SerializedUIPart[]` shape
@@ -67,19 +116,46 @@ export function serializeParts(parts: AgentMessageParts): SerializedUIPart[] {
         // CompletionCheckRunningBlock) handles in-memory mid-stream
         // aborts; we never need this part on disk.
         return [];
-      case "dynamic-tool":
+      case "dynamic-tool": {
+        // Sanitize input before persistence: a non-object value (Opus
+        // emits `""` for no-arg tool calls) would re-poison every
+        // subsequent send if persisted verbatim. The recovery ladder
+        // matches the transport's runtime normalizer.
+        const rawInput =
+          "rawInput" in part
+            ? (part as { rawInput?: unknown }).rawInput
+            : undefined;
+        const sanitized = sanitizeToolInputForPersistence(
+          part.input,
+          rawInput,
+        );
+        if (sanitized.kind === "drop") {
+          // Present-but-malformed input that we cannot recover. Drop
+          // the entire tool part rather than persist a value the
+          // provider would reject on the next send.
+          if (typeof console !== "undefined" && console.warn) {
+            console.warn(
+              `[serialize-parts] dropping dynamic-tool part with ` +
+                `unrecoverable non-object input ` +
+                `(toolName=${part.toolName}, state=${part.state}); ` +
+                `see tool-input-normalize.ts.`,
+            );
+          }
+          return [];
+        }
         return [
           {
             type: "dynamic-tool",
             toolName: part.toolName,
             toolCallId: part.toolCallId,
             state: part.state,
-            input: part.input,
+            input: sanitized.kind === "object" ? sanitized.value : undefined,
             output: "output" in part ? part.output : undefined,
             errorText: "errorText" in part ? part.errorText : undefined,
             approval: "approval" in part ? part.approval : undefined,
           },
         ];
+      }
       default: {
         const p = part as Record<string, unknown>;
         if (
@@ -89,13 +165,31 @@ export function serializeParts(parts: AgentMessageParts): SerializedUIPart[] {
           "state" in p &&
           "input" in p
         ) {
+          // Same input-sanitization contract as the dynamic-tool branch
+          // above. The fallback path is hit by the SDK's `tool-<name>`
+          // shape (built-in browser tools) — a non-object input here is
+          // just as fatal at send time as in the dynamic-tool case.
+          const rawInput = "rawInput" in p ? p.rawInput : undefined;
+          const sanitized = sanitizeToolInputForPersistence(p.input, rawInput);
+          if (sanitized.kind === "drop") {
+            if (typeof console !== "undefined" && console.warn) {
+              console.warn(
+                `[serialize-parts] dropping ${part.type} part with ` +
+                  `unrecoverable non-object input ` +
+                  `(state=${p.state as string}); see ` +
+                  `tool-input-normalize.ts.`,
+              );
+            }
+            return [];
+          }
           return [
             {
               type: "dynamic-tool",
               toolName: part.type.slice(5),
               toolCallId: p.toolCallId as string,
               state: p.state as string,
-              input: p.input,
+              input:
+                sanitized.kind === "object" ? sanitized.value : undefined,
               output: "output" in p ? p.output : undefined,
               errorText: "errorText" in p ? (p.errorText as string) : undefined,
               // Preserve approval metadata on the round-trip so a part

--- a/apps/extension/src/lib/agent/tool-input-normalize.ts
+++ b/apps/extension/src/lib/agent/tool-input-normalize.ts
@@ -1,0 +1,229 @@
+import type { ToolSet } from "ai";
+
+/**
+ * Normalize a tool-call `input` value into a plain JSON object suitable for
+ * provider wire formats, or signal that the tool part cannot be salvaged.
+ *
+ * Background — why this exists at all:
+ *  - The Anthropic Messages API requires every `tool_use.input` to be a JSON
+ *    object (dictionary). A non-object (`""`, `null`, `0`, `[]`, an
+ *    arbitrary string) is rejected at request validation with
+ *    `messages.<i>.content.<j>.tool_use.input: Input should be a valid
+ *    dictionary`. The error path includes a *numeric model-message index*
+ *    only — no tool name, no source UI message id — which makes diagnosis
+ *    from a user error report nearly impossible.
+ *  - Some providers (Gemini, Vertex) coerce non-object inputs to `{}` or a
+ *    `Struct` silently in their SDK adapter, which is why the same
+ *    conversation history that 400s on Opus quietly succeeds when retried
+ *    on Gemini.
+ *  - The model can produce a non-object `input` for several reasons:
+ *      a) Opus glitch on no-arg tool calls — emits `input: ""` instead of
+ *         `input: {}`.
+ *      b) JSON-streamed `input` finishes as a stringified object (`'{"x":1}'`)
+ *         instead of being parsed by the SDK's argument streamer.
+ *      c) An MCP server with a permissive `inputSchema` (e.g. `z.any()` or
+ *         `z.record(string, any)` from `jsonSchemaToZod`'s fallback paths)
+ *         lets a non-object input pass `validateUIMessages`.
+ *      d) Historical chat-db rows persisted with the bad `input` shape
+ *         before this normalizer existed.
+ *
+ * The normalizer is the single chokepoint for outbound tool inputs. It runs
+ * inside the transport's `repairToolPart` and on every code path that
+ * persists or re-loads tool parts, so a non-object input cannot reach
+ * `convertToModelMessages` from any direction.
+ *
+ * Recovery rules, in order:
+ *   1. `value` is already a plain object → keep verbatim.
+ *   2. `value` is a string that JSON-parses to a plain object → parse and
+ *      use it. Recovers Opus's stringified-object emissions.
+ *   3. `rawValue` (the SDK's partial-streamed argument blob) is a plain
+ *      object → use it.
+ *   4. `rawValue` is a string that JSON-parses to a plain object → use it.
+ *      Recovers fully-streamed-but-not-yet-parsed args.
+ *   5. The tool's `inputSchema` accepts `{}` (no required fields) →
+ *      coerce to `{}`. This rescues the *real-world* fail case behind the
+ *      Opus bug: a no-arg MCP tool call where the model emitted `input: ""`.
+ *   6. Otherwise → drop. The part cannot be sent without a valid input,
+ *      and substituting `{}` would fail the tool's strict required-fields
+ *      schema in `validateUIMessages` ("Type validation failed ...
+ *      path: ['list']") and crash the whole turn instead of just dropping
+ *      one tool call.
+ */
+export type NormalizeResult =
+  | { kind: "object"; value: Record<string, unknown> }
+  | { kind: "drop"; reason: string };
+
+/** True iff `v` is a non-null, non-array object literal. */
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Try to parse `s` as JSON. Returns the parsed value on success, `undefined`
+ * on any failure (syntax error, empty string, whitespace-only). Never throws.
+ */
+function tryParseJson(s: string): unknown {
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether a tool's input schema accepts an empty object `{}`. Used by
+ * normalizeToolInput's rule 5 to decide whether a no-arg tool call can be
+ * rescued by coercing its missing/malformed input to `{}`.
+ *
+ * Implementation: ducktype against the Zod-like surface (`safeParse`). The
+ * AI SDK passes Zod schemas through unchanged, so this works for both
+ * built-in tools (Zod schemas defined in lib/agent/tools/*.ts) and MCP
+ * tools (Zod schemas produced by `jsonSchemaToZod`). For tools whose
+ * schema doesn't expose `safeParse` (synthetic/test tools), we
+ * conservatively return false — the part is dropped rather than being
+ * coerced into a value the schema may or may not accept.
+ */
+export function schemaAcceptsEmptyObject(inputSchema: unknown): boolean {
+  if (!inputSchema || typeof inputSchema !== "object") return false;
+  const sp = (inputSchema as { safeParse?: unknown }).safeParse;
+  if (typeof sp !== "function") return false;
+  try {
+    const result = (sp as (x: unknown) => { success: boolean }).call(
+      inputSchema,
+      {},
+    );
+    return result?.success === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Look up the inputSchema for a tool given its UI part `type` and `toolName`.
+ *
+ * UI parts use two type conventions:
+ *  - `dynamic-tool` (the universal one): the actual tool name lives in
+ *    `toolName`. Used for MCP tools, subagent delegate, and any tool
+ *    registered by registry path.
+ *  - `tool-<name>` (the AI SDK's "static" tool convention): the tool name
+ *    is the suffix after `tool-`. Used by built-in browser tools.
+ *
+ * The agent's `ToolSet` is keyed on the tool name in both cases.
+ */
+function lookupToolSchema(
+  tools: ToolSet | undefined,
+  partType: string,
+  toolName: string | undefined,
+): unknown {
+  if (!tools) return undefined;
+  if (partType === "dynamic-tool" && typeof toolName === "string") {
+    const t = tools[toolName];
+    return t?.inputSchema;
+  }
+  if (partType.startsWith("tool-")) {
+    const name = partType.slice("tool-".length);
+    const t = tools[name];
+    return t?.inputSchema;
+  }
+  return undefined;
+}
+
+/**
+ * Normalize a tool-call input. See module-level doc comment for the full
+ * recovery ladder.
+ *
+ * Args:
+ *   value     — the part's `input` field (any shape).
+ *   rawValue  — the part's `rawInput` field (any shape). The AI SDK
+ *               occasionally stashes a partial JSON string here when args
+ *               are still streaming.
+ *   tools     — the agent's ToolSet, used to check whether the tool
+ *               accepts `{}` (rule 5). Optional; if absent, rule 5 is
+ *               skipped and the part is dropped instead of coerced.
+ *   partType  — the UI part's `type` field (`"dynamic-tool"` or
+ *               `"tool-<name>"`). Used to resolve the tool's schema.
+ *   toolName  — the tool's name. For `dynamic-tool` parts this is the
+ *               `toolName` field; for `tool-<name>` parts the caller
+ *               can pass undefined and we'll derive it from `partType`.
+ */
+export function normalizeToolInput(args: {
+  value: unknown;
+  rawValue: unknown;
+  tools: ToolSet | undefined;
+  partType: string;
+  toolName: string | undefined;
+}): NormalizeResult {
+  const { value, rawValue, tools, partType, toolName } = args;
+
+  // Rule 1 — already a plain object.
+  if (isPlainObject(value)) {
+    return { kind: "object", value };
+  }
+
+  // Rule 2 — value is a stringified JSON object.
+  if (typeof value === "string") {
+    const parsed = tryParseJson(value);
+    if (isPlainObject(parsed)) {
+      return { kind: "object", value: parsed };
+    }
+  }
+
+  // Rule 3 — rawValue is a plain object.
+  if (isPlainObject(rawValue)) {
+    return { kind: "object", value: rawValue };
+  }
+
+  // Rule 4 — rawValue is a stringified JSON object (the SDK's
+  // partial-stream stash, or a complete blob the SDK didn't promote
+  // into `input` for some reason).
+  if (typeof rawValue === "string") {
+    const parsed = tryParseJson(rawValue);
+    if (isPlainObject(parsed)) {
+      return { kind: "object", value: parsed };
+    }
+  }
+
+  // Rule 5 — the tool accepts {} (i.e. all properties optional, no
+  // required fields). This is the rescue path for the actual real-world
+  // bug: Opus emitting `input: ""` for a no-arg MCP tool.
+  const schema = lookupToolSchema(tools, partType, toolName);
+  if (schemaAcceptsEmptyObject(schema)) {
+    return { kind: "object", value: {} };
+  }
+
+  // Rule 6 — irrecoverable. Drop.
+  const valueRepr =
+    value === undefined
+      ? "undefined"
+      : value === null
+        ? "null"
+        : Array.isArray(value)
+          ? "array"
+          : typeof value;
+  return {
+    kind: "drop",
+    reason: `non-object tool input (${valueRepr}) and no rescue available`,
+  };
+}
+
+/**
+ * Variant of `normalizeToolInput` for the *persistence* layer (serialize/
+ * deserialize/migration). It applies the same recovery ladder but never
+ * has access to a `ToolSet`, so rule 5 (schema-aware `{}` coercion) is
+ * skipped. A part the persistence layer cannot recover is dropped from
+ * disk, leaving the transport's send-time pass with a clean view.
+ */
+export function normalizeToolInputForPersistence(args: {
+  value: unknown;
+  rawValue?: unknown;
+}): NormalizeResult {
+  return normalizeToolInput({
+    value: args.value,
+    rawValue: args.rawValue,
+    tools: undefined,
+    partType: "",
+    toolName: undefined,
+  });
+}

--- a/apps/extension/src/lib/agent/tool-input-normalize.ts
+++ b/apps/extension/src/lib/agent/tool-input-normalize.ts
@@ -53,9 +53,29 @@ export type NormalizeResult =
   | { kind: "object"; value: Record<string, unknown> }
   | { kind: "drop"; reason: string };
 
-/** True iff `v` is a non-null, non-array object literal. */
+/**
+ * True iff `v` is a plain JSON-shaped object dictionary — accepts object
+ * literals (`{}`, `Object.create(null)`) and rejects arrays, `null`,
+ * primitives, AND non-plain objects (Date, Map, Set, class instances,
+ * RegExp, etc.).
+ *
+ * The Anthropic API requires `tool_use.input` to be a plain JSON object;
+ * a `Date` or class instance would JSON-serialize to a non-conforming
+ * shape (or throw on circular references). The model can't *emit* a
+ * non-plain object directly — it only emits JSON — but a future code
+ * path that programmatically injects a tool input could, and the
+ * normalizer is the chokepoint that catches it.
+ *
+ * Implementation: walks the prototype chain. A plain object's prototype
+ * is either `Object.prototype` (literal `{}`) or `null`
+ * (`Object.create(null)`). Any other prototype indicates a class
+ * instance or built-in (Date, Map, etc.).
+ */
 export function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+  if (typeof v !== "object" || v === null) return false;
+  if (Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
 }
 
 /**

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -656,9 +656,14 @@ async function runV16Fixup(db: IDBPDatabase<ChatDB>): Promise<void> {
         }
         const tp = part as Record<string, unknown>;
         const input = tp.input;
-        // Untouched: input intentionally absent. Legitimate persisted
-        // shape for terminal output-error/output-denied parts.
-        if (input === undefined) {
+        const rawInput = "rawInput" in tp ? tp.rawInput : undefined;
+        // Untouched: input intentionally absent AND no rawInput data to
+        // recover from. Legitimate persisted shape for terminal
+        // output-error/output-denied parts. (A part with `input:
+        // undefined` but a recoverable `rawInput` falls through to the
+        // recovery block below — we want to clean those up rather than
+        // leaving the rescue work for every subsequent send.)
+        if (input === undefined && rawInput === undefined) {
           newParts.push(part);
           continue;
         }
@@ -671,8 +676,8 @@ async function runV16Fixup(db: IDBPDatabase<ChatDB>): Promise<void> {
           newParts.push(part);
           continue;
         }
-        // Present-and-malformed. Try to recover.
-        const rawInput = "rawInput" in tp ? tp.rawInput : undefined;
+        // Either present-and-malformed, or absent-but-rawInput-available.
+        // Try to recover via the normalizer's full ladder.
         const result = normalizeToolInputForPersistence({
           value: input,
           rawValue: rawInput,
@@ -681,10 +686,19 @@ async function runV16Fixup(db: IDBPDatabase<ChatDB>): Promise<void> {
           newParts.push({ ...(part as object), input: result.value } as SerializedUIPart);
           mutated = true;
           cleaned++;
+        } else if (input === undefined) {
+          // input was intentionally absent AND rawInput (if any) didn't
+          // recover. Preserve the part as-is — the SDK tolerates
+          // input:undefined on terminal output-error/output-denied
+          // parts, and the runtime normalizer will drop it at send time
+          // if it's truly unsendable. The migration goal is to clean
+          // recoverable shapes, not to be more aggressive than runtime.
+          newParts.push(part);
         } else {
-          // Irrecoverable — drop the part entirely. Its paired tool-result
-          // (if any) lives on the same UI part, so dropping the whole part
-          // leaves no orphan.
+          // Present-and-malformed AND irrecoverable. Drop the part
+          // entirely; saving it would re-poison every subsequent send.
+          // The paired tool-result (if any) lives on the same UI part,
+          // so dropping the whole part leaves no orphan.
           mutated = true;
           dropped++;
         }

--- a/apps/extension/src/lib/chat-db.ts
+++ b/apps/extension/src/lib/chat-db.ts
@@ -200,7 +200,7 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
     // needed. Read inside the post-open `then` (which runs *after* the
     // upgrade callback completes), so by then the flag reflects whether
     // the synchronous upgrade actually ran the v15 hop.
-    const flags = { needsV15Fixup: false };
+    const flags = { needsV15Fixup: false, needsV16Fixup: false };
     // v7: migrates legacy `{ type: "compaction", auto, ... }` parts
     // to the AI SDK's DataUIPart contract:
     // `{ type: "data-compaction", data: { auto, ... } }`.
@@ -226,7 +226,17 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
     //      `chrome.tabs.get` rejects (the tab is gone) are dropped.
     //      Per-row try/catch — corrupt rows degrade to empty owned-state
     //      with a console.warn rather than aborting the whole upgrade.
-    dbPromise = openDB<ChatDB>("openbrowse-chat", 15, {
+    // v16: tool-input shape sweep. Earlier versions persisted whatever
+    //      `input` shape the SDK gave us on a tool part — including
+    //      Opus's `input: ""` quirk for no-arg MCP calls and other
+    //      non-object values. The Anthropic API rejects a non-object
+    //      `tool_use.input` with HTTP 400 (`Input should be a valid
+    //      dictionary`), so any conversation containing a non-object
+    //      input was permanently broken on Opus until the bad part was
+    //      removed. v16 rewrites every message's `parts` array through
+    //      the input-normalizer's persistence ladder so already-broken
+    //      conversations recover without user action.
+    dbPromise = openDB<ChatDB>("openbrowse-chat", 16, {
       upgrade(db, oldVersion, _newVersion, transaction) {
         if (oldVersion < 1) {
           const convStore = db.createObjectStore("conversations", {
@@ -442,18 +452,35 @@ function getDb(): Promise<IDBPDatabase<ChatDB>> {
           // version number so the post-open fixup runs.
           flags.needsV15Fixup = true;
         }
+
+        if (oldVersion < 16) {
+          // v16: tool-input shape sweep. Re-runs every message's
+          // `parts` through the input-normalizer to evict non-object
+          // `input` values left over from before the sanitization fix.
+          // Like v15, the actual rewrite runs in `runV16Fixup` outside
+          // this transaction so we can `await` the dynamic import of
+          // the serializer module without auto-committing the txn.
+          flags.needsV16Fixup = true;
+        }
       },
     });
-    // Chain the v15 fixup pass into the open promise unconditionally; the
-    // chained handler reads `flags.needsV15Fixup` *after* the upgrade
-    // callback has finished, so it correctly reflects whether the hop ran.
-    // No-op when not needed; failures are logged but not propagated.
+    // Chain the v15 / v16 fixup passes into the open promise unconditionally;
+    // the chained handler reads the flags *after* the upgrade callback has
+    // finished, so they correctly reflect whether each hop ran. No-op when
+    // not needed; failures are logged but not propagated.
     dbPromise = dbPromise.then(async (db) => {
       if (flags.needsV15Fixup) {
         try {
           await runV15Fixup(db);
         } catch (err) {
           console.warn("[chat-db v15] fixup pass failed", err);
+        }
+      }
+      if (flags.needsV16Fixup) {
+        try {
+          await runV16Fixup(db);
+        } catch (err) {
+          console.warn("[chat-db v16] fixup pass failed", err);
         }
       }
       return db;
@@ -567,6 +594,117 @@ async function runV15Fixup(db: IDBPDatabase<ChatDB>): Promise<void> {
         // Even the degrade write failed; leave the row alone.
       }
     }
+  }
+}
+
+/**
+ * Post-upgrade fixup for chat-db v16: rewrites every persisted message's
+ * `parts` so any tool part with a non-object `input` is either recovered
+ * (stringified-JSON / rawInput object → parsed) or dropped. Targets the
+ * Anthropic-only failure mode `tool_use.input: Input should be a valid
+ * dictionary`, which made conversations stuck on Opus until the bad
+ * row was manually purged.
+ *
+ * Lives outside the upgrade transaction so we can `await` the dynamic
+ * import of the persistence-side normalizer without IDB auto-committing
+ * the txn mid-iteration.
+ *
+ * Idempotent: rerunning is safe because the normalizer treats an
+ * already-clean object input as a no-op. Per-row try/catch — a corrupt
+ * message degrades to its original shape (the deserializer's runtime
+ * sanitization is the next line of defense) rather than aborting the
+ * whole pass.
+ */
+async function runV16Fixup(db: IDBPDatabase<ChatDB>): Promise<void> {
+  // Dynamic import: the normalizer module imports zod and other agent
+  // utilities, which we don't want to pay for on every chat-db open.
+  const { normalizeToolInputForPersistence } = await import(
+    "./agent/tool-input-normalize"
+  );
+
+  const isToolPart = (
+    p: unknown,
+  ): p is Record<string, unknown> => {
+    if (!p || typeof p !== "object") return false;
+    const pp = p as { type?: unknown };
+    if (pp.type === "dynamic-tool") return true;
+    if (typeof pp.type === "string" && (pp.type as string).startsWith("tool-"))
+      return true;
+    return false;
+  };
+
+  // Read all messages once, process each in its own short readwrite
+  // transaction. Per-row failure isolation matches the v15 pattern.
+  let allMessages: ChatDB["messages"]["value"][];
+  try {
+    allMessages = await db.getAll("messages");
+  } catch (err) {
+    console.warn("[chat-db v16] failed to read messages:", err);
+    return;
+  }
+
+  let cleaned = 0;
+  let dropped = 0;
+  for (const msg of allMessages) {
+    try {
+      let mutated = false;
+      const newParts: SerializedUIPart[] = [];
+      for (const part of msg.parts) {
+        if (!isToolPart(part)) {
+          newParts.push(part);
+          continue;
+        }
+        const tp = part as Record<string, unknown>;
+        const input = tp.input;
+        // Untouched: input intentionally absent. Legitimate persisted
+        // shape for terminal output-error/output-denied parts.
+        if (input === undefined) {
+          newParts.push(part);
+          continue;
+        }
+        // Already a plain object: untouched.
+        if (
+          input !== null &&
+          typeof input === "object" &&
+          !Array.isArray(input)
+        ) {
+          newParts.push(part);
+          continue;
+        }
+        // Present-and-malformed. Try to recover.
+        const rawInput = "rawInput" in tp ? tp.rawInput : undefined;
+        const result = normalizeToolInputForPersistence({
+          value: input,
+          rawValue: rawInput,
+        });
+        if (result.kind === "object") {
+          newParts.push({ ...(part as object), input: result.value } as SerializedUIPart);
+          mutated = true;
+          cleaned++;
+        } else {
+          // Irrecoverable — drop the part entirely. Its paired tool-result
+          // (if any) lives on the same UI part, so dropping the whole part
+          // leaves no orphan.
+          mutated = true;
+          dropped++;
+        }
+      }
+      if (!mutated) continue;
+      // Avoid emitting the change event during a migration sweep — we'd
+      // wake every active listener for every conversation.
+      await db.put("messages", { ...msg, parts: newParts });
+    } catch (err) {
+      console.warn(
+        `[chat-db v16] failed to clean message ${msg.id}:`,
+        err,
+      );
+    }
+  }
+  if (cleaned > 0 || dropped > 0) {
+    console.info(
+      `[chat-db v16] tool-input sweep: recovered ${cleaned} part(s), ` +
+        `dropped ${dropped} unrecoverable part(s).`,
+    );
   }
 }
 

--- a/apps/extension/src/lib/mcp/__tests__/schema-to-zod.test.ts
+++ b/apps/extension/src/lib/mcp/__tests__/schema-to-zod.test.ts
@@ -297,6 +297,58 @@ describe("jsonSchemaToZod — anyOf / oneOf", () => {
     expect(schema.safeParse({ v: "x" }).success).toBe(true);
     expect(schema.safeParse({ v: 1 }).success).toBe(false);
   });
+
+  it("multi-type array `[\"string\",\"null\"]` behaves like nullable string", () => {
+    // JSON Schema allows `type: ["string", "null"]` as shorthand for a
+    // string-or-null union. Pre-fix we collapsed to `type[0]` and
+    // silently rejected `null`. Now we fan out into a Zod union.
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { v: { type: ["string", "null"] } },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "hello" }).success).toBe(true);
+    expect(schema.safeParse({ v: null }).success).toBe(true);
+    expect(schema.safeParse({ v: 42 }).success).toBe(false);
+    expect(schema.safeParse({ v: true }).success).toBe(false);
+    expect(schema.safeParse({ v: [] }).success).toBe(false);
+  });
+
+  it("multi-type array `[\"number\",\"boolean\"]` accepts both", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { v: { type: ["number", "boolean"] } },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: 1 }).success).toBe(true);
+    expect(schema.safeParse({ v: 1.5 }).success).toBe(true);
+    expect(schema.safeParse({ v: true }).success).toBe(true);
+    expect(schema.safeParse({ v: false }).success).toBe(true);
+    expect(schema.safeParse({ v: "1" }).success).toBe(false);
+    expect(schema.safeParse({ v: null }).success).toBe(false);
+  });
+
+  it("multi-type array preserves description", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        v: { type: ["string", "null"], description: "name or null" },
+      },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "x" }).success).toBe(true);
+    expect(schema.safeParse({ v: null }).success).toBe(true);
+  });
+
+  it("single-element type array `[\"string\"]` collapses to that type", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { v: { type: ["string"] } },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "x" }).success).toBe(true);
+    expect(schema.safeParse({ v: 1 }).success).toBe(false);
+  });
 });
 
 describe("jsonSchemaToZod — arrays", () => {

--- a/apps/extension/src/lib/mcp/__tests__/schema-to-zod.test.ts
+++ b/apps/extension/src/lib/mcp/__tests__/schema-to-zod.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it, vi } from "vitest";
+import { jsonSchemaToZod } from "../schema-to-zod";
+
+describe("jsonSchemaToZod — top-level invariant (always returns object schema)", () => {
+  it("rejects non-object inputs at the top level (THE PROVIDER 400 GUARD)", () => {
+    // This is the central guarantee: for any MCP tool, a non-object input
+    // (the model emits "" or null or 42) fails validateUIMessages and
+    // never reaches the provider's tool_use.input field.
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { q: { type: "string" } },
+    });
+    expect(schema.safeParse("").success).toBe(false);
+    expect(schema.safeParse(null).success).toBe(false);
+    expect(schema.safeParse(42).success).toBe(false);
+    expect(schema.safeParse([]).success).toBe(false);
+    expect(schema.safeParse("hello").success).toBe(false);
+  });
+
+  it("accepts a valid object", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { q: { type: "string" } },
+    });
+    expect(schema.safeParse({ q: "x" }).success).toBe(true);
+    expect(schema.safeParse({}).success).toBe(true); // q is optional
+  });
+
+  it("accepts {} for an all-optional schema (Opus rescue path)", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: [],
+    });
+    expect(schema.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects {} when properties are required", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { list: { type: "string" } },
+      required: ["list"],
+    });
+    expect(schema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — missing/malformed schema falls back to passthrough object", () => {
+  it("undefined → passthrough object", () => {
+    const schema = jsonSchemaToZod(undefined);
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ anything: 1 }).success).toBe(true);
+    expect(schema.safeParse("").success).toBe(false);
+    expect(schema.safeParse(null).success).toBe(false);
+  });
+
+  it("empty schema {} → passthrough object", () => {
+    const schema = jsonSchemaToZod({});
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ x: 1 }).success).toBe(true);
+    expect(schema.safeParse("").success).toBe(false);
+  });
+
+  it("schema with no type but properties → object", () => {
+    const schema = jsonSchemaToZod({
+      properties: { q: { type: "string" } },
+    });
+    expect(schema.safeParse({ q: "x" }).success).toBe(true);
+    expect(schema.safeParse("").success).toBe(false);
+  });
+
+  it("top-level non-object schema (e.g. type: string) is coerced to passthrough object with a warn", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const schema = jsonSchemaToZod({ type: "string" });
+      expect(schema.safeParse({}).success).toBe(true);
+      expect(schema.safeParse("hello").success).toBe(false);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe("jsonSchemaToZod — additionalProperties handling", () => {
+  it("default (undefined) preserves unknown fields (passthrough)", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { q: { type: "string" } },
+    });
+    const result = schema.safeParse({ q: "x", extra: "kept" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).extra).toBe("kept");
+    }
+  });
+
+  it("additionalProperties: true preserves unknown fields", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { q: { type: "string" } },
+      additionalProperties: true,
+    });
+    expect(
+      schema.safeParse({ q: "x", extra: "kept" }).success,
+    ).toBe(true);
+  });
+
+  it("additionalProperties: false rejects unknown fields (strict)", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { q: { type: "string" } },
+      additionalProperties: false,
+    });
+    expect(schema.safeParse({ q: "x" }).success).toBe(true);
+    expect(schema.safeParse({ q: "x", extra: "no" }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — primitive types", () => {
+  it("string", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+    expect(schema.safeParse({ name: "x" }).success).toBe(true);
+    expect(schema.safeParse({ name: 1 }).success).toBe(false);
+  });
+
+  it("number", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { n: { type: "number" } },
+      required: ["n"],
+    });
+    expect(schema.safeParse({ n: 1.5 }).success).toBe(true);
+    expect(schema.safeParse({ n: "1" }).success).toBe(false);
+  });
+
+  it("integer maps to number", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { n: { type: "integer" } },
+      required: ["n"],
+    });
+    expect(schema.safeParse({ n: 1 }).success).toBe(true);
+  });
+
+  it("boolean", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    });
+    expect(schema.safeParse({ ok: true }).success).toBe(true);
+    expect(schema.safeParse({ ok: "true" }).success).toBe(false);
+  });
+
+  it("null", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { n: { type: "null" } },
+      required: ["n"],
+    });
+    expect(schema.safeParse({ n: null }).success).toBe(true);
+    expect(schema.safeParse({ n: 0 }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — string formats", () => {
+  it("uuid", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { id: { type: "string", format: "uuid" } },
+      required: ["id"],
+    });
+    expect(
+      schema.safeParse({ id: "550e8400-e29b-41d4-a716-446655440000" }).success,
+    ).toBe(true);
+    expect(schema.safeParse({ id: "not-uuid" }).success).toBe(false);
+  });
+
+  it("email", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { e: { type: "string", format: "email" } },
+      required: ["e"],
+    });
+    expect(schema.safeParse({ e: "a@b.com" }).success).toBe(true);
+    expect(schema.safeParse({ e: "nope" }).success).toBe(false);
+  });
+
+  it("url", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { u: { type: "string", format: "url" } },
+      required: ["u"],
+    });
+    expect(schema.safeParse({ u: "https://example.com" }).success).toBe(true);
+    expect(schema.safeParse({ u: "not a url" }).success).toBe(false);
+  });
+
+  it("unknown format falls back to plain string", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { x: { type: "string", format: "ipv4-or-something" } },
+      required: ["x"],
+    });
+    expect(schema.safeParse({ x: "anything" }).success).toBe(true);
+    expect(schema.safeParse({ x: 1 }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — enum and const", () => {
+  it("string enum", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { kind: { enum: ["a", "b", "c"] } },
+      required: ["kind"],
+    });
+    expect(schema.safeParse({ kind: "a" }).success).toBe(true);
+    expect(schema.safeParse({ kind: "d" }).success).toBe(false);
+  });
+
+  it("mixed-type enum collapses to literal union", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { v: { enum: ["a", 1, true] } },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "a" }).success).toBe(true);
+    expect(schema.safeParse({ v: 1 }).success).toBe(true);
+    expect(schema.safeParse({ v: true }).success).toBe(true);
+    expect(schema.safeParse({ v: 2 }).success).toBe(false);
+  });
+
+  it("const literal", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { kind: { const: "fixed" } },
+      required: ["kind"],
+    });
+    expect(schema.safeParse({ kind: "fixed" }).success).toBe(true);
+    expect(schema.safeParse({ kind: "other" }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — anyOf / oneOf", () => {
+  it("[T, null] short-circuits to nullable T", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        v: { anyOf: [{ type: "string" }, { type: "null" }] },
+      },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "x" }).success).toBe(true);
+    expect(schema.safeParse({ v: null }).success).toBe(true);
+    expect(schema.safeParse({ v: 1 }).success).toBe(false);
+  });
+
+  it("n-ary anyOf builds a union", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        v: {
+          anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }],
+        },
+      },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "x" }).success).toBe(true);
+    expect(schema.safeParse({ v: 1 }).success).toBe(true);
+    expect(schema.safeParse({ v: true }).success).toBe(true);
+    expect(schema.safeParse({ v: [] }).success).toBe(false);
+  });
+
+  it("oneOf is treated like anyOf", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        v: { oneOf: [{ type: "string" }, { type: "number" }] },
+      },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "x" }).success).toBe(true);
+    expect(schema.safeParse({ v: 1 }).success).toBe(true);
+  });
+
+  it("single-element anyOf collapses to that schema", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { v: { anyOf: [{ type: "string" }] } },
+      required: ["v"],
+    });
+    expect(schema.safeParse({ v: "x" }).success).toBe(true);
+    expect(schema.safeParse({ v: 1 }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — arrays", () => {
+  it("typed item schema", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { ids: { type: "array", items: { type: "string" } } },
+      required: ["ids"],
+    });
+    expect(schema.safeParse({ ids: ["a", "b"] }).success).toBe(true);
+    expect(schema.safeParse({ ids: [1, 2] }).success).toBe(false);
+  });
+
+  it("missing items falls back to z.unknown elements", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { xs: { type: "array" } },
+      required: ["xs"],
+    });
+    expect(schema.safeParse({ xs: [1, "a", true] }).success).toBe(true);
+  });
+
+  it("tuple-form items", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        pair: {
+          type: "array",
+          items: [{ type: "string" }, { type: "number" }],
+        },
+      },
+      required: ["pair"],
+    });
+    expect(schema.safeParse({ pair: ["x", 1] }).success).toBe(true);
+    expect(schema.safeParse({ pair: [1, "x"] }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — nested objects", () => {
+  it("nested object", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        location: {
+          type: "object",
+          properties: {
+            lat: { type: "number" },
+            lon: { type: "number" },
+          },
+          required: ["lat", "lon"],
+        },
+      },
+      required: ["location"],
+    });
+    expect(
+      schema.safeParse({ location: { lat: 1, lon: 2 } }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ location: { lat: "1", lon: 2 } }).success,
+    ).toBe(false);
+  });
+
+  it("nested object with no properties (passthrough)", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: { meta: { type: "object" } },
+      required: ["meta"],
+    });
+    expect(schema.safeParse({ meta: {} }).success).toBe(true);
+    expect(schema.safeParse({ meta: { anything: 1 } }).success).toBe(true);
+    expect(schema.safeParse({ meta: "string" }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — allOf merges branches", () => {
+  it("merges properties and required across branches", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        wrapped: {
+          allOf: [
+            {
+              type: "object",
+              properties: { a: { type: "string" } },
+              required: ["a"],
+            },
+            {
+              type: "object",
+              properties: { b: { type: "number" } },
+              required: ["b"],
+            },
+          ],
+        },
+      },
+      required: ["wrapped"],
+    });
+    expect(
+      schema.safeParse({ wrapped: { a: "x", b: 1 } }).success,
+    ).toBe(true);
+    expect(schema.safeParse({ wrapped: { a: "x" } }).success).toBe(false);
+  });
+});
+
+describe("jsonSchemaToZod — Attio-style real-world fixture", () => {
+  // Mirrors the actual Attio MCP `list-attribute-definitions` tool: object
+  // with all-optional properties, no required fields. The Opus bug:
+  // model emits `input: ""`, the loose pre-fix schema accepted it, the
+  // call landed in chat-db, every subsequent send 400'd Anthropic.
+  // Post-fix: this schema rejects "" structurally.
+  const attioSchema = {
+    type: "object",
+    properties: {
+      object: {
+        type: "string",
+        description: "The object whose attributes to list",
+      },
+      query: { type: "string" },
+      offset: { type: "number" },
+      limit: { type: "number" },
+    },
+  } as const;
+
+  it("rejects '' (the actual Opus bug input)", () => {
+    const schema = jsonSchemaToZod(attioSchema);
+    expect(schema.safeParse("").success).toBe(false);
+  });
+
+  it("rejects null (another Opus emission)", () => {
+    const schema = jsonSchemaToZod(attioSchema);
+    expect(schema.safeParse(null).success).toBe(false);
+  });
+
+  it("accepts {} (the correct empty-args call shape)", () => {
+    const schema = jsonSchemaToZod(attioSchema);
+    expect(schema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts the actual model-emitted input shape", () => {
+    const schema = jsonSchemaToZod(attioSchema);
+    expect(
+      schema.safeParse({ object: "people", query: "founder", limit: 10 })
+        .success,
+    ).toBe(true);
+  });
+
+  it("accepts a partial input (only `object` set)", () => {
+    const schema = jsonSchemaToZod(attioSchema);
+    expect(schema.safeParse({ object: "people" }).success).toBe(true);
+  });
+});

--- a/apps/extension/src/lib/mcp/registry.ts
+++ b/apps/extension/src/lib/mcp/registry.ts
@@ -78,6 +78,12 @@ export class McpRegistry {
         if (permission === "disabled") continue;
 
         const toolKey = `mcp_${mcpTool.serverId}_${mcpTool.name}`;
+        // jsonSchemaToZod handles undefined / malformed inputSchema by
+        // returning `z.object({}).passthrough()` — which still enforces
+        // the top-level object invariant required by Anthropic
+        // (`tool_use.input` must be a dictionary), so a server that
+        // forgot to declare an inputSchema still produces a valid tool
+        // surface that rejects non-object inputs structurally.
         const zodSchema = jsonSchemaToZod(mcpTool.inputSchema);
 
         sdkTools[toolKey] = tool({

--- a/apps/extension/src/lib/mcp/schema-to-zod.ts
+++ b/apps/extension/src/lib/mcp/schema-to-zod.ts
@@ -1,79 +1,317 @@
 import { z } from "zod";
 
+/**
+ * JSON Schema → Zod converter for MCP tools.
+ *
+ * Why this is its own module (not the AI SDK's built-in conversion):
+ *   - MCP servers ship arbitrary JSON Schema in their `tool.inputSchema`
+ *     advertisement. The AI SDK's tool surface expects a Zod (or
+ *     JSON-Schema-shaped) `inputSchema` per tool, used by:
+ *       a) `validateUIMessages` (validates incoming model-streamed input)
+ *       b) `convertToModelMessages` (decides which fields to forward)
+ *       c) per-provider tool-spec serialization (sent to the LLM)
+ *   - We need conversion that's lenient enough to accept real-world
+ *     servers (which use schema features the AI SDK doesn't natively
+ *     map) but strict enough at the TOP LEVEL that a non-object input
+ *     fails validation early — instead of slipping through and tripping
+ *     a downstream provider error like
+ *     `tool_use.input: Input should be a valid dictionary`.
+ *
+ * Top-level invariant: this function always returns a Zod schema whose
+ * top-level type is `object`. A non-object input from any source (model
+ * stream, persisted history, debug payload) fails `validateUIMessages`
+ * structurally and never reaches the wire — which is the failure mode
+ * `tool-input-normalize.ts` was written to backstop.
+ *
+ * Property-level looseness: object properties default to `passthrough()`
+ * unless the schema explicitly says `additionalProperties: false`. Servers
+ * frequently add fields between releases; passthrough preserves
+ * forward-compat without weakening the top-level object check.
+ *
+ * Recognized JSON Schema features:
+ *   - `type`: string, number, integer, boolean, array, object, null.
+ *   - `enum`: string union.
+ *   - `const`: literal value.
+ *   - `anyOf` / `oneOf`: union (with the special `[T, null]` → nullable
+ *     short-circuit). Both n-ary and binary unions are handled.
+ *   - `properties` + `required`: object shape.
+ *   - `items`: array element schema.
+ *   - `additionalProperties: false` → strict object; otherwise passthrough.
+ *   - `description`: applied via `.describe()` on the property.
+ *   - `format`: "uuid", "email", "url", "date-time" map to Zod string
+ *     refinements; unknown formats fall back to a plain string.
+ *
+ * Not recognized (intentionally falls back to z.unknown() at the property
+ * level so model-emitted values still pass through):
+ *   - `$ref`, `definitions` / `$defs` (would require schema resolution).
+ *   - `patternProperties`, `dependencies`.
+ *   - `minimum` / `maximum` / `pattern` / `multipleOf` (constraints).
+ *
+ * For a top-level malformed/missing schema (no `type`, no `properties`,
+ * not `object`-shaped) the converter returns `z.object({}).passthrough()`
+ * — accepts any object, rejects non-objects. This matches what an MCP
+ * server would mean by "no input schema declared".
+ */
+
 type JsonSchema = {
-  type?: string;
+  type?: string | string[];
   properties?: Record<string, JsonSchema>;
   required?: string[];
-  items?: JsonSchema;
+  items?: JsonSchema | JsonSchema[];
   description?: string;
   enum?: unknown[];
+  const?: unknown;
   default?: unknown;
   anyOf?: JsonSchema[];
   oneOf?: JsonSchema[];
+  allOf?: JsonSchema[];
+  additionalProperties?: boolean | JsonSchema;
+  format?: string;
+  // Permit unknown keys; we ignore them at the property level.
+  [k: string]: unknown;
 };
 
-function convertProperty(schema: JsonSchema): z.ZodTypeAny {
-  if (schema.enum) {
-    const values = schema.enum as [string, ...string[]];
-    return z.enum(values);
+/** Apply a description if present, then return the schema. */
+function withDescription<T extends z.ZodTypeAny>(
+  schema: T,
+  source: JsonSchema | undefined,
+): T | z.ZodType {
+  if (source?.description) {
+    return schema.describe(source.description);
+  }
+  return schema;
+}
+
+function convertEnum(values: unknown[]): z.ZodTypeAny {
+  // Zod enums require [string, ...string[]]. Mixed-type enums are rare in
+  // practice (and not a tool-arg pattern), but if we see one we widen to
+  // a literal union.
+  const allStrings = values.every((v) => typeof v === "string");
+  if (allStrings && values.length > 0) {
+    return z.enum(values as [string, ...string[]]);
+  }
+  // Mixed or non-string enum: build a union of literals; if there's only
+  // one value, use a literal directly. Empty enum is degenerate — accept
+  // anything with z.unknown() rather than rejecting all values.
+  if (values.length === 0) return z.unknown();
+  if (values.length === 1) {
+    return z.literal(values[0] as string | number | boolean);
+  }
+  // Build z.union of literals. Zod's literal accepts string|number|boolean.
+  const literals = values.map((v) => {
+    if (
+      typeof v === "string" ||
+      typeof v === "number" ||
+      typeof v === "boolean"
+    ) {
+      return z.literal(v);
+    }
+    // Fall back for null / objects / arrays in the enum.
+    if (v === null) return z.null();
+    return z.unknown();
+  });
+  // Zod 4 union takes a tuple-like array.
+  return z.union(literals as unknown as readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
+}
+
+function convertConst(value: unknown): z.ZodTypeAny {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return z.literal(value);
+  }
+  if (value === null) return z.null();
+  return z.unknown();
+}
+
+function convertString(schema: JsonSchema): z.ZodTypeAny {
+  switch (schema.format) {
+    case "uuid":
+      return z.string().uuid();
+    case "email":
+      return z.string().email();
+    case "url":
+    case "uri":
+      return z.string().url();
+    case "date-time":
+      return z.string().datetime({ offset: true });
+    default:
+      return z.string();
+  }
+}
+
+function convertArray(schema: JsonSchema): z.ZodTypeAny {
+  const items = schema.items;
+  // tuple form (`items: [s1, s2, ...]`) — JSON Schema's positional tuple.
+  // Map each position to its schema; if the schema is missing, accept any.
+  if (Array.isArray(items)) {
+    const tupleParts = items.map((it) => convertProperty(it));
+    if (tupleParts.length === 0) return z.array(z.unknown());
+    // z.tuple(...) signature in Zod 4.
+    return z.tuple(
+      tupleParts as unknown as readonly [z.ZodTypeAny, ...z.ZodTypeAny[]],
+    );
+  }
+  // Single-schema form.
+  if (items && typeof items === "object") {
+    return z.array(convertProperty(items));
+  }
+  return z.array(z.unknown());
+}
+
+function convertProperty(schema: JsonSchema | undefined): z.ZodTypeAny {
+  if (!schema || typeof schema !== "object") return z.unknown();
+
+  // const wins over anything else.
+  if ("const" in schema) {
+    return withDescription(convertConst(schema.const), schema) as z.ZodTypeAny;
   }
 
-  if (schema.anyOf || schema.oneOf) {
-    const variants = (schema.anyOf ?? schema.oneOf)!;
+  if (schema.enum && Array.isArray(schema.enum)) {
+    return withDescription(convertEnum(schema.enum), schema) as z.ZodTypeAny;
+  }
+
+  // Union forms. Special-case `[T, null]` → nullable T, which is the most
+  // common idiom for "T or null" in JSON Schema.
+  const variants = schema.anyOf ?? schema.oneOf;
+  if (variants && Array.isArray(variants) && variants.length > 0) {
     if (variants.length === 2) {
       const nullVariant = variants.find((v) => v.type === "null");
       const otherVariant = variants.find((v) => v.type !== "null");
       if (nullVariant && otherVariant) {
-        return convertProperty(otherVariant).nullable();
+        return withDescription(
+          convertProperty(otherVariant).nullable(),
+          schema,
+        ) as z.ZodTypeAny;
       }
     }
-    return z.any();
+    // n-ary union. Zod 4's union requires at least 2 elements.
+    if (variants.length === 1) {
+      return withDescription(
+        convertProperty(variants[0]),
+        schema,
+      ) as z.ZodTypeAny;
+    }
+    const parts = variants.map((v) => convertProperty(v));
+    return withDescription(
+      z.union(
+        parts as unknown as readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]],
+      ),
+      schema,
+    ) as z.ZodTypeAny;
   }
 
-  switch (schema.type) {
+  // allOf: Zod has no clean "intersection of N schemas" but in practice
+  // MCP servers use this for object refinement. Take the union of all
+  // properties from all branches; merge `required`.
+  if (schema.allOf && Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+    const merged: JsonSchema = { type: "object", properties: {}, required: [] };
+    for (const branch of schema.allOf) {
+      if (branch.properties) {
+        merged.properties = { ...merged.properties, ...branch.properties };
+      }
+      if (branch.required) {
+        merged.required = [
+          ...(merged.required ?? []),
+          ...branch.required,
+        ];
+      }
+    }
+    return withDescription(
+      convertObjectSchema(merged),
+      schema,
+    ) as z.ZodTypeAny;
+  }
+
+  // type can be a string or array (JSON Schema allows multi-type).
+  const type = Array.isArray(schema.type)
+    ? schema.type[0]
+    : schema.type;
+
+  switch (type) {
     case "string":
-      return z.string();
+      return withDescription(convertString(schema), schema) as z.ZodTypeAny;
     case "number":
     case "integer":
-      return z.number();
+      return withDescription(z.number(), schema) as z.ZodTypeAny;
     case "boolean":
-      return z.boolean();
+      return withDescription(z.boolean(), schema) as z.ZodTypeAny;
     case "array":
-      return z.array(schema.items ? convertProperty(schema.items) : z.any());
+      return withDescription(convertArray(schema), schema) as z.ZodTypeAny;
     case "object":
-      return convertObjectSchema(schema);
+      return withDescription(
+        convertObjectSchema(schema),
+        schema,
+      ) as z.ZodTypeAny;
     case "null":
-      return z.null();
+      return withDescription(z.null(), schema) as z.ZodTypeAny;
     default:
-      return z.any();
+      // No type but properties present → object.
+      if (schema.properties) {
+        return withDescription(
+          convertObjectSchema(schema),
+          schema,
+        ) as z.ZodTypeAny;
+      }
+      // Truly unknown: accept anything at the property level. This is
+      // safer than rejecting — at the TOP level we still enforce object
+      // shape via `jsonSchemaToZod`.
+      return withDescription(z.unknown(), schema) as z.ZodTypeAny;
   }
 }
 
 function convertObjectSchema(schema: JsonSchema): z.ZodTypeAny {
-  if (!schema.properties) {
-    return z.record(z.string(), z.any());
-  }
+  const required = new Set(schema.required ?? []);
+  const props = schema.properties ?? {};
 
   const shape: Record<string, z.ZodTypeAny> = {};
-  const required = new Set(schema.required ?? []);
-
-  for (const [key, propSchema] of Object.entries(schema.properties)) {
-    let prop = convertProperty(propSchema);
-    if (propSchema.description) {
-      prop = prop.describe(propSchema.description);
-    }
+  for (const [key, propSchema] of Object.entries(props)) {
+    const prop = convertProperty(propSchema);
     shape[key] = required.has(key) ? prop : prop.optional();
   }
 
-  return z.object(shape);
+  // Closed shape only when explicitly opted in. Default is passthrough so
+  // an MCP server adding new optional fields doesn't strip them.
+  // additionalProperties: false → strict; true | undefined | object → passthrough.
+  const isStrict = schema.additionalProperties === false;
+  const base = z.object(shape);
+  if (isStrict) {
+    return base.strict();
+  }
+  return base.passthrough();
 }
 
-export function jsonSchemaToZod(schema: JsonSchema): z.ZodTypeAny {
-  if (!schema.type && !schema.properties) {
-    return z.object({});
+/**
+ * Top-level entry point. Always returns a Zod schema whose top-level type
+ * is `object` — a non-object input fails validation structurally before
+ * ever reaching the provider. See module-level doc.
+ */
+export function jsonSchemaToZod(schema: JsonSchema | undefined): z.ZodTypeAny {
+  // Missing or malformed schema → accept any object, reject non-objects.
+  if (!schema || typeof schema !== "object") {
+    return z.object({}).passthrough();
   }
-  if (schema.type === "object" || schema.properties) {
+
+  // Top-level object (the common case).
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  if (type === "object" || schema.properties) {
     return convertObjectSchema(schema);
   }
-  return convertProperty(schema);
+
+  // Top-level non-object schema: this is invalid for an MCP tool input
+  // (the spec requires object). Coerce to a passthrough object so the
+  // call doesn't crash the entire tool registry, but log once so the
+  // server author can fix it.
+  if (type && type !== "object") {
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        `[mcp/schema-to-zod] tool inputSchema has top-level type=${JSON.stringify(
+          schema.type,
+        )} (must be "object"); coercing to passthrough object.`,
+      );
+    }
+  }
+  return z.object({}).passthrough();
 }

--- a/apps/extension/src/lib/mcp/schema-to-zod.ts
+++ b/apps/extension/src/lib/mcp/schema-to-zod.ts
@@ -225,10 +225,35 @@ function convertProperty(schema: JsonSchema | undefined): z.ZodTypeAny {
     ) as z.ZodTypeAny;
   }
 
-  // type can be a string or array (JSON Schema allows multi-type).
-  const type = Array.isArray(schema.type)
-    ? schema.type[0]
-    : schema.type;
+  // type can be a string or array. JSON Schema allows multi-type
+  // declarations (`type: ["string", "null"]`) to mean "any of these".
+  // When we see an array, fan out into a union — collapsing to
+  // `type[0]` would silently drop the other branches and reject inputs
+  // the schema actually allows.
+  if (Array.isArray(schema.type) && schema.type.length > 1) {
+    // Build per-type sub-schemas by re-entering convertProperty with
+    // each individual type. We strip `type` so a recursive call with
+    // `enum`/`anyOf` on the same schema doesn't double-fire.
+    const { type: _t, ...rest } = schema;
+    void _t;
+    const variants = schema.type.map((t) =>
+      convertProperty({ ...rest, type: t }),
+    );
+    if (variants.length === 1) {
+      return withDescription(variants[0], schema) as z.ZodTypeAny;
+    }
+    return withDescription(
+      z.union(
+        variants as unknown as readonly [
+          z.ZodTypeAny,
+          z.ZodTypeAny,
+          ...z.ZodTypeAny[]
+        ],
+      ),
+      schema,
+    ) as z.ZodTypeAny;
+  }
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
 
   switch (type) {
     case "string":
@@ -294,11 +319,20 @@ export function jsonSchemaToZod(schema: JsonSchema | undefined): z.ZodTypeAny {
     return z.object({}).passthrough();
   }
 
-  // Top-level object (the common case).
-  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
-  if (type === "object" || schema.properties) {
+  // Top-level object (the common case). For a multi-type at top level
+  // (which is non-conformant per the MCP spec — tool inputs must be
+  // objects — but tolerated): if `"object"` is one of the listed types,
+  // treat the schema as object-typed. Otherwise fall through to the
+  // non-object warning below.
+  const types = Array.isArray(schema.type)
+    ? schema.type
+    : schema.type !== undefined
+      ? [schema.type]
+      : [];
+  if (types.includes("object") || schema.properties) {
     return convertObjectSchema(schema);
   }
+  const type = types[0];
 
   // Top-level non-object schema: this is invalid for an MCP tool input
   // (the spec requires object). Coerce to a passthrough object so the

--- a/packages/bench/src/agent/headless-chat.ts
+++ b/packages/bench/src/agent/headless-chat.ts
@@ -1,8 +1,42 @@
 import type { TokenLimits } from "@agent/compaction";
 import type { AgentUIMessage } from "@agent/message-types";
+import { normalizeToolInputForPersistence } from "@agent/tool-input-normalize";
 import type { UIMessageChunk } from "ai";
 import type { ChatTransport, LanguageModel } from "ai";
 import { runCompaction } from "./run-compaction";
+
+/**
+ * The bench harness consumes the transport's UIMessage stream manually
+ * (mirroring what the real chat hook does in the extension). Tool-call
+ * chunks land here as either `tool-call` or `tool-call-delta` with an
+ * `args` field carrying the input. We pass that input through the same
+ * persistence-side normalizer the extension uses on its serialize/
+ * deserialize boundary so a non-object value never lands in the bench's
+ * accumulated assistant message — which would then 400 the provider on
+ * the next turn or skew the bench's eval results.
+ *
+ * Returns the recovered object, or `{}` if the input couldn't be
+ * recovered. Coercing to {} matches the runtime transport's last-mile
+ * assertion behavior; the bench is non-interactive so we prefer
+ * "complete the run with a flagged eval" over "abort the trial".
+ */
+function normalizeBenchToolArgs(args: unknown): Record<string, unknown> {
+  if (args !== null && typeof args === "object" && !Array.isArray(args)) {
+    return args as Record<string, unknown>;
+  }
+  const result = normalizeToolInputForPersistence({ value: args });
+  if (result.kind === "object") return result.value;
+  // Last-resort coercion. The bench reports each trial's tool calls as
+  // part of its eval output; an empty {} for an irrecoverable input is
+  // visible in the report so the trial author can investigate.
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn(
+      `[bench/headless-chat] tool-call had non-object input ` +
+        `(typeof=${typeof args}); coercing to {}.`,
+    );
+  }
+  return {};
+}
 
 export async function consumeChatStream(
   transport: ChatTransport<AgentUIMessage>,
@@ -57,7 +91,7 @@ export async function consumeChatStream(
           toolName: value.toolName,
           toolCallId: value.toolCallId,
           state: "call-pending" as any,
-          input: value.args,
+          input: normalizeBenchToolArgs(value.args),
         } as any);
       }
     } else if (value.type === "tool-result") {


### PR DESCRIPTION
## The bug

Opus (and any provider, occasionally) emits a non-object `input` for a tool call — most commonly `input: \"\"` for a no-arg MCP tool like Attio's `list-attribute-definitions`. The Anthropic API rejects it with HTTP 400:

```
messages.<i>.content.<j>.tool_use.input: Input should be a valid dictionary
```

Gemini coerces non-object inputs silently in its provider adapter, which is why the same conversation that 400'd on Opus \"just worked\" when retried on Gemini. Once the bad shape was persisted to chat-db, every subsequent send 400'd until the row was manually purged.

## Five layers of defense

Any one of these would have prevented the bug. All five together make it impossible to recur from any direction.

### 1. `lib/agent/tool-input-normalize.ts` (new)

A 6-rule recovery ladder applied at every outbound and persisted boundary:

1. Plain object → keep verbatim.
2. Stringified-JSON object (Opus quirk) → parse + use.
3. `rawInput` is an object → use it.
4. `rawInput` is a stringified-JSON object → parse + use.
5. Tool's schema accepts `{}` (no required fields) → coerce to `{}`. **This is the actual rescue path for the Opus bug** — a no-arg MCP tool gets called as the model intended.
6. Otherwise → DROP. Substituting `{}` would re-trigger the tool's strict required-fields schema in `validateUIMessages` and crash the whole turn instead of just dropping one call.

Wired into `repairToolPart` in `compacting-transport.ts`. Tools are now threaded through `rewriteForLLM` → `healNonTerminalToolParts` → `repairToolPart` so rule 5 has the schema it needs.

### 2. `lib/mcp/schema-to-zod.ts` (rewritten)

Tightened so every MCP tool's resolved Zod schema is a top-level `z.object({...})`. A non-object input now fails `validateUIMessages` structurally instead of slipping through the previous `z.any()` / `z.record(string, any)` fallthroughs.

Newly handled JSON Schema features (none of which the prior implementation did): `additionalProperties` (default passthrough; explicit `false` enforces strict), n-ary `oneOf` / `anyOf` (was binary-only), `allOf` (merges branches), `format` (uuid / email / url / date-time), `const`, multi-type `type` (`type: [\"string\", \"null\"]`), tuple-form `items`.

Property-level `passthrough()` keeps MCP-server schema drift forward-compatible — a server adding a new optional field between releases won't have its values silently stripped.

### 3. Persistence sanitization

`serializeParts` and `deserializeToolPart` route every tool part's `input` through the normalizer:
- Bad shapes never enter chat-db on save.
- Legacy bad rows never reach the live `UIMessage` list on load (drop-on-deserialize).
- Intentionally-absent inputs (terminal `output-error` parts where the SDK tolerates `input: undefined`) are preserved so the UI's \"Interrupted\" badge still renders.

### 4. chat-db v16 migration

`runV16Fixup` sweeps every persisted message's `parts` on first open and either recovers (stringified-JSON / `rawInput` → object) or excises any tool part with a malformed `input`. **Fixes already-broken conversations without user action.** Idempotent (re-running on clean rows is a no-op). Lives outside the upgrade transaction so we can `await` the dynamic import of the normalizer module without IDB auto-committing.

### 5. Last-mile assertion

`assertModelMessageToolInputs` runs immediately before `agent.stream(...)` in both the fast-path and the rejection-loop iteration. If a non-object `tool_use.input` somehow slips through layers 1–4:
- Coerced to `{}` in place (matches Gemini's lenient adapter behavior — user's turn still completes).
- `console.error` logs the model-message index, content-block index, tool name, `typeof`, and a truncated value.

Converts \"the agent mysteriously 400'd on Opus once last week\" into a one-look DevTools entry. **Should never fire in production after layers 1–4** — but if it does, the diagnostic is self-explanatory.

## Bench parity

`packages/bench/src/agent/headless-chat.ts` gets the same normalizer on its `tool-call` chunk path so future regressions surface in `pnpm bench` instead of only on real users.

## Tests

109 new tests added across 6 new files plus extensions to 2 existing ones:

| File | Tests | What it covers |
|---|---|---|
| `tool-input-normalize.test.ts` | 39 | Every recovery rule, all primitive non-object types, both `dynamic-tool` and `tool-<name>` part conventions, persistence variant |
| `mcp/__tests__/schema-to-zod.test.ts` | 38 | Schema converter edge cases incl. real-world Attio-style fixture (the actual Opus bug shape) |
| `persistence-input-sanitize.test.ts` | 14 | Round-trip contract on serialize / deserialize |
| `assert-model-message-tool-inputs.test.ts` | 8 | Last-mile coercion + log content |
| `chat-db-v16-migration.test.ts` | 8 | Migration recovers / drops / preserves the right shapes; idempotent |
| `opus-input-bug-regression.test.ts` | 6 | **Full-pipeline regression** that reproduces the exact production failure end-to-end |
| `tool-state-heal.test.ts` | +2 net | Updated existing tests where pre-fix behavior was incomplete (truncated rawInput strings) |

**All 1496 tests pass; `pnpm compile` clean across the monorepo.**

## Files changed

```
.changeset/fix-tool-input-normalization.md         |  19 +
apps/extension/src/hooks/__tests__/persistence-input-sanitize.test.ts    | 280 +++
apps/extension/src/hooks/useAgentChat.ts                                 |  72 +-
apps/extension/src/lib/__tests__/chat-db-v15-migration.test.ts           |   7 +-
apps/extension/src/lib/__tests__/chat-db-v16-migration.test.ts           | 329 +++
apps/extension/src/lib/agent/__tests__/assert-model-message-tool-inputs.test.ts | 247 +++
apps/extension/src/lib/agent/__tests__/opus-input-bug-regression.test.ts | 362 +++
apps/extension/src/lib/agent/__tests__/tool-input-normalize.test.ts      | 321 +++
apps/extension/src/lib/agent/__tests__/tool-state-heal.test.ts           |  94 ++-
apps/extension/src/lib/agent/compacting-transport.ts                     | 273 +++--
apps/extension/src/lib/agent/serialize-parts.ts                          | 100 ++-
apps/extension/src/lib/agent/tool-input-normalize.ts                     | 229 +++
apps/extension/src/lib/chat-db.ts                                        | 150 +-
apps/extension/src/lib/mcp/__tests__/schema-to-zod.test.ts               | 449 +++++
apps/extension/src/lib/mcp/registry.ts                                   |   6 +
apps/extension/src/lib/mcp/schema-to-zod.ts                              | 306 +++-
packages/bench/src/agent/headless-chat.ts                                |  36 +-
17 files changed, 3123 insertions(+), 157 deletions(-)
```

Changeset bumps `openbrowse` to a patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed tool-call input validation errors that were causing API failures; persisted conversations with broken tool inputs are automatically repaired
* Improved robustness of tool-input handling across the message pipeline to prevent invalid formats from reaching the API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->