### PR TITLE
fix(extension): Memory settings cards no longer overlap

### DIFF
--- a/.changeset/fix-memory-settings-overlap.md
+++ b/.changeset/fix-memory-settings-overlap.md
@@ -1,0 +1,7 @@
+---
+"openbrowse": patch
+---
+
+**Fix overlapping Memory cards in Settings.**
+
+The Memory tab's User Memories and Space Memories sections were rendering on top of each other — the space section's heading visually overlapped the last User Memories card, and the empty-state text appeared in the wrong place. Cause: each list was wrapped in a Radix `ScrollArea` with `max-h-[300px]` but no fixed height, so `ScrollArea.Root` collapsed to 0px while its absolutely-positioned content painted out of flow. Removed the inner scroll regions; the settings panel already has its own outer scroll container, so the two `<section>`s now flow normally with correct spacing.

--- a/apps/extension/src/entrypoints/settings/MemoryTab.tsx
+++ b/apps/extension/src/entrypoints/settings/MemoryTab.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { MemoryItem } from "@/components/memory/MemoryItem";
 import { memoryDb, type Memory } from "@/lib/memory-db";
 import { storage } from "@/lib/storage";
@@ -59,13 +58,11 @@ export function MemoryTab() {
         {userMemories.length === 0 ? (
           <p className="text-sm text-muted-foreground">No memories saved yet</p>
         ) : (
-          <ScrollArea className="max-h-[300px]">
-            <div className="flex flex-col gap-2 pr-2">
-              {userMemories.map((m) => (
-                <MemoryItem key={m.id} memory={m} onDelete={handleDelete} />
-              ))}
-            </div>
-          </ScrollArea>
+          <div className="flex flex-col gap-2">
+            {userMemories.map((m) => (
+              <MemoryItem key={m.id} memory={m} onDelete={handleDelete} />
+            ))}
+          </div>
         )}
       </section>
 
@@ -76,13 +73,11 @@ export function MemoryTab() {
           {spaceMemories.length === 0 ? (
             <p className="text-sm text-muted-foreground">No memories saved yet</p>
           ) : (
-            <ScrollArea className="max-h-[300px]">
-              <div className="flex flex-col gap-2 pr-2">
-                {spaceMemories.map((m) => (
-                  <MemoryItem key={m.id} memory={m} onDelete={handleDelete} />
-                ))}
-              </div>
-            </ScrollArea>
+            <div className="flex flex-col gap-2">
+              {spaceMemories.map((m) => (
+                <MemoryItem key={m.id} memory={m} onDelete={handleDelete} />
+              ))}
+            </div>
           )}
         </section>
       )}


### PR DESCRIPTION
## Problem

In Settings → Memory, the **User Memories** list and the **Space Memories** list rendered on top of each other:

- The Space Memories heading (e.g. "Development Memories") visually overlapped the last User Memories card.
- The empty-state text ("No memories saved yet") appeared in the wrong place.

## Root cause

`MemoryTab.tsx` wrapped each list in a Radix `<ScrollArea className="max-h-[300px]">`. Radix's `ScrollArea.Root` has no intrinsic height — it relies on a definite `h-*`, not just a `max-h` ceiling. With only `max-h`, the Root collapsed to **0px** while its absolutely-positioned inner content painted out of flow. The next sibling `<section>` then rendered directly under the previous heading, creating the overlap.

## Fix

The Settings panel (`SettingsPage.tsx:185`) already has its own outer `overflow-y-auto` container, so the inner scroll regions were both redundant and broken. Replaced both `<ScrollArea>` wrappers in `MemoryTab.tsx` with plain `<div className="flex flex-col gap-2">`. Sibling sections now flow normally with the existing `space-y-6` spacing — the whole Memory tab scrolls as one with the rest of Settings.

## Verification

- `pnpm --filter openbrowse compile` passes.
- Settings → Memory: User Memories renders fully, then a clear gap, then the Space Memories heading and cards. No overlap.
- Empty / mixed states (no Space, Space with zero memories, etc.) all render their own "No memories saved yet" line under the correct heading.

## Changeset

Patch bump for `openbrowse` (`.changeset/fix-memory-settings-overlap.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlapping content in Settings’ Memory view so headings, cards, and empty states now display correctly.
  * Improved layout for “User Memories” and “Space Memories” by removing nested scrolling regions that constrained the lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->