### PR TITLE
fix(broker-release): trust openbrowse-ai/tap before Homebrew bump step

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -180,6 +180,32 @@ jobs:
           name: "@openbrowse/mcp-server v${{ steps.tag.outputs.version }}"
           generate_release_notes: true
 
+      - name: Trust the openbrowse-ai/tap tap
+        # Homebrew 6.0+ (June 2026) requires third-party taps to be
+        # explicitly trusted before their formulae can be loaded. The
+        # dawidd6/action-homebrew-bump-formula action calls
+        # `Formula[...]` internally, which triggers
+        # Homebrew::Trust.require_trusted_formula! and raises
+        # UntrustedTapError for taps not in ~/.homebrew/trust.json.
+        # The action itself makes no provision for trust — it doesn't
+        # accept a `trust` input, doesn't call `brew trust`, and
+        # doesn't set HOMEBREW_NO_REQUIRE_TAP_TRUST.
+        #
+        # `brew trust <tap>` is the Homebrew-intended mechanism for
+        # opting in to a third-party tap. Whole-tap scope: we own
+        # openbrowse-ai/homebrew-tap and every formula in it is ours,
+        # so trusting the tap as a unit auto-covers any future
+        # formulae we add. The trust write is synchronous and
+        # persistent across steps within the same runner instance,
+        # so the next step's `brew ruby main.rb` finds it via the
+        # normal trusted_taps lookup.
+        #
+        # Runners are ephemeral (fresh trust.json every run), so
+        # re-running this step on every release is intentional and
+        # cheap.
+        if: env.HAS_TAP_TOKEN == 'true'
+        run: brew trust openbrowse-ai/tap
+
       - name: Bump Homebrew formula
         # Skipped when HOMEBREW_TAP_TOKEN is not present (e.g. first-run
         # test dispatch before secrets are set up). npm publish still


### PR DESCRIPTION
## What

Fixes the Homebrew bump step in the release workflow, which failed on the `@openbrowse/mcp-server@0.2.0` release retry with:

```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/trust.rb:577:in 'Homebrew::Trust.raise_untrusted!':
Refusing to load formula openbrowse-ai/tap/openbrowse-mcp from untrusted tap openbrowse-ai/tap.
(Homebrew::UntrustedTapError)

Run `brew trust --formula openbrowse-ai/tap/openbrowse-mcp` or `brew trust openbrowse-ai/tap` to trust it.
```

## Root cause

Homebrew 6.0.0 (Jun 11 2026) added trust enforcement for third-party taps ([commit c6f37230](https://github.com/Homebrew/brew/commit/c6f37230435e29ba827dbfe0d380e99a9e98ac6e), on by default). GitHub Actions `ubuntu-latest` runners ship Homebrew 6.0.x, so trust checks fire on every load.

The `dawidd6/action-homebrew-bump-formula` action calls `Formula[name]` internally to compute the version diff. That triggers `Homebrew::Trust.require_trusted_formula!`, which raises `UntrustedTapError` for taps not in `~/.homebrew/trust.json`. The action makes no provision for trust (verified by reading [action.yml](https://raw.githubusercontent.com/dawidd6/action-homebrew-bump-formula/1446dca236b0440c6f02723a3f14f13be2c04ab0/action.yml) — no `trust` input — and [main.rb](https://raw.githubusercontent.com/dawidd6/action-homebrew-bump-formula/1446dca236b0440c6f02723a3f14f13be2c04ab0/main.rb) — no `brew trust` call).

## Fix

One new step immediately before the Homebrew bump:

```yaml
- name: Trust the openbrowse-ai/tap tap
  if: env.HAS_TAP_TOKEN == 'true'
  run: brew trust openbrowse-ai/tap
```

`brew trust <tap>` writes to `~/.homebrew/trust.json` synchronously. The next step's `brew ruby main.rb` reads it during the trust check and returns early at `require_trusted_formula!` (trust.rb:219) because the tap is now in `trustedtaps`.

**Whole-tap scope** (not `--formula`) chosen because we own `openbrowse-ai/homebrew-tap` and every formula in it is ours — future formulae auto-covered without workflow edits. Homebrew's own error message suggests both variants on equal footing.

## Why not `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`

That env var works (`env_config.rb:476-482`) but Homebrew documents it as "not recommended and will be removed in a later release" and marks the corresponding `HOMEBREW_REQUIRE_TAP_TRUST` as `odeprecated: make tap trust checks default in a later release`. `brew trust` is the permanent, tap-scoped, intended path.

## Recovery for 0.2.0

After merge, manually re-run the release workflow:

1. Actions tab → **Release @openbrowse/mcp-server** → **Run workflow**
2. Tag: `@openbrowse/mcp-server@0.2.0`
3. Run.

Idempotent retry:
- **npm publish**: already-published tolerance (added in a previous PR) handles the second attempt — 0.2.0 was successfully published on your last manual run.
- **GitHub Release**: `softprops/action-gh-release@v3` upserts by `tag_name`.
- **Homebrew bump**: runs successfully for the first time.

## Sources

Every claim above is source-cited to the Homebrew and dawidd6 action source trees. Trust check enforcement is definitively enabled by default in Homebrew 6.0.x; `brew trust <tap>` is the canonical CLI to opt in. Written after direct reading of `trust.rb`, `env_config.rb`, `cmd/trust.rb`, and the action's `main.rb` + `action.yml`.

## Validation

- YAML parse (js-yaml): OK
- 1 file changed, 26 insertions (one new workflow step + inline comment explaining rationale)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to trust the Homebrew tap before publishing formula updates, helping Homebrew releases complete successfully under newer requirements.
  * The trust step runs only when the required token is available, preserving existing release behavior otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->