### PR TITLE
fix(mcp-server): persist DCR client registrations across broker restarts

### DIFF
--- a/.changeset/persist-oauth-clients.md
+++ b/.changeset/persist-oauth-clients.md
@@ -1,0 +1,21 @@
+---
+"@openbrowse/mcp-server": patch
+---
+
+Persist OAuth Dynamic Client Registration (DCR) records to
+`~/.openbrowse/clients.json` so registered clients survive broker restarts.
+Previously the client registry was in-memory only; any broker restart wiped
+all registered clients, so MCP hosts that cached their `client_id` hit
+`Unknown client_id` errors in the consent tab on their next authorization
+attempt.
+
+Registered clients are capped at 500 with least-recently-used eviction
+(`last_used_at` refreshed on each successful authorization), and a corrupt
+or unrecognized `clients.json` falls back to an empty registry instead of
+crashing the broker.
+
+Also improves recovery when an unknown `client_id` does reach `/authorize`:
+loopback (`http://127.0.0.1` / `localhost`) redirect URIs now receive a
+spec-compliant `302` with `error=invalid_client` so native MCP hosts can
+auto-recover by re-registering, and all other cases get a human-readable
+recovery page instead of a bare error string.

--- a/packages/mcp-server/src/keys/store.ts
+++ b/packages/mcp-server/src/keys/store.ts
@@ -51,6 +51,10 @@ export async function loadOrCreateKeyPair(): Promise<BrokerKeyPair> {
   const fingerprint = createHash("sha256").update(publicKeyDer).digest("hex").slice(0, 16);
 
   mkdirSync(KEY_DIR(), { recursive: true, mode: 0o700 });
+  // `mode` on mkdirSync only applies at creation (and is masked by umask);
+  // enforce on every write so a pre-existing dir with looser permissions
+  // gets tightened.
+  chmodSync(KEY_DIR(), 0o700);
   const persisted: PersistedKey = {
     algorithm: "Ed25519",
     publicKeyPemSpki,

--- a/packages/mcp-server/src/oauth/__tests__/clients.test.ts
+++ b/packages/mcp-server/src/oauth/__tests__/clients.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 describe("oauth/clients", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "obx-clients-"));
+    vi.stubEnv("HOME", tmpHome);
+    vi.resetModules();
+  });
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
   it("registers a client with redirect_uris and returns a client_id", async () => {
     const { createClientRegistry } = await import("../clients");
     const reg = createClientRegistry();
@@ -37,5 +52,97 @@ describe("oauth/clients", () => {
     const { createClientRegistry } = await import("../clients");
     const reg = createClientRegistry();
     expect(reg.get("missing")).toBeUndefined();
+  });
+
+  it("persists registrations across registry recreations (broker restarts)", async () => {
+    const { createClientRegistry } = await import("../clients");
+    const regA = createClientRegistry();
+    const r = regA.register({
+      client_name: "Survivor",
+      redirect_uris: ["http://127.0.0.1:1234/cb"],
+    });
+    if (!r.ok) throw new Error("setup");
+
+    // Simulate a broker restart: fresh module, fresh registry, same $HOME.
+    vi.resetModules();
+    const { createClientRegistry: recreate } = await import("../clients");
+    const regB = recreate();
+    const found = regB.get(r.client.client_id);
+    expect(found?.client_name).toBe("Survivor");
+    expect(found?.redirect_uris).toEqual(["http://127.0.0.1:1234/cb"]);
+  });
+
+  it("writes clients.json with 0600 and ~/.openbrowse with 0700", async () => {
+    const { createClientRegistry } = await import("../clients");
+    const reg = createClientRegistry();
+    reg.register({ redirect_uris: ["http://127.0.0.1:1/cb"] });
+    const file = join(tmpHome, ".openbrowse", "clients.json");
+    expect(existsSync(file)).toBe(true);
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    expect(statSync(join(tmpHome, ".openbrowse")).mode & 0o777).toBe(0o700);
+  });
+
+  it("evicts least-recently-used clients beyond the cap", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));
+    const { createClientRegistry } = await import("../clients");
+    const reg = createClientRegistry();
+    const ids: string[] = [];
+    for (let i = 0; i < 505; i++) {
+      // Distinct timestamps so LRU ordering is deterministic.
+      vi.advanceTimersByTime(1000);
+      const r = reg.register({ redirect_uris: [`http://127.0.0.1:${i + 1}/cb`] });
+      if (!r.ok) throw new Error("setup");
+      ids.push(r.client.client_id);
+    }
+    // Oldest 5 evicted; newest 500 retained.
+    for (let i = 0; i < 5; i++) expect(reg.get(ids[i]!)).toBeUndefined();
+    for (let i = 5; i < 505; i++) expect(reg.get(ids[i]!)).toBeDefined();
+  });
+
+  it("touch() refreshes last_used_at so touched clients survive eviction", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));
+    const { createClientRegistry } = await import("../clients");
+    const reg = createClientRegistry();
+    const first = reg.register({ redirect_uris: ["http://127.0.0.1:1/cb"] });
+    if (!first.ok) throw new Error("setup");
+    // Fill to the cap; `first` is now the LRU candidate...
+    for (let i = 0; i < 499; i++) {
+      vi.advanceTimersByTime(1000);
+      const r = reg.register({ redirect_uris: [`http://127.0.0.1:${i + 2}/cb`] });
+      if (!r.ok) throw new Error("setup");
+    }
+    // ...unless it gets touched (successful authorize) before overflow.
+    vi.advanceTimersByTime(1000);
+    reg.touch(first.client.client_id);
+    vi.advanceTimersByTime(1000);
+    const overflow = reg.register({ redirect_uris: ["http://127.0.0.1:9999/cb"] });
+    if (!overflow.ok) throw new Error("setup");
+    expect(reg.get(first.client.client_id)).toBeDefined();
+  });
+
+  it("starts empty (without crashing) when clients.json is corrupt", async () => {
+    mkdirSync(join(tmpHome, ".openbrowse"), { recursive: true });
+    writeFileSync(join(tmpHome, ".openbrowse", "clients.json"), "{not json!!");
+    const { createClientRegistry } = await import("../clients");
+    const reg = createClientRegistry();
+    expect(reg.get("anything")).toBeUndefined();
+    // Registry still functions: a new registration overwrites the bad file.
+    const r = reg.register({ redirect_uris: ["http://127.0.0.1:1/cb"] });
+    expect(r.ok).toBe(true);
+    const raw = readFileSync(join(tmpHome, ".openbrowse", "clients.json"), "utf8");
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  it("starts empty when clients.json has an unknown schema version", async () => {
+    mkdirSync(join(tmpHome, ".openbrowse"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".openbrowse", "clients.json"),
+      JSON.stringify({ version: 99, clients: { x: {} } }),
+    );
+    const { createClientRegistry } = await import("../clients");
+    const reg = createClientRegistry();
+    expect(reg.get("x")).toBeUndefined();
   });
 });

--- a/packages/mcp-server/src/oauth/__tests__/clients.test.ts
+++ b/packages/mcp-server/src/oauth/__tests__/clients.test.ts
@@ -82,6 +82,16 @@ describe("oauth/clients", () => {
     expect(statSync(join(tmpHome, ".openbrowse")).mode & 0o777).toBe(0o700);
   });
 
+  it("tightens a pre-existing ~/.openbrowse dir with loose permissions to 0700", async () => {
+    // Simulates a dir created by an older install (or default umask 022).
+    mkdirSync(join(tmpHome, ".openbrowse"), { recursive: true, mode: 0o755 });
+    expect(statSync(join(tmpHome, ".openbrowse")).mode & 0o777).toBe(0o755);
+    const { createClientRegistry } = await import("../clients");
+    const reg = createClientRegistry();
+    reg.register({ redirect_uris: ["http://127.0.0.1:1/cb"] });
+    expect(statSync(join(tmpHome, ".openbrowse")).mode & 0o777).toBe(0o700);
+  });
+
   it("evicts least-recently-used clients beyond the cap", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));

--- a/packages/mcp-server/src/oauth/clients.ts
+++ b/packages/mcp-server/src/oauth/clients.ts
@@ -74,10 +74,13 @@ function load(): PersistedFile {
 
 function persist(state: PersistedFile): void {
   mkdirSync(DIR(), { recursive: true, mode: 0o700 });
+  // `mode` on mkdirSync only applies at creation (and is masked by umask);
+  // enforce on every write so a pre-existing ~/.openbrowse with looser
+  // permissions gets tightened.
+  chmodSync(DIR(), 0o700);
   const path = FILE();
   writeFileSync(path, JSON.stringify(state, null, 2), { mode: 0o600 });
-  // `mode` on writeFileSync only applies at creation; enforce on every write
-  // so a pre-existing file with looser permissions gets tightened.
+  // Same reasoning: `mode` on writeFileSync only applies at creation.
   chmodSync(path, 0o600);
 }
 

--- a/packages/mcp-server/src/oauth/clients.ts
+++ b/packages/mcp-server/src/oauth/clients.ts
@@ -1,10 +1,31 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { randomBytes } from "node:crypto";
+
+const DIR = () => join(process.env.HOME ?? homedir(), ".openbrowse");
+const FILE = () => join(DIR(), "clients.json");
+
+/**
+ * Cap on stored DCR clients. Oldest-by-`last_used_at` entries are evicted
+ * when the cap is exceeded, so a hostile (or merely chatty) host that
+ * re-registers on every connection cannot grow the file without bound.
+ * 500 clients × ~200 bytes ≈ 100 KB worst case.
+ */
+const MAX_CLIENTS = 500;
 
 export interface RegisteredClient {
   client_id: string;
   client_name?: string;
   redirect_uris: string[];
   registered_at: number;
+  /** Updated via `touch()` on successful authorization — drives LRU eviction. */
+  last_used_at: number;
+}
+
+interface PersistedFile {
+  version: 1;
+  clients: Record<string, RegisteredClient>;
 }
 
 export type RegisterResult =
@@ -14,27 +35,105 @@ export type RegisterResult =
 export interface ClientRegistry {
   register(input: { client_name?: string; redirect_uris: string[] }): RegisterResult;
   get(client_id: string): RegisteredClient | undefined;
+  /**
+   * Mark a client as recently used (updates `last_used_at` and persists).
+   * Called on SUCCESSFUL authorization only — failed authorize attempts must
+   * not extend a client's LRU lifetime, otherwise an attacker probing with a
+   * stolen client_id would keep it alive indefinitely.
+   */
+  touch(client_id: string): void;
 }
 
+function emptyState(): PersistedFile {
+  return { version: 1, clients: {} };
+}
+
+function load(): PersistedFile {
+  const path = FILE();
+  if (!existsSync(path)) return emptyState();
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as PersistedFile;
+    // Schema check: unknown versions or malformed shapes fall back to empty
+    // rather than crashing the broker at startup. Existing hosts will hit
+    // "Unknown client_id" once and re-register via DCR — fail-open on
+    // registration, fail-closed on recognition.
+    if (parsed?.version !== 1 || typeof parsed.clients !== "object" || parsed.clients === null) {
+      console.error(
+        `[openbrowse-mcp] ${path} has an unrecognized schema; starting with an empty client registry`,
+      );
+      return emptyState();
+    }
+    return parsed;
+  } catch {
+    console.error(
+      `[openbrowse-mcp] ${path} is unreadable or corrupt; starting with an empty client registry`,
+    );
+    return emptyState();
+  }
+}
+
+function persist(state: PersistedFile): void {
+  mkdirSync(DIR(), { recursive: true, mode: 0o700 });
+  const path = FILE();
+  writeFileSync(path, JSON.stringify(state, null, 2), { mode: 0o600 });
+  // `mode` on writeFileSync only applies at creation; enforce on every write
+  // so a pre-existing file with looser permissions gets tightened.
+  chmodSync(path, 0o600);
+}
+
+function evictLruIfNeeded(state: PersistedFile): void {
+  const entries = Object.entries(state.clients);
+  if (entries.length <= MAX_CLIENTS) return;
+  entries.sort((a, b) => a[1].last_used_at - b[1].last_used_at);
+  const excess = entries.length - MAX_CLIENTS;
+  for (let i = 0; i < excess; i++) {
+    delete state.clients[entries[i]![0]];
+  }
+}
+
+/**
+ * DCR client registry persisted to `~/.openbrowse/clients.json`.
+ *
+ * Persistence matters: MCP hosts cache the `client_id` they received from
+ * `/register` and reuse it across sessions. If the registry lived only in
+ * memory (as it did pre-0.2.1), every broker restart wiped it and hosts hit
+ * `Unknown client_id` on their next `/authorize` — the host-visible symptom
+ * being a confusing error page in the consent tab.
+ *
+ * Follows the same storage pattern as `refresh-tokens.ts`: synchronous JSON
+ * file under `$HOME/.openbrowse`, dir 0700 / file 0600, single-process
+ * access (the broker holds a lock via broker.lock), state mutated in memory
+ * and flushed after every mutation.
+ */
 export function createClientRegistry(): ClientRegistry {
-  const clients = new Map<string, RegisteredClient>();
+  const state = load();
   return {
     register({ client_name, redirect_uris }) {
       if (!Array.isArray(redirect_uris) || redirect_uris.length === 0) {
         return { ok: false, reason: "invalid_redirect_uri" };
       }
       const client_id = randomBytes(12).toString("base64url");
+      const now = Date.now();
       const client: RegisteredClient = {
         client_id,
         client_name,
         redirect_uris,
-        registered_at: Date.now(),
+        registered_at: now,
+        last_used_at: now,
       };
-      clients.set(client_id, client);
+      state.clients[client_id] = client;
+      evictLruIfNeeded(state);
+      persist(state);
       return { ok: true, client };
     },
     get(client_id) {
-      return clients.get(client_id);
+      return state.clients[client_id];
+    },
+    touch(client_id) {
+      const client = state.clients[client_id];
+      if (!client) return;
+      client.last_used_at = Date.now();
+      persist(state);
     },
   };
 }

--- a/packages/mcp-server/src/oauth/refresh-tokens.ts
+++ b/packages/mcp-server/src/oauth/refresh-tokens.ts
@@ -37,7 +37,12 @@ async function load(): Promise<PersistedFile> {
 
 function persist(state: PersistedFile): void {
   const path = FILE();
-  mkdirSync(join(process.env.HOME ?? homedir(), ".openbrowse"), { recursive: true, mode: 0o700 });
+  const dir = join(process.env.HOME ?? homedir(), ".openbrowse");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // `mode` on mkdirSync/writeFileSync only applies at creation (and mkdir's
+  // is masked by umask); enforce on every write so pre-existing paths with
+  // looser permissions get tightened.
+  chmodSync(dir, 0o700);
   writeFileSync(path, JSON.stringify(state, null, 2), { mode: 0o600 });
   chmodSync(path, 0o600);
 }

--- a/packages/mcp-server/src/routes/__tests__/authorize.test.ts
+++ b/packages/mcp-server/src/routes/__tests__/authorize.test.ts
@@ -105,7 +105,9 @@ describe("routes/authorize", () => {
 
     const result = handleAuthorize({
       params: {
-        client_id: "nonexistent",
+        // XSS-shaped client_id: the recovery page interpolates the id into
+        // HTML, so this doubles as escaping coverage for that code path.
+        client_id: "<script>alert('xss')</script>",
         redirect_uri: "https://evil.example.com/cb",
         response_type: "code",
         scope: "task",
@@ -122,8 +124,10 @@ describe("routes/authorize", () => {
     expect(result.kind).toBe("error_page");
     if (result.kind === "error_page") {
       expect(result.status).toBe(400);
-      expect(result.body).toContain("nonexistent");
       expect(result.body).toContain("re-authenticate");
+      // client_id is rendered escaped, never as live markup.
+      expect(result.body).not.toContain("<script>alert");
+      expect(result.body).toContain("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
     }
   });
 
@@ -155,6 +159,8 @@ describe("routes/authorize", () => {
       expect(loc.origin).toBe("http://127.0.0.1:33418");
       expect(loc.pathname).toBe("/callback");
       expect(loc.searchParams.get("error")).toBe("invalid_client");
+      // The description is the host-facing recovery hint — assert it survives.
+      expect(loc.searchParams.get("error_description")).toMatch(/re-register/i);
       expect(loc.searchParams.get("state")).toBe("xyz");
     }
   });

--- a/packages/mcp-server/src/routes/__tests__/authorize.test.ts
+++ b/packages/mcp-server/src/routes/__tests__/authorize.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 describe("routes/authorize", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    // The client registry persists to $HOME/.openbrowse — isolate each test.
+    tmpHome = mkdtempSync(join(tmpdir(), "obx-authz-"));
+    vi.stubEnv("HOME", tmpHome);
+    vi.resetModules();
+  });
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
   it("validates client, mints a code, and returns an HTML page with auto-redirect", async () => {
     const { handleAuthorize } = await import("../authorize");
     const { createClientRegistry } = await import("../../oauth/clients");
@@ -79,7 +94,7 @@ describe("routes/authorize", () => {
     }
   });
 
-  it("rejects unknown client_id", async () => {
+  it("unknown client_id with a non-loopback redirect_uri renders a recovery page (no redirect)", async () => {
     const { handleAuthorize } = await import("../authorize");
     const { createClientRegistry } = await import("../../oauth/clients");
     const { createPendingConsents } = await import("../../oauth/pending-consents");
@@ -91,7 +106,7 @@ describe("routes/authorize", () => {
     const result = handleAuthorize({
       params: {
         client_id: "nonexistent",
-        redirect_uri: "x",
+        redirect_uri: "https://evil.example.com/cb",
         response_type: "code",
         scope: "task",
         state: "s",
@@ -103,8 +118,129 @@ describe("routes/authorize", () => {
       pending,
       codes,
     });
+    // RFC 6749 §4.1.2.1: MUST NOT redirect to an unvalidated redirect_uri.
+    expect(result.kind).toBe("error_page");
+    if (result.kind === "error_page") {
+      expect(result.status).toBe(400);
+      expect(result.body).toContain("nonexistent");
+      expect(result.body).toContain("re-authenticate");
+    }
+  });
+
+  it("unknown client_id with a loopback redirect_uri redirects with error=invalid_client", async () => {
+    const { handleAuthorize } = await import("../authorize");
+    const { createClientRegistry } = await import("../../oauth/clients");
+    const { createPendingConsents } = await import("../../oauth/pending-consents");
+    const { createCodeStore } = await import("../../oauth/codes");
+    const clients = createClientRegistry();
+
+    const result = handleAuthorize({
+      params: {
+        client_id: "stale_id_from_before_restart",
+        redirect_uri: "http://127.0.0.1:33418/callback",
+        response_type: "code",
+        scope: "task",
+        state: "xyz",
+        code_challenge: "ch",
+        code_challenge_method: "S256",
+        resource: "r",
+      },
+      clients,
+      pending: createPendingConsents(),
+      codes: createCodeStore(),
+    });
+    expect(result.kind).toBe("redirect");
+    if (result.kind === "redirect") {
+      const loc = new URL(result.location);
+      expect(loc.origin).toBe("http://127.0.0.1:33418");
+      expect(loc.pathname).toBe("/callback");
+      expect(loc.searchParams.get("error")).toBe("invalid_client");
+      expect(loc.searchParams.get("state")).toBe("xyz");
+    }
+  });
+
+  it("unknown client_id with an HTTPS localhost redirect_uri does NOT redirect (http-only loopback rule)", async () => {
+    const { handleAuthorize } = await import("../authorize");
+    const { createClientRegistry } = await import("../../oauth/clients");
+    const { createPendingConsents } = await import("../../oauth/pending-consents");
+    const { createCodeStore } = await import("../../oauth/codes");
+
+    const result = handleAuthorize({
+      params: {
+        client_id: "nonexistent",
+        redirect_uri: "https://localhost:8443/cb",
+        response_type: "code",
+        scope: "task",
+        state: "s",
+        code_challenge: "ch",
+        code_challenge_method: "S256",
+        resource: "r",
+      },
+      clients: createClientRegistry(),
+      pending: createPendingConsents(),
+      codes: createCodeStore(),
+    });
+    expect(result.kind).toBe("error_page");
+  });
+
+  it("successful authorize touches the client's last_used_at (LRU bookkeeping)", async () => {
+    const { handleAuthorize } = await import("../authorize");
+    const { createClientRegistry } = await import("../../oauth/clients");
+    const { createPendingConsents } = await import("../../oauth/pending-consents");
+    const { createCodeStore } = await import("../../oauth/codes");
+    const clients = createClientRegistry();
+    const reg = clients.register({ redirect_uris: ["http://127.0.0.1:9999/cb"] });
+    if (!reg.ok) throw new Error("setup");
+    const before = clients.get(reg.client.client_id)!.last_used_at;
+
+    await new Promise((r) => setTimeout(r, 5));
+    const result = handleAuthorize({
+      params: {
+        client_id: reg.client.client_id,
+        redirect_uri: "http://127.0.0.1:9999/cb",
+        response_type: "code",
+        scope: "task",
+        state: "s",
+        code_challenge: "ch",
+        code_challenge_method: "S256",
+        resource: "r",
+      },
+      clients,
+      pending: createPendingConsents(),
+      codes: createCodeStore(),
+    });
+    expect(result.kind).toBe("html");
+    expect(clients.get(reg.client.client_id)!.last_used_at).toBeGreaterThan(before);
+  });
+
+  it("failed authorize (bad redirect_uri) does NOT touch last_used_at", async () => {
+    const { handleAuthorize } = await import("../authorize");
+    const { createClientRegistry } = await import("../../oauth/clients");
+    const { createPendingConsents } = await import("../../oauth/pending-consents");
+    const { createCodeStore } = await import("../../oauth/codes");
+    const clients = createClientRegistry();
+    const reg = clients.register({ redirect_uris: ["http://127.0.0.1:9999/cb"] });
+    if (!reg.ok) throw new Error("setup");
+    const before = clients.get(reg.client.client_id)!.last_used_at;
+
+    await new Promise((r) => setTimeout(r, 5));
+    const result = handleAuthorize({
+      params: {
+        client_id: reg.client.client_id,
+        redirect_uri: "http://127.0.0.1:9999/WRONG",
+        response_type: "code",
+        scope: "task",
+        state: "s",
+        code_challenge: "ch",
+        code_challenge_method: "S256",
+        resource: "r",
+      },
+      clients,
+      pending: createPendingConsents(),
+      codes: createCodeStore(),
+    });
     expect(result.kind).toBe("error");
-    if (result.kind === "error") expect(result.message).toMatch(/Unknown client/);
+    expect(clients.get(reg.client.client_id)!.last_used_at).toBe(before);
   });
 
   it("rejects unregistered redirect_uri (exact-match required)", async () => {

--- a/packages/mcp-server/src/routes/authorize.ts
+++ b/packages/mcp-server/src/routes/authorize.ts
@@ -15,7 +15,13 @@ export interface AuthorizeParams {
 
 export type AuthorizeResult =
   | { kind: "html"; body: string }
-  | { kind: "error"; status: 400; message: string };
+  | { kind: "error"; status: 400; message: string }
+  /** OAuth-spec error redirect back to the client's redirect_uri
+   *  (RFC 6749 §4.1.2.1) — only used for loopback redirect URIs. */
+  | { kind: "redirect"; status: 302; location: string }
+  /** Human-facing recovery page for an unknown client_id when no safe
+   *  error redirect is possible. Rendered as HTML with status 400. */
+  | { kind: "error_page"; status: 400; body: string };
 
 const AUTO_APPROVE_MS = 1000;
 
@@ -37,6 +43,57 @@ export interface HandleAuthorizeArgs {
   autoApprove?: boolean;
 }
 
+/**
+ * True when a redirect_uri is a plain-HTTP loopback URL — the shape used by
+ * OAuth 2.1 native-app / PKCE flows (RFC 8252 §7.3). Only these get an
+ * error redirect for unknown client_ids: redirecting errors to an
+ * UNVALIDATED redirect_uri is an open-redirect hazard (RFC 6749 §4.1.2.1
+ * requires the AS to NOT redirect when the client identity can't be
+ * verified), but a loopback URL can only reach a listener on the user's own
+ * machine, so the hazard doesn't apply and the redirect lets well-behaved
+ * hosts auto-recover by re-registering.
+ */
+function isLoopbackRedirect(redirect_uri: string): boolean {
+  try {
+    const u = new URL(redirect_uri);
+    return (
+      u.protocol === "http:" &&
+      (u.hostname === "127.0.0.1" || u.hostname === "localhost" || u.hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function unknownClientPage(client_id: string): string {
+  const id = escapeHtml(client_id);
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>OpenBrowse — Client not recognized</title>
+<style>
+body { font-family: system-ui, sans-serif; max-width: 520px; margin: 80px auto; padding: 32px; line-height: 1.5; color: #111; }
+@media (prefers-color-scheme: dark) {
+  body { background: #0a0a0a; color: #e5e5e5; }
+  .box { border-color: #2a2a2a; background: #141414; }
+  .note { color: #888; }
+  code { background: #1f1f1f; }
+}
+.box { border: 1px solid #ddd; border-radius: 8px; padding: 24px; background: #fafafa; }
+h1 { margin-top: 0; font-size: 18px; }
+code { background: #eee; padding: 2px 6px; border-radius: 4px; font-size: 13px; word-break: break-all; }
+.note { color: #666; font-size: 13px; margin-top: 16px; }
+</style></head>
+<body><div class="box">
+<h1>This app needs to reconnect to OpenBrowse</h1>
+<p>OpenBrowse doesn't recognize the app that opened this page. This can
+happen if OpenBrowse was reinstalled or its local state was reset since the
+app first connected.</p>
+<p><strong>To fix it:</strong> go back to the app (your MCP host) and
+re-authenticate with OpenBrowse. Most hosts re-register automatically when
+you retry the connection.</p>
+<p class="note">Details for debugging: unknown client_id <code>${id}</code></p>
+</div></body></html>`;
+}
+
 export function handleAuthorize({
   params,
   clients,
@@ -46,10 +103,26 @@ export function handleAuthorize({
 }: HandleAuthorizeArgs): AuthorizeResult {
   const client = clients.get(params.client_id);
   if (!client) {
+    // RFC 6749 §4.1.2.1: when the client_id is invalid the AS "MUST NOT
+    // automatically redirect the user-agent to the invalid redirection URI"
+    // — because the redirect_uri is unvalidated. Exception carved out here:
+    // plain-HTTP loopback URIs can only reach the user's own machine, so we
+    // redirect with `error=invalid_client` to let native hosts detect the
+    // stale registration and re-register via DCR without user intervention.
+    if (isLoopbackRedirect(params.redirect_uri)) {
+      const cb = new URL(params.redirect_uri);
+      cb.searchParams.set("error", "invalid_client");
+      cb.searchParams.set(
+        "error_description",
+        "client_id not recognized; re-register via dynamic client registration",
+      );
+      if (params.state) cb.searchParams.set("state", params.state);
+      return { kind: "redirect", status: 302, location: cb.toString() };
+    }
     return {
-      kind: "error",
+      kind: "error_page",
       status: 400,
-      message: `Unknown client_id: ${params.client_id}`,
+      body: unknownClientPage(params.client_id),
     };
   }
   // Exact-string match per RFC 6749 §3.1.2.3 / OAuth 2.1 §1.4.2 — no normalization.
@@ -85,6 +158,10 @@ export function handleAuthorize({
     resource: params.resource,
     state: params.state,
   });
+  // LRU bookkeeping: mark the client as recently used only after all
+  // validations passed. Failed authorize attempts (bad redirect_uri, bad
+  // PKCE, …) must not refresh a client's eviction clock.
+  clients.touch(params.client_id);
 
   const callbackUrl = new URL(params.redirect_uri);
   callbackUrl.searchParams.set("code", code);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -230,6 +230,12 @@ export async function startHttpServer(
           autoApprove: params.get("autoapprove") === "1",
         });
         if (r.kind === "html") return sendText(res, 200, r.body, "text/html; charset=utf-8");
+        if (r.kind === "error_page")
+          return sendText(res, r.status, r.body, "text/html; charset=utf-8");
+        if (r.kind === "redirect") {
+          res.writeHead(r.status, { Location: r.location, "Cache-Control": "no-store" });
+          return res.end();
+        }
         return sendText(res, r.status, r.message);
       }
       if (path === "/token" && req.method === "POST") {


### PR DESCRIPTION
## What

Fixes the `Unknown client_id: Q_0qkf9l3LP8cc3l` error users hit in the consent tab when re-authenticating an MCP host (e.g. `opencode mcp auth openbrowse`) after any broker restart.

## Root cause

The OAuth Dynamic Client Registration (DCR) registry in `src/oauth/clients.ts` was a plain in-memory `Map`, created fresh in `startHttpServer()` on every boot. MCP hosts cache the `client_id` they receive from `POST /register` and reuse it across sessions — so any broker restart (upgrade, reboot, autostart cycle) invalidated every host's cached credentials. The next `GET /authorize` hit `clients.get(client_id) === undefined` and rendered the bare 400 `Unknown client_id` page.

Every neighboring store (`keys/store.ts`, `oauth/refresh-tokens.ts`, `audit/store.ts`) already persists to `~/.openbrowse/`; the client registry was the one stateful component that didn't.

## Fix 1 — persistent client registry

- `clients.ts` now persists to `~/.openbrowse/clients.json`, following the exact storage pattern of `refresh-tokens.ts`: dir `0700`, file `0600` (re-enforced via `chmodSync` on every write), synchronous JSON writes after each mutation, `$HOME` override honored for tests.
- **Schema version field** (`version: 1`) so future format changes migrate instead of crash.
- **Corrupt/unrecognized file → empty registry + stderr log**, not a startup crash. Affected hosts re-register once via DCR (fail-open on registration, fail-closed on recognition).
- **LRU cap of 500 clients** (~100 KB worst case) so a host that re-registers on every connection can't grow the file unbounded. Eviction key is `last_used_at`.
- New `ClientRegistry.touch(client_id)` refreshes `last_used_at`; called by `handleAuthorize` **only after all validations pass**. Failed authorize attempts (bad redirect_uri, bad PKCE) deliberately don't refresh a client's eviction clock — probing with a stolen client_id can't keep it alive.
- Factory stays synchronous, so the `server.ts` callsite is unchanged.

## Fix 2 — unknown-client_id recovery UX

When an unknown `client_id` does reach `/authorize` (stale cache from before this fix, manual state reset, LRU-evicted client):

- **Loopback redirect URIs** (`http://` + `127.0.0.1`/`localhost`/`[::1]`) get a spec-style `302` with `error=invalid_client`, an `error_description` telling the host to re-register, and `state` echo per RFC 6749 §4.1.2.1. RFC 6749 forbids redirecting errors to an *unvalidated* redirect_uri, but a plain-HTTP loopback URL can only reach a listener on the user's own machine (RFC 8252 §7.3 native-app pattern), so the open-redirect hazard doesn't apply — and the redirect is what lets well-behaved MCP hosts auto-recover without user intervention.
- **All other redirect URIs** get a human-readable 400 recovery page ("go back to the app and re-authenticate") instead of the bare error string, with the client_id in a `<code>` block for debugging. `https://localhost` is deliberately NOT redirected (http-only loopback rule).
- `server.ts` handles the two new `AuthorizeResult` kinds (`redirect` → 302 + `Location`; `error_page` → 400 `text/html`).

## Tests: 110 → 120

- **clients.test.ts**: persistence across module-reset "restarts"; file/dir permission assertions; LRU eviction at cap+5; `touch()` rescuing a client from eviction; corrupt-file fallback; unknown-schema fallback. All tests now stub `$HOME`.
- **authorize.test.ts**: loopback stale-id → 302 with `error=invalid_client` + state echo; non-loopback stale-id → 400 recovery page; `https://localhost` NOT redirected; successful authorize touches `last_used_at`; failed authorize does not.

## Manual smoke (tsx, temp `$HOME`)

```text
run1: registered 9CB7YvdocXOApIrN
run2: authorize status 200
PASS: client recognized after restart
stale-id: 302 http://127.0.0.1:41234/cb?error=invalid_client&error_description=...&state=s2
PASS: stale client_id gets invalid_client redirect
non-loopback stale: 400
PASS: non-loopback stale id gets 400 recovery page
```

## Compatibility & rollout

- **Wire protocol unchanged** — DCR/authorize/token flows are identical for known clients.
- **No migration needed**: first boot of the fixed broker starts with an empty `clients.json`; hosts with stale cached client_ids re-register once (now guided by the recovery UX) and never hit this again.
- Existing stale entries in `refresh-tokens.json` keep failing redemption (their `clientId` is unknown) — correct fail-closed behavior, not a regression.
- Changeset included: patch bump → `@openbrowse/mcp-server@0.2.1`.

## After merge

Users with stale credentials do one manual re-auth (`opencode mcp auth openbrowse` or the host's equivalent); subsequent broker restarts are invisible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth client registrations are now persisted on disk, allowing known `client_id`s to survive restarts.
  * Unknown clients on loopback redirect flows now receive a standards-aligned 302 redirect with `error=invalid_client` for smoother recovery.
* **Bug Fixes**
  * Startup now safely falls back to an empty client registry if saved data is missing/corrupt/unknown.
  * Authorization “recent use” tracking is updated only after successful validation, supporting LRU eviction when exceeding the client cap.
  * Tightened filesystem permissions for OAuth client, key, and refresh-token storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->