### PR TITLE
feat(extension): add "Add to space" action to chat thread menu

### DIFF
--- a/.changeset/add-to-space-menu.md
+++ b/.changeset/add-to-space-menu.md
@@ -1,0 +1,13 @@
+---
+"openbrowse": patch
+---
+
+**Add an "Add to space" action to the chat thread actions menu.**
+
+The chat header's ⋯ menu now has an "Add to space" submenu listing your spaces.
+Selecting one moves the conversation into that space; the space it already
+belongs to is disabled, and a "Remove from space" item appears when the
+conversation is currently in a space (moving it back to the global scope). The
+sidebar re-scopes immediately in the same window via a `chat-moved` event, since
+the cross-window `CONVERSATION_UPDATED` broadcast isn't delivered to the sender's
+own context.

--- a/apps/extension/src/entrypoints/_shared/HomeApp.tsx
+++ b/apps/extension/src/entrypoints/_shared/HomeApp.tsx
@@ -467,6 +467,11 @@ export default function HomeApp({ surface }: HomeAppProps) {
     setSelectedFile(null);
     setSelectedSpaceFile(null);
     setSelectedArtifact(null);
+    // Reset synchronously before the async fetch resolves so membership
+    // actions (the header "Add to space" submenu) can't act on the previous
+    // conversation's space during the loading window. Re-set below once this
+    // conversation's row resolves.
+    setConversationSpaceId(null);
     // Clear MCP banner synchronously before the async fetch resolves.
     // Otherwise, switching from an MCP conv to a non-MCP conv briefly
     // renders the previous MCP host's banner above the new chat until

--- a/apps/extension/src/entrypoints/_shared/HomeApp.tsx
+++ b/apps/extension/src/entrypoints/_shared/HomeApp.tsx
@@ -23,6 +23,7 @@ import {
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuPortal,
+    DropdownMenuSeparator,
     DropdownMenuSub,
     DropdownMenuSubContent,
     DropdownMenuSubTrigger,
@@ -50,6 +51,8 @@ import {
     Download,
     Ellipsis,
     FileDown,
+    FolderMinus,
+    FolderPlus,
     PanelRight,
     Pencil,
     Trash2,
@@ -208,6 +211,12 @@ export default function HomeApp({ surface }: HomeAppProps) {
   const scheduleModels = useScheduleModels();
 
   const [conversationTitle, setConversationTitle] = useState<string | null>(
+    null,
+  );
+  // Current space of the active conversation, mirrored so the header
+  // "Add to space" submenu can disable the row it already belongs to and
+  // show "Remove from space" only when it's in one.
+  const [conversationSpaceId, setConversationSpaceId] = useState<string | null>(
     null,
   );
   /**
@@ -447,6 +456,7 @@ export default function HomeApp({ surface }: HomeAppProps) {
   useEffect(() => {
     if (!activeConversationId) {
       setConversationTitle(null);
+      setConversationSpaceId(null);
       setActiveMcpHostName(null);
       setSelectedFile(null);
       setSelectedSpaceFile(null);
@@ -470,6 +480,7 @@ export default function HomeApp({ surface }: HomeAppProps) {
     chatDb.getConversation(activeConversationId).then((conv) => {
       if (cancelled) return;
       setConversationTitle(conv?.title ?? null);
+      setConversationSpaceId(conv?.spaceId ?? null);
       setActiveMcpHostName(
         conv?.source === "mcp" ? conv.mcpHostName ?? "MCP host" : null,
       );
@@ -624,6 +635,36 @@ export default function HomeApp({ surface }: HomeAppProps) {
       }
     }
   }, [deleteTarget, activeConversationId]);
+
+  // Move a conversation into a space (or, with `spaceId === null`, back out
+  // to the global/no-space scope). Persists the change, mirrors it into local
+  // header state when it targets the active conversation, and nudges the
+  // sidebar to re-scope. The cross-window CONVERSATION_UPDATED broadcast that
+  // updateConversation emits is not delivered to the sender's own context, so
+  // the same-window sidebar relies on the `chat-moved` event below.
+  const handleAddConversationToSpace = useCallback(
+    async (convId: string, spaceId: string | null) => {
+      const dest = spaceId
+        ? spaces.find((s) => s.id === spaceId)?.name ?? "space"
+        : null;
+      try {
+        await chatDb.updateConversation(convId, {
+          spaceId,
+          updatedAt: Date.now(),
+        });
+        if (convId === activeConversationIdRef.current) {
+          setConversationSpaceId(spaceId);
+        }
+        window.dispatchEvent(
+          new CustomEvent("chat-moved", { detail: { id: convId } }),
+        );
+        toast.success(dest ? `Added to ${dest}` : "Removed from space");
+      } catch {
+        toast.error("Couldn't move the conversation. Please try again.");
+      }
+    },
+    [spaces],
+  );
 
   const handleNewConversation = useCallback((id: string) => {
     setView("chat");
@@ -834,6 +875,60 @@ export default function HomeApp({ surface }: HomeAppProps) {
                         <Pencil className="size-3.5" />
                         Rename
                       </DropdownMenuItem>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <FolderPlus className="size-3.5" />
+                          Add to space
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={4}
+                            className="min-w-44"
+                          >
+                            {spaces.length === 0 ? (
+                              <DropdownMenuItem disabled>
+                                No spaces yet
+                              </DropdownMenuItem>
+                            ) : (
+                              spaces.map((s) => (
+                                <DropdownMenuItem
+                                  key={s.id}
+                                  disabled={s.id === conversationSpaceId}
+                                  onClick={() => {
+                                    if (!activeConversationId) return;
+                                    void handleAddConversationToSpace(
+                                      activeConversationId,
+                                      s.id,
+                                    );
+                                  }}
+                                >
+                                  <span className="text-sm leading-none">
+                                    {s.icon ?? "\uD83D\uDCC1"}
+                                  </span>
+                                  <span className="truncate">{s.name}</span>
+                                </DropdownMenuItem>
+                              ))
+                            )}
+                            {conversationSpaceId && (
+                              <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                  onClick={() => {
+                                    if (!activeConversationId) return;
+                                    void handleAddConversationToSpace(
+                                      activeConversationId,
+                                      null,
+                                    );
+                                  }}
+                                >
+                                  <FolderMinus className="size-3.5" />
+                                  Remove from space
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
                       <DropdownMenuSub>
                         <DropdownMenuSubTrigger>
                           <Download className="size-3.5" />

--- a/apps/extension/src/entrypoints/_shared/components/HomeSidebar.tsx
+++ b/apps/extension/src/entrypoints/_shared/components/HomeSidebar.tsx
@@ -87,6 +87,12 @@ export function HomeSidebar({
   const [generatingTitles, setGeneratingTitles] = useState<Set<string>>(new Set());
   const leaveTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const sidebarRef = useRef<HTMLElement>(null);
+  // Monotonic refresh token. `refresh` can be invoked concurrently from
+  // several triggers (active-conversation change, delete-failed, chat-moved,
+  // cross-window broadcasts); tagging each run lets a slower earlier refresh
+  // (e.g. one started before a move) be discarded so only the latest commits
+  // sidebar rows.
+  const refreshSeq = useRef(0);
 
   const activeSpace = activeSpaceId
     ? spaces.find((s) => s.id === activeSpaceId) ?? null
@@ -98,6 +104,7 @@ export function HomeSidebar({
   }, [pinned]);
 
   const refresh = useCallback(async () => {
+    const reqId = ++refreshSeq.current;
     // Normal chats: scope-filtered roots (subagent children excluded
     // upstream, and `source === "mcp"` background tasks excluded —
     // those surface in the Background Tasks panel instead). When
@@ -130,6 +137,9 @@ export function HomeSidebar({
       if (!seen.has(run.id)) merged.push(run);
     }
     merged.sort((a, b) => b.createdAt - a.createdAt);
+    // Ignore stale resolutions: a newer refresh has superseded this one
+    // (e.g. this run started before a chat-moved event fired its own).
+    if (reqId !== refreshSeq.current) return;
     setConversations(merged);
   }, [activeSpaceId]);
 

--- a/apps/extension/src/entrypoints/_shared/components/HomeSidebar.tsx
+++ b/apps/extension/src/entrypoints/_shared/components/HomeSidebar.tsx
@@ -165,15 +165,24 @@ export function HomeSidebar({
     function onDeleteFailed() {
       refresh();
     }
+    // A conversation was moved into/out of a space from another surface in
+    // this same window (the header "Add to space" menu). The cross-window
+    // CONVERSATION_UPDATED broadcast isn't delivered to the sender's own
+    // context, so re-scope the list from the source of truth here.
+    function onMoved() {
+      refresh();
+    }
     window.addEventListener("chat-title-generating", onGenerating);
     window.addEventListener("chat-title-updated", onUpdated);
     window.addEventListener("chat-deleted", onDeleted);
     window.addEventListener("chat-deleted-failed", onDeleteFailed);
+    window.addEventListener("chat-moved", onMoved);
     return () => {
       window.removeEventListener("chat-title-generating", onGenerating);
       window.removeEventListener("chat-title-updated", onUpdated);
       window.removeEventListener("chat-deleted", onDeleted);
       window.removeEventListener("chat-deleted-failed", onDeleteFailed);
+      window.removeEventListener("chat-moved", onMoved);
     };
   }, [refresh]);
 


### PR DESCRIPTION
Adds an **"Add to space"** submenu to the chat header actions menu (the ⋯ menu next to Rename/Export/Delete).

## What it does
- Lists your spaces; selecting one moves the current conversation into that space (`chatDb.updateConversation({ spaceId })`).
- The space the conversation already belongs to is shown but disabled (no-op).
- A **"Remove from space"** item appears (below a separator) when the conversation is in a space, moving it back to the global/no-space scope.
- Empty state ("No spaces yet") when there are no spaces.
- Success/error toast on completion.

## Notes
- The sidebar re-scopes immediately in the same window via a new `chat-moved` window event, since the cross-window `CONVERSATION_UPDATED` broadcast isn't delivered to the sender's own context (mirrors the existing `chat-deleted` optimistic pattern).
- `conversationSpaceId` is tracked alongside `conversationTitle` so the submenu can disable the current space and conditionally show "Remove from space".

## Validation
- `tsc --noEmit` passes.
- Diagnostics clean on both changed files.
- Changeset added (`openbrowse`: patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Add to space” option to the chat actions menu.
  * Move conversations into available spaces or remove them from a space to return them to the global view.
  * The current space is shown as unavailable when selecting a destination.
  * Conversation lists update immediately after moving a conversation.
  * Success and error notifications provide feedback for move actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->