### PR TITLE
fix(broker-release): pin dawidd6/action-homebrew-bump-formula to real v7 SHA

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -187,7 +187,7 @@ jobs:
         # `HAS_TAP_TOKEN` is defined at job level so this if: sees a
         # stable value regardless of step-level env eval order.
         if: env.HAS_TAP_TOKEN == 'true'
-        uses: dawidd6/action-homebrew-bump-formula@d09b568334bfea0f4586b25c9d9e5c98b1ff8916 # v6.0.0
+        uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           # Tap slug: `<owner>/<repo>` without the `homebrew-` prefix.


### PR DESCRIPTION
## What

Fixes the release workflow that failed on the `@openbrowse/mcp-server@0.2.0` release run:

```
Error: Unable to resolve action `dawidd6/action-homebrew-bump-formula@d09b568334bfea0f4586b25c9d9e5c98b1ff8916`,
unable to find version `d09b568334bfea0f4586b25c9d9e5c98b1ff8916`
```

The SHA pinned in `.github/workflows/release-mcp-server.yml` doesn't exist on the upstream `dawidd6/action-homebrew-bump-formula` repo. It was a bad SHA committed earlier — combined with a `# v6.0.0` tag comment that also doesn't exist (the upstream uses `vN` major-only tags, not `vN.Y.Z`).

## Why the release still shipped partially

The failure was at the workflow's setup phase ("Prepare all required actions"), which runs BEFORE any user step:
- ✅ Git tag `@openbrowse/mcp-server@0.2.0` — created by Changesets earlier in the same pipeline
- ✅ GitHub Release `@openbrowse/mcp-server@0.2.0` — created by the Changesets action itself
- ❌ **npm publish** — did NOT run
- ❌ **Homebrew formula bump** — did NOT run

Verified: `@openbrowse/mcp-server@0.2.0` is NOT on the npm registry.

## Fix

Pin to the real v7 SHA `1446dca236b0440c6f02723a3f14f13be2c04ab0`:

```diff
-uses: dawidd6/action-homebrew-bump-formula@d09b568334bfea0f4586b25c9d9e5c98b1ff8916 # v6.0.0
+uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
```

- v7 is the current stable major tag on upstream (released 2025-12-02, 7+ months soak)
- v7 reverts a v6 approach to Homebrew 5.0 compatibility that was itself buggy
- SHA-pin format matches every other action reference in this repo's workflows
- Verified via `gh api repos/dawidd6/action-homebrew-bump-formula/commits/1446dca...`

## Recovery after merge

After this merges, manually re-run the release workflow for 0.2.0:

1. Actions tab → **Release @openbrowse/mcp-server** → **Run workflow**
2. Enter tag: `@openbrowse/mcp-server@0.2.0`
3. Run

The workflow drives:
- npm publish (will succeed — 0.2.0 doesn't exist yet)
- GitHub Release update (touches the existing release; `softprops/action-gh-release` is idempotent)
- Homebrew formula bump against `openbrowse-ai/tap/openbrowse-mcp`

The `already-published` tolerance on the npm publish step (from a previous PR) makes this retry-safe.

## Local validation

- `gh api repos/dawidd6/action-homebrew-bump-formula/commits/1446dca236b0440c6f02723a3f14f13be2c04ab0` → returns valid commit (message: "Merge pull request #113 from dawidd6/revert-103-fix-homebrew-5-issue-102-clean")
- YAML parse (js-yaml): OK
- 1 file changed, 1 insertion(+), 1 deletion(-)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Homebrew release automation to a newer supported version, improving reliability for formula publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->