### PR TITLE
fix(mcp-bridge): stop trust-prompt flicker loop and stale-session reconnect wedge

### DIFF
--- a/.changeset/fix-mcp-tofu-reconnect-loop.md
+++ b/.changeset/fix-mcp-tofu-reconnect-loop.md
@@ -1,0 +1,14 @@
+---
+"@openbrowse/mcp-server": patch
+"openbrowse": patch
+---
+
+**Fix MCP bridge trust-prompt flicker loop and stale-session reconnect wedge.**
+
+Two related reliability fixes in the extension↔broker WebSocket handshake:
+
+- **`hello-defer` stops the trust-prompt flicker.** The broker armed a fixed 5s `hello-timeout` after sending `hello-challenge`, but first-run TOFU (and key-rotation) require a *human* to approve the broker's identity in the extension UI — which can't happen in 5s. The broker would close the socket, the extension would reconnect and re-prompt, and the "verify this MCP helper" dialog flickered on/off every few seconds, making pairing nearly impossible. The extension now sends a `hello-defer` message the moment it needs a human decision; the broker cancels the short timeout and holds the socket open under a generous trust-decision window instead. The fast-fail path is preserved for genuinely dead/hung connections (the common already-trusted case still answers in milliseconds).
+
+- **Pong-based liveness eviction unwedges reconnects.** The broker enforces a single active session and rejects a second connection with `session_already_active`. If the paired extension's socket died *uncleanly* (MV3 service-worker suspend, sleep/wake, network blip — no TCP FIN), the broker kept the session registered and rejected every reconnect until the OS TCP stack timed the dead socket out (minutes), leaving the panel stuck on "Not connected." The broker now pings each established session and terminates a socket that misses a pong, so a dead session self-clears within ~1–2 heartbeat intervals and the extension can re-pair. The heartbeat interval is configurable via `heartbeatIntervalMs` (default 20s).
+
+Tests: broker WS suite covers the deferred-then-completed handshake and dead-peer eviction; the extension connect suite covers sending `hello-defer` on both the TOFU and key-mismatch paths.

--- a/apps/extension/src/entrypoints/background/mcp-bridge/__tests__/connect.test.ts
+++ b/apps/extension/src/entrypoints/background/mcp-bridge/__tests__/connect.test.ts
@@ -28,7 +28,8 @@ class FakeWebSocket {
 
   // Simulate broker messages
   receive(msg: unknown) {
-    if (this.onmessage) this.onmessage({ data: JSON.stringify(msg) } as MessageEvent);
+    if (this.onmessage)
+      this.onmessage({ data: JSON.stringify(msg) } as MessageEvent);
   }
 
   open() {
@@ -85,7 +86,11 @@ describe("mcp-bridge/connect", () => {
       protocolVersion: 1,
       brokerVersion: "0.0.0",
       publicKeyFingerprint: "fp123",
-      processInfo: { pid: 999, executablePath: "/x/openbrowse-mcp", startedAt: 0 },
+      processInfo: {
+        pid: 999,
+        executablePath: "/x/openbrowse-mcp",
+        startedAt: 0,
+      },
       nonce: "nonce123",
     });
 
@@ -99,8 +104,15 @@ describe("mcp-bridge/connect", () => {
         processInfo: expect.objectContaining({ pid: 999 }),
       }),
     );
-    // No hello-response sent yet
-    expect(ws.sent.length).toBe(0);
+    // No hello-response yet — but we DO send a hello-defer so the broker
+    // holds the socket open while the user decides (prevents the trust
+    // prompt from flickering in a reconnect loop).
+    expect(ws.sent.length).toBe(1);
+    const deferred = JSON.parse(ws.sent[0]);
+    expect(deferred).toEqual({
+      type: "hello-defer",
+      reason: "awaiting_user_trust",
+    });
 
     handler.stop();
   });
@@ -182,8 +194,13 @@ describe("mcp-bridge/connect", () => {
         presentedFingerprint: "new_fp_does_not_match",
       }),
     );
-    // hello-response NOT sent
-    expect(ws.sent.length).toBe(0);
+    // hello-response NOT sent — a hello-defer is sent instead so the
+    // broker keeps the socket open while the user resolves the mismatch.
+    expect(ws.sent.length).toBe(1);
+    expect(JSON.parse(ws.sent[0])).toEqual({
+      type: "hello-defer",
+      reason: "awaiting_user_trust",
+    });
     handler.stop();
   });
 });

--- a/apps/extension/src/entrypoints/background/mcp-bridge/index.ts
+++ b/apps/extension/src/entrypoints/background/mcp-bridge/index.ts
@@ -4,6 +4,7 @@ import {
   isHelloReject,
   isRpcRequest,
   PROTOCOL_VERSION,
+  type HelloDeferMessage,
   type HelloResponseMessage,
   type RpcRequestMessage,
 } from "./protocol";
@@ -113,9 +114,11 @@ export function connectToBroker(opts: ConnectOptions): BrokerConnection {
    * every few seconds and the trust prompt flickers in a reconnect loop.
    */
   function sendHelloDefer(socket: WebSocket): void {
-    socket.send(
-      JSON.stringify({ type: "hello-defer", reason: "awaiting_user_trust" }),
-    );
+    const msg: HelloDeferMessage = {
+      type: "hello-defer",
+      reason: "awaiting_user_trust",
+    };
+    socket.send(JSON.stringify(msg));
   }
 
   async function handleMessage(socket: WebSocket, raw: string): Promise<void> {

--- a/apps/extension/src/entrypoints/background/mcp-bridge/index.ts
+++ b/apps/extension/src/entrypoints/background/mcp-bridge/index.ts
@@ -1,9 +1,9 @@
 import {
-  PROTOCOL_VERSION,
   isHelloChallenge,
   isHelloProof,
   isHelloReject,
   isRpcRequest,
+  PROTOCOL_VERSION,
   type HelloResponseMessage,
   type RpcRequestMessage,
 } from "./protocol";
@@ -28,8 +28,16 @@ export interface RpcHandlerContext {
 
 export interface ConnectOptions {
   url: string;
-  onTofuPrompt?: (info: { fingerprint: string; processInfo: TrustRecord["processInfo"]; nonce: string; binarySha256?: string }) => void;
-  onKeyMismatch?: (info: { storedFingerprint: string; presentedFingerprint: string }) => void;
+  onTofuPrompt?: (info: {
+    fingerprint: string;
+    processInfo: TrustRecord["processInfo"];
+    nonce: string;
+    binarySha256?: string;
+  }) => void;
+  onKeyMismatch?: (info: {
+    storedFingerprint: string;
+    presentedFingerprint: string;
+  }) => void;
   /**
    * Called when the broker's `binarySha256` differs from the value stored
    * at TOFU time. Advisory only — the connection is NOT blocked. Both
@@ -81,11 +89,33 @@ export function connectToBroker(opts: ConnectOptions): BrokerConnection {
       protocolVersion: PROTOCOL_VERSION,
       extensionVersion: manifest.version,
       capabilities: {
-        tools: ["get_context", "list_windows", "list_spaces", "read_page", "screenshot", "task", "cancel_task", "open_url"],
+        tools: [
+          "get_context",
+          "list_windows",
+          "list_spaces",
+          "read_page",
+          "screenshot",
+          "task",
+          "cancel_task",
+          "open_url",
+        ],
         profile: "Default",
       },
     };
     socket.send(JSON.stringify(msg));
+  }
+
+  /**
+   * Tell the broker we can't answer the challenge yet because a human
+   * must approve its identity (first-run TOFU or key-rotation mismatch).
+   * This cancels the broker's short hello-timeout so the socket stays
+   * open while the user decides — without it the connection is torn down
+   * every few seconds and the trust prompt flickers in a reconnect loop.
+   */
+  function sendHelloDefer(socket: WebSocket): void {
+    socket.send(
+      JSON.stringify({ type: "hello-defer", reason: "awaiting_user_trust" }),
+    );
   }
 
   async function handleMessage(socket: WebSocket, raw: string): Promise<void> {
@@ -98,7 +128,11 @@ export function connectToBroker(opts: ConnectOptions): BrokerConnection {
 
     // Broker heartbeat — no action needed; the incoming WS data event
     // already reset the MV3 idle timer.
-    if (typeof msg === "object" && msg !== null && (msg as { type: unknown }).type === "ping") {
+    if (
+      typeof msg === "object" &&
+      msg !== null &&
+      (msg as { type: unknown }).type === "ping"
+    ) {
       return;
     }
 
@@ -106,17 +140,22 @@ export function connectToBroker(opts: ConnectOptions): BrokerConnection {
       lastBrokerVersion = msg.brokerVersion;
       const trusted = await getTrustedFingerprint();
       if (trusted === null) {
-        // First-time TOFU prompt
+        // First-time TOFU prompt. Tell the broker to hold the socket
+        // open while we wait for the user's trust decision.
         pendingChallenge = {
           fingerprint: msg.publicKeyFingerprint,
           processInfo: msg.processInfo,
           nonce: msg.nonce,
           binarySha256: msg.binarySha256,
         };
+        sendHelloDefer(socket);
         opts.onTofuPrompt?.(pendingChallenge);
         return;
       }
       if (trusted !== msg.publicKeyFingerprint) {
+        // Key rotation / mismatch also needs a human decision, so defer
+        // to keep the socket alive rather than letting it time out.
+        sendHelloDefer(socket);
         opts.onKeyMismatch?.({
           storedFingerprint: trusted,
           presentedFingerprint: msg.publicKeyFingerprint,
@@ -168,17 +207,13 @@ export function connectToBroker(opts: ConnectOptions): BrokerConnection {
     }
 
     if (isRpcRequest(msg)) {
-      await dispatchRpc(
-        msg,
-        socket.send.bind(socket),
-        {
-          // Phase 1 has no OAuth flow yet, so we use the host's
-          // self-reported name as the subject (collisions across hosts
-          // are therefore possible — tightened in Phase 3).
-          sub: msg.hostInfo?.name ?? "unknown",
-          client_name: msg.hostInfo?.name,
-        },
-      );
+      await dispatchRpc(msg, socket.send.bind(socket), {
+        // Phase 1 has no OAuth flow yet, so we use the host's
+        // self-reported name as the subject (collisions across hosts
+        // are therefore possible — tightened in Phase 3).
+        sub: msg.hostInfo?.name ?? "unknown",
+        client_name: msg.hostInfo?.name,
+      });
       return;
     }
   }
@@ -186,7 +221,9 @@ export function connectToBroker(opts: ConnectOptions): BrokerConnection {
   return {
     async start() {
       ws = new WebSocket(opts.url);
-      ws.onopen = () => { /* awaiting hello-challenge */ };
+      ws.onopen = () => {
+        /* awaiting hello-challenge */
+      };
       ws.onmessage = (ev) => {
         void handleMessage(ws!, typeof ev.data === "string" ? ev.data : "");
       };
@@ -351,11 +388,16 @@ export async function dispatchRpc(
       default:
         // Unknown methods don't get an audit row — they never reached a
         // handler. The error envelope still surfaces to the host.
-        send(JSON.stringify({
-          type: "rpc-error",
-          id: msg.id,
-          error: { code: "method_not_found", message: `unknown method: ${(msg as { method: string }).method}` },
-        }));
+        send(
+          JSON.stringify({
+            type: "rpc-error",
+            id: msg.id,
+            error: {
+              code: "method_not_found",
+              message: `unknown method: ${(msg as { method: string }).method}`,
+            },
+          }),
+        );
         return;
     }
     await recordAudit({ outcome: "ok" });
@@ -363,10 +405,12 @@ export async function dispatchRpc(
   } catch (err) {
     const code = (err as { code?: string }).code ?? "internal_error";
     await recordAudit({ outcome: outcomeFromError(err), errorCode: code });
-    send(JSON.stringify({
-      type: "rpc-error",
-      id: msg.id,
-      error: { code, message: (err as Error).message },
-    }));
+    send(
+      JSON.stringify({
+        type: "rpc-error",
+        id: msg.id,
+        error: { code, message: (err as Error).message },
+      }),
+    );
   }
 }

--- a/apps/extension/src/entrypoints/background/mcp-bridge/protocol.ts
+++ b/apps/extension/src/entrypoints/background/mcp-bridge/protocol.ts
@@ -28,6 +28,22 @@ export interface HelloProofMessage {
   sessionId: string;
 }
 
+/**
+ * Sent by the extension immediately after a `hello-challenge` when it
+ * cannot answer straight away because it must ask a human to approve the
+ * broker's identity (first-run TOFU, or a key-rotation mismatch).
+ *
+ * The broker reacts by cancelling its short hello-timeout and arming a
+ * much longer "trust decision" window, keeping the socket open while the
+ * user decides. Without this, the broker would tear the socket down after
+ * a few seconds and the extension's trust prompt would flicker in an
+ * endless reconnect loop.
+ */
+export interface HelloDeferMessage {
+  type: "hello-defer";
+  reason: "awaiting_user_trust";
+}
+
 export interface HelloRejectMessage {
   type: "hello-reject";
   reason: "protocol_version_unsupported" | "session_already_active";
@@ -89,9 +105,17 @@ export interface TaskEventMessage {
   /** Compact event payload — tool name, args summary, brief result preview. */
   event:
     | { kind: "step-start"; toolName: string; argsPreview: string }
-    | { kind: "step-finish"; toolName: string; durationMs: number; resultPreview: string }
+    | {
+        kind: "step-finish";
+        toolName: string;
+        durationMs: number;
+        resultPreview: string;
+      }
     | { kind: "text"; text: string }
-    | { kind: "todo-updated"; todos: { id: string; text: string; done: boolean }[] }
+    | {
+        kind: "todo-updated";
+        todos: { id: string; text: string; done: boolean }[];
+      }
     | { kind: "user-confirmed"; outcome: "allow" | "deny" };
 }
 
@@ -151,6 +175,7 @@ export type WsMessage =
   | HelloResponseMessage
   | HelloProofMessage
   | HelloRejectMessage
+  | HelloDeferMessage
   | RpcRequestMessage
   | RpcResultMessage
   | RpcErrorMessage
@@ -162,7 +187,9 @@ export type WsMessage =
   | PingMessage;
 
 function hasType(x: unknown, t: string): x is { type: string } {
-  return typeof x === "object" && x !== null && (x as { type: unknown }).type === t;
+  return (
+    typeof x === "object" && x !== null && (x as { type: unknown }).type === t
+  );
 }
 
 export function isHelloChallenge(x: unknown): x is HelloChallengeMessage {
@@ -173,6 +200,9 @@ export function isHelloResponse(x: unknown): x is HelloResponseMessage {
 }
 export function isHelloProof(x: unknown): x is HelloProofMessage {
   return hasType(x, "hello-proof");
+}
+export function isHelloDefer(x: unknown): x is HelloDeferMessage {
+  return hasType(x, "hello-defer");
 }
 export function isHelloReject(x: unknown): x is HelloRejectMessage {
   return hasType(x, "hello-reject");

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -162,6 +162,21 @@ export function corsHeadersForPath(
 export async function startHttpServer(
   opts: ServerOptions = {},
 ): Promise<RunningServer> {
+  // Validate the optional liveness interval up front. An invalid value
+  // (NaN, zero, negative, fractional, or above Node's max timer delay)
+  // would make the broker's heartbeat `setInterval` misbehave — busy-loop
+  // for <=0/NaN, or get clamped to 1ms with a warning above 2^31-1.
+  const { heartbeatIntervalMs } = opts;
+  if (
+    heartbeatIntervalMs !== undefined &&
+    (!Number.isInteger(heartbeatIntervalMs) ||
+      heartbeatIntervalMs <= 0 ||
+      heartbeatIntervalMs > 2_147_483_647)
+  ) {
+    throw new RangeError(
+      `heartbeatIntervalMs must be a positive integer <= 2147483647 ms, got ${heartbeatIntervalMs}`,
+    );
+  }
   const cfg = buildConfig({ port: opts.port });
   const keys = await loadOrCreateKeyPair();
   const clients = createClientRegistry();
@@ -354,16 +369,14 @@ export async function startHttpServer(
   });
 
   const baseUrl = `http://localhost:${port}`;
-  attachWsServer({
+  const wss = attachWsServer({
     httpServer: server,
     publicKeyFingerprint: keys.fingerprint,
     privateKey: keys.privateKey,
     brokerVersion: "0.0.0",
     registry: sessions,
     refreshTokens,
-    ...(opts.heartbeatIntervalMs !== undefined
-      ? { heartbeatIntervalMs: opts.heartbeatIntervalMs }
-      : {}),
+    ...(heartbeatIntervalMs !== undefined ? { heartbeatIntervalMs } : {}),
   });
   return {
     port,
@@ -379,7 +392,15 @@ export async function startHttpServer(
     close: () =>
       new Promise<void>((resolve) => {
         clearInterval(sweepInterval);
-        server.close(() => resolve());
+        // Terminate any live extension sockets first so `server.close()`
+        // isn't left waiting on upgraded WebSocket connections, then
+        // release the WS server before shutting the HTTP server down.
+        for (const client of wss.clients) {
+          client.terminate();
+        }
+        wss.close(() => {
+          server.close(() => resolve());
+        });
       }),
   };
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,33 +1,39 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { URL } from "node:url";
+import { createArtifactStore, type ArtifactStore } from "./artifacts/store";
 import { buildConfig, type Config } from "./config";
 import { loadOrCreateKeyPair, type BrokerKeyPair } from "./keys/store";
 import { createClientRegistry, type ClientRegistry } from "./oauth/clients";
 import { createCodeStore, type CodeStore } from "./oauth/codes";
 import { createPendingConsents, type PendingConsents } from "./oauth/pending-consents";
-import {
-  createRefreshTokenStore,
-  type RefreshTokenStore,
-} from "./oauth/refresh-tokens";
-import {
-  wellKnownProtectedResource,
-  wellKnownAuthorizationServer,
-} from "./routes/well-known";
-import { buildJwks } from "./routes/jwks";
-import { handleAuthorize } from "./routes/authorize";
-import { handleToken } from "./routes/token";
-import { handleRegister } from "./routes/register";
-import { handleMcp, type RpcForwarder } from "./routes/mcp";
-import { handleArtifact } from "./routes/artifact";
-import { createArtifactStore, type ArtifactStore } from "./artifacts/store";
 import { createRateLimiter, DEFAULT_RATE_LIMITS } from "./oauth/rate-limit";
+import {
+    createRefreshTokenStore,
+    type RefreshTokenStore,
+} from "./oauth/refresh-tokens";
+import { handleArtifact } from "./routes/artifact";
+import { handleAuthorize } from "./routes/authorize";
+import { buildJwks } from "./routes/jwks";
+import { handleMcp, type RpcForwarder } from "./routes/mcp";
+import { handleRegister } from "./routes/register";
+import { handleToken } from "./routes/token";
+import {
+    wellKnownAuthorizationServer,
+    wellKnownProtectedResource,
+} from "./routes/well-known";
+import { createRpcForwarder } from "./ws/rpc";
 import { attachWsServer } from "./ws/server";
 import { SessionRegistry } from "./ws/session";
-import { createRpcForwarder } from "./ws/rpc";
 
 export interface ServerOptions {
   port?: number;
   rpcForwarder?: RpcForwarder;
+  /**
+   * Interval (ms) for the extension session heartbeat/liveness ping.
+   * Forwarded to `attachWsServer`; mainly overridden by tests to drive
+   * dead-peer eviction quickly. Defaults to 20s.
+   */
+  heartbeatIntervalMs?: number;
 }
 
 export interface RunningServer {
@@ -355,6 +361,9 @@ export async function startHttpServer(
     brokerVersion: "0.0.0",
     registry: sessions,
     refreshTokens,
+    ...(opts.heartbeatIntervalMs !== undefined
+      ? { heartbeatIntervalMs: opts.heartbeatIntervalMs }
+      : {}),
   });
   return {
     port,

--- a/packages/mcp-server/src/ws/__tests__/server.test.ts
+++ b/packages/mcp-server/src/ws/__tests__/server.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 
 interface RunningServer {
@@ -65,9 +65,10 @@ describe("ws/server", () => {
         protocolVersion: 1,
       });
       expect(typeof (challenge as { nonce: string }).nonce).toBe("string");
-      expect(typeof (challenge as { publicKeyFingerprint: string }).publicKeyFingerprint).toBe(
-        "string",
-      );
+      expect(
+        typeof (challenge as { publicKeyFingerprint: string })
+          .publicKeyFingerprint,
+      ).toBe("string");
 
       ws.send(
         JSON.stringify({
@@ -89,7 +90,48 @@ describe("ws/server", () => {
     }
   });
 
-  it("rejects second connection while one is already paired", async () => {
+  it("holds the socket open after hello-defer and completes on a later hello-response", async () => {
+    const server = await startTestServer();
+    try {
+      const ws = new WebSocket(`ws://localhost:${server.port}/ws`);
+      const reader = bufferedReader(ws);
+      let closed = false;
+      ws.once("close", () => {
+        closed = true;
+      });
+      await new Promise((r) => ws.once("open", r));
+      await reader.next(); // challenge
+
+      // Extension signals it needs a human trust decision.
+      ws.send(
+        JSON.stringify({ type: "hello-defer", reason: "awaiting_user_trust" }),
+      );
+
+      // Wait well past the old 5s hello-timeout to prove the socket is
+      // no longer torn down while awaiting the user.
+      await new Promise((r) => setTimeout(r, 6_000));
+      expect(closed).toBe(false);
+
+      // User approves; the deferred handshake now completes.
+      ws.send(
+        JSON.stringify({
+          type: "hello-response",
+          protocolVersion: 1,
+          extensionVersion: "0.0.0-test",
+          capabilities: { tools: ["get_context"], profile: "Default" },
+        }),
+      );
+
+      const proof = await reader.next();
+      expect(proof).toMatchObject({ type: "hello-proof" });
+
+      ws.close();
+    } finally {
+      await server.close();
+    }
+  }, 10_000);
+
+  it("rejects a second connection while one is already paired", async () => {
     const server = await startTestServer();
     try {
       const ws1 = new WebSocket(`ws://localhost:${server.port}/ws`);
@@ -106,7 +148,9 @@ describe("ws/server", () => {
       );
       await r1.next(); // hello-proof
 
-      // Second connection should be rejected
+      // Second connection should be rejected — the broker enforces a
+      // single active session, so two live extensions can't ping-pong
+      // takeovers.
       const ws2 = new WebSocket(`ws://localhost:${server.port}/ws`);
       const r2 = bufferedReader(ws2);
       await new Promise((r) => ws2.once("open", r));
@@ -131,6 +175,66 @@ describe("ws/server", () => {
       await server.close();
     }
   });
+
+  it("evicts a paired session whose socket stops answering pings", async () => {
+    // A single extension whose socket dies uncleanly (no TCP FIN) must not
+    // wedge the broker: the liveness ping/pong should detect the dead peer,
+    // terminate the socket, clear the session, and let a fresh connection
+    // pair. We drive it fast with a short heartbeat interval and a client
+    // that never pongs (`autoPong: false`).
+    const { startHttpServer } = await import("../../server");
+    const server = await startHttpServer({ port: 0, heartbeatIntervalMs: 120 });
+    try {
+      const dead = new WebSocket(`ws://localhost:${server.port}/ws`, {
+        autoPong: false,
+      });
+      const rDead = bufferedReader(dead);
+      let deadClosed = false;
+      dead.once("close", () => {
+        deadClosed = true;
+      });
+      await new Promise((r) => dead.once("open", r));
+      await rDead.next(); // challenge
+      dead.send(
+        JSON.stringify({
+          type: "hello-response",
+          protocolVersion: 1,
+          extensionVersion: "0.0.0",
+          capabilities: { tools: [], profile: "Default" },
+        }),
+      );
+      await rDead.next(); // hello-proof — session established
+
+      // The broker pings each interval; with pongs suppressed it should
+      // terminate this socket within ~2 intervals.
+      const deadline = Date.now() + 2_000;
+      while (!deadClosed && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      expect(deadClosed).toBe(true);
+
+      // Session was cleared, so a fresh client can now pair.
+      const live = new WebSocket(`ws://localhost:${server.port}/ws`);
+      const rLive = bufferedReader(live);
+      await new Promise((r) => live.once("open", r));
+      await rLive.next(); // challenge
+      live.send(
+        JSON.stringify({
+          type: "hello-response",
+          protocolVersion: 1,
+          extensionVersion: "0.0.0",
+          capabilities: { tools: [], profile: "Default" },
+        }),
+      );
+      const proof = await rLive.next();
+      expect(proof).toMatchObject({ type: "hello-proof" });
+
+      live.close();
+      dead.close();
+    } finally {
+      await server.close();
+    }
+  }, 10_000);
 
   it("rejects mismatched protocol version", async () => {
     const server = await startTestServer();
@@ -169,8 +273,14 @@ describe("ws/server", () => {
     const server = await startHttpServer({ port: 0 });
     try {
       // Seed a couple of tokens so we can observe deletion.
-      const t1 = server.refreshTokens.issue({ clientId: "c-revoke", scope: "openbrowse" });
-      const t2 = server.refreshTokens.issue({ clientId: "c-keep", scope: "openbrowse" });
+      const t1 = server.refreshTokens.issue({
+        clientId: "c-revoke",
+        scope: "openbrowse",
+      });
+      const t2 = server.refreshTokens.issue({
+        clientId: "c-keep",
+        scope: "openbrowse",
+      });
 
       const ws = new WebSocket(`ws://localhost:${server.port}/ws`);
       const reader = bufferedReader(ws);
@@ -250,7 +360,10 @@ describe("ws/server", () => {
     const { startHttpServer } = await import("../../server");
     const server = await startHttpServer({ port: 0 });
     try {
-      const t = server.refreshTokens.issue({ clientId: "c-unaffected", scope: "openbrowse" });
+      const t = server.refreshTokens.issue({
+        clientId: "c-unaffected",
+        scope: "openbrowse",
+      });
 
       const ws = new WebSocket(`ws://localhost:${server.port}/ws`);
       const reader = bufferedReader(ws);
@@ -269,7 +382,9 @@ describe("ws/server", () => {
       // Garbage payload — should be silently dropped.
       ws.send("{ not json");
       // Wrong-type payload — should also be ignored.
-      ws.send(JSON.stringify({ type: "totally-unknown", clientId: "c-unaffected" }));
+      ws.send(
+        JSON.stringify({ type: "totally-unknown", clientId: "c-unaffected" }),
+      );
 
       // Give the server a moment to (not) react.
       await new Promise((r) => setTimeout(r, 50));

--- a/packages/mcp-server/src/ws/__tests__/server.test.ts
+++ b/packages/mcp-server/src/ws/__tests__/server.test.ts
@@ -236,6 +236,15 @@ describe("ws/server", () => {
     }
   }, 10_000);
 
+  it("rejects an invalid heartbeatIntervalMs at startup", async () => {
+    const { startHttpServer } = await import("../../server");
+    for (const bad of [0, -1, 1.5, Number.NaN, 2_147_483_648]) {
+      await expect(
+        startHttpServer({ port: 0, heartbeatIntervalMs: bad }),
+      ).rejects.toThrow(/heartbeatIntervalMs/);
+    }
+  });
+
   it("rejects mismatched protocol version", async () => {
     const server = await startTestServer();
     try {

--- a/packages/mcp-server/src/ws/protocol.ts
+++ b/packages/mcp-server/src/ws/protocol.ts
@@ -24,6 +24,22 @@ export interface HelloProofMessage {
   sessionId: string;
 }
 
+/**
+ * Sent by the extension immediately after a `hello-challenge` when it
+ * cannot answer straight away because it must ask a human to approve the
+ * broker's identity (first-run TOFU, or a key-rotation mismatch).
+ *
+ * The broker reacts by cancelling its short hello-timeout and arming a
+ * much longer "trust decision" window, keeping the socket open while the
+ * user decides. Without this, the broker would tear the socket down after
+ * a few seconds and the extension's trust prompt would flicker in an
+ * endless reconnect loop.
+ */
+export interface HelloDeferMessage {
+  type: "hello-defer";
+  reason: "awaiting_user_trust";
+}
+
 export interface HelloRejectMessage {
   type: "hello-reject";
   reason: "protocol_version_unsupported" | "session_already_active";
@@ -85,9 +101,17 @@ export interface TaskEventMessage {
   /** Compact event payload — tool name, args summary, brief result preview. */
   event:
     | { kind: "step-start"; toolName: string; argsPreview: string }
-    | { kind: "step-finish"; toolName: string; durationMs: number; resultPreview: string }
+    | {
+        kind: "step-finish";
+        toolName: string;
+        durationMs: number;
+        resultPreview: string;
+      }
     | { kind: "text"; text: string }
-    | { kind: "todo-updated"; todos: { id: string; text: string; done: boolean }[] }
+    | {
+        kind: "todo-updated";
+        todos: { id: string; text: string; done: boolean }[];
+      }
     | { kind: "user-confirmed"; outcome: "allow" | "deny" };
 }
 
@@ -147,6 +171,7 @@ export type WsMessage =
   | HelloResponseMessage
   | HelloProofMessage
   | HelloRejectMessage
+  | HelloDeferMessage
   | RpcRequestMessage
   | RpcResultMessage
   | RpcErrorMessage
@@ -158,7 +183,9 @@ export type WsMessage =
   | PingMessage;
 
 function hasType(x: unknown, t: string): x is { type: string } {
-  return typeof x === "object" && x !== null && (x as { type: unknown }).type === t;
+  return (
+    typeof x === "object" && x !== null && (x as { type: unknown }).type === t
+  );
 }
 
 export function isHelloChallenge(x: unknown): x is HelloChallengeMessage {
@@ -169,6 +196,9 @@ export function isHelloResponse(x: unknown): x is HelloResponseMessage {
 }
 export function isHelloProof(x: unknown): x is HelloProofMessage {
   return hasType(x, "hello-proof");
+}
+export function isHelloDefer(x: unknown): x is HelloDeferMessage {
+  return hasType(x, "hello-defer");
 }
 export function isHelloReject(x: unknown): x is HelloRejectMessage {
   return hasType(x, "hello-reject");

--- a/packages/mcp-server/src/ws/server.ts
+++ b/packages/mcp-server/src/ws/server.ts
@@ -1,17 +1,18 @@
-import { WebSocketServer, WebSocket } from "ws";
-import type { Server } from "node:http";
 import { createHash, randomBytes, sign, type KeyObject } from "node:crypto";
 import { readFileSync } from "node:fs";
+import type { Server } from "node:http";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
+import type { RefreshTokenStore } from "../oauth/refresh-tokens";
 import {
-  PROTOCOL_VERSION,
-  isHelloResponse,
-  isRevokeHost,
-  type HelloChallengeMessage,
-  type HelloProofMessage,
-  type HelloRejectMessage,
+    PROTOCOL_VERSION,
+    isHelloDefer,
+    isHelloResponse,
+    isRevokeHost,
+    type HelloChallengeMessage,
+    type HelloProofMessage,
+    type HelloRejectMessage,
 } from "./protocol";
 import { SessionRegistry, type ExtensionSession } from "./session";
-import type { RefreshTokenStore } from "../oauth/refresh-tokens";
 
 /**
  * SHA-256 of the broker binary, computed once at module load.
@@ -48,10 +49,26 @@ export interface AttachOpts {
    * callers in `server.ts` always pass one through.
    */
   refreshTokens?: RefreshTokenStore;
+  /**
+   * How often (ms) the broker pings an established session's socket to
+   * both keep the MV3 service worker alive and detect a dead peer. A
+   * socket that misses a full interval without a pong is terminated so
+   * its session is cleared and the extension can re-pair. Defaults to
+   * 20s; overridable mainly so tests can drive eviction quickly.
+   */
+  heartbeatIntervalMs?: number;
 }
 
 export function attachWsServer(opts: AttachOpts): WebSocketServer {
-  const { httpServer, publicKeyFingerprint, privateKey, brokerVersion, registry, refreshTokens } = opts;
+  const {
+    httpServer,
+    publicKeyFingerprint,
+    privateKey,
+    brokerVersion,
+    registry,
+    refreshTokens,
+    heartbeatIntervalMs = 20_000,
+  } = opts;
   const wss = new WebSocketServer({ noServer: true });
 
   httpServer.on("upgrade", (request, socket, head) => {
@@ -82,23 +99,77 @@ export function attachWsServer(opts: AttachOpts): WebSocketServer {
     };
     ws.send(JSON.stringify(challenge));
 
-    const helloTimeout = setTimeout(() => {
+    // Handshake timers.
+    //
+    // `helloTimer` fast-fails a dead or hung extension that never answers
+    // the challenge. But first-run TOFU (and key-rotation) require a
+    // *human* to approve the broker's identity in the extension UI, which
+    // can't happen in 5s. When the extension signals `hello-defer`, we
+    // swap the short timeout for a much longer `trustTimer` so the socket
+    // stays open while the user decides. Without this, the socket is torn
+    // down every few seconds and the extension's trust prompt flickers in
+    // an endless reconnect loop.
+    const HELLO_TIMEOUT_MS = 5_000;
+    const TRUST_DECISION_TIMEOUT_MS = 5 * 60_000;
+    let helloTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
       ws.close(4000, "hello timeout");
-    }, 5000);
+    }, HELLO_TIMEOUT_MS);
+    let trustTimer: ReturnType<typeof setTimeout> | null = null;
 
-    ws.once("message", (raw) => {
-      clearTimeout(helloTimeout);
+    function clearHandshakeTimers(): void {
+      if (helloTimer !== null) {
+        clearTimeout(helloTimer);
+        helloTimer = null;
+      }
+      if (trustTimer !== null) {
+        clearTimeout(trustTimer);
+        trustTimer = null;
+      }
+    }
+
+    // Drop the handshake timers if the socket closes before the handshake
+    // finishes (e.g. the user declined the trust prompt). Registered with
+    // `once` so it never lingers past a single close.
+    ws.once("close", clearHandshakeTimers);
+
+    // The handshake listener is a persistent `on` (not `once`) because a
+    // `hello-defer` may precede the real `hello-response`. It removes
+    // itself with `ws.off` before the post-handshake control listener is
+    // attached, so later messages (e.g. `revoke-host`) don't fall through
+    // to the "expected hello-response" path.
+    function onHandshakeMessage(raw: RawData): void {
       let msg: unknown;
       try {
         msg = JSON.parse(raw.toString("utf8"));
       } catch {
+        clearHandshakeTimers();
         ws.close(4001, "invalid JSON");
         return;
       }
+
+      // Extension is asking a human to approve us. Hold the connection
+      // open (bounded by a generous timeout) until it either sends
+      // `hello-response` (approved) or drops the socket (declined).
+      if (isHelloDefer(msg)) {
+        if (helloTimer !== null) {
+          clearTimeout(helloTimer);
+          helloTimer = null;
+        }
+        if (trustTimer === null) {
+          trustTimer = setTimeout(() => {
+            ws.close(4005, "trust decision timeout");
+          }, TRUST_DECISION_TIMEOUT_MS);
+        }
+        return;
+      }
+
       if (!isHelloResponse(msg)) {
+        clearHandshakeTimers();
         ws.close(4002, "expected hello-response");
         return;
       }
+      clearHandshakeTimers();
+      ws.off("message", onHandshakeMessage);
       if (msg.protocolVersion !== PROTOCOL_VERSION) {
         const reject: HelloRejectMessage = {
           type: "hello-reject",
@@ -110,6 +181,12 @@ export function attachWsServer(opts: AttachOpts): WebSocketServer {
         ws.close(4003);
         return;
       }
+      // Enforce a single active extension session. If one already exists,
+      // reject the newcomer rather than stealing the session — otherwise
+      // two live extensions (e.g. two Chrome profiles pointed at the same
+      // broker) would ping-pong takeovers every reconnect. The rejected
+      // side retries on its own backoff; whichever paired first stays
+      // connected.
       if (registry.hasActiveSession()) {
         const reject: HelloRejectMessage = {
           type: "hello-reject",
@@ -123,9 +200,11 @@ export function attachWsServer(opts: AttachOpts): WebSocketServer {
       }
 
       const sessionId = randomBytes(16).toString("base64url");
-      const signature = sign(null, Buffer.from(`${nonce}.${sessionId}`), privateKey).toString(
-        "base64url",
-      );
+      const signature = sign(
+        null,
+        Buffer.from(`${nonce}.${sessionId}`),
+        privateKey,
+      ).toString("base64url");
       const proof: HelloProofMessage = {
         type: "hello-proof",
         signature,
@@ -142,15 +221,40 @@ export function attachWsServer(opts: AttachOpts): WebSocketServer {
       };
       registry.setSession(session);
 
-      // Heartbeat: send periodic pings to keep the extension's MV3
-      // service worker alive. Incoming WS data counts as an event that
-      // resets Chrome's idle timer, preventing the SW from being killed.
-      const HEARTBEAT_INTERVAL_MS = 20_000;
+      // Heartbeat + liveness.
+      //
+      // The app-level `{type:"ping"}` keeps the extension's MV3 service
+      // worker alive: an incoming WS message resets Chrome's idle timer.
+      //
+      // The WebSocket-level `ws.ping()` detects a *dead* peer. A single
+      // extension whose socket dies uncleanly (SW crash, sleep/wake,
+      // network blip — no TCP FIN) would otherwise keep its session
+      // registered here, and because the broker enforces a single session
+      // the extension's reconnect would be rejected with
+      // `session_already_active` until the OS TCP stack finally times the
+      // dead socket out (minutes). Instead we require a pong each
+      // interval; a socket that misses one is terminated, which fires the
+      // `close` handler below, clears the session, and lets the extension
+      // re-pair within ~one interval.
+      let isAlive = true;
+      ws.on("pong", () => {
+        isAlive = true;
+      });
       const heartbeat = setInterval(() => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: "ping", ts: Date.now() }));
+        if (ws.readyState !== WebSocket.OPEN) return;
+        if (!isAlive) {
+          // No pong since the previous tick — treat the peer as gone.
+          ws.terminate();
+          return;
         }
-      }, HEARTBEAT_INTERVAL_MS);
+        isAlive = false;
+        try {
+          ws.ping();
+        } catch {
+          // Socket may have died between the readyState check and here.
+        }
+        ws.send(JSON.stringify({ type: "ping", ts: Date.now() }));
+      }, heartbeatIntervalMs);
 
       // Phase 3 / Task 11: handle post-handshake server-bound messages.
       // The RPC forwarder (ws/rpc.ts) attaches its own listener for
@@ -187,7 +291,9 @@ export function attachWsServer(opts: AttachOpts): WebSocketServer {
           registry.clearSession();
         }
       });
-    });
+    }
+
+    ws.on("message", onHandshakeMessage);
   });
 
   return wss;


### PR DESCRIPTION
## Summary

Two related reliability fixes in the extension↔broker MCP handshake.

### 1. `hello-defer` — stops the trust-prompt flicker loop
The broker armed a fixed **5s hello-timeout** after `hello-challenge`, but first-run TOFU (and key-rotation) need a **human** to approve the broker in the extension UI — which can't happen in 5s. The broker closed the socket, the extension reconnected and re-prompted, and the "verify this MCP helper" dialog flickered on/off every few seconds, making pairing nearly impossible.

Now the extension sends a `hello-defer` message the moment it needs a human decision; the broker cancels the short timeout and holds the socket open under a generous trust-decision window. The fast-fail path is preserved for genuinely dead/hung connections (already-trusted reconnects still answer in ms).

### 2. Pong-based liveness eviction — unwedges reconnects
The broker enforces a single session and rejects a second connection with `session_already_active`. If the paired extension's socket died **uncleanly** (MV3 service-worker suspend, sleep/wake, no TCP FIN), the broker kept the session and rejected every reconnect until the OS TCP stack timed the dead socket out (minutes) — stuck on "Not connected."

The broker now pings each established session and terminates a socket that misses a pong, so a dead session self-clears within ~1–2 heartbeat intervals. Interval configurable via `heartbeatIntervalMs` (default 20s).

## Tests
- Broker WS suite: deferred-then-completed handshake, dead-peer eviction, single-session reject preserved.
- Extension connect suite: sends `hello-defer` on both TOFU and key-mismatch paths.
- Full broker suite green (124 tests); `tsc --noEmit` clean on both packages.

## Notes
- Adds a `hello-defer` message to the WS protocol (mirrored in broker + extension).
- Changeset included: `patch` for `@openbrowse/mcp-server` and `openbrowse`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented trust prompts from flickering or disconnecting while awaiting approval.
  * Improved recovery from stale connections by detecting and removing unresponsive sessions.
  * Added a five-minute window for completing trust decisions.

* **New Features**
  * Added configurable heartbeat timing, defaulting to 20 seconds, to help maintain reliable connections.

* **Tests**
  * Added coverage for deferred handshakes, trust decisions, and cleanup of disconnected sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->