### PR TITLE
feat(files): add "Open in new tab" to the Space file viewer

### DIFF
--- a/.changeset/file-viewer-open-in-new-tab.md
+++ b/.changeset/file-viewer-open-in-new-tab.md
@@ -1,0 +1,11 @@
+---
+"openbrowse": patch
+---
+
+**Add an "Open in new tab" action to the Space file viewer.**
+
+The file viewer's header now offers an "Open in new tab" button (next to Download) when viewing a Space's workspace file. Clicking it pops the file out into a dedicated `file.html` tab that renders the same `FileViewerPanel` full-screen, so large files, PDFs, sheets, HTML previews, and code can be read without the constraints of the side rail.
+
+- `components/files/FileViewerPanel.tsx` — new optional `openInNewTab` prop. When set, renders an `ExternalLink` icon button that calls `chrome.tabs.create` with `file.html?path=<opfs-path>&name=<file-name>`. Off by default, so conversation-file surfaces are unchanged. Because OPFS is scoped to the extension origin and shared across every extension page, the new tab reads the exact same file by path — no blob handoff across contexts is needed.
+- `entrypoints/file/` — new standalone tab entrypoint (mirrors the artifact tab). `main.tsx` reads `path`/`name` from the query string, applies the app theme via `useTheme`, and mounts `FileViewerPanel` with `onClose={() => window.close()}`. It intentionally omits `openInNewTab` so the standalone tab doesn't offer to re-open a copy of itself.
+- `entrypoints/_shared/components/LandingPage.tsx` and `RightRail.tsx` — pass `openInNewTab` at the three Space workspace-file viewer call sites (xl rail, stacked rail, and the sidebar rail).

--- a/apps/extension/src/components/files/FileViewerPanel.tsx
+++ b/apps/extension/src/components/files/FileViewerPanel.tsx
@@ -354,11 +354,15 @@ export function FileViewerPanel({
   };
 
   const handleOpenInNewTab = () => {
-    chrome.tabs.create({
-      url: chrome.runtime.getURL(
-        `file.html?path=${encodeURIComponent(filePath)}&name=${encodeURIComponent(fileName)}`,
-      ),
-    });
+    chrome.tabs
+      .create({
+        url: chrome.runtime.getURL(
+          `file.html?path=${encodeURIComponent(filePath)}&name=${encodeURIComponent(fileName)}`,
+        ),
+      })
+      .catch(() => {
+        toast.error(`Couldn't open "${fileName}" in a new tab`);
+      });
   };
 
   const handleSaveToSpace = async () => {

--- a/apps/extension/src/components/files/FileViewerPanel.tsx
+++ b/apps/extension/src/components/files/FileViewerPanel.tsx
@@ -21,6 +21,7 @@ import {
   X,
   Download,
   RefreshCw,
+  ExternalLink,
   FileIcon,
   FileCheck,
   FileClock,
@@ -65,6 +66,14 @@ interface FileViewerPanelProps {
    * with an explanatory tooltip (matching the Working Folder card).
    */
   spaceId?: string | null;
+  /**
+   * When true, renders an "Open in new tab" action that opens this same file
+   * in the standalone `file.html` viewer tab. Off by default; enabled by
+   * surfaces (e.g. the Space file rail) where popping the file out to its own
+   * tab is useful. The standalone tab itself omits this so it doesn't offer
+   * to re-open a copy of itself.
+   */
+  openInNewTab?: boolean;
   onClose: () => void;
   className?: string;
 }
@@ -145,6 +154,7 @@ export function FileViewerPanel({
   fileName,
   conversationId,
   spaceId,
+  openInNewTab = false,
   onClose,
   className,
 }: FileViewerPanelProps) {
@@ -343,6 +353,14 @@ export function FileViewerPanel({
     setRefreshKey((k) => k + 1);
   };
 
+  const handleOpenInNewTab = () => {
+    chrome.tabs.create({
+      url: chrome.runtime.getURL(
+        `file.html?path=${encodeURIComponent(filePath)}&name=${encodeURIComponent(fileName)}`,
+      ),
+    });
+  };
+
   const handleSaveToSpace = async () => {
     if (
       !conversationId ||
@@ -451,6 +469,11 @@ export function FileViewerPanel({
               disabled={loaded === null}
               onClick={handleSaveToSpace}
             />
+          )}
+          {openInNewTab && (
+            <IconButton onClick={handleOpenInNewTab} tooltip="Open in new tab">
+              <ExternalLink className="size-3.5" />
+            </IconButton>
           )}
           <IconButton
             onClick={handleDownload}

--- a/apps/extension/src/entrypoints/_shared/components/LandingPage.tsx
+++ b/apps/extension/src/entrypoints/_shared/components/LandingPage.tsx
@@ -746,6 +746,7 @@ export function LandingPage({
               filePath={`spaces/${space.id}/workspace/${selectedSpaceFile}`}
               fileName={selectedSpaceFile.split("/").pop() ?? selectedSpaceFile}
               spaceId={space.id}
+              openInNewTab
               onClose={() => setSelectedSpaceFile(null)}
             />
           </motion.div>
@@ -821,6 +822,7 @@ export function LandingPage({
                 filePath={`spaces/${space.id}/workspace/${selectedSpaceFile}`}
                 fileName={selectedSpaceFile.split("/").pop() ?? selectedSpaceFile}
                 spaceId={space.id}
+                openInNewTab
                 onClose={() => setSelectedSpaceFile(null)}
               />
             ) : (

--- a/apps/extension/src/entrypoints/_shared/components/RightRail.tsx
+++ b/apps/extension/src/entrypoints/_shared/components/RightRail.tsx
@@ -296,6 +296,7 @@ export function RightRail({
                   }
                   conversationId={conversationId}
                   spaceId={spaceId}
+                  openInNewTab
                   onClose={() => onSelectSpaceFile(null)}
                 />
               </motion.div>

--- a/apps/extension/src/entrypoints/file/index.html
+++ b/apps/extension/src/entrypoints/file/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="manifest.type" content="unlisted" />
+    <link id="favicon" rel="icon" type="image/png" href="/icon/32.png" />
+    <title>OpenBrowse File</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/extension/src/entrypoints/file/main.tsx
+++ b/apps/extension/src/entrypoints/file/main.tsx
@@ -1,0 +1,52 @@
+// apps/extension/src/entrypoints/file/main.tsx
+import { FileViewerPanel } from "@/components/files/FileViewerPanel";
+import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useTheme } from "@/hooks/useTheme";
+import React from "react";
+import ReactDOM from "react-dom/client";
+// Reuse the artifact tab's stylesheet — it's a generic theme + shiki + code
+// styling bundle with nothing artifact-specific, so it applies cleanly to the
+// standalone file viewer too.
+import "../artifact/app.css";
+
+// The opener (FileViewerPanel's "Open in new tab") passes the OPFS path and a
+// display name. OPFS is scoped to the extension origin and shared across every
+// extension page, so this tab can read the exact same file by path.
+const params = new URLSearchParams(window.location.search);
+const filePath = params.get("path") ?? "";
+const fileName =
+  params.get("name") ?? filePath.split("/").pop() ?? filePath ?? "File";
+
+if (fileName) document.title = `${fileName} — OpenBrowse`;
+
+function ThemedApp() {
+  useTheme();
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      {filePath ? (
+        // No `openInNewTab` here: this *is* the standalone tab, so re-offering
+        // it would just spawn a duplicate of itself. Close returns to the tab
+        // the user came from by closing this one.
+        <FileViewerPanel
+          filePath={filePath}
+          fileName={fileName}
+          onClose={() => window.close()}
+          className="h-screen"
+        />
+      ) : (
+        <div className="flex h-screen items-center justify-center p-6 text-sm text-muted-foreground">
+          No file path was provided.
+        </div>
+      )}
+      <Toaster />
+    </TooltipProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <ThemedApp />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## What

Adds an **"Open in new tab"** action to the Space file viewer. It pops the file out into a dedicated full-screen `file.html` tab that renders the same `FileViewerPanel` — handy for reading large files, PDFs, sheets, HTML previews, and code without the side rail's width constraints.

## How

- **`FileViewerPanel`** — new optional `openInNewTab` prop (default off). When set, renders an `ExternalLink` button next to Download that opens `file.html?path=<opfs-path>&name=<file-name>`. OPFS is origin-scoped and shared across extension pages, so the new tab reads the same file by path — no blob handoff needed.
- **`entrypoints/file/`** — new standalone tab entrypoint mirroring the artifact tab. Reads `path`/`name` from the query string, applies the app theme, and mounts `FileViewerPanel` with `onClose={() => window.close()}`. Omits `openInNewTab` so it can't re-open a copy of itself.
- **`LandingPage` (×2) / `RightRail` (×1)** — pass `openInNewTab` at the three Space workspace-file call sites.

## Scope

Opt-in by design: only the Space file viewers get the button. Conversation-file surfaces are unchanged.

## Validation

- `pnpm compile` (tsc) passes
- `pnpm wxt build` succeeds and emits `.output/chrome-mv3/file.html`

Changeset: `patch` bump for `openbrowse`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Open in new tab”** action to the Space file viewer (via an external-link button).
  * Clicking it opens the file in a dedicated, full-screen tab with the same file context.
  * Included a graceful fallback message when the viewer tab is opened without a valid file path.
  * The new tab closes automatically when the viewer is dismissed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->