### PR TITLE
fix(connectors): update Notion hosted MCP URL to mcp.notion.com

### DIFF
--- a/.changeset/fix-notion-mcp-url.md
+++ b/.changeset/fix-notion-mcp-url.md
@@ -1,0 +1,17 @@
+---
+"openbrowse": patch
+---
+
+**Fix Notion connector "Failed to connect" by updating the hosted MCP URL to notion.com.**
+
+The Notion connector definition pointed at `https://mcp.notion.so/mcp`, which no longer resolves — DNS lookups for `mcp.notion.so` fail outright. Notion moved its hosted MCP endpoint to `https://mcp.notion.com/mcp`.
+
+Because the very first request in `discoverOAuthMetadata` (the `GET` against the MCP URL to read `WWW-Authenticate: resource_metadata=...`) never got a response, every downstream fallback path in `handleOAuthStart` also failed against the same dead host, and the entire flow rejected with a fetch error before `chrome.identity.launchWebAuthFlow` was ever reached. The user saw an immediate "Failed to connect Notion" toast the moment they clicked Connect.
+
+Verified the corrected host end-to-end:
+
+- `GET https://mcp.notion.com/mcp` → `401` with `WWW-Authenticate: Bearer realm="OAuth", resource_metadata="https://mcp.notion.com/.well-known/oauth-protected-resource/mcp", ...` — matches the RFC 9728 discovery path OpenBrowse already implements.
+- The resource metadata declares `authorization_servers: ["https://mcp.notion.com"]`.
+- `GET https://mcp.notion.com/.well-known/oauth-authorization-server` returns full RFC 8414 metadata: `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, PKCE (`S256`), and `grant_types_supported: ["authorization_code", "refresh_token"]` — so both the initial exchange and silent refresh-after-SW-restart paths are supported.
+
+Fix: `packages/connectors/src/notion.ts` — change the `url` field from `https://mcp.notion.so/mcp` to `https://mcp.notion.com/mcp`. No other files reference the old host.

--- a/packages/connectors/src/notion.ts
+++ b/packages/connectors/src/notion.ts
@@ -11,7 +11,7 @@ export const definition: ConnectorDefinition = {
   icon: { light: "notion.svg", dark: "notion-dark.svg" },
   description: "Pages, databases, and workspace content",
   category: "productivity",
-  url: "https://mcp.notion.so/mcp",
+  url: "https://mcp.notion.com/mcp",
   auth: { type: "oauth" },
   docsUrl: "https://developers.notion.com",
   formatLabel(toolName, result): ToolResultLabel | null {


### PR DESCRIPTION
## Summary

Notion's hosted MCP endpoint moved from `mcp.notion.so` to `mcp.notion.com`. The old hostname no longer resolves (DNS failure), so clicking **Connect** on the Notion connector produced an immediate "Failed to connect Notion" toast — the first `fetch` in `discoverOAuthMetadata` and every fallback path all failed against the dead host, and `handleOAuthStart` rejected before `chrome.identity.launchWebAuthFlow` was ever invoked.

Single-line fix: update `packages/connectors/src/notion.ts` to point at `https://mcp.notion.com/mcp`.

## Root cause

`apps/extension/src/entrypoints/background/mcp-messages.ts:85` performs `GET <serverUrl>` to read the `WWW-Authenticate: resource_metadata=…` header (RFC 9728). With `serverUrl = https://mcp.notion.so/mcp`, the request fails at DNS lookup. The origin-level and path-aware `.well-known/oauth-authorization-server` fallbacks also hit the same dead host. The catch in `handleOAuthStart` then responds with `{ ok: false, error }` and the settings UI surfaces the toast (`ConnectorsTab.tsx:110`).

## Verification against the corrected host

- `GET https://mcp.notion.com/mcp` → `401` with
  `WWW-Authenticate: Bearer realm="OAuth", resource_metadata="https://mcp.notion.com/.well-known/oauth-protected-resource/mcp", …`
- Resource metadata declares `authorization_servers: ["https://mcp.notion.com"]`
- `GET https://mcp.notion.com/.well-known/oauth-authorization-server` returns full RFC 8414 metadata including `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, PKCE `S256`, and `grant_types_supported: ["authorization_code", "refresh_token"]` — so both the initial exchange and the silent refresh-after-SW-restart path in `mcp-oauth.ts` are supported.

## Changes

- `packages/connectors/src/notion.ts` — `url: "https://mcp.notion.so/mcp"` → `https://mcp.notion.com/mcp`
- `.changeset/fix-notion-mcp-url.md` — patch changeset for `openbrowse`

## Not verified

The full OAuth handshake through `chrome.identity.launchWebAuthFlow` wasn't executed end-to-end (that requires loading the extension). The curl-verified discovery chain covers everything upstream of the browser auth flow, which is exactly where the failure was.