### PR TITLE
fix(changeset): drop non-existent @openbrowse/extension entry

### DIFF
--- a/.changeset/broker-heartbeat-keepalive.md
+++ b/.changeset/broker-heartbeat-keepalive.md
@@ -1,6 +1,5 @@
 ---
 "@openbrowse/mcp-server": patch
-"@openbrowse/extension": patch
 ---
 
 Fix recurring `extension_not_connected` errors caused by Chrome's MV3


### PR DESCRIPTION
### Summary

Post-merge fix for #192. The `changeset version` step in the release workflow failed with:

```
Error: Found changeset broker-heartbeat-keepalive for package @openbrowse/extension which is not in the workspace
```

### Changes

- Removed the `@openbrowse/extension` line from `.changeset/broker-heartbeat-keepalive.md`. The extension package is actually named `openbrowse` and is `private: true`, so it can't be referenced in a changeset. Only `@openbrowse/mcp-server: patch` remains.

### Testing

- Confirmed extension package name is `openbrowse` with `private: true` via `apps/extension/package.json`
- Changeset now only references a real, publishable workspace package

### Screenshots / recordings

N/A

### Checklist

- [ ] Tested locally with `pnpm dev`
- [ ] `pnpm compile` passes
- [ ] `pnpm test` passes
- [x] Ran `pnpm changeset` if this PR changes user-facing behavior
- [x] No unrelated changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability by keeping background connections alive more consistently.
  * Reduced unexpected disconnects by sending periodic heartbeat signals and making reconnection checks more frequent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->