### PR TITLE
fix(extension): unwedge clickElement on background tabs + lift Chrome throttling

### DIFF
--- a/.changeset/fix-background-tab-throttling.md
+++ b/.changeset/fix-background-tab-throttling.md
@@ -1,0 +1,15 @@
+---
+"openbrowse": patch
+---
+
+**Fix `clickElement` stalling indefinitely when chatting from home / new tab, and lift Chrome's background-tab throttling on every worked tab.**
+
+When the user submitted a message from `home.html` or `newtab.html`, the agent's `clickElement` tool would freeze in the "pending" state until the user manually switched to the tab the agent was working on — at which point the click would finally complete and the agent would resume. Root cause: `viewport.waitForLayoutFlush` issued an in-page `await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))` via CDP `Runtime.evaluate { awaitPromise: true }`, and Chrome throttles `requestAnimationFrame` to ~1 Hz then 0 Hz on backgrounded tabs. The intended `timeout: 1000` field on `Runtime.evaluate` is silently dropped by Chrome (the field exists for `Runtime.callFunctionOn`, not `Runtime.evaluate`), so the await actually had no bound — the click pipeline hung until rAF fired again, which only happened when the tab became visible.
+
+Fixed at three layers, complementary not redundant:
+
+- `cdp-session.attach` now issues `Emulation.setPageVisibilityOverride { visibility: "visible" }` and `Page.setWebLifecycleState { state: "active" }` on every CDP-attached tab. The page sees `document.visibilityState === "visible"`, so Chrome stops throttling rAF, `setTimeout`, and the lifecycle freeze that bites long-running background tabs. Both calls are best-effort (some targets reject the override) and need no detach reciprocal — Chrome resets them when the debugger detaches.
+- `viewport.waitForLayoutFlush` now races the `Runtime.evaluate` call against a host-side 1500 ms `setTimeout`. Even if the visibility override doesn't take effect for some reason (Chrome version regressing the override, page using `requestPostAnimationFrame`/compositor timeline that's compositor-paused), the click pipeline can never wedge — proceeding with a slightly-stale layout read is strictly better than hanging. Drops the misleading unused `timeout: 1000` CDP field.
+- `capture-utils.captureScreenshot`'s `-32000 Unable to capture screenshot` retry path now flips `captureBeyondViewport: true` for the second attempt (when not already set). The off-screen renderer path doesn't depend on a fresh compositor frame, so it succeeds on tabs whose compositor has paused — the dominant `-32000` cause in production. Retry without the 600 ms wait in this case (the wait only helped the legacy "renderer mid-paint" race, not compositor pause).
+
+Net effect: agent tools (clickElement, screenshot, executeOnPage with in-page awaits, CUA loop captures) all run at foreground speed on backgrounded worked tabs, no matter which surface the user is chatting from.

--- a/apps/extension/src/lib/agent/__tests__/capture-utils.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/capture-utils.test.ts
@@ -64,11 +64,46 @@ describe("captureScreenshot — overlay hiding", () => {
     expect(methods.filter((m) => m === "Page.captureScreenshot").length).toBe(2);
   });
 
-  it("retries once on a transient capture failure", async () => {
+  it("retries on a transient capture failure with captureBeyondViewport flipped on", async () => {
+    // First call fails with -32000; retry should succeed. The retry MUST
+    // pass `captureBeyondViewport: true` (the off-screen renderer path)
+    // because the dominant cause of -32000 in production is a backgrounded
+    // tab whose compositor isn't committing frames — captureBeyondViewport
+    // doesn't depend on a fresh compositor frame.
     const { driver, calls } = recordingDriver({ captureFails: 1 });
     const data = await captureScreenshot(driver, 1);
     expect(data).toBe("QUJD");
-    expect(calls.filter((c) => c.method === "Page.captureScreenshot").length).toBe(2);
+
+    const captureCalls = calls.filter(
+      (c) => c.method === "Page.captureScreenshot",
+    );
+    expect(captureCalls.length).toBe(2);
+
+    // First attempt: caller's params (no captureBeyondViewport).
+    expect(captureCalls[0].params).toEqual({ format: "png" });
+
+    // Retry attempt: same params PLUS captureBeyondViewport: true.
+    expect(captureCalls[1].params).toEqual({
+      format: "png",
+      captureBeyondViewport: true,
+    });
+  });
+
+  it("retries WITHOUT changing params when captureBeyondViewport was already on (fullPage callers)", async () => {
+    // When the caller (e.g. screenshot tool's fullPage mode) already
+    // requested captureBeyondViewport, there's no further escape hatch —
+    // retry with the same params.
+    const { driver, calls } = recordingDriver({ captureFails: 1 });
+    const params = { format: "png", captureBeyondViewport: true };
+    const data = await captureScreenshot(driver, 1, params);
+    expect(data).toBe("QUJD");
+
+    const captureCalls = calls.filter(
+      (c) => c.method === "Page.captureScreenshot",
+    );
+    expect(captureCalls.length).toBe(2);
+    expect(captureCalls[0].params).toEqual(params);
+    expect(captureCalls[1].params).toEqual(params);
   });
 
   it("still captures when overlay hide/restore is unavailable", async () => {

--- a/apps/extension/src/lib/agent/__tests__/cdp-session-visibility-override.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/cdp-session-visibility-override.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Background-tab throttle override in `cdp-session.attach`.
+ *
+ * Every CDP-attached tab should immediately receive
+ * `Emulation.setPageVisibilityOverride { visibility: "visible" }` and
+ * `Page.setWebLifecycleState { state: "active" }` so Chrome stops
+ * throttling rAF/timers/lifecycle on the worked tab when the agent's host
+ * (home.html / newtab.html / side panel) is not focused on it.
+ *
+ * Without this, the agent's `clickElement` tool stalls indefinitely until
+ * the user manually focuses the worked tab — see
+ * `viewport.waitForLayoutFlush` for the rAF wait that wedges. These tests
+ * pin down:
+ *
+ *   1. Both commands are issued on attach, in order, with the right params.
+ *   2. Failures of either command are swallowed (some targets reject the
+ *      override; the attach must still succeed).
+ *   3. The override is applied exactly once per attach (not on every
+ *      sendCommand round-trip).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface SendCall {
+  method: string;
+  params: unknown;
+}
+
+function stubChrome(opts: {
+  visibilityFails?: boolean;
+  lifecycleFails?: boolean;
+} = {}): {
+  attachCalls: number[];
+  sendCalls: SendCall[];
+} {
+  const attachCalls: number[] = [];
+  const sendCalls: SendCall[] = [];
+  vi.stubGlobal("chrome", {
+    tabs: {
+      onRemoved: { addListener: () => {} },
+      onReplaced: { addListener: () => {} },
+      onUpdated: { addListener: () => {} },
+      onActivated: { addListener: () => {} },
+      onCreated: { addListener: () => {} },
+      get: () => Promise.resolve({ id: 1, url: "" }),
+    },
+    debugger: {
+      onDetach: { addListener: () => {} },
+      onEvent: { addListener: () => {} },
+      attach: vi.fn((target: { tabId: number }) => {
+        attachCalls.push(target.tabId);
+        return Promise.resolve();
+      }),
+      detach: vi.fn(() => Promise.resolve()),
+      sendCommand: vi.fn(
+        (_target: { tabId: number }, method: string, params: unknown) => {
+          sendCalls.push({ method, params });
+          if (
+            opts.visibilityFails &&
+            method === "Emulation.setPageVisibilityOverride"
+          ) {
+            return Promise.reject(
+              new Error("override unsupported on this target"),
+            );
+          }
+          if (opts.lifecycleFails && method === "Page.setWebLifecycleState") {
+            return Promise.reject(new Error("lifecycle unsupported"));
+          }
+          return Promise.resolve({});
+        },
+      ),
+    },
+  });
+  return { attachCalls, sendCalls };
+}
+
+describe("cdp-session.attach: background-tab throttle override", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("issues setPageVisibilityOverride + setWebLifecycleState immediately after attach", async () => {
+    const { attachCalls, sendCalls } = stubChrome();
+    const { attach } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    await attach(42);
+
+    expect(attachCalls).toEqual([42]);
+    // Both override commands were issued (order: visibility first, then
+    // lifecycle), with the correct params.
+    const overrideMethods = sendCalls
+      .filter(
+        (c) =>
+          c.method === "Emulation.setPageVisibilityOverride" ||
+          c.method === "Page.setWebLifecycleState",
+      )
+      .map((c) => c.method);
+    expect(overrideMethods).toEqual([
+      "Emulation.setPageVisibilityOverride",
+      "Page.setWebLifecycleState",
+    ]);
+
+    const visCall = sendCalls.find(
+      (c) => c.method === "Emulation.setPageVisibilityOverride",
+    );
+    expect(visCall?.params).toEqual({ visibility: "visible" });
+
+    const lifeCall = sendCalls.find(
+      (c) => c.method === "Page.setWebLifecycleState",
+    );
+    expect(lifeCall?.params).toEqual({ state: "active" });
+  });
+
+  it("swallows setPageVisibilityOverride failures and still installs the session", async () => {
+    const { sendCalls } = stubChrome({ visibilityFails: true });
+    const { attach, sendCommand } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    // attach must NOT throw even though setPageVisibilityOverride rejects.
+    const session = await attach(42);
+    expect(session.attached).toBe(true);
+
+    // Lifecycle command still runs even though visibility failed (each
+    // override is independently best-effort).
+    const lifeCall = sendCalls.find(
+      (c) => c.method === "Page.setWebLifecycleState",
+    );
+    expect(lifeCall).toBeDefined();
+
+    // Subsequent sendCommand calls work normally — proves the session is
+    // healthy after a failed override.
+    await expect(sendCommand(42, "Runtime.evaluate", { expression: "1" }))
+      .resolves.toBeDefined();
+  });
+
+  it("swallows setWebLifecycleState failures and still installs the session", async () => {
+    const { sendCalls } = stubChrome({ lifecycleFails: true });
+    const { attach, sendCommand } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    const session = await attach(42);
+    expect(session.attached).toBe(true);
+
+    // Visibility command still ran.
+    const visCall = sendCalls.find(
+      (c) => c.method === "Emulation.setPageVisibilityOverride",
+    );
+    expect(visCall).toBeDefined();
+
+    await expect(sendCommand(42, "Runtime.evaluate", { expression: "1" }))
+      .resolves.toBeDefined();
+  });
+
+  it("applies the override exactly once per attach (idempotent attach => idempotent override)", async () => {
+    const { sendCalls } = stubChrome();
+    const { attach } = await import("../cdp-session");
+    const { tabRegistry } = await import("../tab-registry");
+    tabRegistry.__resetForTests!();
+
+    // Three attaches in a row — only the first does the chrome.debugger.attach
+    // round-trip; the rest are no-ops. Override commands must follow the
+    // same shape: one set per real attach, not per logical attach() call.
+    await attach(42);
+    await attach(42);
+    await attach(42);
+
+    const visCount = sendCalls.filter(
+      (c) => c.method === "Emulation.setPageVisibilityOverride",
+    ).length;
+    const lifeCount = sendCalls.filter(
+      (c) => c.method === "Page.setWebLifecycleState",
+    ).length;
+    expect(visCount).toBe(1);
+    expect(lifeCount).toBe(1);
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/viewport-layout-flush-timeout.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/viewport-layout-flush-timeout.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Host-side timeout on `viewport.waitForLayoutFlush`.
+ *
+ * The function used to issue `Runtime.evaluate { awaitPromise: true }` with
+ * an in-page Promise that waits two requestAnimationFrame callbacks. CDP
+ * `Runtime.evaluate` has no `timeout` field — it's silently dropped by
+ * Chrome. So when the worked tab is backgrounded, Chrome throttles rAF to
+ * ~1 Hz then 0 Hz, the in-page Promise never resolves, and the CDP call
+ * hangs forever — wedging `clickElement` until the user manually focuses
+ * the tab.
+ *
+ * The fix: race the `driver.sendCommand` against a host-side `setTimeout`.
+ * The function is best-effort by contract, so a timeout resolves normally
+ * (the click pipeline proceeds with slightly-stale layout, which is
+ * strictly better than wedging).
+ *
+ * This test pins down: even when `Runtime.evaluate` never resolves,
+ * `waitForLayoutFlush` returns within the host-side budget.
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import type { BrowserDriver } from "../driver";
+import { waitForLayoutFlush } from "../viewport";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function neverResolvingDriver(): BrowserDriver {
+  return {
+    sendCommand: vi.fn(
+      () =>
+        // Never resolves, never rejects — the failure mode we're guarding
+        // against (rAF throttled to 0 Hz on a backgrounded tab).
+        new Promise(() => {}),
+    ),
+  } as unknown as BrowserDriver;
+}
+
+describe("viewport.waitForLayoutFlush — host-side timeout", () => {
+  it("returns within the timeout budget when Runtime.evaluate never resolves", async () => {
+    vi.useFakeTimers();
+    const driver = neverResolvingDriver();
+
+    const promise = waitForLayoutFlush(driver, 1);
+
+    // Advance past the host-side timeout (1500ms). Without the timeout
+    // this would hang the test indefinitely.
+    await vi.advanceTimersByTimeAsync(1600);
+
+    // Should have resolved by now.
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("resolves immediately when Runtime.evaluate resolves quickly (foreground happy path)", async () => {
+    const driver = {
+      sendCommand: vi.fn(async () => ({})),
+    } as unknown as BrowserDriver;
+
+    const start = Date.now();
+    await waitForLayoutFlush(driver, 1);
+    const elapsed = Date.now() - start;
+
+    // Foreground path: should complete well under the 1500ms timeout
+    // (typically <10ms — a single resolved promise).
+    expect(elapsed).toBeLessThan(500);
+    expect(driver.sendCommand).toHaveBeenCalledWith(
+      1,
+      "Runtime.evaluate",
+      expect.objectContaining({
+        awaitPromise: true,
+        returnByValue: true,
+      }),
+    );
+  });
+
+  it("does NOT pass an unsupported `timeout` field to Runtime.evaluate", async () => {
+    // The CDP Runtime.evaluate spec has no `timeout` field. The previous
+    // implementation passed `timeout: 1000` which Chrome silently ignored
+    // (and was masked as "the wait is bounded" by misleading comments).
+    // We removed it; this test guards against it being added back.
+    const driver = {
+      sendCommand: vi.fn(async () => ({})),
+    } as unknown as BrowserDriver;
+
+    await waitForLayoutFlush(driver, 1);
+
+    const call = (driver.sendCommand as ReturnType<typeof vi.fn>).mock.calls[0];
+    const params = call[2] as Record<string, unknown>;
+    expect(params).not.toHaveProperty("timeout");
+  });
+
+  it("swallows CDP errors (debugger detached, etc.) without throwing", async () => {
+    const driver = {
+      sendCommand: vi.fn(async () => {
+        throw new Error("Detached while handling command");
+      }),
+    } as unknown as BrowserDriver;
+
+    await expect(waitForLayoutFlush(driver, 1)).resolves.toBeUndefined();
+  });
+});

--- a/apps/extension/src/lib/agent/capture-utils.ts
+++ b/apps/extension/src/lib/agent/capture-utils.ts
@@ -53,8 +53,23 @@ async function setOverlaysHidden(
  * base64 PNG (no `data:` prefix). `params` is forwarded to
  * `Page.captureScreenshot` (defaults to `{ format: "png" }`).
  *
- * Includes one short retry on the transient `-32000 Unable to capture
- * screenshot` CDP error seen when the renderer is mid-paint or throttled.
+ * Retry strategy on the transient `-32000 Unable to capture screenshot`
+ * error (renderer mid-paint, compositor not committing, throttled
+ * background tab):
+ *
+ *   1. First attempt with the caller's params.
+ *   2. On failure: retry IMMEDIATELY with `captureBeyondViewport: true`
+ *      forced on, unless the caller already had it set. The off-screen
+ *      renderer path doesn't depend on a fresh compositor frame, so it
+ *      succeeds on tabs the compositor has paused — the dominant cause of
+ *      the -32000 error in production. No 600 ms wait between attempts:
+ *      the first attempt failed because of compositor state, not a
+ *      mid-paint race, and waiting doesn't help the off-screen path.
+ *
+ * If the caller already passed `captureBeyondViewport: true` (the
+ * `screenshot` tool's `fullPage` mode), the retry uses identical params
+ * with a 600 ms settle wait — same shape as the legacy retry, since the
+ * off-screen flip isn't an option.
  */
 export async function captureScreenshot(
   driver: BrowserDriver,
@@ -71,17 +86,25 @@ export async function captureScreenshot(
       );
       return r.data;
     } catch (firstErr) {
-      // `Page.captureScreenshot` intermittently fails with `-32000 Unable to
-      // capture screenshot` while the renderer is mid-paint/navigation. Wait
-      // ~600ms — long enough for a typical paint/commit to settle without
-      // noticeably stalling the agent — then retry once. Preserve the first
-      // error as the `cause` so the retry failure doesn't lose context.
-      await new Promise((r) => setTimeout(r, 600));
+      // Pick the retry strategy. When the caller hasn't already enabled
+      // captureBeyondViewport, flip it on for the retry: the off-screen
+      // renderer path is robust to background-tab compositor pauses, which
+      // is the dominant -32000 cause now that visibility-override lifts
+      // most other throttling. When captureBeyondViewport was already on,
+      // there's no further escape hatch — retry with identical params after
+      // a short wait (legacy behavior).
+      const alreadyBeyondViewport = params.captureBeyondViewport === true;
+      const retryParams = alreadyBeyondViewport
+        ? params
+        : { ...params, captureBeyondViewport: true };
+      if (alreadyBeyondViewport) {
+        await new Promise((r) => setTimeout(r, 600));
+      }
       try {
         const r = await driver.sendCommand<{ data: string }>(
           tabId,
           "Page.captureScreenshot",
-          params,
+          retryParams,
         );
         return r.data;
       } catch (secondErr) {

--- a/apps/extension/src/lib/agent/cdp-session.ts
+++ b/apps/extension/src/lib/agent/cdp-session.ts
@@ -225,6 +225,70 @@ async function doAttach(tabId: number): Promise<Session> {
     enabledDomains: new Set(),
   };
   sessions.set(tabId, session);
+
+  // Lift Chrome's background-tab throttling on every tab the agent attaches
+  // to. Without this, a worked tab that isn't currently focused (the common
+  // case when the user is looking at home.html / newtab.html / the side
+  // panel) is subject to three compounding throttles that wedge or slow
+  // down agent tools:
+  //
+  //   1. requestAnimationFrame is throttled to ~1 Hz then 0 Hz. This is the
+  //      direct cause of `clickElement` stalling indefinitely until the
+  //      user switches to the worked tab — `viewport.waitForLayoutFlush`
+  //      awaits two rAFs in-page via `Runtime.evaluate { awaitPromise:
+  //      true }`, which never resolves on a backgrounded tab.
+  //   2. setTimeout in the page is throttled to a 1 Hz floor (worse over
+  //      time). Bites any in-page wait, including user `executeOnPage`
+  //      scripts that await a frame.
+  //   3. After ~5 minutes, Chrome demotes the renderer's main thread and
+  //      the compositor stops committing — `Page.captureScreenshot`
+  //      starts returning `-32000 Unable to capture screenshot`.
+  //
+  // `Emulation.setPageVisibilityOverride { visibility: "visible" }` makes
+  // the page see itself as visible — `document.visibilityState === "visible"`,
+  // rAF/timer throttling lifted — without changing actual tab/window focus.
+  // `Page.setWebLifecycleState { state: "active" }` prevents Chrome from
+  // freezing the tab (the more aggressive lifecycle pause that survives
+  // even the visibility override). Together they make agent tools run as
+  // if every worked tab were foregrounded.
+  //
+  // Both are best-effort: some targets reject the override (DevTools tabs,
+  // chrome:// URLs, certain Chrome versions). A failure here must not break
+  // the attach — the tab is still attached and tools will work, just at
+  // background-tab speed. Chrome resets these overrides automatically when
+  // the debugger detaches, so no teardown reciprocal is needed in
+  // `release()`.
+  //
+  // Side effect to be aware of: pages that pause autoplay/animation when
+  // hidden won't pause for the agent. For an agent-driven worktab this is
+  // almost always the desired behavior (the agent needs to interact with
+  // the page as if a human were viewing it).
+  const dbg = requireDebugger();
+  try {
+    await dbg.sendCommand!(
+      { tabId },
+      "Emulation.setPageVisibilityOverride",
+      { visibility: "visible" },
+    );
+  } catch (err) {
+    console.debug(
+      `[cdp-session] tab ${tabId} setPageVisibilityOverride failed:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  try {
+    await dbg.sendCommand!(
+      { tabId },
+      "Page.setWebLifecycleState",
+      { state: "active" },
+    );
+  } catch (err) {
+    console.debug(
+      `[cdp-session] tab ${tabId} setWebLifecycleState failed:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
   return session;
 }
 

--- a/apps/extension/src/lib/agent/viewport.ts
+++ b/apps/extension/src/lib/agent/viewport.ts
@@ -85,23 +85,41 @@ export async function scrollIntoViewIfNeeded(
  * pre-scroll position. Two rAFs is Playwright's pattern: the first lets
  * style/layout flush, the second ensures the scroll commit has landed.
  *
- * Best-effort. Times out at 1 second so a stuck rAF (e.g. tab in
- * background) can never wedge a click.
+ * Best-effort: a host-side 1500 ms timeout caps the wait so a stuck rAF
+ * (e.g. a fully-throttled background tab where the visibility override in
+ * cdp-session didn't take effect, or a page using requestPostAnimationFrame
+ * / compositor-driven timelines that remain paused) can never wedge a click.
+ *
+ * NB: the `timeout` field on CDP `Runtime.evaluate` does NOT exist (unlike
+ * `Runtime.callFunctionOn`); Chrome silently drops it. The only real
+ * timeout is the host-side `Promise.race` below — which is why a wedged
+ * `awaitPromise: true` would otherwise hang forever.
  */
 export async function waitForLayoutFlush(
   driver: BrowserDriver,
   tabId: TabId,
 ): Promise<void> {
+  // Race the in-page rAF wait against a host-side timeout. Resolve normally
+  // on either path — this function is documented as best-effort, and
+  // proceeding with a slightly-stale layout read is strictly better than
+  // wedging the click pipeline. The `try/catch` around the race still
+  // catches genuine CDP errors (detach, target gone) so they don't escape.
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
-    await driver.sendCommand(tabId, "Runtime.evaluate", {
+    const cdpCall = driver.sendCommand(tabId, "Runtime.evaluate", {
       expression:
         "new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))",
       awaitPromise: true,
       returnByValue: true,
-      timeout: 1000,
     });
+    const timeout = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(resolve, 1500);
+    });
+    await Promise.race([cdpCall, timeout]);
   } catch {
     // Renderer was busy / debugger detached — don't block the click.
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
## Symptom

When the user submits a message from `home.html` or `newtab.html`, the agent's `clickElement` tool freezes in the "pending" state. Switching to the tab the agent is working on unblocks it — the click dither animation appears, the tool completes, and the agent's generation resumes.

Reported here: clickElement stalls until the user manually focuses the worked tab. typeInElement / pressKey / etc. don't have the issue.

## Root cause

`viewport.waitForLayoutFlush` (used only by `clickElement`) awaits two `requestAnimationFrame` callbacks in-page via CDP `Runtime.evaluate { awaitPromise: true }`. Chrome throttles rAF to ~1 Hz then 0 Hz on backgrounded tabs, so the in-page Promise never resolves.

The author's intended `timeout: 1000` field on `Runtime.evaluate` is silently dropped by Chrome — that field exists for `Runtime.callFunctionOn`, not `Runtime.evaluate`. The accompanying comment ("Times out at 1 second so a stuck rAF (e.g. tab in background) can never wedge a click") was wrong. The await had no bound, so the click pipeline hung until rAF fired again, which only happened when the worked tab was foregrounded.

This was latent before but surfaced from `eba409b` (chat UI on the new-tab page): with `home`/`newtab` as the chat surface, the worked tab is necessarily backgrounded the moment the user starts typing.

## Fix (three layers, complementary not redundant)

### 1. Lift Chrome's background-tab throttling on every CDP-attached tab — `cdp-session.ts`

After `chrome.debugger.attach`, fire two best-effort CDP commands:
- `Emulation.setPageVisibilityOverride { visibility: "visible" }` — page sees `document.visibilityState === "visible"`, Chrome lifts rAF/timer throttling.
- `Page.setWebLifecycleState { state: "active" }` — prevents the more aggressive lifecycle freeze that survives the visibility override.

Both wrapped in independent try/catch with `console.debug` logging — failures don't break the attach (some targets reject the override). No detach reciprocal needed — Chrome resets these when the debugger detaches.

This alone fixes the reported click stall. The next two layers are belt-and-braces.

### 2. Host-side timeout on the rAF wait — `viewport.ts`

Race `Runtime.evaluate` against a host-side 1500 ms `setTimeout`. Even if the visibility override doesn't take effect (Chrome version regressing it, page using `requestPostAnimationFrame`/compositor timelines that remain paused), the click pipeline cannot wedge. Proceeding with a slightly-stale layout is strictly better than hanging.

Drops the misleading unused `timeout: 1000` CDP field; updates the docstring to describe the actual timeout source.

### 3. Smarter screenshot retry — `capture-utils.ts`

The existing `-32000 Unable to capture screenshot` retry repeated the same call after 600 ms. Now: flip `captureBeyondViewport: true` on the retry (when not already set). The off-screen renderer path doesn't depend on a fresh compositor frame, so it succeeds on tabs whose compositor has paused — the dominant `-32000` cause now that visibility-override lifts most other throttling. Skip the 600 ms wait in the new path (it only helped the legacy "renderer mid-paint" race, not compositor pause).

When the caller already had `captureBeyondViewport: true` (e.g. screenshot tool's `fullPage` mode), there's no further escape hatch — retry with same params after the legacy 600 ms wait.

## Net effect

- `clickElement` no longer stalls on backgrounded worked tabs.
- `Page.captureScreenshot` succeeds on first try in the common case (visibility override unblocks the compositor); falls through to `captureBeyondViewport` on the residual cases.
- `setTimeout` inside `executeOnPage` runs at full speed on background tabs.
- All other tools (typeInElement, pressKey, snapshot, CUA loop captures) inherit the throttle lift transparently.

## Trade-offs / things to note

- **Visibility-override side effect:** pages that pause autoplay/animations when `document.visibilityState === "hidden"` will not pause for the agent. For an agent-driven worktab this is almost always the desired behavior (the agent needs to interact as if a human were viewing).
- **Lifecycle override side effect:** none — `Page.setWebLifecycleState { state: "active" }` is the default for foregrounded tabs.
- **The host page itself.** The agent loop runs in the home/newtab/sidepanel page's renderer. When `home`/`newtab` itself becomes backgrounded (user switches away to look at the worked tab), host-side `setTimeout` calls in our own JS get throttled too. This PR doesn't address that — it would require restructuring the agent loop. Not blocking the reported bug; the fix here removes the symptom regardless.
- **Why not move the agent loop to the SW.** Considered and rejected: MV3 SW idle eviction (~30 s) breaks long agent runs, and the `Chat` instance / OPFS / IndexedDB / run-ownership state is bound to a stable host page. The home-page-as-host design (\`scheduled-run.ensureHomePage\`, \`run-ownership.ts\`, the cross-tab mirror in \`stream-mirror.ts\`) is correct and stays.

## Tests

- 4 new tests in `cdp-session-visibility-override.test.ts`: command order, param shapes, swallowed failures, idempotent application.
- 4 new tests in `viewport-layout-flush-timeout.test.ts`: timeout fires when CDP never resolves, foreground happy path, no \`timeout\` field in CDP params (regression guard), CDP errors swallowed.
- Updated `capture-utils.test.ts`: retry now passes \`captureBeyondViewport: true\` (when not already on); legacy params-unchanged retry preserved for pre-set callers.

All 1684 extension tests pass. \`pnpm -r --parallel compile\` clean across the workspace.

## Files

| File | Change |
|---|---|
| \`apps/extension/src/lib/agent/cdp-session.ts\` | +58 lines in \`doAttach\`: visibility/lifecycle override |
| \`apps/extension/src/lib/agent/viewport.ts\` | \`waitForLayoutFlush\` host-side timeout |
| \`apps/extension/src/lib/agent/capture-utils.ts\` | \`-32000\` retry flips \`captureBeyondViewport\` |
| \`apps/extension/src/lib/agent/__tests__/cdp-session-visibility-override.test.ts\` | new |
| \`apps/extension/src/lib/agent/__tests__/viewport-layout-flush-timeout.test.ts\` | new |
| \`apps/extension/src/lib/agent/__tests__/capture-utils.test.ts\` | retry assertions updated |
| \`.changeset/fix-background-tab-throttling.md\` | patch |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when interacting from background tabs so clicks no longer stall indefinitely.
  * Reduced delays when screenshots fail by retrying more intelligently.
  * Added a timeout safeguard for layout waits so the app keeps responding even if browser rendering is slowed down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->