### PR TITLE
fix(extension): restore plan-approval flow under SW-host (regressed by #176)

### DIFF
--- a/.changeset/fix-plan-approval-sw-host-regression.md
+++ b/.changeset/fix-plan-approval-sw-host-regression.md
@@ -1,0 +1,54 @@
+---
+"openbrowse": patch
+---
+
+**Fix plan-approval flow under SW-host (regression): the approval card mounts again and approving a plan updates the same assistant bubble in place.**
+
+PR #176 (MCP subagent bridge) inadvertently reverted the coordinated fixes
+landed in #174, reintroducing two user-visible regressions on the
+post-`proposePlan`-approval path (and every approval-gated Ask-mode tool):
+
+1. **Approval card never appeared; the tool jumped straight to "Interrupted."**
+   The SW agent host's `healLastAssistantInChatDb` ran on every run-termination
+   path — including the natural pause-for-approval path — and rewrote
+   `approval-requested` parts to `output-denied` in chat-db. The renderer then
+   re-hydrated the in-memory message list from chat-db, so
+   `findPendingPlanApproval` returned null and `PlanApprovalCard` never mounted;
+   Ask-mode prompts rendered as denied before the user could act.
+
+2. **Approving a plan left the original bubble stuck at "Drafting plan…"**
+   The renderer's `CompactingChatTransport` minted a fresh `crypto.randomUUID()`
+   as the assistant message id on every call — including resumes — overriding the
+   AI SDK's `getResponseUIMessageId` continuation logic. The post-approval
+   `output-available` chunk landed in a NEW assistant message, leaving the
+   original `proposePlan` part stranded in `approval-responded` ("Drafting
+   plan…") while a duplicate row appeared below it.
+
+Fixes (re-applied from #174 onto the post-#176 tree):
+
+- `entrypoints/background/agent-host/heal-chatdb.ts` — `healSerializedParts`
+  again leaves `approval-requested` parts untouched. The SDK pauses there
+  intentionally; healing it treats a legitimate resting state as an
+  interruption. Renderer-side `healPendingTools` still collapses
+  `approval-requested → output-denied` on the next user action, which is the
+  correct point.
+- `lib/agent/compacting-transport.ts` — both the fast path and the
+  rejection-loop path again pass `originalMessages` to
+  `result.toUIMessageStream({ ... })`, so the SDK reuses the last assistant
+  message's id on resume and extends the existing bubble instead of pushing a
+  duplicate. Fresh turns (last input is a user message) still get a new UUID.
+- `entrypoints/background/agent-host/run.ts` — `pumpMessages` again threads the
+  input transcript's trailing assistant message into
+  `readUIMessageStream({ message })`, seeding the SW persister's `state.message`
+  with the existing parts before resume chunks layer on top.
+
+**Known follow-up (out of scope).** #174 also closed a reload-race in the brief
+post-approval window (a `persistApprovedAssistantMessage` write in
+`useAgentChat.ts`). #176's rewrite of that hook removed the helper; re-applying
+it against the new architecture is deferred to a separate change. The two
+regressions above — the ones users hit in Plan and Ask mode — are covered here.
+
+**Test surface.** Restored the `heal-chatdb.test.ts` regression guards pinning
+the `approval-requested`-is-not-a-heal-target contract, including the
+end-to-end pending-`proposePlan` case. All agent-host and transport suites pass;
+typecheck clean.

--- a/apps/extension/src/entrypoints/background/agent-host/__tests__/heal-chatdb.test.ts
+++ b/apps/extension/src/entrypoints/background/agent-host/__tests__/heal-chatdb.test.ts
@@ -98,22 +98,25 @@ describe("healSerializedParts — heals non-terminal tool parts to output-error"
     ).toEqual({ url: "https://example.com" });
   });
 
-  it("heals approval-requested to output-denied", () => {
-    // Symmetric to renderer healPendingTools: a request-state approval
-    // with no human response becomes a denial.
+  it("leaves approval-requested untouched (intentional resting state, not stranded)", () => {
+    // `approval-requested` is the AI SDK's resting state when a tool with
+    // `approval: { required: true }` is called — the SDK is parked there
+    // waiting for the renderer's Approve/Deny. It is INTENTIONAL, not
+    // stranded. Rewriting it to output-denied (the pre-fix behavior)
+    // caused PlanApprovalCard to never mount and Ask-mode prompts to
+    // render as denied before the user could act. The renderer-side
+    // healPendingTools still collapses approval-requested → output-denied
+    // on the next user action, which IS the correct point.
     const parts: SerializedUIPart[] = [
       toolPart("approval-requested", {
         approval: { id: "ap_1" },
       }),
     ];
     const result = healSerializedParts(parts);
-    expect(result.changed).toBe(true);
-    const tp = result.parts[0] as {
-      state: string;
-      approval?: { approved?: boolean };
-    };
-    expect(tp.state).toBe("output-denied");
-    expect(tp.approval?.approved).toBe(false);
+    expect(result.changed).toBe(false);
+    expect(result.parts[0]).toBe(parts[0]); // same reference, untouched
+    const tp = result.parts[0] as { state: string };
+    expect(tp.state).toBe("approval-requested");
   });
 
   it("heals approval-responded to output-error regardless of approval.approved", () => {
@@ -167,7 +170,11 @@ describe("healSerializedParts — heals non-terminal tool parts to output-error"
     expect(result.parts[2]).toBe(step); // same reference
   });
 
-  it("heals multiple stranded tools in one message", () => {
+  it("heals stranded tools but preserves approval-requested in a mixed message", () => {
+    // A message can carry both a genuinely stranded tool (input-streaming)
+    // and an intentional approval-requested tool (the SDK paused for user
+    // approval). The stranded one heals to output-error; the pending
+    // approval is preserved verbatim so the renderer can still surface it.
     const parts: SerializedUIPart[] = [
       toolPart("input-streaming", { toolCallId: "t1" }),
       { type: "text", text: "and another" },
@@ -179,7 +186,11 @@ describe("healSerializedParts — heals non-terminal tool parts to output-error"
     const result = healSerializedParts(parts);
     expect(result.changed).toBe(true);
     expect((result.parts[0] as { state: string }).state).toBe("output-error");
-    expect((result.parts[2] as { state: string }).state).toBe("output-denied");
+    // Pending approval preserved verbatim — same reference, same state.
+    expect(result.parts[2]).toBe(parts[2]);
+    expect((result.parts[2] as { state: string }).state).toBe(
+      "approval-requested",
+    );
   });
 });
 
@@ -315,6 +326,60 @@ describe("healLastAssistantInChatDb — integration with chat-db", () => {
     // a2 got healed.
     const a2Tool = (after[3].parts[0] as { state: string }).state;
     expect(a2Tool).toBe("output-error");
+  });
+
+  it("returns {healed: false} when the last assistant message has a pending proposePlan approval", async () => {
+    // End-to-end regression for the Plan-mode bug: the SW host calls
+    // this helper from its `finally` block on every run termination,
+    // including the natural pause-for-approval path. Before the fix it
+    // wrote `output-denied` to chat-db, which the renderer's STREAM_DONE
+    // handler then rehydrated into the in-memory message list — making
+    // `findPendingPlanApproval` return null and the `PlanApprovalCard`
+    // never mount. Lock in that the chat-db row is left exactly as the
+    // persister wrote it.
+    await seedConversation("c1");
+    const proposePart: SerializedUIPart = {
+      type: "dynamic-tool",
+      toolName: "proposePlan",
+      toolCallId: "toolu_propose_1",
+      state: "approval-requested",
+      input: {
+        goal: "Research three mechanical keyboards on Amazon.",
+        sites: ["https://www.amazon.com"],
+        todos: [{ content: "Search for top 3 mechanical keyboards" }],
+        allowNetwork: false,
+      },
+      approval: { id: "ap_propose_1" },
+    } as SerializedUIPart;
+    await seedMessages("c1", [
+      {
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "research keyboards" }],
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [proposePart],
+      },
+    ]);
+
+    const result = await healLastAssistantInChatDb("c1");
+    expect(result.healed).toBe(false);
+
+    // chat-db is untouched: the proposePlan part is still in
+    // `approval-requested`, ready for the renderer's PlanApprovalCard
+    // to surface for the user.
+    const after = await chatDb.getMessages("c1");
+    const tp = after[1].parts[0] as {
+      state: string;
+      toolName?: string;
+      approval?: { id?: string; approved?: boolean };
+    };
+    expect(tp.state).toBe("approval-requested");
+    expect(tp.toolName).toBe("proposePlan");
+    expect(tp.approval?.id).toBe("ap_propose_1");
+    expect(tp.approval?.approved).toBeUndefined();
   });
 
   it("is idempotent — second call after a successful heal is a no-op", async () => {

--- a/apps/extension/src/entrypoints/background/agent-host/heal-chatdb.ts
+++ b/apps/extension/src/entrypoints/background/agent-host/heal-chatdb.ts
@@ -5,30 +5,41 @@
  *
  *   1. Natural completion — the for-await loop drains, persister wrote
  *      the final assistant message with terminal tool states.
- *   2. Explicit stop — `chat.stop()` / Esc Esc / Stop button → abort
+ *   2. Natural pause for approval — the AI SDK closes its stream when
+ *      the model called a tool with `approval: { required: true }`. The
+ *      LAST persisted assistant message has a tool in `approval-requested`
+ *      state, waiting on the renderer to call `addToolApprovalResponse`.
+ *      This is NOT a stranded state — see the docstring on
+ *      `healSerializedParts` for why we leave it alone.
+ *   3. Explicit stop — `chat.stop()` / Esc Esc / Stop button → abort
  *      signal → `for await` body's `if (signal.aborted) break;` exits.
  *      The LAST persisted message can have a tool in `input-streaming`
  *      or `input-available` (model was mid-arguments-emit, hadn't
  *      reached output yet).
- *   3. Provider error mid-stream — the `Promise.all([fanout, message])`
+ *   4. Provider error mid-stream — the `Promise.all([fanout, message])`
  *      catch branch fires; the persister's last write may be partial.
- *   4. SW crash / port disconnect — persister may not have flushed the
+ *   5. SW crash / port disconnect — persister may not have flushed the
  *      latest chunk.
  *
  * Renderer-side `healPendingTools` runs on the NEXT user action
  * (submit / queued drain / continue / retry). It heals the in-memory
- * `messages` and writes the changed messages back to chat-db. But:
+ * `messages` and writes the changed messages back to chat-db, including
+ * the `approval-requested → output-denied` transition this SW heal
+ * deliberately skips (by then the user has implicitly abandoned the
+ * approval prompt). But:
  *
  *   - If the user never acts again (closes tab, reload, dropped session)
  *     the chat-db row stays stranded.
  *   - The UI considers a chat with a non-terminal tool part as "loading"
  *     forever (spinner + stop button stuck enabled).
  *
- * This SW-side heal closes that gap: at run termination we read the
- * last persisted assistant message, apply the same heal semantics
- * (mirrored from `heal-pending-tools.ts`), and write back if anything
- * changed. Symmetric to renderer heal; needed because the renderer's
- * heal is gated on a user action that may never come.
+ * This SW-side heal closes that gap for the cases where the SDK can no
+ * longer resume (input-streaming, input-available, approval-responded):
+ * at run termination we read the last persisted assistant message,
+ * apply heal semantics for those states, and write back if anything
+ * changed. Symmetric to renderer heal for those states; deliberately
+ * narrower than renderer heal for `approval-requested`, which the SDK
+ * CAN still resume so long as the renderer surfaces the prompt.
  *
  * Operates directly on `SerializedUIPart[]` (the chat-db encoding) to
  * avoid the deserialize-then-serialize round-trip. ALL tool parts in
@@ -56,16 +67,36 @@ export interface HealResult {
  * `{changed: false, parts: <same ref>}` when nothing needed healing so
  * callers can skip the chat-db write.
  *
- * Heal targets (mirroring `healPendingTools`):
+ * Heal targets:
  *
- *   - `approval-requested` → `output-denied` (approval.approved = false)
  *   - `approval-responded`:
  *       - approved=false → `output-denied`
  *       - approved=true OR missing → `output-error` (SDK can no longer
  *         resume; emit a paired result so the next user message doesn't
  *         trip "tool_use without tool_result").
- *   - Any other non-terminal state → `output-error` with
- *     `TOOL_HEAL_INTERRUPT_TEXT`.
+ *   - Any other non-terminal state (`input-streaming`, `input-available`,
+ *     unknown states) → `output-error` with `TOOL_HEAL_INTERRUPT_TEXT`.
+ *
+ * NOT a heal target — `approval-requested` is INTENTIONALLY preserved:
+ *
+ *   `approval-requested` is the AI SDK's resting state when a tool with
+ *   `approval: { required: true }` is called. The SDK closes its
+ *   ReadableStream there and waits for the renderer to call
+ *   `addToolApprovalResponse` (Approve/Deny). The SW agent host's
+ *   `pumpMessages` loop sees the stream end and falls through to this
+ *   heal — but the state is *intentional*, not stranded. Rewriting it
+ *   to `output-denied` (the pre-fix behavior) caused `PlanApprovalCard`
+ *   to never mount in Plan mode and Ask-mode tool prompts to render as
+ *   denied before the user could act. The renderer-side
+ *   `healPendingTools` still collapses `approval-requested` →
+ *   `output-denied` on the next user action (edit/retry/regenerate),
+ *   which IS the correct point — by then the user has implicitly
+ *   abandoned the approval prompt.
+ *
+ *   Trade-off: if the SW dies AND no renderer ever reopens the
+ *   conversation, the chat-db row stays in `approval-requested`. That's
+ *   acceptable: the only consumer is the renderer, and the renderer
+ *   heals it on first interaction.
  *
  * Inputs on healed parts are PRESERVED (a real input is kept on the
  * heal output). Missing input is left undefined — never synthesized to
@@ -86,20 +117,15 @@ export function healSerializedParts(parts: SerializedUIPart[]): HealResult {
       continue;
     }
 
-    changed = true;
-
-    // approval-requested → output-denied
+    // approval-requested is intentionally preserved — see the docstring
+    // above for the full rationale. The SDK is parked here waiting for
+    // the renderer's approval response; this is not a stranded state.
     if (state === "approval-requested") {
-      const approval = (part as { approval?: { id: string } }).approval;
-      out.push({
-        ...part,
-        state: "output-denied",
-        approval: approval
-          ? { id: approval.id, approved: false }
-          : undefined,
-      } as SerializedUIPart);
+      out.push(part);
       continue;
     }
+
+    changed = true;
 
     // approval-responded — depends on the user's choice
     if (state === "approval-responded") {

--- a/apps/extension/src/entrypoints/background/agent-host/run.ts
+++ b/apps/extension/src/entrypoints/background/agent-host/run.ts
@@ -215,6 +215,7 @@ export function startRun(args: StartRunArgs, deps: StartRunDeps): RunControl {
       persister,
       snapshot,
       handle,
+      args.messages,
     );
 
     let errMessage: string | null = null;
@@ -229,6 +230,12 @@ export function startRun(args: StartRunArgs, deps: StartRunDeps): RunControl {
     // error, disconnect) because the persister writes the in-flight
     // assistant message incrementally and may leave non-terminal tool
     // states (e.g. `input-streaming`) when the run terminates mid-tool.
+    //
+    // `approval-requested` is intentionally NOT a heal target — the
+    // SDK closes its stream there waiting for the renderer's approval
+    // response, so the natural end-of-run path lands here with a
+    // legitimately pending approval. See `heal-chatdb.ts`'s
+    // `healSerializedParts` docstring for the full rationale.
     //
     // CRITICAL TIMING: This MUST run BEFORE `emitDone` / `emitError`
     // (which flip `handle.status` and notify subscribers). If we notify
@@ -349,6 +356,7 @@ async function pumpMessages(
   persister: AssistantStreamPersister,
   snapshot: SnapshotBroadcaster,
   handle: RunHandle,
+  inputMessages: AgentUIMessage[],
 ): Promise<void> {
   // Mirror pumpFanout's abort-cancels-reader behavior. `readUIMessageStream`
   // consumes the source stream internally, so cancelling that source
@@ -376,7 +384,43 @@ async function pumpMessages(
     });
   })();
 
-  const uiStream = readUIMessageStream<AgentUIMessage>({ stream: cancellable });
+  // Seed the SDK's stream consumer with the last assistant message
+  // from the input transcript when present. This is what makes resume
+  // (approval → continuation) work end-to-end on the SW side:
+  //
+  //   - `createStreamingUIMessageState` (ai/dist/index.mjs:5298-5313)
+  //     uses `state.message = lastMessage` when `lastMessage.role`
+  //     is "assistant", so existing parts on the resumed message are
+  //     preserved as new chunks layer on top.
+  //   - Without this, `state.message` starts with `parts: []`, and the
+  //     SW's persister upserts the chat-db row with ONLY the chunks
+  //     emitted on the resume stream (e.g. the proposePlan
+  //     output-available + a `navigate` input-streaming) — losing the
+  //     original `proposePlan` input + approval metadata that the
+  //     UI needs to render the post-approval state correctly. The
+  //     visible symptom is the original `proposePlan` breadcrumb stuck
+  //     at "Drafting plan..." while a duplicate "Plan approved" row
+  //     appears below it.
+  //   - The matching `originalMessages` is passed at the transport
+  //     side (`compacting-transport.ts`) so the SDK's own
+  //     `getResponseUIMessageId` aligns the start chunk's messageId
+  //     with the resume target.
+  //
+  // Falls back to `undefined` for fresh turns (last message is user),
+  // matching the SDK's "no continuation" path. The check is gated on
+  // the TRAILING message's role — not a backward scan for any earlier
+  // assistant — because the SDK's own continuation logic in
+  // `getResponseUIMessageId` only considers `originalMessages.at(-1)`.
+  // A backward scan would pick a historical assistant on every fresh
+  // user turn that has any prior assistant in the transcript, seeding
+  // the SW persister with an unrelated message's id and parts.
+  const tail = inputMessages.at(-1);
+  const lastAssistant = tail?.role === "assistant" ? tail : undefined;
+
+  const uiStream = readUIMessageStream<AgentUIMessage>({
+    stream: cancellable,
+    ...(lastAssistant ? { message: lastAssistant } : {}),
+  });
   for await (const message of uiStream) {
     if (handle.abort.signal.aborted) break;
     if (message.role !== "assistant") continue;

--- a/apps/extension/src/lib/agent/compacting-transport.ts
+++ b/apps/extension/src/lib/agent/compacting-transport.ts
@@ -240,6 +240,27 @@ export class CompactingChatTransport<TOOLS extends ToolSet = ToolSet>
           abortSignal,
         });
         return result.toUIMessageStream({
+          // Pass the validated input messages so the SDK's
+          // `getResponseUIMessageId` (ai/dist/index.mjs:5081-5090) can
+          // reuse the LAST assistant message's id when present —
+          // converting an approval resume into a continuation of the
+          // existing assistant turn instead of a new bubble. Without
+          // this, our `generateMessageId` callback below was minting a
+          // fresh UUID on every transport call, including resumes,
+          // which broke the SDK's built-in continuation contract:
+          // `Chat.makeRequest` does `replaceLastMessage` only when
+          // `state.message.id === this.lastMessage.id` — with a fresh
+          // UUID that comparison is always false and the SDK
+          // `pushMessage`s a duplicate assistant bubble for the
+          // post-approval continuation. (This is what leaves the
+          // original `proposePlan` part stuck at "Drafting plan..." —
+          // its `output-available` lands on the new bubble instead.)
+          //
+          // The SDK gates the override on the LAST message's role being
+          // "assistant", so fresh turns (last is user) still fall
+          // through to the `generateMessageId` callback below for a
+          // brand-new id.
+          originalMessages: validatedMessages,
           // Mint a stable id for this assistant response. Without this,
           // the SDK's `processUIMessageStream` leaves `state.message.id`
           // at its `""` default (the `start` chunk omits `messageId`
@@ -1033,6 +1054,14 @@ export interface RejectionLoopAgent {
   }): Promise<{
     toUIMessageStream(options?: {
       generateMessageId?: () => string;
+      /**
+       * Passed through to the SDK so its built-in resume continuation
+       * (`getResponseUIMessageId` in ai/dist/index.mjs) can reuse the
+       * LAST assistant message's id when the input ends in one. Required
+       * for the approval-resume path; see the call site in
+       * `runWithRejectionLoop`.
+       */
+      originalMessages?: AgentUIMessage[];
     }): ReadableStream<UIMessageChunk>;
   }>;
 }
@@ -1136,6 +1165,12 @@ export function runWithRejectionLoop(args: {
 
           const observed = await pipeAndObserve(
             result.toUIMessageStream({
+              // Pass the current loop's `messages` (which mutates as
+              // synthetic user turns are appended per rejection round)
+              // so the SDK reuses the LAST assistant message's id when
+              // the loop is resuming an approval. See the matching call
+              // in the fast path above for the full rationale.
+              originalMessages: messages,
               // See the fast-path call site above for why this matters
               // (id:"" → all chunks coalesce into one chat-db row).
               generateMessageId: () => crypto.randomUUID(),


### PR DESCRIPTION
## Summary

PR #176 (MCP subagent bridge) inadvertently reverted the coordinated fixes landed in #174, reintroducing two user-visible regressions on the post-`proposePlan`-approval path (and every approval-gated Ask-mode tool). This PR re-applies #174's logic onto the current tree.

### Symptoms (reproduced on prod v0.13.2)
1. **Approval card never appeared** — the tool jumped straight to "Interrupted" and generation stopped. Hit both Plan mode (`proposePlan`) and Ask-mode tool approvals.
2. **Approving a plan left the original bubble stuck at "Drafting plan…"** with a duplicate "Plan approved" row appearing below it.

### Root cause
- **Symptom 1:** the SW agent host's `healLastAssistantInChatDb` ran on the natural pause-for-approval path and rewrote `approval-requested` → `output-denied` in chat-db, so `findPendingPlanApproval` returned null and `PlanApprovalCard` never mounted.
- **Symptom 2:** `CompactingChatTransport` minted a fresh `crypto.randomUUID()` on every call including resumes, overriding the SDK's `getResponseUIMessageId` continuation — the post-approval `output-available` landed in a new assistant message.

### Fix (re-applied from #174)
- `agent-host/heal-chatdb.ts` — leave `approval-requested` untouched (intentional resting state, not stranded).
- `lib/agent/compacting-transport.ts` — pass `originalMessages` on both the fast path and the rejection-loop path so the SDK reuses the last assistant id on resume.
- `agent-host/run.ts` — seed `pumpMessages`' `readUIMessageStream({ message })` with the trailing assistant message so the persister preserves existing parts.
- `agent-host/__tests__/heal-chatdb.test.ts` — restore the regression guards (incl. the end-to-end pending-`proposePlan` case).

### Known follow-up (out of scope)
#174 also closed a reload-race in the brief post-approval window (a `persistApprovedAssistantMessage` write in `useAgentChat.ts`). #176's rewrite of that hook removed the helper; re-applying it against the new architecture is deferred to a separate change. Still present on main; not one of the two symptoms above.

## Testing
- 130 agent-host + transport + approval unit tests pass; typecheck clean.
- Verified end-to-end in a v0.13.2-parity build: approval card mounts, plan approval resolves the original bubble in place, agent continues to completion. Confirmed in both Plan and Ask mode.

Reverts the regression from #176 · restores #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plan approval flows when running under the service-worker host.
  * Preserved pending approval prompts so plan approval cards remain available during pauses.
  * Resuming an approval now continues the existing assistant message instead of creating duplicates.
  * Improved resume behavior by retaining the correct conversation context and message state.
  * Added regression coverage for pending plan approvals and chat recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->