### PR TITLE
fix(broker-release): put linuxbrew on PATH before running brew trust

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -203,8 +203,26 @@ jobs:
         # Runners are ephemeral (fresh trust.json every run), so
         # re-running this step on every release is intentional and
         # cheap.
+        #
+        # PATH: ubuntu-latest ships linuxbrew at
+        # /home/linuxbrew/.linuxbrew but does NOT put it on PATH —
+        # the dawidd6 action sets up its own brew environment
+        # internally, which is why the bump step finds brew while a
+        # bare `brew` in this step gets "command not found" (exit
+        # 127). `brew shellenv` is the canonical fix. The trust
+        # write lands in ~/.homebrew/trust.json (keyed on $HOME,
+        # which is the same runner user for both steps), so the
+        # action's internal brew sees it regardless of which brew
+        # setup path each step used.
+        #
+        # `brew trust <tap>` does not require the tap to be
+        # installed first — verified in cmd/trust.rb: it validates
+        # the name and writes it to trust.json without touching the
+        # tap itself.
         if: env.HAS_TAP_TOKEN == 'true'
-        run: brew trust openbrowse-ai/tap
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew trust openbrowse-ai/tap
 
       - name: Bump Homebrew formula
         # Skipped when HOMEBREW_TAP_TOKEN is not present (e.g. first-run


### PR DESCRIPTION
## What

Follow-up to #184. The `brew trust` step failed on the release re-run with:

```
Run brew trust openbrowse-ai/tap
brew: command not found
Error: Process completed with exit code 127.
```

## Root cause

`ubuntu-latest` ships linuxbrew at `/home/linuxbrew/.linuxbrew` but does **not** put it on `PATH`. The `dawidd6/action-homebrew-bump-formula` action sets up its own brew environment internally (via `Homebrew/actions/setup-homebrew`), which is why the bump step can run brew while a bare `brew` in a standalone step cannot.

## Fix

Standard shellenv idiom:

```yaml
run: |
  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
  brew trust openbrowse-ai/tap
```

The linuxbrew prefix is confirmed by the original `UntrustedTapError` stack trace (`/home/linuxbrew/.linuxbrew/Homebrew/Library/...`).

## Why the trust still carries over to the action's step

`brew trust` writes to `~/.homebrew/trust.json`, keyed on `$HOME` — same runner user for both steps — so the action's internally-set-up brew reads the same trust file regardless of PATH differences.

Also verified in [Homebrew `cmd/trust.rb`](https://raw.githubusercontent.com/Homebrew/brew/main/Library/Homebrew/cmd/trust.rb): `brew trust <tap>` does **not** require the tap to be installed first — it validates the name and writes it to trust.json directly via `Trust.trust!` without touching the tap.

## Recovery for 0.2.0

After merge: Actions → **Release @openbrowse/mcp-server** → Run workflow → tag `@openbrowse/mcp-server@0.2.0`. npm publish and GH Release remain idempotent on retry; the Homebrew bump runs with the tap trusted.

## Validation

- YAML parse (js-yaml): OK
- 1 file changed, +19/-1 (shellenv line + comment)