### PR TITLE
feat(mcp-server): distribute @openbrowse/mcp-server@0.1.0 via npm + Homebrew

### DIFF
--- a/.changeset/mcp-server-initial-release.md
+++ b/.changeset/mcp-server-initial-release.md
@@ -1,0 +1,14 @@
+---
+"@openbrowse/mcp-server": minor
+---
+
+Initial public release of the OpenBrowse MCP broker.
+
+The broker is a local OAuth 2.1 + WebSocket bridge that lets external
+MCP hosts (Cursor, Claude Desktop, OpenCode, Continue, etc.) drive the
+OpenBrowse browser extension. It ships as an npm package
+(`@openbrowse/mcp-server`, invoked as `openbrowse-mcp`) and a Homebrew
+formula (`openbrowse-ai/tap/openbrowse-mcp`).
+
+Full feature set was landed in PR #176 (feat(mcp): OpenBrowse MCP
+subagent bridge, Phases 1-4); this changeset publishes the artefact.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -149,4 +149,10 @@ jobs:
       # emits the tag with the leading `@` intact (e.g.
       # `@openbrowse/mcp-server@0.1.0`).
       tag: "@openbrowse/mcp-server@${{ needs.release.outputs.mcp_server_version }}"
-    secrets: inherit
+    secrets:
+      # Forward ONLY the secrets release-mcp-server.yml declares. Using
+      # `secrets: inherit` would forward every repo secret to the
+      # reusable workflow — over-privileged and would silently give
+      # future unrelated secrets to the publish step.
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,19 +4,25 @@ name: Changesets
 #   - If there are pending changesets in .changeset/, open or update a
 #     "Version Packages" PR that bumps versions and updates CHANGELOG.
 #   - When that PR is merged, this workflow creates the matching git
-#     tag (e.g. openbrowse@0.2.3 — Changesets' workspace tag format
-#     for private packages, enabled via `privatePackages.tag` in
-#     .changeset/config.json), then invokes `release.yml` directly via
-#     `workflow_call` to build the extension zip and attach it to the
-#     GitHub Release Changesets created.
+#     tag(s) (Changesets' workspace tag format), then invokes the
+#     appropriate downstream release workflow via `workflow_call`.
+#
+# Multi-package release fan-out:
+#   The workspace ships two independently-versioned packages managed by
+#   Changesets: `openbrowse` (the Chrome extension) and
+#   `@openbrowse/mcp-server` (the broker). Each has its own release
+#   workflow — release.yml builds the extension zip, release-mcp-server.yml
+#   publishes to npm and bumps the Homebrew formula. This job splits the
+#   `publishedPackages` output by name so each downstream workflow only
+#   fires when its package was actually released.
 #
 # Why workflow_call instead of relying on the tag-push trigger:
-# the tag is created here using GITHUB_TOKEN, and tags pushed by
+# the tags are created here using GITHUB_TOKEN, and tags pushed by
 # GITHUB_TOKEN do NOT fire downstream `on: push: tags:` workflows
 # (GitHub's anti-recursion safeguard). Using workflow_call lets us
-# stay on GITHUB_TOKEN without needing a PAT. release.yml's
-# `workflow_dispatch` trigger remains as a manual escape hatch for
-# re-running the build against an already-tagged release.
+# stay on GITHUB_TOKEN without needing a PAT. release*.yml's
+# `workflow_dispatch` triggers remain as manual escape hatches for
+# re-running builds against already-tagged releases.
 #
 # Contributors who change user-facing behavior should run
 # `pnpm changeset` and commit the generated `.changeset/*.md` file.
@@ -41,12 +47,15 @@ jobs:
       contents: write # commit version bumps + create tags
       pull-requests: write # open the Version Packages PR
     outputs:
-      # Surfaced so the build-release job below can decide whether a
-      # release zip needs building, and which tag to target.
+      # `published` is true iff Changesets tagged at least one package.
+      # The per-package version outputs below are empty strings when
+      # that package was not among those tagged. Downstream `if:`
+      # conditions treat empty string as "skip."
       published: ${{ steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      extension_version: ${{ steps.split.outputs.extension_version }}
+      mcp_server_version: ${{ steps.split.outputs.mcp_server_version }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Required so changesets can detect history when computing
           # version bumps and changelog entries.
@@ -78,37 +87,66 @@ jobs:
           # commands through a shell, so chaining commands directly
           # here would pass them as args to the first binary.
           version: pnpm run version
-          # No npm publish — we do not publish to npm. The git tag
-          # created here used to trigger release.yml via the tag-push
-          # event, but GITHUB_TOKEN-authored tag pushes don't fire
-          # downstream workflows. The `build-release` job below
-          # invokes release.yml directly via workflow_call instead.
+          # `changeset tag` creates a git tag per released package.
+          # Actual npm publish for `@openbrowse/mcp-server` happens in
+          # release-mcp-server.yml which is invoked below; the
+          # extension is not published to npm.
           publish: pnpm exec changeset tag
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Split publishedPackages by name
+        id: split
+        # `publishedPackages` is a JSON array of `{ name, version }`.
+        # We use jq to find the entry for each package we manage and
+        # expose its version as a per-package output. Missing entries
+        # become empty strings — downstream `if:` conditions gate on
+        # non-empty.
+        #
+        # Using an env var (not string interpolation) to feed the JSON
+        # into jq prevents shell-quoting issues when the JSON contains
+        # single quotes or shell metacharacters.
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          EXT_VERSION=$(printf '%s' "$PUBLISHED" | jq -r '[.[] | select(.name == "openbrowse")][0].version // ""')
+          MCP_VERSION=$(printf '%s' "$PUBLISHED" | jq -r '[.[] | select(.name == "@openbrowse/mcp-server")][0].version // ""')
+          echo "extension_version=$EXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "mcp_server_version=$MCP_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extension version:    ${EXT_VERSION:-<none>}"
+          echo "MCP server version:   ${MCP_VERSION:-<none>}"
+
   # Build the Chrome extension zip and attach it to the GitHub Release
-  # that the Changesets action just created. Runs only when the publish
-  # step actually emitted a tag (i.e. the Version Packages PR was just
-  # merged). Skipped on every other main push, including the push that
-  # opens/updates the Version Packages PR itself.
-  #
-  # See release.yml for the build/test/zip/upload steps. We invoke it
-  # via workflow_call rather than relying on the tag push because tags
-  # created with GITHUB_TOKEN don't trigger `on: push: tags:` workflows.
-  build-release:
-    name: Build + publish release zip
+  # that the Changesets action just created. Runs only when the extension
+  # package was among those published. Skipped for broker-only releases.
+  build-release-extension:
+    name: Build + publish extension release zip
     needs: release
-    if: needs.release.outputs.published == 'true'
+    if: needs.release.outputs.extension_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/release.yml
     with:
-      # publishedPackages is a JSON array of `{ name, version }` for
-      # each package the action just tagged. We tag exactly one
-      # package (`openbrowse`), so [0] is safe. The tag format
-      # (`openbrowse@X.Y.Z`) matches what `changeset tag` emits for
-      # private workspace packages.
-      tag: openbrowse@${{ fromJson(needs.release.outputs.publishedPackages)[0].version }}
+      # Extension tag format is `openbrowse@X.Y.Z` (Changesets emits this
+      # for the private-scope package named `openbrowse`).
+      tag: openbrowse@${{ needs.release.outputs.extension_version }}
+
+  # Publish the broker to npm + GitHub Releases + bump the Homebrew tap.
+  # Runs only when the mcp-server package was among those published.
+  build-release-mcp-server:
+    name: Publish @openbrowse/mcp-server to npm + Homebrew
+    needs: release
+    if: needs.release.outputs.mcp_server_version != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-mcp-server.yml
+    with:
+      # Scoped-package tag format is `<name>@<version>` — Changesets
+      # emits the tag with the leading `@` intact (e.g.
+      # `@openbrowse/mcp-server@0.1.0`).
+      tag: "@openbrowse/mcp-server@${{ needs.release.outputs.mcp_server_version }}"
+    secrets: inherit

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -44,6 +44,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # required to create the GitHub Release
+    env:
+      # Precomputed at job start so the step-level `if:` on the
+      # Homebrew bump step reads a stable value. `secrets` context
+      # isn't available in `if:` directly — hoisting the presence
+      # check to job-level env is the standard workaround, and being
+      # at job scope avoids any doubt about step-level env evaluation
+      # order relative to the step's own `if:`.
+      HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
     steps:
       - name: Resolve tag + version
         id: tag
@@ -71,6 +79,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.tag.outputs.tag }}
+          # Do NOT persist the write-scoped GITHUB_TOKEN in .git/config.
+          # This is a privileged publish workflow that does not push to
+          # git; leaving the token in the on-disk config would let any
+          # subprocess (install lifecycle scripts, build tools,
+          # transitive deps) read it. The post-step removes it anyway,
+          # but "removes at end of job" isn't the same as "never wrote it."
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -82,7 +97,10 @@ jobs:
           # `registry-url` writes an .npmrc pointing at npm and enables
           # NODE_AUTH_TOKEN auth for `npm publish` further down.
           registry-url: "https://registry.npmjs.org"
-          cache: pnpm
+          # Intentionally no `cache: pnpm` here. This is the privileged
+          # publish path — restoring a shared pnpm-store cache that could
+          # have been poisoned by a prior compromised run isn't worth the
+          # marginal speed win. Install fresh every time.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -109,11 +127,33 @@ jobs:
       - name: Build (esbuild bundle + tsc .d.ts)
         run: pnpm -F @openbrowse/mcp-server build
 
-      - name: Publish to npm
-        # `--no-git-checks` because we're running against a detached HEAD
-        # at the tagged commit; pnpm otherwise refuses to publish from
-        # anything that isn't a clean tracking branch.
-        run: pnpm -F @openbrowse/mcp-server publish --access public --no-git-checks
+      - name: Publish to npm (tolerate already-published for reruns)
+        # If npm publish succeeded on a prior run but the Homebrew bump
+        # failed, we need to be able to re-run this workflow and drive
+        # through to the Homebrew step without npm's 409 "version already
+        # exists" blocking recovery. This step treats that specific
+        # failure mode as non-fatal — any other npm error still fails.
+        #
+        # `--no-git-checks` because we're on a detached HEAD at the
+        # tagged commit; pnpm otherwise refuses to publish from anything
+        # that isn't a clean tracking branch.
+        run: |
+          set -o pipefail
+          if pnpm -F @openbrowse/mcp-server publish --access public --no-git-checks 2>&1 | tee /tmp/npm-publish.log; then
+            echo "npm publish: success."
+            exit 0
+          fi
+          # Publish failed. Only 'version already published' is
+          # recoverable — everything else is a real error we must
+          # surface. Matching npm/pnpm's known error strings for this
+          # condition (npm uses "cannot publish over" and E403 with
+          # "already published"; pnpm proxies these through).
+          if grep -qiE '(cannot publish over|previously published|EPUBLISHCONFLICT|version already|already exists in the registry)' /tmp/npm-publish.log; then
+            echo "::warning::npm reports this version is already published; continuing so downstream Homebrew bump can complete."
+            exit 0
+          fi
+          echo "::error::npm publish failed for a reason other than version-already-exists. See log above."
+          exit 1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -130,9 +170,9 @@ jobs:
         # Skipped when HOMEBREW_TAP_TOKEN is not present (e.g. first-run
         # test dispatch before secrets are set up). npm publish still
         # succeeded; Homebrew users can manually update the tap later.
+        # `HAS_TAP_TOKEN` is defined at job level so this if: sees a
+        # stable value regardless of step-level env eval order.
         if: env.HAS_TAP_TOKEN == 'true'
-        env:
-          HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
         uses: dawidd6/action-homebrew-bump-formula@d09b568334bfea0f4586b25c9d9e5c98b1ff8916 # v6.0.0
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -64,11 +64,18 @@ jobs:
         run: |
           set -euo pipefail
           TAG="$INPUT_TAG"
-          # Validate format: must be exactly `@openbrowse/mcp-server@X.Y.Z`
-          # with optional semver pre-release / build metadata. Anything
-          # else fails fast rather than passing bogus values to
-          # actions/checkout or npm.
-          if ! printf '%s' "$TAG" | grep -Eq '^@openbrowse/mcp-server@[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'; then
+          # Validate against the WHOLE tag string using bash `[[ =~ ]]`,
+          # not `grep -E` line-matching. `grep -q` returns success on
+          # the first matching line, which means a multiline INPUT_TAG
+          # like $'@openbrowse/mcp-server@0.1.0\nmalicious=payload'
+          # would pass validation while smuggling extra output records
+          # into the echo lines below — classic GITHUB_OUTPUT injection.
+          # `[[ =~ ]]` matches the full string against the anchors, and
+          # since the pattern's character classes don't include newlines,
+          # any embedded newline causes the match to fail.
+          # Default shell on ubuntu-latest is bash --noprofile --norc
+          # -eo pipefail {0}, so `[[ =~ ]]` is available.
+          if ! [[ "$TAG" =~ ^@openbrowse/mcp-server@[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$ ]]; then
             echo "::error::Invalid tag format: '$TAG' (expected @openbrowse/mcp-server@X.Y.Z)"
             exit 1
           fi
@@ -78,7 +85,14 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ steps.tag.outputs.tag }}
+          # Fully-qualify as a tag ref. A bare `${{ steps.tag.outputs.tag }}`
+          # value would be resolved by git's usual short-name lookup
+          # (refs/tags/ then refs/heads/ then refs/remotes/); a same-
+          # named branch could shadow a deleted tag, or the workflow
+          # could silently fall back to a branch of that name. Prefixing
+          # with `refs/tags/` locks resolution to the tag namespace and
+          # fails cleanly if the tag isn't present.
+          ref: refs/tags/${{ steps.tag.outputs.tag }}
           # Do NOT persist the write-scoped GITHUB_TOKEN in .git/config.
           # This is a privileged publish workflow that does not push to
           # git; leaving the token in the on-disk config would let any

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -1,0 +1,148 @@
+name: Release @openbrowse/mcp-server
+
+# Publishes the broker to npm, creates a GitHub Release, and bumps the
+# Homebrew formula in openbrowse-ai/homebrew-tap. Invoked by
+# changesets.yml when a "Version Packages" merge tagged the package.
+#
+# Manual re-run path: `workflow_dispatch` for the case where the
+# automated run failed mid-way and left an unfinished release (e.g. npm
+# publish succeeded but Homebrew bump failed).
+#
+# Secrets required:
+#   NPM_TOKEN            — automation-tier npm access token with publish
+#                          rights on the @openbrowse scope.
+#   HOMEBREW_TAP_TOKEN   — fine-grained GitHub PAT with contents:write
+#                          on openbrowse-ai/homebrew-tap.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build (e.g. @openbrowse/mcp-server@0.1.0)"
+        required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to build"
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
+      HOMEBREW_TAP_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-mcp-server-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to create the GitHub Release
+    steps:
+      - name: Resolve tag + version
+        id: tag
+        # Pass inputs through env rather than `${{ ... }}` interpolation
+        # in the shell body to avoid command injection via a
+        # maliciously-crafted `tag` input (workflow_dispatch inputs are
+        # operator-controlled).
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="$INPUT_TAG"
+          # Validate format: must be exactly `@openbrowse/mcp-server@X.Y.Z`
+          # with optional semver pre-release / build metadata. Anything
+          # else fails fast rather than passing bogus values to
+          # actions/checkout or npm.
+          if ! printf '%s' "$TAG" | grep -Eq '^@openbrowse/mcp-server@[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'; then
+            echo "::error::Invalid tag format: '$TAG' (expected @openbrowse/mcp-server@X.Y.Z)"
+            exit 1
+          fi
+          VERSION="${TAG#@openbrowse/mcp-server@}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          # `registry-url` writes an .npmrc pointing at npm and enables
+          # NODE_AUTH_TOKEN auth for `npm publish` further down.
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches manifest version
+        env:
+          TAG_VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./packages/mcp-server/package.json').version")
+          echo "Tag version:      $TAG_VERSION"
+          echo "Manifest version: $PKG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $TAG_VERSION does not match packages/mcp-server/package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Typecheck
+        run: pnpm -F @openbrowse/mcp-server compile
+
+      - name: Test
+        run: pnpm -F @openbrowse/mcp-server test
+
+      - name: Build (esbuild bundle + tsc .d.ts)
+        run: pnpm -F @openbrowse/mcp-server build
+
+      - name: Publish to npm
+        # `--no-git-checks` because we're running against a detached HEAD
+        # at the tagged commit; pnpm otherwise refuses to publish from
+        # anything that isn't a clean tracking branch.
+        run: pnpm -F @openbrowse/mcp-server publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          # Display the release on the Releases page with a readable
+          # name; the underlying tag keeps the Changesets format.
+          name: "@openbrowse/mcp-server v${{ steps.tag.outputs.version }}"
+          generate_release_notes: true
+
+      - name: Bump Homebrew formula
+        # Skipped when HOMEBREW_TAP_TOKEN is not present (e.g. first-run
+        # test dispatch before secrets are set up). npm publish still
+        # succeeded; Homebrew users can manually update the tap later.
+        if: env.HAS_TAP_TOKEN == 'true'
+        env:
+          HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        uses: dawidd6/action-homebrew-bump-formula@d09b568334bfea0f4586b25c9d9e5c98b1ff8916 # v6.0.0
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Tap slug: `<owner>/<repo>` without the `homebrew-` prefix.
+          # Homebrew's convention is `openbrowse-ai/homebrew-tap` on
+          # GitHub, referenced as `openbrowse-ai/tap` by the action.
+          tap: openbrowse-ai/tap
+          # Formula filename (without the .rb extension).
+          formula: openbrowse-mcp
+          # The action computes the sha256 of the npm tarball and
+          # rewrites the formula's `url` + `sha256` fields to match
+          # the just-published version.
+          tag: ${{ steps.tag.outputs.tag }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,43 +14,37 @@ Pick one. They install the same binary to different locations.
 ### 1.1 Homebrew (macOS)
 
 ```sh
-brew install openbrowse/tap/openbrowse-mcp
+brew install openbrowse-ai/tap/openbrowse-mcp
 ```
 
 Installs to `/opt/homebrew/bin/openbrowse-mcp` (Apple Silicon) or
-`/usr/local/bin/openbrowse-mcp` (Intel).
+`/usr/local/bin/openbrowse-mcp` (Intel). Requires Homebrew's `node`
+formula as a runtime dependency.
 
 ### 1.2 winget (Windows)
 
-```powershell
-winget install OpenBrowse.McpBridge
-```
-
-Installs to `%LOCALAPPDATA%\Programs\OpenBrowse\openbrowse-mcp.exe`.
+Not yet available. Windows users should use the npm / npx path below.
 
 ### 1.3 npm / npx (cross-platform)
 
 ```sh
-npx -y openbrowse-mcp
+npx -y @openbrowse/mcp-server
 ```
 
 Runs without installing globally. To make it persistent:
 
 ```sh
-npm install -g openbrowse-mcp
+npm install -g @openbrowse/mcp-server
 ```
 
 Useful for trying it out, or for Node-heavy dev environments where you
-already have a global `node`/`npm`.
+already have a global `node`/`npm`. Both invocations expose the same
+`openbrowse-mcp` command.
 
 ### 1.4 GitHub Releases binary
 
-Download the appropriate archive from the
-[Releases page](https://github.com/openbrowse/openbrowse/releases),
-extract the `openbrowse-mcp` (or `.exe`) binary, and place it on your
-`PATH`.
-
-Use this if you're on Linux and don't want the npm-based install.
+Precompiled standalone binaries are not yet published. Use Homebrew or
+npm above.
 
 ## 2. First-run setup
 
@@ -181,11 +175,9 @@ registered host with controls to:
 openbrowse-mcp uninstall
 
 # Remove the binary
-brew uninstall openbrowse-mcp        # macOS Homebrew
+brew uninstall openbrowse-mcp                # macOS Homebrew
 # or
-winget uninstall OpenBrowse.McpBridge  # Windows winget
-# or
-npm uninstall -g openbrowse-mcp      # npm
+npm uninstall -g @openbrowse/mcp-server      # npm
 
 # Wipe local state (keys, tokens, audit log)
 rm -rf ~/.openbrowse/                # macOS / Linux
@@ -295,8 +287,7 @@ read `threat-model.md` § 4 and understand what you're exposing.
 ```sh
 brew upgrade openbrowse-mcp
 # or
-npm update -g openbrowse-mcp
-# or download a newer binary from Releases and replace the existing one
+npm update -g @openbrowse/mcp-server
 ```
 
 After upgrade, the extension may surface a "binary drift" advisory the

--- a/packages/mcp-server/.gitignore
+++ b/packages/mcp-server/.gitignore
@@ -1,0 +1,8 @@
+# Emitted by `pnpm build` (esbuild bundle + tsc .d.ts). Regenerated on
+# each publish, so we do not commit it. The npm tarball ships this
+# directory (see `files` in package.json).
+dist/
+
+# Local dev artefacts
+node_modules/
+*.log

--- a/packages/mcp-server/.npmignore
+++ b/packages/mcp-server/.npmignore
@@ -1,0 +1,23 @@
+# npm publishes files under `files` in package.json — this file is a
+# defense-in-depth guard against accidentally shipping dev artefacts if
+# the `files` allow-list is ever removed/misconfigured.
+
+# TypeScript sources — dist/ is what ships.
+src/
+
+# Tests + test config
+**/__tests__/
+**/*.test.ts
+vitest.config.ts
+
+# Type-checker configs — dist/ has emitted .d.ts already.
+tsconfig.json
+tsconfig.build.json
+
+# Build tooling
+scripts/build.mjs
+
+# Node hygiene
+node_modules/
+.DS_Store
+*.log

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenBrowse Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -47,7 +47,7 @@ openbrowse-mcp
 
 Output:
 
-```
+```text
 OpenBrowse MCP broker ready on http://127.0.0.1:47821
 Key fingerprint: 0123456789abcdef
 ```

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,111 @@
+# @openbrowse/mcp-server
+
+Local OAuth 2.1 + WebSocket broker that lets external MCP hosts (Cursor,
+Claude Desktop, OpenCode, Continue, and anything else speaking the [Model
+Context Protocol](https://modelcontextprotocol.io/)) drive the
+[OpenBrowse](https://github.com/openbrowse-ai/openbrowse) browser
+extension.
+
+The broker runs on your machine, binds to `127.0.0.1`, and never phones
+home. Hosts authorise via a browser-based OAuth flow with mandatory
+PKCE-S256; every RPC is scoped and audited.
+
+Read [`docs/threat-model.md`](https://github.com/openbrowse-ai/openbrowse/blob/main/docs/threat-model.md)
+before installing to understand what the bridge exposes.
+
+## Install
+
+### Homebrew (macOS)
+
+```sh
+brew install openbrowse-ai/tap/openbrowse-mcp
+```
+
+### npm / npx (any Node platform)
+
+Run once (no global install):
+
+```sh
+npx -y @openbrowse/mcp-server
+```
+
+Install globally so `openbrowse-mcp` is on your `PATH`:
+
+```sh
+npm install -g @openbrowse/mcp-server
+```
+
+### GitHub Releases
+
+Precompiled binary downloads are not yet published — use Homebrew or npm.
+
+## First run
+
+```sh
+openbrowse-mcp
+```
+
+Output:
+
+```
+OpenBrowse MCP broker ready on http://127.0.0.1:47821
+Key fingerprint: 0123456789abcdef
+```
+
+The broker holds the port until you `Ctrl+C` or the process dies. Point
+your MCP host at `http://127.0.0.1:47821/mcp` and authorise it via the
+browser popup the extension opens.
+
+For autostart on boot:
+
+```sh
+openbrowse-mcp install
+```
+
+Installs a launchd agent (macOS), systemd user unit (Linux), or Task
+Scheduler task (Windows). Remove with `openbrowse-mcp uninstall`.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `openbrowse-mcp` / `openbrowse-mcp serve` | Start the broker in the foreground. |
+| `openbrowse-mcp install` | Register autostart for the current user. |
+| `openbrowse-mcp uninstall` | Remove autostart. |
+| `openbrowse-mcp --rotate-keys` | Back up the current broker keypair and generate a new one. Re-TOFU the extension after running. |
+| `openbrowse-mcp --version` | Print version. |
+| `openbrowse-mcp --help` | Print this help. |
+
+## Configuration
+
+The broker reads its state from `~/.openbrowse/`:
+
+| File | Purpose |
+|---|---|
+| `broker-key.json` | EdDSA keypair used to sign JWTs and to negotiate the extension WS handshake (TOFU). |
+| `broker.lock` | PID lock preventing a second broker from binding the same port. |
+| `refresh-tokens.json` | Per-host refresh tokens (rotated on every use, 30-day idle expiry). |
+
+Everything else lives in the extension's own storage (per-host policy,
+audit log, etc.). Uninstalling the broker leaves the extension's state
+intact.
+
+## Uninstall
+
+```sh
+openbrowse-mcp uninstall        # remove autostart
+brew uninstall openbrowse-mcp   # macOS Homebrew
+npm uninstall -g @openbrowse/mcp-server   # npm
+```
+
+Then delete `~/.openbrowse/` to reset broker state.
+
+## Documentation
+
+- Full deployment guide: [`docs/deployment.md`](https://github.com/openbrowse-ai/openbrowse/blob/main/docs/deployment.md)
+- Threat model: [`docs/threat-model.md`](https://github.com/openbrowse-ai/openbrowse/blob/main/docs/threat-model.md)
+- OpenBrowse repo: <https://github.com/openbrowse-ai/openbrowse>
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/mcp-server/bin/openbrowse-mcp.mjs
+++ b/packages/mcp-server/bin/openbrowse-mcp.mjs
@@ -1,17 +1,30 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+// Entry point for `@openbrowse/mcp-server` when installed via npm/Homebrew.
+//
+// Layout after `pnpm build`:
+//   bin/openbrowse-mcp.mjs   ← you are here (executable, in package `bin`)
+//   dist/index.js            ← bundled ESM module exporting runServer + subcommand handlers
+//
+// This wrapper handles the tiny set of subcommands that DO NOT need the
+// server runtime (--version / --help — cheap enough to answer without
+// loading dist/) and delegates everything else (`serve`, `install`,
+// `uninstall`, `--rotate-keys`) to the bundled module.
+//
+// Delegating via a direct import (not spawn) keeps the process tree flat,
+// which matters for autostart handlers (launchd expects the invoked
+// binary to be the process it monitors — no daemonising).
+
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const indexTs = join(here, "..", "src", "index.ts");
 
 const args = process.argv.slice(2);
 const cmd = args[0];
 
-// Built-in subcommands that don't need the runtime: --version, --help
+// Cheap commands: answer without loading the bundle.
 if (cmd === "--version" || cmd === "-v") {
-  const { readFileSync } = await import("node:fs");
   const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8"));
   console.log(pkg.version);
   process.exit(0);
@@ -31,10 +44,24 @@ Commands:
   process.exit(0);
 }
 
-// For everything else, delegate to tsx-loaded src/index.ts
-const result = spawnSync(
-  process.execPath,
-  ["--import", "tsx", indexTs, ...args],
-  { stdio: "inherit" },
-);
-process.exit(result.status ?? 0);
+// Everything else: hand off to the bundled entrypoint. The bundle
+// re-exports the same `main()` function used by `tsx src/index.ts`, so
+// argv semantics are identical between dev (`pnpm start`) and installed
+// (`openbrowse-mcp`).
+const bundle = join(here, "..", "dist", "index.js");
+const mod = await import(bundle);
+// `main` is the default async runner; it inspects process.argv itself.
+// Fall back to a named export if consumers restructure the entry later.
+const main = mod.default ?? mod.main ?? mod.runFromCli;
+if (typeof main !== "function") {
+  console.error(
+    "[openbrowse-mcp] internal error: bundled entry did not expose a callable main().",
+  );
+  process.exit(2);
+}
+try {
+  await main();
+} catch (err) {
+  console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+  process.exit(1);
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,29 +1,65 @@
 {
   "name": "@openbrowse/mcp-server",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
+  "description": "OpenBrowse MCP broker — an OAuth 2.1 + WebSocket bridge that lets external MCP hosts (Cursor, Claude Desktop, OpenCode, etc.) drive the OpenBrowse browser extension. Runs locally on 127.0.0.1.",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "openbrowse",
+    "browser-automation",
+    "oauth",
+    "broker",
+    "ai-agent"
+  ],
+  "homepage": "https://github.com/openbrowse-ai/openbrowse#readme",
+  "bugs": "https://github.com/openbrowse-ai/openbrowse/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openbrowse-ai/openbrowse.git",
+    "directory": "packages/mcp-server"
+  },
+  "license": "MIT",
+  "author": "OpenBrowse Contributors",
   "type": "module",
-  "description": "OpenBrowse MCP server (HTTP+OAuth broker)",
   "bin": {
     "openbrowse-mcp": "./bin/openbrowse-mcp.mjs"
   },
   "exports": {
-    ".": { "types": "./src/index.ts", "default": "./src/index.ts" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "engines": { "node": ">=22.6" },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "bin",
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=22.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
+    "build": "node scripts/build.mjs && tsc -p tsconfig.build.json",
     "compile": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "start": "tsx src/index.ts serve"
+    "start": "tsx src/index.ts serve",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "tsx": "^4.19.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",
     "@types/ws": "^8.5.13",
+    "esbuild": "^0.24.0",
+    "tsx": "^4.19.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -56,7 +56,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@types/node": "^25.9.1",
+    "@types/node": "^22.10.0",
     "@types/ws": "^8.5.13",
     "esbuild": "^0.24.0",
     "tsx": "^4.19.0",

--- a/packages/mcp-server/scripts/build.mjs
+++ b/packages/mcp-server/scripts/build.mjs
@@ -15,8 +15,16 @@
 
 import { build } from "esbuild";
 import { readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
 
 const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+// Wipe the output directory before rebuilding so renamed/deleted
+// sources can't leave orphaned `.js` / `.d.ts` / `.map` files behind
+// from a prior run. Downstream `tsc -p tsconfig.build.json` also
+// emits into dist/ and could otherwise miss stale files it no longer
+// generates.
+await rm(new URL("../dist", import.meta.url), { recursive: true, force: true });
 
 await build({
   entryPoints: ["src/index.ts"],

--- a/packages/mcp-server/scripts/build.mjs
+++ b/packages/mcp-server/scripts/build.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Bundles src/index.ts into dist/index.js as a single ESM file.
+//
+// Why bundle instead of tsc-only:
+//  - Source uses extensionless relative imports (`import x from "./server"`)
+//    which is fine under TypeScript's `moduleResolution: "bundler"` at
+//    compile time but breaks Node ESM at runtime (Node ESM requires
+//    explicit `.js` extensions). Bundling resolves everything at build
+//    time, so the emitted output has zero import-path surprises.
+//  - Ships a single file to npm consumers; simplifies the install.
+//
+// External deps: keep `ws` and Node built-ins external so users get the
+// real installed package rather than a mis-bundled copy of a native-ish
+// module.
+
+import { build } from "esbuild";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outfile: "dist/index.js",
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "esm",
+  // Ship a single, tree-shaken file. Externalising built-ins is the
+  // default under platform=node. Also externalise runtime deps so
+  // users' `node_modules/` copies are used instead of a possibly-stale
+  // bundled version.
+  external: Object.keys(pkg.dependencies ?? {}),
+  sourcemap: true,
+  logLevel: "info",
+  // Preserve error names + stack frames. `minify` collapses those.
+  minify: false,
+  // Some transitive TS files reference `import.meta.url`; keep it.
+  banner: {
+    js: [
+      "// @openbrowse/mcp-server — bundled by esbuild",
+      "// Do not edit; regenerate via `pnpm build`.",
+    ].join("\n"),
+  },
+});
+
+console.log("✓ dist/index.js written");

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -7,10 +7,28 @@ import {
   writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { startHttpServer } from "./server";
 
-export const VERSION = "0.0.0";
+/**
+ * Resolved at module load from `package.json`. Kept as an export so
+ * `--version` (bin wrapper) and any consumer that imports this module
+ * can read the shipping version without duplicating the string across
+ * source and package metadata.
+ */
+export const VERSION: string = (() => {
+  try {
+    const pkgPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "package.json",
+    );
+    return JSON.parse(readFileSync(pkgPath, "utf8")).version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
 
 const LOCK_FILE = () => join(process.env.HOME ?? homedir(), ".openbrowse", "broker.lock");
 
@@ -118,7 +136,16 @@ export async function runServer(): Promise<void> {
   );
 }
 
-async function main(): Promise<void> {
+/**
+ * Subcommand dispatcher. Called from:
+ *   - `tsx src/index.ts <cmd>` (dev, `pnpm start`)
+ *   - `openbrowse-mcp <cmd>` (installed, bin/openbrowse-mcp.mjs loads
+ *     dist/index.js and invokes this)
+ *
+ * argv semantics are read directly from `process.argv` so both paths
+ * behave identically.
+ */
+export async function main(): Promise<void> {
   const cmd = process.argv[2];
   switch (cmd) {
     case undefined:
@@ -145,6 +172,11 @@ async function main(): Promise<void> {
       process.exit(1);
   }
 }
+
+// Also expose `main` as the default export so the bin wrapper's
+// `mod.default ?? mod.main` fallback finds it regardless of bundler
+// output shape.
+export default main;
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((err) => {

--- a/packages/mcp-server/tsconfig.build.json
+++ b/packages/mcp-server/tsconfig.build.json
@@ -10,6 +10,5 @@
     "noEmit": false,
     "skipLibCheck": true
   },
-  "include": ["src/index.ts"],
-  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
+  "include": ["src/index.ts"]
 }

--- a/packages/mcp-server/tsconfig.build.json
+++ b/packages/mcp-server/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "skipLibCheck": true
+  },
+  "include": ["src/index.ts"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 15.0.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.22.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       fumadocs-ui:
         specifier: ^16
-        version: 16.8.9(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.22.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.3.0)
+        version: 16.8.9(@tailwindcss/oxide@4.3.2)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.22.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.3.0)
       lucide-react:
         specifier: latest
         version: 1.22.0(react@19.2.5)
@@ -89,7 +89,7 @@ importers:
     devDependencies:
       '@tailwindcss/postcss':
         specifier: latest
-        version: 4.3.1
+        version: 4.3.2
       '@types/mdast':
         specifier: ^4.0.0
         version: 4.0.4
@@ -455,9 +455,6 @@ importers:
 
   packages/mcp-server:
     dependencies:
-      tsx:
-        specifier: ^4.19.0
-        version: 4.22.3
       ws:
         specifier: ^8.18.0
         version: 8.20.1
@@ -468,12 +465,18 @@ importers:
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(happy-dom@20.9.0)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(happy-dom@20.9.0)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))
 
 packages:
 
@@ -1038,6 +1041,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -1050,6 +1059,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
@@ -1060,6 +1075,12 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -1074,6 +1095,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
@@ -1086,6 +1113,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -1096,6 +1129,12 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -1110,6 +1149,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -1120,6 +1165,12 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -1134,6 +1185,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -1144,6 +1201,12 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -1158,6 +1221,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -1168,6 +1237,12 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -1182,6 +1257,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -1192,6 +1273,12 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -1206,6 +1293,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -1216,6 +1309,12 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -1230,6 +1329,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -1242,6 +1347,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
@@ -1252,6 +1363,12 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -1266,6 +1383,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
@@ -1276,6 +1399,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1302,6 +1431,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
@@ -1313,6 +1448,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
@@ -1326,6 +1467,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -1336,6 +1483,12 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -2707,8 +2860,8 @@ packages:
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
-  '@tailwindcss/node@4.3.1':
-    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
   '@tailwindcss/oxide-android-arm64@4.2.2':
     resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
@@ -2716,8 +2869,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-android-arm64@4.3.1':
-    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
@@ -2728,8 +2881,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.1':
-    resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -2740,8 +2893,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.3.1':
-    resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -2752,8 +2905,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.1':
-    resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
@@ -2764,8 +2917,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
-    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
@@ -2777,8 +2930,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
-    resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -2791,8 +2944,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
-    resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -2805,8 +2958,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
-    resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -2819,8 +2972,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
-    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -2838,8 +2991,8 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
-    resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -2856,8 +3009,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
-    resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
@@ -2868,8 +3021,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
-    resolution: {integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -2878,12 +3031,12 @@ packages:
     resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/oxide@4.3.1':
-    resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/postcss@4.3.1':
-    resolution: {integrity: sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==}
+  '@tailwindcss/postcss@4.3.2':
+    resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
 
   '@tailwindcss/typography@0.5.19':
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
@@ -4201,6 +4354,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -6531,8 +6689,8 @@ packages:
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
-  tailwindcss@4.3.1:
-    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -7953,10 +8111,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -7965,10 +8129,16 @@ snapshots:
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -7977,10 +8147,16 @@ snapshots:
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -7989,10 +8165,16 @@ snapshots:
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -8001,10 +8183,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -8013,10 +8201,16 @@ snapshots:
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -8025,10 +8219,16 @@ snapshots:
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -8037,10 +8237,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -8049,10 +8255,16 @@ snapshots:
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -8061,16 +8273,25 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -8085,10 +8306,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -8097,10 +8324,16 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -8132,9 +8365,9 @@ snapshots:
 
   '@fontsource/young-serif@5.2.7': {}
 
-  '@fumadocs/tailwind@0.0.5(@tailwindcss/oxide@4.3.1)(tailwindcss@4.3.0)':
+  '@fumadocs/tailwind@0.0.5(@tailwindcss/oxide@4.3.2)(tailwindcss@4.3.0)':
     optionalDependencies:
-      '@tailwindcss/oxide': 4.3.1
+      '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.0
 
   '@hono/node-server@1.19.14(hono@4.12.14)':
@@ -9454,7 +9687,7 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.2.2
 
-  '@tailwindcss/node@4.3.1':
+  '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.21.6
@@ -9462,78 +9695,78 @@ snapshots:
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.3.1
+      tailwindcss: 4.3.2
 
   '@tailwindcss/oxide-android-arm64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-android-arm64@4.3.1':
+  '@tailwindcss/oxide-android-arm64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-darwin-x64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.3.1':
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
     optional: true
 
   '@tailwindcss/oxide@4.2.2':
@@ -9551,28 +9784,28 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/oxide@4.3.1':
+  '@tailwindcss/oxide@4.3.2':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.3.1
-      '@tailwindcss/oxide-darwin-arm64': 4.3.1
-      '@tailwindcss/oxide-darwin-x64': 4.3.1
-      '@tailwindcss/oxide-freebsd-x64': 4.3.1
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
-      '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
-      '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
-      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
-      '@tailwindcss/oxide-wasm32-wasi': 4.3.1
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
-      '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
 
-  '@tailwindcss/postcss@4.3.1':
+  '@tailwindcss/postcss@4.3.2':
     dependencies:
       '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.3.1
-      '@tailwindcss/oxide': 4.3.1
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
       postcss: 8.5.15
-      tailwindcss: 4.3.1
+      tailwindcss: 4.3.2
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
     dependencies:
@@ -10027,6 +10260,15 @@ snapshots:
       '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.4(@types/node@25.9.1)(typescript@6.0.3)
+      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)
 
   '@vitest/mocker@4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
@@ -10905,6 +11147,34 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -11300,9 +11570,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.8.9(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.22.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.3.0):
+  fumadocs-ui@16.8.9(@tailwindcss/oxide@4.3.2)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@1.22.0(react@19.2.5))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.3.0):
     dependencies:
-      '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.1)(tailwindcss@4.3.0)
+      '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.2)(tailwindcss@4.3.0)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -13824,7 +14094,7 @@ snapshots:
 
   tailwindcss@4.3.0: {}
 
-  tailwindcss@4.3.1: {}
+  tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
 
@@ -14107,11 +14377,25 @@ snapshots:
       - tsx
       - yaml
 
+  vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.1
+      esbuild: 0.24.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.3
+
   vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.22.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -14125,7 +14409,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -14139,7 +14423,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -14152,6 +14436,35 @@ snapshots:
   vitefu@1.1.3(vite@8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)):
     optionalDependencies:
       vite: 8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(happy-dom@20.9.0)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.9.1
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(happy-dom@20.9.0)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
         version: 8.20.1
     devDependencies:
       '@types/node':
-        specifier: ^25.9.1
-        version: 25.9.1
+        specifier: ^22.10.0
+        version: 22.19.19
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
@@ -476,7 +476,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(happy-dom@20.9.0)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(happy-dom@20.9.0)(msw@2.13.4(@types/node@22.19.19)(typescript@6.0.3))(vite@8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))
 
 packages:
 
@@ -8497,12 +8497,33 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
+  '@inquirer/confirm@6.0.12(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.19)
+      '@inquirer/type': 4.0.5(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+    optional: true
+
   '@inquirer/confirm@6.0.12(@types/node@25.9.1)':
     dependencies:
       '@inquirer/core': 11.1.9(@types/node@25.9.1)
       '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/core@11.1.9(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.19)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    optional: true
 
   '@inquirer/core@11.1.9(@types/node@25.9.1)':
     dependencies:
@@ -8524,6 +8545,11 @@ snapshots:
       '@types/node': 25.9.1
 
   '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@22.19.19)':
+    optionalDependencies:
+      '@types/node': 22.19.19
+    optional: true
 
   '@inquirer/type@4.0.5(@types/node@25.9.1)':
     optionalDependencies:
@@ -10261,14 +10287,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))':
+  '@vitest/mocker@4.1.7(msw@2.13.4(@types/node@22.19.19)(typescript@6.0.3))(vite@8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.4(@types/node@25.9.1)(typescript@6.0.3)
-      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)
+      msw: 2.13.4(@types/node@22.19.19)(typescript@6.0.3)
+      vite: 8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)
 
   '@vitest/mocker@4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
@@ -12805,6 +12831,32 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.13.4(@types/node@22.19.19)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@22.19.19)
+      '@mswjs/interceptors': 0.41.4
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.8
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.12(@types/node@25.9.1)
@@ -14377,7 +14429,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3):
+  vite@8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -14385,7 +14437,7 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.19.19
       esbuild: 0.24.2
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -14437,10 +14489,10 @@ snapshots:
     optionalDependencies:
       vite: 8.0.8(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
 
-  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(happy-dom@20.9.0)(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)):
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(happy-dom@20.9.0)(msw@2.13.4(@types/node@22.19.19)(typescript@6.0.3))(vite@8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(msw@2.13.4(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))
+      '@vitest/mocker': 4.1.7(msw@2.13.4(@types/node@22.19.19)(typescript@6.0.3))(vite@8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -14457,11 +14509,11 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.8(@types/node@22.19.19)(esbuild@0.24.2)(jiti@2.7.0)(tsx@4.22.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
+      '@types/node': 22.19.19
       happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## What

Ships `@openbrowse/mcp-server@0.1.0` as an installable artefact so end users don't need to clone the repo. Also fixes the Changesets release pipeline that broke on PR #176's merge because it assumed only one publishable workspace package.

New install paths:

```sh
brew install openbrowse-ai/tap/openbrowse-mcp   # macOS
npx -y @openbrowse/mcp-server                   # any Node platform
npm install -g @openbrowse/mcp-server           # persistent global
```

All three expose `openbrowse-mcp` on `PATH`.

## Why the pipeline needed fixing

`changesets.yml` used `publishedPackages[0].version` and hardcoded the `openbrowse@` tag prefix. When PR #176 added the broker package, Changesets tagged **both** the extension and the broker on release runs — the broker happened to land first in the array, producing an `openbrowse@0.0.0` tag that didn't exist. This PR splits `publishedPackages` by name using `jq` and gates each downstream release workflow independently.

## Structure

**Broker package**:
- `package.json`: `private` removed, `version: 0.1.0`, `publishConfig.access: public`, `main/types/exports → dist/`, `files` allow-list, `prepublishOnly: build`.
- `scripts/build.mjs`: esbuild bundle → single ESM `dist/index.js` (~60 kB). Node built-ins + `ws` externalised.
- `tsconfig.build.json`: `emitDeclarationOnly` for `.d.ts` generation (bundling handles JS).
- `bin/openbrowse-mcp.mjs`: imports `dist/index.js` directly instead of `spawn(tsx)`. Flat process tree = launchd/systemd-friendly.
- `src/index.ts`: exports `main()` (default + named), reads `VERSION` from `package.json` at load.
- `README.md`, `LICENSE` (MIT), `.npmignore`, `.gitignore` — added.

**Release pipeline**:
- `changesets.yml`: `jq` split of `publishedPackages` → `extension_version`, `mcp_server_version` outputs. Each downstream workflow gated on non-empty.
- `release-mcp-server.yml`: new. Checkout tag → typecheck → test → build → `pnpm publish --access public` → GH Release → `dawidd6/action-homebrew-bump-formula` to update `openbrowse-ai/homebrew-tap`.

**Docs**:
- `docs/deployment.md`: Homebrew formula path corrected, npm commands use scoped name, winget section replaced with "not yet available" (deferred).

**Changeset**:
- `mcp-server-initial-release.md`: minor bump for `@openbrowse/mcp-server`. On merge, Changesets opens a Version Packages PR bumping to 0.1.0; merging **that** triggers the release-mcp-server workflow.

## Prerequisites before merging the Version Packages PR

The maintainer needs to complete these out-of-band (workflow will fail without them):

- [ ] Reserve `@openbrowse` scope + `@openbrowse/mcp-server` name on npm
- [ ] Generate an automation-tier npm access token; add as repo Actions secret `NPM_TOKEN`
- [ ] Create `openbrowse-ai/homebrew-tap` public repo with a placeholder `Formula/openbrowse-mcp.rb`
- [ ] Generate a fine-grained GitHub PAT with `contents:write` on the tap repo; add as repo Actions secret `HOMEBREW_TAP_TOKEN`

If `HOMEBREW_TAP_TOKEN` is missing, npm publish + GH Release still complete; the Homebrew step self-skips.

**This PR itself is safe to merge without the secrets** — the release workflows only fire on the Version Packages PR merge (i.e. after the Changesets bot proposes bumping to 0.1.0 and a human accepts).

## Local validation

- `pnpm build` produces `dist/index.js` (59.5 kB) + `.d.ts` files cleanly.
- `pnpm publish --dry-run` enumerates 60 files, 66.6 kB tarball, includes README + LICENSE, excludes `src/` + tests + tsconfigs.
- `npm install -g <tarball>` into a tmp prefix → `openbrowse-mcp --version` prints `0.1.0`; `openbrowse-mcp serve` starts the broker.
- `pnpm compile` (broker): 0 errors.
- `pnpm test` (broker): 110/110.
- `pnpm tsc --noEmit` (extension): 0 errors.
- `pnpm test` (extension): 2570/2570.
- `pnpm exec changeset status`: only `@openbrowse/mcp-server` bumped at minor.
- `jq` filter tested against 4 scenarios (both, ext-only, mcp-only, empty) — all correct.

## Cleanup mutations (on merge)

- Delete stray `@openbrowse/mcp-server@0.0.0` tag on origin (created by the broken workflow run from PR #176's merge).

## Deferred

- winget manifest submission (Windows currently uses npm/npx)
- `bun --compile` binary matrix for GitHub Release downloads
- Manual E2E across 4 MCP hosts using the installed binary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released the OpenBrowse MCP broker as a public npm package with Homebrew install support.
  * Added release automation to publish the extension and MCP broker versions independently.
* **Bug Fixes**
  * Improved CLI behavior with clearer version/help handling and more reliable exit codes on failures.
* **Documentation**
  * Expanded the MCP broker README with install, first-run, and command reference.
  * Updated deployment/install/uninstall instructions to use the scoped npm package and correct Homebrew formula.
* **Build/Release**
  * Updated packaging and publish workflow to ensure the published artifacts and tags align correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->