### PR TITLE
feat(local-models): run WebLLM models as agents, and chat-only models as chat

### DIFF
--- a/.changeset/feat-webllm-local-models.md
+++ b/.changeset/feat-webllm-local-models.md
@@ -1,0 +1,36 @@
+---
+"openbrowse": minor
+---
+
+**Run local WebLLM models as browser agents — and let chat-only models actually be used for chat.** All 139 prebuilt WebLLM models are now surfaced with source-derived metadata, driven from the service-worker agent loop through a new offscreen bridge, and models that can't call tools run a lightweight chat-only path instead of being unselectable dead weight.
+
+Previously the local providers were effectively decorative: the agent loop runs in the service worker, but WebGPU (WebLLM) and `chrome.ai` (Gemini Nano) only exist in the offscreen document, so a local model could never drive a turn. Models were also listed with hand-maintained context windows, and any model without tool calling could be downloaded but never used anywhere.
+
+**Local-model bridge (service worker ↔ offscreen).** A Port-based protocol lets the SW drive a `LanguageModelV3` that physically lives in the offscreen document: `__bridge__/local-model-messages.ts` (wire protocol, with the V3 types derived structurally from the SDK's `LanguageModel` union), `local-model-sw-adapter.ts` (SW-side proxy implementing `doStream`/`doGenerate` over the Port, including mid-stream abort), and `offscreen/lm-stream.ts` (offscreen handler). `createLanguageModel` dispatches on runtime context — SW gets the proxy, offscreen builds the real model, renderer throws.
+
+**Source-derived model catalog.** Every model is generated from a new snapshot (`web-llm-model-context.ts`, 139 entries) instead of hand-maintained values: each model's real context window read from its `mlc-chat-config.json`, plus VRAM, prefill chunk size and sliding-window flag.
+
+- **Context windows are raised to each model's real ceiling.** `context_window_size` is a runtime KV-cache limit, not a compile-time one, so it's overridden per model via `engineConfig.appConfig.model_list[].overrides` (the top-level `appConfig` option is ignored by `@browser-ai/web-llm`). The KV cache is paged and grows on demand, so a large window costs nothing at load time. The 5 sliding-window models are excluded — they're driven by `sliding_window_size` instead.
+- `maxOutputTokens` is derived (a quarter of the window, capped at 4096) rather than a flat 1024, so long chat replies aren't truncated.
+- Only the 5 models mlc compiles with native function calling carry the `tools` capability; the rest are chat-only until there's per-model evidence, rather than guessing.
+- **A browsable catalog** replaces the flat 139-row dump: an always-visible Installed section, families collapsed by default, quantization variants folded behind one row, and capability / context-window / low-resource badges.
+
+**Agent eligibility, and a real chat-only path.** `agentModelGate` encodes what driving the browser agent actually requires: tool calling, plus a context window that can fit one turn (system prompt + tool schemas + page snapshot). It's wired into the agent-only pickers (composer, scheduled tasks), which render ineligible models disabled with a reason.
+
+- Because every OpenBrowse mode (`ask`/`plan`/`act`) is an *approval* mode of a tool-driven agent, a chat-only model had nowhere to go. `composerModelGate` now lets the composer select one anyway, and it runs a new lean chat-only transport: no browser or MCP tools, no page snapshot or per-turn blocks, no completion check, and a short system prompt instead of the full agent prompt — which is the point, since small local models can neither fit nor reliably follow it. Compaction and usage tracking are retained. The Plan/Act switch hides for these models, since there are no tool calls to gate.
+
+**Corrupted-output notice (WebLLM only).** Some WebLLM builds load and report success but emit token salad on specific GPUs/drivers — a known quantization + WebGPU issue, not an extension bug. Without a signal, users see nonsense and blame OpenBrowse.
+
+- A pure, dependency-free detector (`offscreen/coherence.ts`) scores output for that failure mode: writing-system mixing, `U+FFFD` replacement characters, letter/digit fusions, overlong run-together words, and degenerate repetition. Writing systems are counted as *groups* so legitimately multi-script languages (Japanese kanji + kana + Latin) don't read as corruption, and fenced code, inline code, URLs and long hex/base64 blobs are excluded so real agent output isn't misjudged. It's deliberately biased to false negatives — a working model must never be called broken.
+- Detection is **passive, not a probe**: replies the model has already produced are scored for free, rather than loading every model to test it. Scoped to `web-llm`; cloud providers have no such failure mode. On a garbled verdict the composer shows a dismissible notice naming the cause and the fix (try a different quantization — a q4f32 build often works where q4f16 fails). Output is never swallowed.
+- The catalog carries a matching note up front, so the failure mode is discoverable before a 5 GB download.
+
+**Fixes and hardening.**
+
+- **The UI no longer freezes right after sending to a local model.** Agent turns and chat-title generation were building two engines for the same model and contending on the GPU; all on-device generation now serializes behind a dependency-free FIFO engine lock, and title generation reuses the shared engine.
+- **A cold local load is visible instead of looking hung.** WASM instantiate + WebGPU shader compilation can take seconds with zero token output, so load progress is broadcast (throttled to whole percents) and surfaced in the composer as "Loading model… N%".
+- Model downloads are serialized and de-duplicated, and downloaded models are reconciled into saved settings so downloading no longer dirties the unsaved-changes bar.
+- Models whose declared output modality has no text (e.g. image/video models routed through the AI Gateway) are excluded from the models.dev registry import.
+- **Chat-title generation never resolved a compound `provider:model` id**, comparing the whole key against a bare model id — so titles were silently skipped for normally-selected models. Now normalized like the landing-page path.
+
+**Test surface.** +71 tests: the bridge adapter and offscreen handler (including mid-stream abort and error coercion), the download queue, the engine lock (FIFO ordering, rejection propagation, and no queue wedge after a failure), the catalog grouping helpers, the agent/composer/chat-only gates, and the coherence detector — scored against real captured q4f16 garbage plus healthy English, Japanese, Russian, Hindi, code, URL- and hash-heavy replies. All 2,686 tests pass; `tsc --noEmit` clean.

--- a/apps/extension/src/components/chat/ChatInput.tsx
+++ b/apps/extension/src/components/chat/ChatInput.tsx
@@ -44,6 +44,10 @@ import { summarizeMessages } from "@/lib/agent/summarize-messages";
 import { chatDb } from "@/lib/chat-db";
 import { openSettingsTab } from "@/lib/open-settings";
 import type { ThinkingConfig, ConversationMode } from "@/lib/types";
+import {
+  composerModelGate,
+  isChatOnlyModel,
+} from "@/registry/agent-capability";
 import { cn } from "@/lib/utils";
 import type { JSONContent } from "@tiptap/core";
 import HardBreak from "@tiptap/extension-hard-break";
@@ -1252,6 +1256,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
               favoriteModels={favoriteModels}
               onFavoriteToggle={onFavoriteToggle}
               showRecommended
+              modelGate={composerModelGate}
               placeholder="Select a model..."
               open={modelSelectorOpen}
               onOpenChange={setModelSelectorOpen}
@@ -1310,9 +1315,22 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
               }
             />
           )}
-          {mode && onModeChange && (
-            <ModeSwitch mode={mode} onChange={onModeChange} hasPlan={hasPlan} />
-          )}
+          {mode &&
+            onModeChange &&
+            // Approval modes (Plan/Act) are meaningless for a chat-only model:
+            // it can't call tools, so there are no tool calls to gate. Hide the
+            // switch when we know the selected model lacks `tools` (undefined
+            // capabilities → unknown → keep showing).
+            !(
+              selectedModelCapabilities != null &&
+              isChatOnlyModel({ capabilities: selectedModelCapabilities })
+            ) && (
+              <ModeSwitch
+                mode={mode}
+                onChange={onModeChange}
+                hasPlan={hasPlan}
+              />
+            )}
         </div>
 
         {/* Action buttons */}

--- a/apps/extension/src/components/chat/ChatView.tsx
+++ b/apps/extension/src/components/chat/ChatView.tsx
@@ -3,7 +3,13 @@ import {
   type TabMentionAttrs,
   type Attachment,
 } from "./ChatInput";
+import {
+  composerModelGate,
+  isAgentCapableModel,
+} from "@/registry/agent-capability";
 import { MessageList } from "./MessageList";
+import { useLocalModelOutputWarning } from "./useLocalModelOutputWarning";
+import type { ModelOption } from "./ModelPicker";
 import { PendingMentionBubble } from "./PendingMentionBubble";
 import { computeShowThinking } from "./compute-show-thinking";
 import { PlanApprovalCard } from "./PlanApprovalCard";
@@ -60,6 +66,7 @@ import {
   Pencil,
   Settings2,
   Sparkles,
+  TriangleAlert,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -418,6 +425,10 @@ export function ChatView({
 
   const providerModels = useConfiguredModels(settings);
 
+  // Passive WebLLM corruption notice — see useLocalModelOutputWarning.
+  const { warning: garbledOutput, dismiss: dismissGarbledOutput } =
+    useLocalModelOutputWarning();
+
   // Auto-select a default model when none is set and at least one
   // provider is now configured. Mirrors the same effect in LandingPage
   // so that whichever surface the user lands on after entering their
@@ -427,25 +438,44 @@ export function ChatView({
   // chat input stays disabled until the user manually picks a model,
   // which made the post-config UX feel broken.
   useEffect(() => {
-    if (agentSettings.agentModel) return;
     if (providerModels.length === 0) return;
 
-    const isAvailable = (key: string) => {
+    const findModel = (key: string): ModelOption | undefined => {
       const [pid, ...rest] = key.split(":");
       const mid = rest.join(":");
-      return providerModels.some(
-        (g) => g.provider === pid && g.models.some((m) => m.id === mid),
-      );
+      const group = providerModels.find((g) => g.provider === pid);
+      return group?.models.find((m) => m.id === mid);
     };
+
+    // Keep an existing selection as long as it's a valid composer choice —
+    // agent-capable OR chat-only (chat-only models run the lightweight
+    // chat-only transport, so they're legitimate selections; see
+    // `composerModelGate`). A model not yet in the configured list (e.g. still
+    // downloading) is kept too. Only an explicitly unselectable selection (e.g.
+    // tool-capable but context-too-small) triggers a re-pick, and only when a
+    // capable alternative exists (otherwise `pick` stays null).
+    if (agentSettings.agentModel) {
+      const current = findModel(agentSettings.agentModel);
+      if (!current) return;
+      const gate = composerModelGate(current);
+      if (gate.ok || gate.allowSelect === true) return;
+    }
 
     let pick: string | null = null;
 
-    const favorite = settings.favoriteModels.find(isAvailable);
+    // Prefer a configured favorite that can actually run the agent.
+    const favorite = settings.favoriteModels.find((key) => {
+      const m = findModel(key);
+      return !!m && isAgentCapableModel(m);
+    });
     if (favorite) pick = favorite;
 
+    // Then a recommended, agent-capable model.
     if (!pick) {
       for (const group of providerModels) {
-        const rec = group.models.find((m) => m.recommended);
+        const rec = group.models.find(
+          (m) => m.recommended && isAgentCapableModel(m),
+        );
         if (rec) {
           pick = `${group.provider}:${rec.id}`;
           break;
@@ -453,10 +483,15 @@ export function ChatView({
       }
     }
 
+    // Then the first agent-capable model available anywhere.
     if (!pick) {
-      const group = providerModels[0];
-      const model = group?.models[0];
-      if (group && model) pick = `${group.provider}:${model.id}`;
+      for (const group of providerModels) {
+        const m = group.models.find((mm) => isAgentCapableModel(mm));
+        if (m) {
+          pick = `${group.provider}:${m.id}`;
+          break;
+        }
+      }
     }
 
     if (pick) setAgentModel(pick);
@@ -1006,6 +1041,27 @@ export function ChatView({
               </QueueSectionContent>
             </QueueSection>
           </Queue>
+        )}
+        {garbledOutput && (
+          <div className="mx-2 mb-2 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 py-2 text-xs">
+            <TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500" />
+            <div className="min-w-0 flex-1 leading-relaxed text-muted-foreground">
+              <span className="font-medium text-foreground">
+                This model is producing corrupted output on your GPU.
+              </span>{" "}
+              A known WebLLM issue with some quantizations — not a problem with
+              your setup. Try a different quantization (a q4f32 build often works
+              when q4f16 fails) or another model.
+            </div>
+            <button
+              type="button"
+              onClick={dismissGarbledOutput}
+              aria-label="Dismiss"
+              className="shrink-0 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          </div>
         )}
         <ChatInputHalo space={space}>
           {pendingPlanApproval ? (

--- a/apps/extension/src/components/chat/GeneratingIndicator.tsx
+++ b/apps/extension/src/components/chat/GeneratingIndicator.tsx
@@ -9,9 +9,12 @@
  * `entrypoints/sidepanel/app.css` and `entrypoints/_shared/home.css` so the
  * indicator works on every surface that mounts a ChatView.
  */
+import { useLocalModelLoadProgress } from "./useLocalModelLoadProgress";
+
 export function GeneratingIndicator() {
+  const load = useLocalModelLoadProgress();
   return (
-    <div className="flex w-full items-start pt-3">
+    <div className="flex w-full items-center gap-2 pt-3">
       <svg
         viewBox="0 0 9 9"
         className="h-4 w-4 animate-scale-pulse"
@@ -30,6 +33,11 @@ export function GeneratingIndicator() {
         <rect x="0" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
         <rect x="8" y="4" width="1" height="1" fill="currentColor" className="text-blue-500 outward-edge" />
       </svg>
+      {load && (
+        <span className="text-xs text-muted-foreground">
+          Loading model… {Math.round(load.progress * 100)}%
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/extension/src/components/chat/ModelPicker.tsx
+++ b/apps/extension/src/components/chat/ModelPicker.tsx
@@ -77,6 +77,19 @@ interface ModelPickerProps {
 
   /** Optional extra UI rendered above each model row's tooltip card. */
   renderModelInfo?: (model: ModelOption) => ReactNode;
+  /**
+   * Per-model gate for agent-only pickers. When it returns `{ ok: false }`,
+   * the row is rendered disabled with `reason` as a badge and cannot be
+   * selected — UNLESS `allowSelect` is true, in which case the row stays
+   * selectable and `reason` renders as an advisory badge (e.g. the composer's
+   * "Chat only" models). Omit (or return `{ ok: true }`) to allow every model
+   * — the default for utility pickers (tidy / compaction / evaluator).
+   */
+  modelGate?: (model: ModelOption) => {
+    ok: boolean;
+    reason?: string;
+    allowSelect?: boolean;
+  };
   /** Optional footer rendered below the list (e.g. Configure button). */
   footer?: ReactNode;
   /** Optional extra block under the footer (e.g. thinking toggle). */
@@ -176,6 +189,7 @@ export function ModelPicker({
   open: controlledOpen,
   onOpenChange,
   portalContainer,
+  modelGate,
   disabled = false,
 }: ModelPickerProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
@@ -215,11 +229,13 @@ export function ModelPicker({
     if (defaultOption) map.set(defaultOption.value, true);
     for (const group of providerModels) {
       for (const m of group.models) {
-        map.set(`${group.provider}:${m.id}`, group.enabled);
+        const g = modelGate ? modelGate(m) : null;
+        const gatedOut = g ? !g.ok && g.allowSelect !== true : false;
+        map.set(`${group.provider}:${m.id}`, group.enabled && !gatedOut);
       }
     }
     return map;
-  }, [providerModels, defaultOption]);
+  }, [providerModels, defaultOption, modelGate]);
 
   // Precomputed searchable text per compound id. Used by base-ui's
   // internal `filter` (below) so its highlight/keyboard-nav set agrees
@@ -327,10 +343,18 @@ export function ModelPicker({
     starState: "filled" | "outline" | "hover";
   }) => {
     const compoundId = `${item.providerId}:${item.id}`;
+    const gate = modelGate ? modelGate(item.model) : { ok: true as const };
+    const gateAllowsSelect = gate.ok || gate.allowSelect === true;
+    const rowEnabled = item.enabled && gateAllowsSelect;
+    const reasonLabel = !item.enabled
+      ? "Not configured"
+      : !gate.ok
+        ? gate.reason
+        : null;
     const row = (
       <ComboboxItem
         value={compoundId}
-        disabled={!item.enabled}
+        disabled={!rowEnabled}
         onPointerMove={() => setHighlightedModelId(compoundId)}
         onFocus={() => setHighlightedModelId(compoundId)}
       >
@@ -343,9 +367,9 @@ export function ModelPicker({
           }
         />
         <span className="flex-1 truncate">{item.name}</span>
-        {!item.enabled && (
+        {reasonLabel && (
           <span className="mr-2 text-[10px] text-muted-foreground">
-            Not configured
+            {reasonLabel}
           </span>
         )}
         {onFavoriteToggle && (

--- a/apps/extension/src/components/chat/useLocalModelLoadProgress.ts
+++ b/apps/extension/src/components/chat/useLocalModelLoadProgress.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+export interface LocalModelLoadProgress {
+  modelId: string;
+  /** 0..1 */
+  progress: number;
+  text: string;
+}
+
+/**
+ * Listens for `LOCAL_MODEL_LOAD_PROGRESS` broadcasts emitted by the offscreen
+ * document while a local (WebLLM) model's engine loads on the first turn of an
+ * agent run.
+ *
+ * A cold local load (WASM instantiate + WebGPU shader compilation) can take
+ * several seconds with zero token output, which reads as a frozen UI. Surfacing
+ * this turns the dead time into visible progress. Returns the latest progress,
+ * or `null` when idle or once the load completes (progress >= 1), at which point
+ * the normal generating indicator takes over.
+ */
+export function useLocalModelLoadProgress(): LocalModelLoadProgress | null {
+  const [progress, setProgress] = useState<LocalModelLoadProgress | null>(null);
+
+  useEffect(() => {
+    const listener = (msg: unknown) => {
+      const m = msg as {
+        type?: string;
+        modelId?: string;
+        progress?: number;
+        text?: string;
+      };
+      if (m?.type !== "LOCAL_MODEL_LOAD_PROGRESS") return;
+      const p = typeof m.progress === "number" ? m.progress : 0;
+      if (p >= 1) {
+        setProgress(null);
+        return;
+      }
+      setProgress({ modelId: m.modelId ?? "", progress: p, text: m.text ?? "" });
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => chrome.runtime.onMessage.removeListener(listener);
+  }, []);
+
+  return progress;
+}

--- a/apps/extension/src/components/chat/useLocalModelOutputWarning.ts
+++ b/apps/extension/src/components/chat/useLocalModelOutputWarning.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface LocalModelOutputWarning {
+  modelId: string;
+  /** Signals that tripped the coherence check (e.g. "3 replacement characters"). */
+  reasons: string[];
+}
+
+/**
+ * Listens for `LOCAL_MODEL_OUTPUT_GARBLED` broadcasts from the offscreen
+ * document, emitted when a finished WebLLM reply scores as corrupted.
+ *
+ * Some WebLLM builds load and report success but emit token salad on specific
+ * GPUs/drivers — a known quantization + WebGPU issue, not a bug in the
+ * extension. Without a signal, the user just sees nonsense and reasonably
+ * concludes the app is broken. Surfacing it names the cause and the fix
+ * (try another quantization or model).
+ *
+ * Stays visible until dismissed, since the offending reply remains on screen. A
+ * newer warning replaces an older one.
+ */
+export function useLocalModelOutputWarning(): {
+  warning: LocalModelOutputWarning | null;
+  dismiss: () => void;
+} {
+  const [warning, setWarning] = useState<LocalModelOutputWarning | null>(null);
+
+  useEffect(() => {
+    const listener = (msg: unknown) => {
+      const m = msg as {
+        type?: string;
+        modelId?: string;
+        reasons?: unknown;
+      };
+      if (m?.type !== "LOCAL_MODEL_OUTPUT_GARBLED") return;
+      setWarning({
+        modelId: m.modelId ?? "",
+        reasons: Array.isArray(m.reasons) ? (m.reasons as string[]) : [],
+      });
+    };
+    chrome.runtime.onMessage.addListener(listener);
+    return () => chrome.runtime.onMessage.removeListener(listener);
+  }, []);
+
+  const dismiss = useCallback(() => setWarning(null), []);
+  return { warning, dismiss };
+}

--- a/apps/extension/src/entrypoints/_shared/components/CreateScheduledTaskDialog.tsx
+++ b/apps/extension/src/entrypoints/_shared/components/CreateScheduledTaskDialog.tsx
@@ -1,5 +1,6 @@
 // src/entrypoints/_shared/components/CreateScheduledTaskDialog.tsx
-import { useEffect, useRef, useState } from "react";
+import { ModelPicker } from "@/components/chat/ModelPicker";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -7,11 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Kbd } from "@/components/ui/kbd";
 import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
+import { Kbd } from "@/components/ui/kbd";
 import {
   Select,
   SelectContent,
@@ -19,13 +17,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ModelPicker } from "@/components/chat/ModelPicker";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import { useConfiguredModels } from "@/hooks/useConfiguredModels";
-import { storage } from "@/lib/storage";
 import { DEFAULT_SETTINGS } from "@/lib/constants";
-import type { Settings } from "@/lib/types";
 import { taskDb } from "@/lib/schedule/task-db";
-import type { Schedule, ScheduleKind, ScheduledTask } from "@/lib/schedule/types";
+import type {
+  Schedule,
+  ScheduleKind,
+  ScheduledTask,
+} from "@/lib/schedule/types";
+import { storage } from "@/lib/storage";
+import type { Settings } from "@/lib/types";
+import { agentModelGate } from "@/registry/agent-capability";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
   open: boolean;
@@ -230,6 +235,7 @@ export function CreateScheduledTaskDialog({
             providerModels={providerModels}
             value={agentModel || undefined}
             onValueChange={setAgentModel}
+            modelGate={agentModelGate}
             placeholder="Select a model"
             portalContainer={formRef}
           />
@@ -307,7 +313,9 @@ export function CreateScheduledTaskDialog({
 
           <div className="flex items-start justify-between gap-3 rounded-lg border p-3">
             <div className="min-w-0">
-              <label className="text-sm font-medium">Auto-approve tool actions</label>
+              <label className="text-sm font-medium">
+                Auto-approve tool actions
+              </label>
               <p className="text-xs text-muted-foreground">
                 Lets the scheduled run use tools that normally ask for
                 confirmation (it runs with no one watching). Off by default.

--- a/apps/extension/src/entrypoints/offscreen/__tests__/coherence.test.ts
+++ b/apps/extension/src/entrypoints/offscreen/__tests__/coherence.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  COHERENCE_CANARY_PROMPT,
+  evaluateCanaryReply,
+  scoreCoherence,
+} from "../coherence";
+
+/**
+ * Real captured output from Hermes-3-Llama-3.1-8B (q4f16) on an Apple Metal
+ * GPU, replying to the prompt "hello world". The model loaded and reported
+ * success. This is the exact class of failure the detector exists to catch.
+ */
+const REAL_GARBLED_REPLY =
+  "Coltsresetellaovsky fav-describedby-whá958puaugeihan:// (_REFiggerslinger " +
+  "Lux-Lervalbert protontook Bern Angeles activityEQUALóvleftright básदर AD " +
+  "Cochphpadinndaieżоменħ Creativeалеabwe-May326ывiboldvrieriggers Dhabi " +
+  "介.scalablytyped,abethzioola680_PS Funnyxdfulkanessonkla.xmlbeansornadoldatavisorhap " +
+  "gre nackte unreal387 RuntimeObject,ursettydam,घIBUT Fam-logo amon " +
+  "Cunningham460&actionignon LENabbo counterimitsurespremium580овер449trysviders " +
+  "Ünacci|string://Question Lamar many McCarthyचsitherurs\uFFFDaste Prompt " +
+  "Prototypegnore ifad\uFFFD\uFFFD vinc114[баханистIDD\uFFFD Weissayarunders Wahl " +
+  "Cocktailτιαëmëmphp FoleybertafiladayVERN addCriterion andagleicky\uFFFDalatplerylon " +
+  "gmailPREC_HI __.swingikink-familyckerkart accordinglyerrick-tíوWalalletusalxDB " +
+  "jadxMocksither erkenERGYavraspod Roose htonlamp bid\uFFFDDNvisor\uFFFDbes\uFFFD " +
+  "ficuratxdf wo://_REFشمالىCU actorampp certif-fشمالى Pazد\uFFFD cancgencysink " +
+  "gameTimeophelu Linkedj Purpleiten completelygetC slam/umdisman 438شهرى " +
+  "fumann.lyotenttrysaget kommentltkér\uFFFD_Abstractンピ";
+
+/** The AI-generated chat title from the same broken model. */
+const REAL_GARBLED_TITLE =
+  "Hello473ceae,...abeth favourleston सलua hab://<decltype 사 emp";
+
+describe("scoreCoherence — detects real corruption", () => {
+  it("flags the captured Hermes-3 q4f16 salad as garbled", () => {
+    const r = scoreCoherence(REAL_GARBLED_REPLY);
+    expect(r.verdict).toBe("garbled");
+    expect(r.reasons.length).toBeGreaterThan(0);
+    // Should trip several independent signals, not squeak by on one.
+    expect(r.signals.replacementChars).toBeGreaterThanOrEqual(2);
+    expect(r.signals.scriptGroups.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("flags the short garbled chat title too", () => {
+    // Only ~9 words, so this proves detection doesn't depend on long samples.
+    expect(scoreCoherence(REAL_GARBLED_TITLE).verdict).toBe("garbled");
+  });
+
+  it("flags degenerate token-loop output", () => {
+    // mlc-llm #2982: a broken quantization emitting one special token forever.
+    const looped = "<|reserved_special_token_247|>".repeat(64);
+    const r = scoreCoherence(looped);
+    expect(r.verdict).toBe("garbled");
+    expect(r.signals.maxImmediateRepeat).toBeGreaterThanOrEqual(6);
+  });
+
+  it("flags a repeated-word loop (whitespace-separated degeneration)", () => {
+    const r = scoreCoherence("the the the the the the the the the the");
+    expect(r.verdict).toBe("garbled");
+  });
+});
+
+describe("scoreCoherence — does not flag healthy output", () => {
+  it("accepts an ordinary English reply", () => {
+    const r = scoreCoherence(
+      "Hello! It's nice to meet you. How can I help you today?",
+    );
+    expect(r.verdict).toBe("ok");
+    expect(r.reasons).toEqual([]);
+  });
+
+  it("accepts technical prose containing quantization ids", () => {
+    // Guards the letter+digit fusion rule: "q4f16" is legitimate and short.
+    const r = scoreCoherence(
+      "The q4f16 build uses 4-bit weights, while q4f32 keeps fp32 accumulators.",
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("accepts a Japanese reply (Han + Kana + Latin is normal there)", () => {
+    // Regression guard for naive script counting: Japanese legitimately mixes
+    // kanji, hiragana and katakana, plus Latin — that must not read as salad.
+    const r = scoreCoherence("こんにちは！私はAIアシスタントです。何かお手伝いできますか？");
+    expect(r.signals.scriptGroups).toContain("CJK");
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("accepts a Russian reply", () => {
+    const r = scoreCoherence("Привет! Я могу помочь вам с вашими вопросами.");
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("accepts a Hindi reply", () => {
+    const r = scoreCoherence("नमस्ते! मैं आपकी कैसे मदद कर सकता हूँ?");
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("accepts a reply containing a code snippet", () => {
+    const r = scoreCoherence(
+      "Sure — use `arr.map((x) => x * 2)` to double each element of the array.",
+    );
+    expect(r.verdict).toBe("ok");
+  });
+});
+
+describe("scoreCoherence — tolerates legitimate technical output", () => {
+  // Agent replies routinely contain URLs, code and hashes. Those trip the
+  // word-level signals (letter/digit fusions, overlong words) even though the
+  // model is perfectly healthy, so they must be excluded before scoring.
+  it("accepts a reply that is mostly long URLs", () => {
+    const r = scoreCoherence(
+      "I opened these pages: https://example.com/a/b?token=aX92kdl2mZq10ppQ and " +
+        "https://docs.example.org/guide/v2/getting-started?ref=abc123def456ghi789 " +
+        "and summarised both for you.",
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("accepts a reply containing a fenced code block", () => {
+    const r = scoreCoherence(
+      "Here is the script I ran to collect the rows:\n\n" +
+        "```js\nconst rows = [...document.querySelectorAll('tr')].map((r) => r.innerText);\n" +
+        "const b64 = btoa(JSON.stringify(rows));\n```\n\nIt returned twelve rows.",
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("accepts a reply quoting hashes and base64", () => {
+    const r = scoreCoherence(
+      "The file digest is 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 " +
+        "and the encoded payload begins iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ. " +
+        "Both match what you sent earlier, so nothing changed.",
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("still catches corruption that appears alongside code", () => {
+    // Stripping must not become a loophole: whole-sample signals (replacement
+    // chars, script mixing) are still read from the raw text.
+    const r = scoreCoherence(
+      "```js\nconst x = 1;\n```\n" + REAL_GARBLED_REPLY,
+    );
+    expect(r.verdict).toBe("garbled");
+  });
+});
+
+describe("scoreCoherence — inconclusive cases", () => {
+  it("reports empty output as inconclusive, not garbled", () => {
+    expect(scoreCoherence("").verdict).toBe("inconclusive");
+    expect(scoreCoherence("   \n ").verdict).toBe("inconclusive");
+  });
+
+  it("reports a terse reply as inconclusive rather than guessing", () => {
+    const r = scoreCoherence("OK");
+    expect(r.verdict).toBe("inconclusive");
+    expect(r.reasons).toEqual(["too short to assess"]);
+  });
+});
+
+describe("evaluateCanaryReply", () => {
+  it("has a canary prompt with one unambiguous answer", () => {
+    expect(COHERENCE_CANARY_PROMPT).toMatch(/OK/);
+  });
+
+  it("passes a compliant terse reply that scoreCoherence alone can't judge", () => {
+    expect(scoreCoherence("OK").verdict).toBe("inconclusive");
+    expect(evaluateCanaryReply("OK").verdict).toBe("ok");
+    expect(evaluateCanaryReply("  ok.  ").verdict).toBe("ok");
+  });
+
+  it("passes a coherent but non-compliant reply", () => {
+    // A small model ignoring the instruction is not a broken model.
+    const r = evaluateCanaryReply(
+      "Sure, I can do that. The word you asked for is OK.",
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  it("still fails a reply that starts with OK then degenerates", () => {
+    // Compliance must never override structural corruption.
+    const r = evaluateCanaryReply(`OK ${REAL_GARBLED_REPLY}`);
+    expect(r.verdict).toBe("garbled");
+  });
+
+  it("fails the real garbled reply", () => {
+    expect(evaluateCanaryReply(REAL_GARBLED_REPLY).verdict).toBe("garbled");
+  });
+});

--- a/apps/extension/src/entrypoints/offscreen/__tests__/download-queue.test.ts
+++ b/apps/extension/src/entrypoints/offscreen/__tests__/download-queue.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { createSerialQueue } from "../download-queue";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("createSerialQueue", () => {
+  it("dedupes concurrent requests for the same key onto one promise", async () => {
+    const q = createSerialQueue();
+    const d = deferred<string>();
+    let calls = 0;
+    const task = () => {
+      calls++;
+      return d.promise;
+    };
+
+    const p1 = q.run("k", task);
+    const p2 = q.run("k", task);
+
+    // Same promise handed back — the task was not invoked a second time.
+    expect(p1).toBe(p2);
+
+    d.resolve("done");
+    await expect(p1).resolves.toBe("done");
+    expect(calls).toBe(1);
+  });
+
+  it("runs tasks one at a time in FIFO order", async () => {
+    const q = createSerialQueue();
+    const order: string[] = [];
+    const dA = deferred<void>();
+
+    const pA = q.run("A", async () => {
+      order.push("A-start");
+      await dA.promise;
+      order.push("A-end");
+    });
+    const pB = q.run("B", async () => {
+      order.push("B-start");
+    });
+
+    await tick();
+    // B must not start until A finishes.
+    expect(order).toEqual(["A-start"]);
+
+    dA.resolve();
+    await Promise.all([pA, pB]);
+    expect(order).toEqual(["A-start", "A-end", "B-start"]);
+  });
+
+  it("keeps running the queue after a task rejects", async () => {
+    const q = createSerialQueue();
+    const order: string[] = [];
+
+    const pA = q.run("A", async () => {
+      order.push("A");
+      throw new Error("boom");
+    });
+    const pB = q.run("B", async () => {
+      order.push("B");
+    });
+
+    await expect(pA).rejects.toThrow("boom");
+    await pB;
+    expect(order).toEqual(["A", "B"]);
+  });
+
+  it("allows the same key to run again after it settles", async () => {
+    const q = createSerialQueue();
+    let calls = 0;
+    await q.run("k", async () => {
+      calls++;
+    });
+    await q.run("k", async () => {
+      calls++;
+    });
+    expect(calls).toBe(2);
+  });
+
+  it("reports active state while work is queued", async () => {
+    const q = createSerialQueue();
+    const d = deferred<void>();
+    expect(q.isActive()).toBe(false);
+    const p = q.run("k", () => d.promise);
+    expect(q.isActive()).toBe(true);
+    d.resolve();
+    await p;
+    await tick();
+    expect(q.isActive()).toBe(false);
+  });
+});

--- a/apps/extension/src/entrypoints/offscreen/__tests__/engine-lock.test.ts
+++ b/apps/extension/src/entrypoints/offscreen/__tests__/engine-lock.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { withLocalEngineLock } from "../engine-lock";
+
+/**
+ * `withLocalEngineLock` serializes on-device generations so the shared WebGPU /
+ * Nano engine is never double-loaded (the "UI freezes right after send" bug).
+ * The lock keeps module-level state, so every test awaits its own work to
+ * settle before finishing.
+ */
+describe("withLocalEngineLock", () => {
+  it("runs queued work one at a time, in FIFO order", async () => {
+    const events: string[] = [];
+    const task = (name: string, ms: number) =>
+      withLocalEngineLock(async () => {
+        events.push(`${name}:start`);
+        await new Promise((r) => setTimeout(r, ms));
+        events.push(`${name}:end`);
+        return name;
+      });
+
+    // Deliberately give the first task the longest delay: if the lock were not
+    // serializing, "b" would start before "a" finished.
+    const results = await Promise.all([task("a", 20), task("b", 1), task("c", 1)]);
+
+    expect(results).toEqual(["a", "b", "c"]);
+    expect(events).toEqual([
+      "a:start",
+      "a:end",
+      "b:start",
+      "b:end",
+      "c:start",
+      "c:end",
+    ]);
+  });
+
+  it("propagates the rejection to its own caller", async () => {
+    await expect(
+      withLocalEngineLock(async () => {
+        throw new Error("generation failed");
+      }),
+    ).rejects.toThrow("generation failed");
+  });
+
+  it("does not wedge the queue after a rejection", async () => {
+    const failed = withLocalEngineLock(async () => {
+      throw new Error("boom");
+    });
+    // Queue a follow-up before the failure settles, so it is chained onto the
+    // rejected link rather than a fresh one.
+    const after = withLocalEngineLock(async () => "recovered");
+
+    await expect(failed).rejects.toThrow("boom");
+    await expect(after).resolves.toBe("recovered");
+  });
+
+  it("still serializes work queued after a rejection", async () => {
+    const events: string[] = [];
+    const boom = withLocalEngineLock(async () => {
+      events.push("boom");
+      throw new Error("boom");
+    });
+    const next = withLocalEngineLock(async () => {
+      events.push("next:start");
+      await new Promise((r) => setTimeout(r, 5));
+      events.push("next:end");
+    });
+
+    await expect(boom).rejects.toThrow("boom");
+    await next;
+    expect(events).toEqual(["boom", "next:start", "next:end"]);
+  });
+});

--- a/apps/extension/src/entrypoints/offscreen/__tests__/lm-stream.test.ts
+++ b/apps/extension/src/entrypoints/offscreen/__tests__/lm-stream.test.ts
@@ -1,0 +1,309 @@
+import type {
+  LocalModelProviderId,
+  LocalModelStreamPart,
+  LocalModelV3,
+} from "@/registry/providers/__bridge__/local-model-messages";
+import { describe, expect, it, vi } from "vitest";
+import { attachLocalModelPort } from "../lm-stream";
+
+/**
+ * The offscreen handler owns one `offscreen-lm:*` Port: it builds/reuses the
+ * real local model and drives `doStream`/`doGenerate`, streaming parts back.
+ * These tests inject a fake model + fake Port and assert:
+ *
+ *  - stream mode posts one `LM_CHUNK` per part, then `LM_DONE`;
+ *  - `LM_CANCEL` aborts the signal handed to the model, and the worker stops
+ *    emitting tokens (the mid-stream abort requirement);
+ *  - generate mode posts a single `LM_GENERATE_RESULT`;
+ *  - `error` stream parts carrying an `Error` are coerced to a string;
+ *  - model construction failure posts `LM_ERROR`.
+ */
+
+interface FakePort {
+  port: chrome.runtime.Port;
+  posted: unknown[];
+  emit: (msg: unknown) => void;
+  emitDisconnect: () => void;
+}
+
+function makeFakePort(): FakePort {
+  const messageListeners: ((m: unknown) => void)[] = [];
+  const disconnectListeners: (() => void)[] = [];
+  const posted: unknown[] = [];
+
+  const port = {
+    name: "offscreen-lm:abc",
+    postMessage: (m: unknown) => posted.push(m),
+    disconnect: vi.fn(),
+    onMessage: {
+      addListener: (fn: (m: unknown) => void) => messageListeners.push(fn),
+      removeListener: () => {},
+    },
+    onDisconnect: {
+      addListener: (fn: () => void) => disconnectListeners.push(fn),
+      removeListener: () => {},
+    },
+  } as unknown as chrome.runtime.Port;
+
+  return {
+    port,
+    posted,
+    emit: (msg) => messageListeners.slice().forEach((fn) => fn(msg)),
+    emitDisconnect: () => disconnectListeners.slice().forEach((fn) => fn()),
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function startMsg(mode: "stream" | "generate") {
+  return {
+    type: "LM_START",
+    mode,
+    providerId: "web-llm" as LocalModelProviderId,
+    config: {},
+    modelId: "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+    options: { prompt: [] },
+  };
+}
+
+/** Minimal fake `LanguageModelV3` whose behavior the test controls. */
+function fakeModel(impl: Partial<LocalModelV3>): LocalModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "web-llm",
+    modelId: "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+    supportedUrls: {},
+    doStream: async () => ({ stream: new ReadableStream() }),
+    doGenerate: async () => ({
+      content: [],
+      finishReason: "stop",
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      warnings: [],
+    }),
+    ...impl,
+  } as LocalModelV3;
+}
+
+describe("attachLocalModelPort", () => {
+  it("streams one LM_CHUNK per part then LM_DONE", async () => {
+    const fake = makeFakePort();
+    const parts: LocalModelStreamPart[] = [
+      { type: "text-delta", id: "1", delta: "he" },
+      { type: "text-delta", id: "1", delta: "llo" },
+    ];
+    const model = fakeModel({
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(c) {
+            for (const p of parts) c.enqueue(p);
+            c.close();
+          },
+        }),
+      }),
+    });
+
+    attachLocalModelPort(fake.port, { getModel: async () => model });
+    fake.emit(startMsg("stream"));
+    await flush();
+
+    expect(fake.posted).toEqual([
+      { type: "LM_CHUNK", part: parts[0] },
+      { type: "LM_CHUNK", part: parts[1] },
+      { type: "LM_DONE" },
+    ]);
+  });
+
+  it("LM_CANCEL aborts the model signal and stops emitting tokens", async () => {
+    const fake = makeFakePort();
+    let capturedSignal: AbortSignal | undefined;
+    let streamController: ReadableStreamDefaultController | null = null;
+
+    const model = fakeModel({
+      doStream: async (options: { abortSignal?: AbortSignal }) => {
+        capturedSignal = options.abortSignal;
+        const stream = new ReadableStream({
+          start(c) {
+            streamController = c;
+            c.enqueue({
+              type: "text-delta",
+              id: "1",
+              delta: "first",
+            } satisfies LocalModelStreamPart);
+          },
+        });
+        // A well-behaved local model stops when aborted.
+        options.abortSignal?.addEventListener("abort", () => {
+          try {
+            streamController?.close();
+          } catch {
+            /* already closed */
+          }
+        });
+        return { stream };
+      },
+    });
+
+    attachLocalModelPort(fake.port, { getModel: async () => model });
+    fake.emit(startMsg("stream"));
+    await flush();
+
+    // First token delivered; stream is still open awaiting more.
+    expect(fake.posted).toEqual([
+      {
+        type: "LM_CHUNK",
+        part: { type: "text-delta", id: "1", delta: "first" },
+      },
+    ]);
+
+    fake.emit({ type: "LM_CANCEL" });
+    await flush();
+
+    expect(capturedSignal?.aborted).toBe(true);
+    // No further chunks after the cancel — only the terminal LM_DONE.
+    expect(fake.posted).toEqual([
+      {
+        type: "LM_CHUNK",
+        part: { type: "text-delta", id: "1", delta: "first" },
+      },
+      { type: "LM_DONE" },
+    ]);
+  });
+
+  it("generate mode posts a single LM_GENERATE_RESULT", async () => {
+    const fake = makeFakePort();
+    const result = {
+      content: [{ type: "text", text: "done" }],
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    };
+    const model = fakeModel({ doGenerate: async () => result as never });
+
+    attachLocalModelPort(fake.port, { getModel: async () => model });
+    fake.emit(startMsg("generate"));
+    await flush();
+
+    expect(fake.posted).toEqual([{ type: "LM_GENERATE_RESULT", result }]);
+  });
+
+  it("coerces an Error in an error stream part to a string", async () => {
+    const fake = makeFakePort();
+    const model = fakeModel({
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(c) {
+            c.enqueue({
+              type: "error",
+              error: new Error("kaboom"),
+            } satisfies LocalModelStreamPart);
+            c.close();
+          },
+        }),
+      }),
+    });
+
+    attachLocalModelPort(fake.port, { getModel: async () => model });
+    fake.emit(startMsg("stream"));
+    await flush();
+
+    expect(fake.posted).toEqual([
+      { type: "LM_CHUNK", part: { type: "error", error: "kaboom" } },
+      { type: "LM_DONE" },
+    ]);
+  });
+
+  it("posts LM_ERROR when model construction fails", async () => {
+    const fake = makeFakePort();
+    attachLocalModelPort(fake.port, {
+      getModel: async () => {
+        throw new Error("no WebGPU");
+      },
+    });
+    fake.emit(startMsg("stream"));
+    await flush();
+
+    expect(fake.posted).toEqual([{ type: "LM_ERROR", message: "no WebGPU" }]);
+  });
+});
+
+/**
+ * Passive coherence check: a finished WebLLM reply that scores as corrupted
+ * broadcasts LOCAL_MODEL_OUTPUT_GARBLED so the UI can explain the known
+ * quantization/WebGPU failure instead of leaving the user with mystery
+ * nonsense. Deliberately scoped to `web-llm` — cloud providers don't have this
+ * failure mode and scoring them would be pure overhead.
+ */
+describe("attachLocalModelPort — passive coherence check", () => {
+  /** Real captured corruption from Hermes-3-Llama-3.1-8B q4f16 on Metal. */
+  const GARBLED =
+    "Coltsresetellaovsky fav-describedby-wh\u00e1958puaugeihan (_REFiggerslinger " +
+    "b\u00e1s\u0926\u0930 Cochphpadinndaie\u017c\u043e\u043c\u0435\u043d\u0127 " +
+    "Creative\u0430\u043b\u0435abwe-May326\u044b\u0432ibold \u4ecb unreal387 " +
+    "Cunningham460 McCarthy\u0447sitherurs\uFFFDaste ifad\uFFFD\uFFFD " +
+    "\u0634\u0645\u0627\u0644\u0649CU \u30f3\u30d4";
+
+  function streamOf(text: string) {
+    return fakeModel({
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(c) {
+            c.enqueue({ type: "text-delta", id: "1", delta: text });
+            c.close();
+          },
+        }),
+      }),
+    });
+  }
+
+  function garbledBroadcasts(spy: {
+    mock: { calls: unknown[][] };
+  }): { type?: string; modelId?: string }[] {
+    return spy.mock.calls
+      .map((c) => c[0] as { type?: string; modelId?: string })
+      .filter((m) => m?.type === "LOCAL_MODEL_OUTPUT_GARBLED");
+  }
+
+  it("broadcasts when a WebLLM reply is corrupted", async () => {
+    const spy = vi.spyOn(chrome.runtime, "sendMessage");
+    const fake = makeFakePort();
+    attachLocalModelPort(fake.port, { getModel: async () => streamOf(GARBLED) });
+    fake.emit(startMsg("stream"));
+    await flush();
+
+    const sent = garbledBroadcasts(spy);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      modelId: "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+    });
+    // Still streams the tokens through — the check never swallows output.
+    expect(fake.posted.at(-1)).toEqual({ type: "LM_DONE" });
+    spy.mockRestore();
+  });
+
+  it("stays silent on a healthy WebLLM reply", async () => {
+    const spy = vi.spyOn(chrome.runtime, "sendMessage");
+    const fake = makeFakePort();
+    attachLocalModelPort(fake.port, {
+      getModel: async () => streamOf("Hello! How can I help you today?"),
+    });
+    fake.emit(startMsg("stream"));
+    await flush();
+
+    expect(garbledBroadcasts(spy)).toHaveLength(0);
+    spy.mockRestore();
+  });
+
+  it("does not score non-WebLLM providers", async () => {
+    const spy = vi.spyOn(chrome.runtime, "sendMessage");
+    const fake = makeFakePort();
+    attachLocalModelPort(fake.port, { getModel: async () => streamOf(GARBLED) });
+    fake.emit({
+      ...startMsg("stream"),
+      providerId: "browser-ai" as LocalModelProviderId,
+    });
+    await flush();
+
+    expect(garbledBroadcasts(spy)).toHaveLength(0);
+    spy.mockRestore();
+  });
+});

--- a/apps/extension/src/entrypoints/offscreen/ai.ts
+++ b/apps/extension/src/entrypoints/offscreen/ai.ts
@@ -4,7 +4,15 @@ import type { AIProvider, ModelStatus, Settings } from "@/lib/types";
 import { getProvider } from "@/registry/providers";
 import { browserAI, doesBrowserSupportBrowserAI } from "@browser-ai/core";
 import { doesBrowserSupportWebLLM, webLLM } from "@browser-ai/web-llm";
-import { deleteModelAllInfoInCache, hasModelInCache } from "@mlc-ai/web-llm";
+import {
+  type AppConfig,
+  deleteModelAllInfoInCache,
+  hasModelInCache,
+  prebuiltAppConfig,
+} from "@mlc-ai/web-llm";
+import { WEB_LLM_MODEL_CONTEXT } from "@/registry/providers/web-llm-model-context";
+import { createSerialQueue } from "./download-queue";
+import { withLocalEngineLock } from "./engine-lock";
 
 export interface CloudConfig {
   cloudProvider: Settings["cloudProvider"];
@@ -20,7 +28,85 @@ let currentModel:
 let currentProvider: AIProvider | null = null;
 let currentModelId: string | null = null;
 
-async function createCloudModel(cloudConfig: CloudConfig, modelIdOverride?: string) {
+/**
+ * All local-model downloads funnel through one serial queue. WebLLM / Gemini
+ * Nano share a single WebGPU / `chrome.ai` engine in this offscreen document;
+ * running two loads at once contends on that engine and stalls at 0%. The
+ * queue also dedupes a model against itself, so a double-click or a duplicate
+ * `DOWNLOAD_MODEL` message can't launch the same download twice.
+ */
+const downloadQueue = createSerialQueue();
+
+/**
+ * Construct a WebLLM model handle with its context window raised from mlc's
+ * conservative prebuilt default (4096) to the model's real, sourced window
+ * (see `web-llm-model-context.ts`).
+ *
+ * The override must ride on `engineConfig.appConfig`: `@browser-ai/web-llm`
+ * declares a top-level `appConfig` option but its runtime ignores it, only
+ * forwarding `engineConfig` into `new MLCEngine(...)`. mlc's `reload()` then
+ * merges `overrides.context_window_size` over the fetched model config, and
+ * the paged KV cache treats it as a ceiling that grows on demand — so a large
+ * window costs nothing at load (verified empirically at 131072).
+ */
+let lastProgressPct = -1;
+
+function reportLocalModelLoadProgress(
+  modelId: string,
+  progress: number,
+  text: string,
+): void {
+  // mlc fires the init-progress callback very frequently (per tensor/shard).
+  // Throttle to whole-percent changes so we don't flood every extension
+  // context (and its console) with hundreds of near-identical messages.
+  const pct = Math.round((progress ?? 0) * 100);
+  if (pct === lastProgressPct && pct < 100) return;
+  lastProgressPct = pct >= 100 ? -1 : pct;
+  try {
+    chrome.runtime.sendMessage({
+      type: "LOCAL_MODEL_LOAD_PROGRESS",
+      modelId,
+      progress,
+      text,
+    });
+  } catch {
+    // Best-effort UX signal; no receiver (or offscreen teardown) is fine.
+  }
+}
+
+function createWebLLM(modelId: string): ReturnType<typeof webLLM> {
+  // Surface the lazy engine load (WASM instantiate + WebGPU shader compile)
+  // that happens on the first generation of an agent turn. mlc's
+  // `_initializeEngine` falls back to this constructor callback when no
+  // per-call progress cb is supplied, so it fires for inference but NOT for
+  // downloads (which pass their own via `createSessionWithProgress`, which
+  // takes precedence).
+  const initProgressCallback = (report: { progress: number; text: string }) =>
+    reportLocalModelLoadProgress(modelId, report.progress, report.text);
+  const override = WEB_LLM_MODEL_CONTEXT[modelId]?.overrideContextWindowSize;
+  if (!override) return webLLM(modelId, { initProgressCallback });
+  const appConfig: AppConfig = {
+    ...prebuiltAppConfig,
+    model_list: prebuiltAppConfig.model_list.map((m) =>
+      m.model_id === modelId
+        ? {
+            ...m,
+            overrides: {
+              ...(m.overrides ?? {}),
+              context_window_size: override,
+              sliding_window_size: -1,
+            },
+          }
+        : m,
+    ),
+  };
+  return webLLM(modelId, { initProgressCallback, engineConfig: { appConfig } });
+}
+
+async function createCloudModel(
+  cloudConfig: CloudConfig,
+  modelIdOverride?: string,
+) {
   const apiKey = cloudConfig.cloudApiKey;
   if (!apiKey) {
     throw new Error(
@@ -95,7 +181,7 @@ export async function getModel(
     return currentModel;
   }
 
-  currentModel = webLLM(modelId);
+  currentModel = createWebLLM(modelId);
   currentProvider = "web-llm";
   currentModelId = modelId;
   return currentModel;
@@ -216,7 +302,7 @@ export async function checkAvailability(
           message: `${modelId} downloaded — ready to load`,
         };
       }
-      const model = webLLM(modelId);
+      const model = createWebLLM(modelId);
       const avail = await model.availability();
       if (avail === "available") {
         return {
@@ -252,8 +338,16 @@ export async function checkAvailability(
 export async function downloadModel(
   modelId: string,
 ): Promise<{ success: boolean; message: string }> {
+  return downloadQueue.run(`web-llm:${modelId}`, () =>
+    performDownloadModel(modelId),
+  );
+}
+
+async function performDownloadModel(
+  modelId: string,
+): Promise<{ success: boolean; message: string }> {
   try {
-    const model = webLLM(modelId);
+    const model = createWebLLM(modelId);
     const modelKey = `web-llm:${modelId}`;
     await model.createSessionWithProgress((progress: number) => {
       chrome.runtime
@@ -299,6 +393,15 @@ export async function downloadModel(
 }
 
 export async function downloadBrowserAI(): Promise<{
+  success: boolean;
+  message: string;
+}> {
+  return downloadQueue.run("browser-ai:gemini-nano", () =>
+    performDownloadBrowserAI(),
+  );
+}
+
+async function performDownloadBrowserAI(): Promise<{
   success: boolean;
   message: string;
 }> {
@@ -473,7 +576,7 @@ export async function getModelFromRegistry(
   ) {
     return currentModel;
   }
-  currentModel = webLLM(modelId);
+  currentModel = createWebLLM(modelId);
   currentProvider = "web-llm";
   currentModelId = modelId;
   return currentModel;
@@ -499,7 +602,7 @@ export async function testConnectionFromRegistry(
       model = browserAI("text");
     } else if (provider.setup === "web-llm") {
       const resolvedModelId = modelId || provider.models[0]?.id || "";
-      model = webLLM(resolvedModelId);
+      model = createWebLLM(resolvedModelId);
     } else {
       return { success: false, message: "Unknown setup type", responseTime: 0 };
     }
@@ -537,26 +640,39 @@ export async function generateChatTitle(
   const provider = getProvider(providerId);
   if (!provider) throw new Error(`Unknown provider: ${providerId}`);
 
+  const isLocal =
+    provider.setup === "browser-ai" || provider.setup === "web-llm";
+
   let model;
   if (provider.setup === "byok") {
     model = await provider.createLanguageModel(config, modelId);
-  } else if (provider.setup === "browser-ai") {
-    model = browserAI("text");
-  } else if (provider.setup === "web-llm") {
-    model = webLLM(modelId);
+  } else if (isLocal) {
+    // Reuse the agent run's cached engine instead of constructing a second one
+    // (createWebLLM / browserAI). A separate engine would re-load the model's
+    // multi-GB weights concurrently with the agent's first turn — the freeze
+    // right after send. See getModelFromRegistry + createWebLLM.
+    model = await getModelFromRegistry(providerId, config, modelId);
   } else {
     return { title: userMessage.slice(0, 50) };
   }
 
-  const { text } = await generateText({
-    model,
-    prompt: `Summarize the following message into a short chat title (3-6 words). Output ONLY the title, nothing else.
+  const runGenerate = () =>
+    generateText({
+      model,
+      prompt: `Summarize the following message into a short chat title (3-6 words). Output ONLY the title, nothing else.
 
 Message: "${userMessage.slice(0, 300)}"
 
 Title:`,
-    maxOutputTokens: 30,
-  });
+      maxOutputTokens: 30,
+    });
+
+  // Local models share one on-device engine with the agent loop; hold the
+  // engine lock so title generation never overlaps an active agent turn (which
+  // would contend on / interrupt the same engine).
+  const { text } = isLocal
+    ? await withLocalEngineLock(runGenerate)
+    : await runGenerate();
 
   const raw = text
     .trim()
@@ -612,9 +728,12 @@ export async function generateGroupLabel(
   } else if (provider.setup === "browser-ai") {
     model = browserAI("text");
   } else if (provider.setup === "web-llm") {
-    model = webLLM(modelId);
+    model = createWebLLM(modelId);
   } else {
-    return { title: (context.chatTitle || "Agent").slice(0, 24), color: "grey" };
+    return {
+      title: (context.chatTitle || "Agent").slice(0, 24),
+      color: "grey",
+    };
   }
 
   const tabsSnippet = context.tabs
@@ -675,7 +794,7 @@ export async function testConnection(
         webllmModel ||
         DEFAULT_SETTINGS.webllmModel ||
         "Llama-3.2-3B-Instruct-q4f16_1-MLC";
-      model = webLLM(modelId);
+      model = createWebLLM(modelId);
     } else {
       return { success: false, message: "AI is disabled", responseTime: 0 };
     }

--- a/apps/extension/src/entrypoints/offscreen/coherence.ts
+++ b/apps/extension/src/entrypoints/offscreen/coherence.ts
@@ -1,0 +1,237 @@
+/**
+ * Pure gibberish detector for local-model output.
+ *
+ * Some WebLLM models load and report success but emit token salad on specific
+ * GPUs/drivers — a known quantization + WebGPU failure mode (q4f16 builds are
+ * frequent offenders, and the same model works fine on other machines). It is
+ * therefore NOT something a sourced model catalog or a CI test can know: it has
+ * to be observed at runtime on the actual device.
+ *
+ * This module is the scoring half of that check, kept pure and dependency-free
+ * so it is fully unit-testable without a GPU, WebGPU, or model weights (same
+ * rationale as `engine-lock.ts`). A runtime probe supplies the text; everything
+ * here is string analysis.
+ *
+ * Design bias: **false negatives over false positives.** Calling a working
+ * model broken is far worse than missing a broken one, and a genuinely tiny
+ * model (0.5B) can produce weak-but-valid prose. So `garbled` is only returned
+ * on strong structural evidence, and anything unclear is `inconclusive`.
+ */
+
+export type CoherenceVerdict = "ok" | "garbled" | "inconclusive";
+
+export interface CoherenceSignals {
+  /** U+FFFD replacement characters — near-certain broken-token output. */
+  replacementChars: number;
+  /**
+   * Distinct writing-system *groups* present among letters. Grouped (not raw
+   * script names) so legitimately multi-script languages don't look corrupt:
+   * Japanese mixes Han + Hiragana + Katakana normally, so those count once.
+   */
+  scriptGroups: string[];
+  /** Words mixing two space-separated writing systems (e.g. "May326ыві"). */
+  intraWordScriptMixes: number;
+  /** Long words fusing letters and digits (e.g. "whá958puaugeihan"). */
+  letterDigitFusions: number;
+  /** Improbably long unbroken words (e.g. "counterimitsurespremium"). */
+  overlongWords: number;
+  /** Highest number of immediate back-to-back repeats of any substring. */
+  maxImmediateRepeat: number;
+  /** Total word-like tokens. */
+  wordCount: number;
+  /** Share of words flagged malformed by any of the word-level signals. */
+  malformedRatio: number;
+}
+
+export interface CoherenceResult {
+  verdict: CoherenceVerdict;
+  /** Why this verdict — surfaced in diagnostics and UI tooltips. */
+  reasons: string[];
+  signals: CoherenceSignals;
+}
+
+/**
+ * Writing systems, mapped to the group used for counting. Scripts that share a
+ * language (Japanese: Han/Kana) collapse into one group, as do the Indic
+ * scripts, so a legitimate non-English answer isn't mistaken for salad.
+ */
+const SCRIPTS: ReadonlyArray<{ group: string; re: RegExp; spaced: boolean }> = [
+  { group: "Latin", re: /[A-Za-z\u00C0-\u024F]/, spaced: true },
+  { group: "Greek", re: /[\u0370-\u03FF]/, spaced: true },
+  { group: "Cyrillic", re: /[\u0400-\u04FF]/, spaced: true },
+  { group: "Hebrew", re: /[\u0590-\u05FF]/, spaced: true },
+  { group: "Arabic", re: /[\u0600-\u06FF]/, spaced: true },
+  { group: "Indic", re: /[\u0900-\u097F]/, spaced: true },
+  { group: "Indic", re: /[\u0980-\u09FF]/, spaced: true },
+  { group: "Indic", re: /[\u0B80-\u0BFF]/, spaced: true },
+  // Unspaced scripts: word-internal mixing is normal, so they never count
+  // toward `intraWordScriptMixes`.
+  { group: "Thai", re: /[\u0E00-\u0E7F]/, spaced: false },
+  { group: "Hangul", re: /[\u1100-\u11FF\uAC00-\uD7AF]/, spaced: false },
+  { group: "CJK", re: /[\u3040-\u30FF]/, spaced: false },
+  { group: "CJK", re: /[\u3400-\u4DBF\u4E00-\u9FFF]/, spaced: false },
+];
+
+/** Cap analysis cost on pathological output. */
+const MAX_ANALYZED_CHARS = 4_000;
+
+/**
+ * Strip the parts of a reply that legitimately look like noise to the
+ * word-level signals: fenced code blocks, inline code spans, URLs and long
+ * bare hex/base64 blobs. Real agent output is full of these, and a false
+ * "this model is broken" verdict is far more damaging than a missed one.
+ * Only natural-language prose is scored.
+ */
+function extractProse(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, " ")
+    .replace(/\b[0-9a-f]{16,}\b/gi, " ")
+    .replace(/\b[A-Za-z0-9+/]{32,}={0,2}\b/g, " ");
+}
+
+/** A word longer than this is almost certainly run-together garbage. */
+const OVERLONG_WORD = 24;
+
+/**
+ * Letter+digit fusions shorter than this are legitimate in technical prose
+ * ("q4f16", "3D", "GPT4"), so only longer fusions count.
+ */
+const MIN_FUSION_LENGTH = 8;
+
+function scriptGroupsOf(text: string, spacedOnly = false): string[] {
+  const found = new Set<string>();
+  for (const s of SCRIPTS) {
+    if (spacedOnly && !s.spaced) continue;
+    if (s.re.test(text)) found.add(s.group);
+  }
+  return [...found];
+}
+
+/**
+ * Longest run of an immediately-repeated substring. Catches both spaced
+ * degeneration ("the the the …") and unspaced token loops (the
+ * `<|reserved_special_token_247|>` failure mode), which a whitespace split
+ * would miss entirely.
+ */
+function maxImmediateRepeat(text: string): number {
+  let max = 1;
+  for (const m of text.matchAll(/(.{1,60}?)\1{2,}/gs)) {
+    const unit = m[1];
+    if (!unit.trim()) continue; // runs of pure whitespace are not degeneration
+    max = Math.max(max, Math.floor(m[0].length / unit.length));
+  }
+  return max;
+}
+
+export function scoreCoherence(text: string): CoherenceResult {
+  const raw = text.slice(0, MAX_ANALYZED_CHARS);
+  // Word-level signals score prose only (see `extractProse`), but the
+  // whole-sample signals — replacement chars, script mixing, degeneration —
+  // are read from the raw text, since corruption there is meaningful wherever
+  // it appears.
+  const sample = extractProse(raw);
+  const words = sample.match(/[\p{L}\p{N}_]+/gu) ?? [];
+
+  let intraWordScriptMixes = 0;
+  let letterDigitFusions = 0;
+  let overlongWords = 0;
+  const malformed = new Set<string>();
+
+  for (const w of words) {
+    let bad = false;
+    if (scriptGroupsOf(w, true).length >= 2) {
+      intraWordScriptMixes++;
+      bad = true;
+    }
+    if (
+      w.length >= MIN_FUSION_LENGTH &&
+      /\p{L}/u.test(w) &&
+      /\p{Nd}/u.test(w)
+    ) {
+      letterDigitFusions++;
+      bad = true;
+    }
+    if (w.length >= OVERLONG_WORD) {
+      overlongWords++;
+      bad = true;
+    }
+    if (bad) malformed.add(w);
+  }
+
+  const signals: CoherenceSignals = {
+    replacementChars: (raw.match(/\uFFFD/g) ?? []).length,
+    scriptGroups: scriptGroupsOf(raw),
+    intraWordScriptMixes,
+    letterDigitFusions,
+    overlongWords,
+    maxImmediateRepeat: maxImmediateRepeat(raw),
+    wordCount: words.length,
+    malformedRatio: words.length === 0 ? 0 : malformed.size / words.length,
+  };
+
+  if (raw.trim().length === 0) {
+    return { verdict: "inconclusive", reasons: ["no output"], signals };
+  }
+
+  // Strong evidence of corruption. Any single one is decisive.
+  const reasons: string[] = [];
+  if (signals.replacementChars >= 2) {
+    reasons.push(`${signals.replacementChars} replacement characters`);
+  }
+  if (signals.scriptGroups.length >= 3) {
+    reasons.push(`mixes ${signals.scriptGroups.length} writing systems (${signals.scriptGroups.join(", ")})`);
+  }
+  if (signals.intraWordScriptMixes >= 2) {
+    reasons.push(`${signals.intraWordScriptMixes} words mix writing systems internally`);
+  }
+  if (signals.maxImmediateRepeat >= 6) {
+    reasons.push(`a fragment repeats ${signals.maxImmediateRepeat} times in a row`);
+  }
+  if (signals.malformedRatio >= 0.25 && signals.wordCount >= 8) {
+    reasons.push(`${Math.round(signals.malformedRatio * 100)}% of words are malformed`);
+  }
+  if (reasons.length > 0) return { verdict: "garbled", reasons, signals };
+
+  // Not enough text to judge structurally. Deliberately not "ok": a caller
+  // wanting a positive signal from a terse reply should use the canary below.
+  if (signals.wordCount < 3) {
+    return { verdict: "inconclusive", reasons: ["too short to assess"], signals };
+  }
+
+  return { verdict: "ok", reasons: [], signals };
+}
+
+/**
+ * Canary prompt for the runtime probe: short enough to be cheap on an 8B model,
+ * and with a single unambiguous correct answer so compliance is checkable.
+ */
+export const COHERENCE_CANARY_PROMPT =
+  "Reply with exactly this word and nothing else: OK";
+
+const CANARY_EXPECTED = "ok";
+
+/**
+ * Evaluate a reply to {@link COHERENCE_CANARY_PROMPT}.
+ *
+ * Structural corruption is checked FIRST and wins, so a reply that happens to
+ * begin with "ok" but then degenerates is still `garbled`. Compliance is only
+ * used to turn a clean-but-terse reply ("OK") into a positive verdict — never
+ * to fail a model, because a small model may ignore the instruction while being
+ * perfectly coherent.
+ */
+export function evaluateCanaryReply(text: string): CoherenceResult {
+  const structural = scoreCoherence(text);
+  if (structural.verdict === "garbled") return structural;
+
+  const normalized = text.trim().toLowerCase().replace(/[^a-z]/g, "");
+  if (normalized.startsWith(CANARY_EXPECTED)) {
+    return {
+      verdict: "ok",
+      reasons: ["matched the canary reply"],
+      signals: structural.signals,
+    };
+  }
+  return structural;
+}

--- a/apps/extension/src/entrypoints/offscreen/download-queue.ts
+++ b/apps/extension/src/entrypoints/offscreen/download-queue.ts
@@ -1,0 +1,64 @@
+/**
+ * Serialize + dedupe long-running local-model downloads.
+ *
+ * WebLLM and Gemini Nano load their weights into a single WebGPU / `chrome.ai`
+ * engine per offscreen document. Two loads kicked off at once contend on that
+ * engine and stall — the "stuck at 0%" symptom. This queue runs at most one
+ * task at a time in FIFO order, and collapses concurrent requests for the same
+ * key onto one shared in-flight promise, so a double-click (or a duplicate
+ * message) can't launch the same download twice.
+ *
+ * A failed task never breaks the chain: the next queued task still runs.
+ * Once a task settles its key is released, so a later retry starts fresh.
+ */
+export interface SerialQueue {
+  /**
+   * Enqueue `task` under `key`. If a task with the same key is already
+   * in-flight (running or waiting), the existing promise is returned and
+   * `task` is not invoked again.
+   */
+  run<T>(key: string, task: () => Promise<T>): Promise<T>;
+  /** True while any task is queued or running. */
+  isActive(): boolean;
+}
+
+export function createSerialQueue(): SerialQueue {
+  let tail: Promise<unknown> = Promise.resolve();
+  const inFlight = new Map<string, Promise<unknown>>();
+
+  function run<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const existing = inFlight.get(key) as Promise<T> | undefined;
+    if (existing) return existing;
+
+    // Chain after whatever is queued. A prior rejection must not break the
+    // chain, so run `task` regardless of how the predecessor settled.
+    const started = tail.then(
+      () => task(),
+      () => task(),
+    );
+
+    // Keep the chain non-rejecting so future links always proceed.
+    tail = started.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    inFlight.set(key, started);
+    // Release the key as soon as `started` settles. Registered here (before
+    // the caller awaits `started`) so it runs on the first settle microtask,
+    // ahead of the caller's continuation — a subsequent run(key) after an
+    // `await` therefore sees the key already cleared and starts fresh.
+    const release = () => {
+      if (inFlight.get(key) === started) inFlight.delete(key);
+    };
+    void started.then(release, release);
+
+    return started;
+  }
+
+  function isActive(): boolean {
+    return inFlight.size > 0;
+  }
+
+  return { run, isActive };
+}

--- a/apps/extension/src/entrypoints/offscreen/engine-lock.ts
+++ b/apps/extension/src/entrypoints/offscreen/engine-lock.ts
@@ -1,0 +1,26 @@
+/**
+ * Serializes on-device model generation in the offscreen document.
+ *
+ * WebLLM (WebGPU) and Gemini Nano (`chrome.ai`) run on this document's main
+ * thread and share a single engine per model. Running two generations at once
+ * — e.g. the agent run (via the local-model bridge) and chat-title generation
+ * firing on the same send — double-loads weights and contends on the GPU,
+ * which surfaces as the UI freezing right after a message is sent.
+ *
+ * Every local-model generation funnels through this lock so only one holds the
+ * engine at a time. It is a plain FIFO promise chain with no dependencies, so
+ * it is safe to import from both `ai.ts` and the bridge handler without
+ * dragging the heavy WebGPU import graph into unit tests.
+ */
+let chain: Promise<unknown> = Promise.resolve();
+
+export function withLocalEngineLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = chain.then(fn, fn);
+  // Keep the chain alive whether or not `fn` rejected, so one failed
+  // generation never wedges every subsequent one.
+  chain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}

--- a/apps/extension/src/entrypoints/offscreen/lm-stream.ts
+++ b/apps/extension/src/entrypoints/offscreen/lm-stream.ts
@@ -1,0 +1,214 @@
+/**
+ * Offscreen-side handler for the local-model bridge.
+ *
+ * The SW-hosted agent loop reaches WebLLM / Gemini Nano through an
+ * `offscreen-lm:<uuid>` Port (see `registry/providers/__bridge__`). This
+ * module owns the offscreen end of that Port: it builds (or reuses) the real
+ * `LanguageModelV3` for the requested provider — which physically runs in
+ * this document against WebGPU / `chrome.ai` — drives `doStream`/`doGenerate`,
+ * and streams the parts back to the SW.
+ *
+ * Model construction is delegated to `offscreen/ai.ts::getModelFromRegistry`
+ * so we share its engine cache: a long-running run does not reload weights on
+ * every request. `getModel` is injectable for tests.
+ */
+
+import {
+  isLocalModelPortName,
+  type LmStartMessage,
+  type LocalModelGenerateResult,
+  type LocalModelProviderId,
+  type LocalModelRequest,
+  type LocalModelResponse,
+  type LocalModelStreamPart,
+  type LocalModelV3,
+} from "@/registry/providers/__bridge__/local-model-messages";
+import { scoreCoherence } from "./coherence";
+import { withLocalEngineLock } from "./engine-lock";
+
+type GetLocalModel = (
+  providerId: LocalModelProviderId,
+  config: Record<string, string>,
+  modelId: string,
+) => Promise<LocalModelV3>;
+
+export interface LocalModelPortDeps {
+  getModel?: GetLocalModel;
+}
+
+async function defaultGetModel(
+  providerId: LocalModelProviderId,
+  config: Record<string, string>,
+  modelId: string,
+): Promise<LocalModelV3> {
+  const { getModelFromRegistry } = await import("./ai");
+  return (await getModelFromRegistry(
+    providerId,
+    config,
+    modelId,
+  )) as LocalModelV3;
+}
+
+/**
+ * `error` stream parts may carry a live `Error` (not JSON-serializable);
+ * coerce it to a message string so it survives the Port. Other parts are
+ * plain data.
+ */
+function sanitizePart(part: LocalModelStreamPart): LocalModelStreamPart {
+  const p = part as { type?: string; error?: unknown };
+  if (p.type === "error") {
+    const message =
+      p.error instanceof Error ? p.error.message : String(p.error);
+    return { type: "error", error: message } as LocalModelStreamPart;
+  }
+  return part;
+}
+
+/**
+ * Passive coherence check on a finished WebLLM reply.
+ *
+ * Some WebLLM builds load fine but emit token salad on specific GPUs/drivers (a
+ * known quantization + WebGPU failure mode). Rather than proactively probing
+ * every model — which costs a full load per verdict — we score output the model
+ * has *already* produced, which is free, and tell the user what is wrong instead
+ * of leaving them to wonder whether the extension is broken.
+ *
+ * Scoped to `web-llm`: it is the only provider with this failure mode, and
+ * scoring cloud output would be pure overhead. Fires only on a `garbled`
+ * verdict; `inconclusive` (short or empty replies) stays silent.
+ */
+function checkOutputCoherence(providerId: string, modelId: string, text: string): void {
+  if (providerId !== "web-llm") return;
+  const { verdict, reasons } = scoreCoherence(text);
+  if (verdict !== "garbled") return;
+  try {
+    chrome.runtime.sendMessage({
+      type: "LOCAL_MODEL_OUTPUT_GARBLED",
+      modelId,
+      reasons,
+    });
+  } catch {
+    // Best-effort UX signal; no receiver is fine.
+  }
+}
+
+/** Concatenate the text a `doGenerate` result produced, for the check above. */
+function textOfGenerateResult(result: LocalModelGenerateResult): string {
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (p): p is { type: "text"; text: string } =>
+        (p as { type?: string })?.type === "text" &&
+        typeof (p as { text?: unknown })?.text === "string",
+    )
+    .map((p) => p.text)
+    .join("");
+}
+
+/**
+ * Attach the offscreen-side protocol to a single Port. Exported for testing
+ * with a fake Port; production wiring goes through
+ * {@link registerLocalModelStreamListener}.
+ */
+export function attachLocalModelPort(
+  port: chrome.runtime.Port,
+  deps: LocalModelPortDeps = {},
+): void {
+  const getModel = deps.getModel ?? defaultGetModel;
+  let abort: AbortController | null = null;
+  let handling = false;
+
+  const post = (msg: LocalModelResponse) => {
+    try {
+      port.postMessage(msg);
+    } catch {
+      // Port closed by the SW mid-flight; nothing to do.
+    }
+  };
+
+  const handleStart = async (msg: LmStartMessage) => {
+    if (handling) return;
+    handling = true;
+    abort = new AbortController();
+    const signal = abort.signal;
+    try {
+      const model = await getModel(msg.providerId, msg.config, msg.modelId);
+
+      // Serialize against other on-device generations (chat-title, another
+      // chat's agent turn) so we never double-load or contend on the shared
+      // WebGPU / Nano engine.
+      await withLocalEngineLock(async () => {
+        if (msg.mode === "generate") {
+          const result: LocalModelGenerateResult = await model.doGenerate({
+            ...msg.options,
+            abortSignal: signal,
+          });
+          checkOutputCoherence(
+            msg.providerId,
+            msg.modelId,
+            textOfGenerateResult(result),
+          );
+          post({ type: "LM_GENERATE_RESULT", result });
+          return;
+        }
+
+        const { stream } = await model.doStream({
+          ...msg.options,
+          abortSignal: signal,
+        });
+        const reader = stream.getReader();
+        // Accumulate assistant text purely for the coherence check below. Only
+        // text deltas are collected, so tool-call payloads never enter it.
+        let streamedText = "";
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            const part = value as { type?: string; delta?: unknown };
+            if (part?.type === "text-delta" && typeof part.delta === "string") {
+              streamedText += part.delta;
+            }
+            post({ type: "LM_CHUNK", part: sanitizePart(value) });
+          }
+        } finally {
+          reader.releaseLock();
+        }
+        checkOutputCoherence(msg.providerId, msg.modelId, streamedText);
+        post({ type: "LM_DONE" });
+      });
+    } catch (err) {
+      post({
+        type: "LM_ERROR",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      handling = false;
+    }
+  };
+
+  port.onMessage.addListener((raw: LocalModelRequest) => {
+    if (raw?.type === "LM_START") {
+      void handleStart(raw);
+    } else if (raw?.type === "LM_CANCEL") {
+      abort?.abort();
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    abort?.abort();
+  });
+}
+
+/**
+ * Register the `chrome.runtime.onConnect` listener for local-model Ports.
+ * Idempotent-safe to call once at offscreen startup.
+ */
+export function registerLocalModelStreamListener(
+  deps: LocalModelPortDeps = {},
+): void {
+  chrome.runtime.onConnect.addListener((port) => {
+    if (!isLocalModelPortName(port.name)) return;
+    attachLocalModelPort(port, deps);
+  });
+}

--- a/apps/extension/src/entrypoints/offscreen/main.ts
+++ b/apps/extension/src/entrypoints/offscreen/main.ts
@@ -9,6 +9,7 @@ import {
   testConnection,
   testConnectionFromRegistry,
 } from "./ai";
+import { registerLocalModelStreamListener } from "./lm-stream";
 import {
   clearPersistedPythonLog,
   getPersistedPythonLog,
@@ -16,6 +17,12 @@ import {
 } from "./python";
 import { handleSandboxExecute, isSandboxExecutePayload } from "./sandbox-host";
 import { sortTabs } from "./sort";
+
+// Local-model bridge: the SW-hosted agent loop opens `offscreen-lm:*` Ports
+// to drive WebLLM / Gemini Nano inference here (WebGPU + `chrome.ai` only
+// exist in this document). Registered once at load, alongside the
+// request/response `chrome.runtime.onMessage` handler below.
+registerLocalModelStreamListener();
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.target !== "offscreen") return;

--- a/apps/extension/src/entrypoints/settings/LocalModelCatalog.tsx
+++ b/apps/extension/src/entrypoints/settings/LocalModelCatalog.tsx
@@ -1,0 +1,274 @@
+import type { Settings } from "@/lib/types";
+import type { ProviderDefinition } from "@/registry/providers/types";
+import { WEB_LLM_MODEL_CONTEXT } from "@/registry/providers/web-llm-model-context";
+import { InlineHelp } from "@/components/ui/inline-help";
+import { ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  type BaseModel,
+  formatContextWindow,
+  groupLocalModels,
+  isBaseDownloaded,
+} from "./local-model-catalog";
+import { ModelRow, type ModelState } from "./ProviderSection";
+
+interface LocalModelCatalogProps {
+  provider: ProviderDefinition;
+  settings: Settings;
+  modelStates: Record<string, ModelState>;
+  downloadBusy?: boolean;
+  onDownload: (providerId: string, modelId: string) => void;
+  onDelete: (providerId: string, modelId: string) => void;
+  query?: string;
+}
+
+function isLowResource(modelId: string): boolean {
+  return WEB_LLM_MODEL_CONTEXT[modelId]?.lowResource ?? false;
+}
+
+/**
+ * Browsable catalog for a local provider with many models (WebLLM). Instead of
+ * a flat list of ~139 quantization variants it shows:
+ *   - an "Installed" section (downloaded models, always visible), and
+ *   - a "Catalog" grouped by family (collapsed by default), where each base
+ *     model collapses its quant variants behind a single expandable row.
+ * A search query auto-expands everything so matches are never hidden.
+ */
+export function LocalModelCatalog({
+  provider,
+  settings,
+  modelStates,
+  downloadBusy = false,
+  onDownload,
+  onDelete,
+  query,
+}: LocalModelCatalogProps) {
+  const q = (query || "").trim().toLowerCase();
+  const downloaded = settings.downloadedModels;
+
+  const filtered = useMemo(() => {
+    if (!q) return provider.models;
+    return provider.models.filter(
+      (m) => m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q),
+    );
+  }, [provider.models, q]);
+
+  const families = useMemo(() => groupLocalModels(filtered), [filtered]);
+
+  const installed = useMemo(
+    () =>
+      families
+        .flatMap((f) => f.bases)
+        .filter((b) => isBaseDownloaded(b, downloaded))
+        .sort((a, b) => a.baseName.localeCompare(b.baseName)),
+    [families, downloaded],
+  );
+
+  const [openFamilies, setOpenFamilies] = useState<Set<string>>(new Set());
+  const toggleFamily = (family: string) =>
+    setOpenFamilies((prev) => {
+      const next = new Set(prev);
+      if (next.has(family)) next.delete(family);
+      else next.add(family);
+      return next;
+    });
+
+  const rowFor = (modelId: string, displayName: string, isDownloaded: boolean) => {
+    const model = filtered.find((m) => m.id === modelId);
+    if (!model) return null;
+    return (
+      <ModelRow
+        key={modelId}
+        model={model}
+        provider={provider}
+        displayName={displayName}
+        downloaded={isDownloaded}
+        state={modelStates[`${provider.id}:${modelId}`]}
+        downloadBusy={downloadBusy}
+        onDownload={() => onDownload(provider.id, modelId)}
+        onDelete={() => onDelete(provider.id, modelId)}
+      />
+    );
+  };
+
+  return (
+    <div className="mt-5 flex flex-col gap-4">
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        Local models run entirely in your browser, so quality varies by
+        device. Some may produce{" "}
+        <InlineHelp term="garbled output">
+          These models run through WebGPU, and certain quantizations don't
+          work correctly on every GPU or driver. The model still loads, but
+          generates random tokens instead of coherent text. This is a known
+          WebLLM limitation, not a problem with your setup.
+        </InlineHelp>{" "}
+        on some hardware. If that happens, try a different quantization (a
+        q4f32 build often works when q4f16 fails) or another model.
+      </p>
+      {installed.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Installed
+          </p>
+          {installed.flatMap((base) =>
+            base.variants
+              .filter((v) => downloaded.includes(v.model.id))
+              .map((v) =>
+                rowFor(
+                  v.model.id,
+                  base.variants.length > 1
+                    ? `${base.baseName} · ${v.quant}`
+                    : base.baseName,
+                  true,
+                ),
+              ),
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Catalog
+        </p>
+        {families.length === 0 && (
+          <p className="px-2 py-1 text-xs text-muted-foreground">
+            No models match your search.
+          </p>
+        )}
+        {families.map((family) => {
+          const open = q !== "" || openFamilies.has(family.family);
+          const installedCount = family.bases.filter((b) =>
+            isBaseDownloaded(b, downloaded),
+          ).length;
+          return (
+            <div key={family.family} className="flex flex-col">
+              <button
+                type="button"
+                onClick={() => toggleFamily(family.family)}
+                className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-left hover:bg-muted/50"
+              >
+                <ChevronRight
+                  className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
+                    open ? "rotate-90" : ""
+                  }`}
+                />
+                <span className="text-sm font-medium">{family.family}</span>
+                <span className="text-[10px] text-muted-foreground">
+                  {family.bases.length} model
+                  {family.bases.length === 1 ? "" : "s"}
+                  {installedCount > 0 ? ` · ${installedCount} installed` : ""}
+                </span>
+              </button>
+              {open && (
+                <div className="ml-4 flex flex-col gap-1 border-l pl-2">
+                  {family.bases.map((base) => (
+                    <CatalogBaseRow
+                      key={base.baseKey}
+                      base={base}
+                      providerId={provider.id}
+                      downloaded={downloaded}
+                      rowFor={rowFor}
+                      forceOpen={q !== ""}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CapabilityBadges({
+  capabilities,
+  lowResource,
+}: {
+  capabilities: BaseModel["capabilities"];
+  lowResource: boolean;
+}) {
+  const badges = [...capabilities.filter((c) => c !== "chat")];
+  return (
+    <span className="flex gap-1">
+      {badges.map((cap) => (
+        <span
+          key={cap}
+          className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+        >
+          {cap}
+        </span>
+      ))}
+      {lowResource && (
+        <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          light
+        </span>
+      )}
+    </span>
+  );
+}
+
+function CatalogBaseRow({
+  base,
+  providerId,
+  downloaded,
+  rowFor,
+  forceOpen,
+}: {
+  base: BaseModel;
+  providerId: string;
+  downloaded: string[];
+  rowFor: (
+    modelId: string,
+    displayName: string,
+    isDownloaded: boolean,
+  ) => React.ReactNode;
+  forceOpen: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // Single-variant base: render the row directly, no nesting.
+  if (base.variants.length === 1) {
+    const v = base.variants[0];
+    return <>{rowFor(v.model.id, base.baseName, downloaded.includes(v.model.id))}</>;
+  }
+
+  const expanded = open || forceOpen;
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <ChevronRight
+            className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
+              expanded ? "rotate-90" : ""
+            }`}
+          />
+          <span className="truncate text-sm">{base.baseName}</span>
+          <CapabilityBadges
+            capabilities={base.capabilities}
+            lowResource={isLowResource(base.variants[0].model.id)}
+          />
+          {base.variants[0].model.contextWindow ? (
+            <span className="text-[10px] text-muted-foreground">
+              {formatContextWindow(base.variants[0].model.contextWindow)} ctx
+            </span>
+          ) : null}
+        </span>
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {base.variants.length} versions
+        </span>
+      </button>
+      {expanded && (
+        <div className="ml-5 flex flex-col gap-1">
+          {base.variants.map((v) =>
+            rowFor(v.model.id, v.quant || v.model.name, downloaded.includes(v.model.id)),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/extension/src/entrypoints/settings/ModelsTab.tsx
+++ b/apps/extension/src/entrypoints/settings/ModelsTab.tsx
@@ -1,9 +1,9 @@
+import { Kbd } from "@/components/ui/kbd";
+import { useProviders } from "@/hooks/useProviders";
+import type { Settings } from "@/lib/types";
+import { QUIRKS } from "@/registry/models-dev/quirks";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Settings } from "@/lib/types";
-import { useProviders } from "@/hooks/useProviders";
-import { Kbd } from "@/components/ui/kbd";
-import { QUIRKS } from "@/registry/models-dev/quirks";
 import { ProviderSection, type ModelState } from "./ProviderSection";
 
 interface ModelsTabProps {
@@ -26,11 +26,21 @@ const CURATED_IDS = new Set<string>([
 
 export function ModelsTab({ settings, onChange }: ModelsTabProps) {
   const { providers } = useProviders();
-  const [modelStates, setModelStates] = useState<Record<string, ModelState>>({});
+  const [modelStates, setModelStates] = useState<Record<string, ModelState>>(
+    {},
+  );
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
   const [searchFocused, setSearchFocused] = useState(false);
+
+  // The download-progress listener below is registered once (mount-time)
+  // and would otherwise close over stale settings/onChange. Mirror the
+  // latest values into refs so the completion handler stays correct.
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   // "/" focuses the search box (when not already typing somewhere), so
   // the input is reachable without the mouse.
@@ -55,7 +65,13 @@ export function ModelsTab({ settings, onChange }: ModelsTabProps) {
   // Listen for download progress messages from background
   useEffect(() => {
     function handleMessage(message: unknown) {
-      const msg = message as { type?: string; modelKey?: string; progress?: number; done?: boolean; error?: string };
+      const msg = message as {
+        type?: string;
+        modelKey?: string;
+        progress?: number;
+        done?: boolean;
+        error?: string;
+      };
       if (msg.type === "DOWNLOAD_PROGRESS" && msg.modelKey) {
         setModelStates((prev) => ({
           ...prev,
@@ -66,6 +82,15 @@ export function ModelsTab({ settings, onChange }: ModelsTabProps) {
             error: msg.error,
           },
         }));
+        if (msg.done && !msg.error) {
+          const modelId = msg.modelKey.split(":").slice(1).join(":");
+          const current = settingsRef.current.downloadedModels;
+          if (modelId && !current.includes(modelId)) {
+            onChangeRef.current({
+              downloadedModels: [...current, modelId],
+            });
+          }
+        }
       }
     }
 
@@ -124,6 +149,15 @@ export function ModelsTab({ settings, onChange }: ModelsTabProps) {
   // While searching, expand the long tail so the search isn't lying.
   const longTailVisible = hasQuery || showAll;
 
+  // Local models share one WebGPU / chrome.ai engine in the offscreen
+  // document and download one at a time (the offscreen queue serializes
+  // them). Disable the other Download buttons while one is in flight so the
+  // user can't queue up loads that would otherwise appear stuck at 0%.
+  const anyDownloading = useMemo(
+    () => Object.values(modelStates).some((s) => s.downloading),
+    [modelStates],
+  );
+
   return (
     <div className="flex flex-col">
       <div className="px-4 pt-4 pb-3">
@@ -170,6 +204,7 @@ export function ModelsTab({ settings, onChange }: ModelsTabProps) {
             settings={settings}
             onChange={onChange}
             modelStates={modelStates}
+            downloadBusy={anyDownloading}
             onDownload={handleDownload}
             onDelete={handleDelete}
             query={query}
@@ -190,6 +225,7 @@ export function ModelsTab({ settings, onChange }: ModelsTabProps) {
                 settings={settings}
                 onChange={onChange}
                 modelStates={modelStates}
+                downloadBusy={anyDownloading}
                 onDownload={handleDownload}
                 onDelete={handleDelete}
                 query={query}

--- a/apps/extension/src/entrypoints/settings/ProviderSection.tsx
+++ b/apps/extension/src/entrypoints/settings/ProviderSection.tsx
@@ -1,9 +1,14 @@
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import type { ProviderDefinition, ModelDefinition } from "@/registry/providers/types";
-import type { Settings } from "@/lib/types";
-import { ProviderConfigDialog } from "./ProviderConfigDialog";
 import { RegistryIcon } from "@/components/ui/registry-icon";
+import type { Settings } from "@/lib/types";
+import type {
+  ModelDefinition,
+  ProviderDefinition,
+} from "@/registry/providers/types";
+import { useState } from "react";
+import { ProviderConfigDialog } from "./ProviderConfigDialog";
+import { LocalModelCatalog } from "./LocalModelCatalog";
+import { formatContextWindow } from "./local-model-catalog";
 
 export interface ModelState {
   modelKey: string; // "providerId:modelId"
@@ -17,6 +22,8 @@ interface ProviderSectionProps {
   settings: Settings;
   onChange: (patch: Partial<Settings>) => void;
   modelStates: Record<string, ModelState>;
+  /** True while any model download is in flight (see ModelsTab). */
+  downloadBusy?: boolean;
   onDownload: (providerId: string, modelId: string) => void;
   onDelete: (providerId: string, modelId: string) => void;
   query?: string;
@@ -27,6 +34,7 @@ export function ProviderSection({
   settings,
   onChange,
   modelStates,
+  downloadBusy = false,
   onDownload,
   onDelete,
   query,
@@ -35,7 +43,8 @@ export function ProviderSection({
   const [expanded, setExpanded] = useState(false);
 
   const providerConfig = settings.providerConfigs[provider.id] ?? {};
-  const isConfigured = provider.setup !== "byok" || Object.keys(providerConfig).length > 0;
+  const isConfigured =
+    provider.setup !== "byok" || Object.keys(providerConfig).length > 0;
 
   function isModelDownloaded(modelId: string) {
     return settings.downloadedModels.includes(modelId);
@@ -51,11 +60,15 @@ export function ProviderSection({
   }
 
   const q = (query || "").trim().toLowerCase();
-  const providerMatches = q ? (provider.name.toLowerCase().includes(q) || provider.id.toLowerCase().includes(q)) : false;
+  const providerMatches = q
+    ? provider.name.toLowerCase().includes(q) ||
+      provider.id.toLowerCase().includes(q)
+    : false;
 
   const filteredModels = provider.models.filter((m) => {
     if (!q) return true;
-    if (m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q)) return true;
+    if (m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q))
+      return true;
     return providerMatches;
   });
 
@@ -71,8 +84,12 @@ export function ProviderSection({
             <RegistryIcon id={provider.id} className="w-5 h-5" />
           </div>
           <div>
-            <h3 className="text-sm font-medium leading-none">{provider.name}</h3>
-            <p className="text-xs text-muted-foreground mt-0.5">{provider.description}</p>
+            <h3 className="text-sm font-medium leading-none">
+              {provider.name}
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {provider.description}
+            </p>
           </div>
         </div>
 
@@ -87,8 +104,22 @@ export function ProviderSection({
         )}
       </div>
 
-      {/* Models list (only for non-BYOK providers since BYOK models are all auto-available) */}
-      {provider.setup !== "byok" && (
+      {/* WebLLM has ~139 models (mostly quant variants); render the grouped,
+          collapsible catalog instead of a flat list. */}
+      {provider.setup !== "byok" && provider.id === "web-llm" && (
+        <LocalModelCatalog
+          provider={provider}
+          settings={settings}
+          modelStates={modelStates}
+          downloadBusy={downloadBusy}
+          onDownload={onDownload}
+          onDelete={onDelete}
+          query={query}
+        />
+      )}
+
+      {/* Other local providers (few models) keep the simple flat list. */}
+      {provider.setup !== "byok" && provider.id !== "web-llm" && (
         <div className="flex flex-col gap-1 mt-5">
           {visibleModels.map((model) => (
             <ModelRow
@@ -97,6 +128,7 @@ export function ProviderSection({
               provider={provider}
               downloaded={isModelDownloaded(model.id)}
               state={modelStates[`${provider.id}:${model.id}`]}
+              downloadBusy={downloadBusy}
               onDownload={() => onDownload(provider.id, model.id)}
               onDelete={() => onDelete(provider.id, model.id)}
             />
@@ -138,30 +170,39 @@ export function ProviderSection({
   );
 }
 
-function ModelRow({
+export function ModelRow({
   model,
   provider,
   downloaded,
   state,
+  downloadBusy = false,
   onDownload,
   onDelete,
+  displayName,
 }: {
   model: ModelDefinition;
   provider: ProviderDefinition;
   downloaded: boolean;
   state?: ModelState;
+  downloadBusy?: boolean;
   onDownload: () => void;
   onDelete: () => void;
+  /** Overrides the row label (e.g. base name without the quant tag). */
+  displayName?: string;
 }) {
-  const needsDownload = provider.setup === "web-llm" || provider.setup === "browser-ai";
+  const needsDownload =
+    provider.setup === "web-llm" || provider.setup === "browser-ai";
   const isDownloading = state?.downloading ?? false;
   const error = state?.error;
+  // Block starting a new download while another one is running; the offscreen
+  // engine loads models one at a time.
+  const blockedByOther = downloadBusy && !isDownloading;
 
   return (
     <div className="flex flex-col rounded-md px-2 py-1.5 hover:bg-muted/50">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="text-sm truncate">{model.name}</span>
+          <span className="text-sm truncate">{displayName ?? model.name}</span>
           {model.capabilities.length > 0 && (
             <div className="flex gap-1">
               {model.capabilities.map((cap) => (
@@ -174,8 +215,15 @@ function ModelRow({
               ))}
             </div>
           )}
+          {model.contextWindow ? (
+            <span className="text-[10px] text-muted-foreground">
+              {formatContextWindow(model.contextWindow)} ctx
+            </span>
+          ) : null}
           {needsDownload && !downloaded && model.downloadSize && (
-            <span className="text-[10px] text-muted-foreground">{model.downloadSize}</span>
+            <span className="text-[10px] text-muted-foreground">
+              {model.downloadSize}
+            </span>
           )}
         </div>
 
@@ -186,11 +234,9 @@ function ModelRow({
               size="sm"
               className="h-6 text-xs px-2"
               onClick={onDownload}
-              disabled={isDownloading}
+              disabled={isDownloading || blockedByOther}
             >
-              {isDownloading
-                ? `${state?.progress ?? 0}%`
-                : "Download"}
+              {isDownloading ? `${state?.progress ?? 0}%` : "Download"}
             </Button>
           )}
 
@@ -207,9 +253,7 @@ function ModelRow({
         </div>
       </div>
 
-      {error && (
-        <p className="text-xs text-destructive mt-1 ml-0.5">{error}</p>
-      )}
+      {error && <p className="text-xs text-destructive mt-1 ml-0.5">{error}</p>}
     </div>
   );
 }

--- a/apps/extension/src/entrypoints/settings/SettingsPage.tsx
+++ b/apps/extension/src/entrypoints/settings/SettingsPage.tsx
@@ -199,6 +199,17 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
           )}
           {activeTab === "models" && (
             <ModelsTab settings={settings} onChange={async (patch) => {
+              // Model download/delete persists `downloadedModels` immediately
+              // (the background writes storage via add/removeDownloadedModel).
+              // Reconcile it into BOTH working and saved state so it never
+              // registers as an unsaved change, without disturbing other
+              // in-flight field edits.
+              if (patch.downloadedModels) {
+                const next = patch.downloadedModels;
+                setSettings((prev) => ({ ...prev, downloadedModels: next }));
+                setSavedSettings((prev) => ({ ...prev, downloadedModels: next }));
+                return;
+              }
               const updated = { ...settings, ...patch };
               setSettings(updated);
               if (patch.providerConfigs) {

--- a/apps/extension/src/entrypoints/settings/__tests__/local-model-catalog.test.ts
+++ b/apps/extension/src/entrypoints/settings/__tests__/local-model-catalog.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { ModelDefinition } from "@/registry/providers/types";
+import {
+  familyOf,
+  formatContextWindow,
+  groupLocalModels,
+  isBaseDownloaded,
+  splitQuant,
+} from "../local-model-catalog";
+
+function m(id: string, caps: ModelDefinition["capabilities"] = ["chat"]): ModelDefinition {
+  return { id, name: id, capabilities: caps };
+}
+
+describe("splitQuant", () => {
+  it("strips the MLC suffix and normalizes the quant tag", () => {
+    expect(splitQuant("Llama-3.2-3B-Instruct-q4f16_1-MLC")).toEqual({
+      base: "Llama-3.2-3B-Instruct",
+      quant: "q4f16",
+    });
+    expect(splitQuant("Qwen2.5-7B-Instruct-q4f32_1-MLC")).toEqual({
+      base: "Qwen2.5-7B-Instruct",
+      quant: "q4f32",
+    });
+    expect(splitQuant("Phi-3-mini-q0f16-MLC")).toEqual({
+      base: "Phi-3-mini",
+      quant: "q0f16",
+    });
+  });
+
+  it("returns an empty quant when the id has none", () => {
+    expect(splitQuant("Some-Model")).toEqual({ base: "Some-Model", quant: "" });
+  });
+});
+
+describe("familyOf", () => {
+  it("uses the leading dash-segment", () => {
+    expect(familyOf("Llama-3.2-3B-Instruct")).toBe("Llama");
+    expect(familyOf("Qwen2.5-7B-Instruct")).toBe("Qwen2.5");
+    expect(familyOf("DeepSeek-R1-Distill-Llama-8B")).toBe("DeepSeek");
+  });
+});
+
+describe("groupLocalModels", () => {
+  it("collapses quant variants under one base and groups by family", () => {
+    const groups = groupLocalModels([
+      m("Llama-3.2-3B-Instruct-q4f32_1-MLC"),
+      m("Llama-3.2-3B-Instruct-q4f16_1-MLC"),
+      m("Llama-3.1-8B-Instruct-q4f16_1-MLC"),
+      m("Qwen2.5-7B-Instruct-q4f16_1-MLC"),
+    ]);
+    expect(groups.map((g) => g.family)).toEqual(["Llama", "Qwen2.5"]);
+    const llama = groups[0];
+    expect(llama.bases.map((b) => b.baseKey)).toEqual([
+      "Llama-3.1-8B-Instruct",
+      "Llama-3.2-3B-Instruct",
+    ]);
+    // recommended (q4f16) sorted ahead of q4f32
+    const threeB = llama.bases[1];
+    expect(threeB.variants.map((v) => v.quant)).toEqual(["q4f16", "q4f32"]);
+  });
+
+  it("unions capabilities across variants", () => {
+    const groups = groupLocalModels([
+      m("Hermes-3-Llama-3.1-8B-q4f16_1-MLC", ["chat", "tools"]),
+      m("Hermes-3-Llama-3.1-8B-q4f32_1-MLC", ["chat", "tools"]),
+    ]);
+    expect(groups[0].bases[0].capabilities).toEqual(["chat", "tools"]);
+  });
+});
+
+describe("isBaseDownloaded", () => {
+  it("is true when any variant is downloaded", () => {
+    const [group] = groupLocalModels([
+      m("Llama-3.2-3B-Instruct-q4f16_1-MLC"),
+      m("Llama-3.2-3B-Instruct-q4f32_1-MLC"),
+    ]);
+    const base = group.bases[0];
+    expect(isBaseDownloaded(base, ["Llama-3.2-3B-Instruct-q4f32_1-MLC"])).toBe(true);
+    expect(isBaseDownloaded(base, ["something-else"])).toBe(false);
+  });
+});
+
+describe("formatContextWindow", () => {
+  it("renders compact K labels", () => {
+    expect(formatContextWindow(131072)).toBe("128K");
+    expect(formatContextWindow(32768)).toBe("32K");
+    expect(formatContextWindow(8192)).toBe("8K");
+    expect(formatContextWindow(4096)).toBe("4K");
+    expect(formatContextWindow(512)).toBe("512");
+  });
+});

--- a/apps/extension/src/entrypoints/settings/local-model-catalog.ts
+++ b/apps/extension/src/entrypoints/settings/local-model-catalog.ts
@@ -1,0 +1,133 @@
+import type { ModelDefinition } from "@/registry/providers/types";
+
+/**
+ * Grouping helpers that turn the flat prebuilt WebLLM model list (~139 entries,
+ * mostly quantization variants of the same base model) into a browsable
+ * catalog: family → base model → quant variants. Pure and dependency-free so
+ * it's unit-testable.
+ */
+
+export interface QuantVariant {
+  model: ModelDefinition;
+  /** Normalized quant tag, e.g. "q4f16" ("" when the id carries none). */
+  quant: string;
+}
+
+export interface BaseModel {
+  /** Model id with the quant tag stripped, e.g. "Llama-3.2-3B-Instruct". */
+  baseKey: string;
+  /** Display name, e.g. "Llama 3.2 3B Instruct". */
+  baseName: string;
+  /** Coarse family bucket, e.g. "Llama". */
+  family: string;
+  /** Quant variants, recommended first. */
+  variants: QuantVariant[];
+  /** Union of capabilities across variants. */
+  capabilities: ModelDefinition["capabilities"];
+}
+
+export interface FamilyGroup {
+  family: string;
+  bases: BaseModel[];
+}
+
+const QUANT_RE = /-(q\d+f\d+(?:_\d+)?|q0f\d+)$/i;
+
+/** Split an mlc model id into its quant-less base and normalized quant tag. */
+export function splitQuant(id: string): { base: string; quant: string } {
+  const noMlc = id.replace(/-MLC$/i, "");
+  const m = noMlc.match(QUANT_RE);
+  if (m && m.index !== undefined) {
+    return {
+      base: noMlc.slice(0, m.index),
+      quant: m[1].toLowerCase().replace(/_\d+$/, ""),
+    };
+  }
+  return { base: noMlc, quant: "" };
+}
+
+/** Coarse family bucket = the leading dash-segment of the base id. */
+export function familyOf(base: string): string {
+  return base.split("-")[0] || base;
+}
+
+function baseDisplayName(base: string): string {
+  return base.replace(/-/g, " ").replace(/\s+/g, " ").trim();
+}
+
+// Lower = preferred as the default variant: small + good quality first.
+const QUANT_ORDER: Record<string, number> = {
+  q4f16: 0,
+  q4f32: 1,
+  q3f16: 2,
+  q0f16: 3,
+  q0f32: 4,
+};
+function quantRank(quant: string): number {
+  return QUANT_ORDER[quant] ?? 9;
+}
+
+/**
+ * Group models into families → base models → variants. Families and bases are
+ * ordered alphabetically; variants within a base are ordered by
+ * recommended-first (see {@link quantRank}).
+ */
+export function groupLocalModels(models: ModelDefinition[]): FamilyGroup[] {
+  const bases = new Map<string, BaseModel>();
+
+  for (const model of models) {
+    const { base, quant } = splitQuant(model.id);
+    let entry = bases.get(base);
+    if (!entry) {
+      entry = {
+        baseKey: base,
+        baseName: baseDisplayName(base),
+        family: familyOf(base),
+        variants: [],
+        capabilities: [],
+      };
+      bases.set(base, entry);
+    }
+    entry.variants.push({ model, quant });
+    for (const cap of model.capabilities) {
+      if (!entry.capabilities.includes(cap)) entry.capabilities.push(cap);
+    }
+  }
+
+  for (const entry of bases.values()) {
+    entry.variants.sort(
+      (a, b) => quantRank(a.quant) - quantRank(b.quant) || a.quant.localeCompare(b.quant),
+    );
+  }
+
+  const families = new Map<string, BaseModel[]>();
+  for (const entry of bases.values()) {
+    const list = families.get(entry.family) ?? [];
+    list.push(entry);
+    families.set(entry.family, list);
+  }
+
+  return [...families.entries()]
+    .map(([family, list]) => ({
+      family,
+      bases: list.sort((a, b) => a.baseName.localeCompare(b.baseName)),
+    }))
+    .sort((a, b) => a.family.localeCompare(b.family));
+}
+
+/** True when any variant of the base model is downloaded. */
+export function isBaseDownloaded(
+  base: BaseModel,
+  downloadedModels: string[],
+): boolean {
+  return base.variants.some((v) => downloadedModels.includes(v.model.id));
+}
+
+/** Compact context-window label, e.g. 131072 -> "128K", 8192 -> "8K". */
+export function formatContextWindow(tokens: number): string {
+  if (tokens >= 1024) {
+    const k = tokens / 1024;
+    return Number.isInteger(k) ? `${k}K` : `${Math.round(tokens / 1000)}K`;
+  }
+  return String(tokens);
+}

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -2320,8 +2320,21 @@ export function useAgentChat({
 
         const titleConvId = convId;
         const titleMessage = input.trim();
+        // `agentSettings.agentModel` is a compound "<providerId>:<modelId>" key
+        // (legacy stored values may be a flat model id). Both segments must be
+        // split before lookup: comparing the whole compound key against a bare
+        // `m.id` never matches, which silently skipped title generation for
+        // every normally-selected model. Mirrors LandingPage's resolution.
+        const [providerIdStr, ...modelIdParts] =
+          agentSettings.agentModel.split(":");
+        const hasProvider = modelIdParts.length > 0;
+        const normalizedModelId = hasProvider
+          ? modelIdParts.join(":")
+          : agentSettings.agentModel;
         const provider = registryProviders.find((p) =>
-          p.models.some((m) => m.id === agentSettings.agentModel)
+          hasProvider
+            ? p.id === providerIdStr
+            : p.models.some((m) => m.id === normalizedModelId),
         );
         if (provider && titleMessage) {
           const config = settings.providerConfigs[provider.id] ?? {};
@@ -2330,7 +2343,7 @@ export function useAgentChat({
             type: "GENERATE_CHAT_TITLE",
             providerId: provider.id,
             config,
-            modelId: agentSettings.agentModel,
+            modelId: normalizedModelId,
             userMessage: titleMessage,
           }).then((res: any) => {
             if (res?.title) {

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -108,7 +108,12 @@ import {
 import type { PlanExtensionData, SerializedUIPart } from "./message-types";
 import type { BrowserTool } from "./types";
 
-import { SYSTEM_PROMPT, CUA_DELEGATION_PROMPT } from "./system-prompt";
+import { isChatOnlyModel } from "@/registry/agent-capability";
+import {
+  SYSTEM_PROMPT,
+  CUA_DELEGATION_PROMPT,
+  CHAT_ONLY_SYSTEM_PROMPT,
+} from "./system-prompt";
 import { buildEditingArtifactBlock } from "./artifact-edit-context";
 
 /**
@@ -1977,6 +1982,92 @@ function resolveCuaSelection(
   return { configured, modelId, provider, actualModelId, config };
 }
 
+/**
+ * Lean transport for the **chat-only** path — used when the selected model
+ * lacks the `tools` capability and therefore can't drive the browser agent.
+ * The composer still lets the user pick such a model (see `composerModelGate`)
+ * to hold a plain conversation. This deliberately skips everything the agent
+ * path assembles: no browser/MCP tools, no page snapshot or per-turn blocks,
+ * no completion-check or curator, and a minimal system prompt — so small local
+ * models aren't handed the large agent prompt they can't fit or reliably
+ * follow. Compaction and usage recording are retained so long chats still work
+ * and the Context popover stays live.
+ */
+function createChatOnlyTransport(args: {
+  model: LanguageModel;
+  modelDef: ModelDefinition | undefined;
+  qualifiedModelId: string;
+  transportCid: () => string | null;
+  providerId: string;
+  actualModelId: string;
+  thinkingConfig?: {
+    enabled: boolean;
+    config?: import("../types").ThinkingConfig;
+  };
+}): ChatTransport<AgentUIMessage> {
+  const {
+    model,
+    modelDef,
+    qualifiedModelId,
+    transportCid,
+    providerId,
+    actualModelId,
+    thinkingConfig,
+  } = args;
+
+  let providerOptions: ToolLoopAgentSettings["providerOptions"];
+  if (thinkingConfig?.enabled && thinkingConfig.config) {
+    providerOptions = buildThinkingProviderOptions(
+      providerId,
+      actualModelId,
+      thinkingConfig.config,
+    ) as ToolLoopAgentSettings["providerOptions"];
+  }
+
+  let needsMidStreamCompaction = false;
+  let transportLastTotalTokens = 0;
+
+  const agent = new ToolLoopAgent({
+    model,
+    tools: {},
+    instructions: CHAT_ONLY_SYSTEM_PROMPT,
+    ...(providerOptions && { providerOptions }),
+    onStepFinish: (stepResult) => {
+      const usage = stepResult.usage;
+      if (usage.inputTokens != null || usage.outputTokens != null) {
+        transportLastTotalTokens =
+          (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+      }
+      if (
+        transportLastTotalTokens > 0 &&
+        shouldCompact(transportLastTotalTokens, modelDef)
+      ) {
+        needsMidStreamCompaction = true;
+      }
+      void recordUsageForStep(
+        transportCid(),
+        {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+        },
+        modelDef,
+        qualifiedModelId,
+      );
+    },
+    stopWhen: () => needsMidStreamCompaction,
+  });
+
+  return new CompactingChatTransport({
+    agent,
+    onSendStart: () => {
+      needsMidStreamCompaction = false;
+    },
+    getActiveConversationId: () => transportCid(),
+    // No completion-check or curator wiring: a chat-only turn has no tool
+    // calls to review and no site-skill activity to curate.
+  });
+}
+
 export async function createAgentTransport(
   settings: Settings,
   agentModel: string,
@@ -2058,6 +2149,23 @@ export async function createAgentTransport(
     setHeadlessRunPolicy(conversationId, {
       autoApprove: headless.autoApprove,
       allowDelegate: headless.allowDelegate ?? false,
+    });
+  }
+
+  // Chat-only short-circuit: a model without the `tools` capability can't
+  // drive the browser agent. Rather than build the full agent transport it
+  // could never use, run the lean chat-only path (no tools, no page context,
+  // minimal prompt). Only the composer can select such a model (see
+  // `composerModelGate`); agent-only surfaces (scheduled tasks) gate it out.
+  if (modelDef != null && isChatOnlyModel(modelDef)) {
+    return createChatOnlyTransport({
+      model,
+      modelDef,
+      qualifiedModelId,
+      transportCid,
+      providerId: provider.id,
+      actualModelId,
+      thinkingConfig,
     });
   }
 

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -173,3 +173,17 @@ Worked example — "like the comments on my own LinkedIn posts from the last 7 d
 4. \`snapshot\`/\`screenshot\`/\`executeOnPage\` to list the comments now shown.
 5. For each comment, CUA: "Click Like on the comment by <person> at <position>." (one action per call)
 6. Identify the #2 most recent post and repeat from step 3.`;
+
+/**
+ * Minimal system prompt for the chat-only path — used when the selected model
+ * lacks the `tools` capability and therefore can't drive the browser agent
+ * (see `createChatOnlyTransport` in `agent-transport.ts`). Deliberately short:
+ * the whole point of chat-only mode is to avoid the large agent prompt (tool
+ * schemas, page snapshot, approval/mode scaffolding) that small local models
+ * can't fit or reliably follow. No browser context is injected.
+ */
+export const CHAT_ONLY_SYSTEM_PROMPT = `You are a helpful AI assistant running locally in the user's browser through OpenBrowse.
+
+You are in lightweight chat-only mode: you have no access to browser tools, the current page, the file system, or any way to take actions on the user's behalf. Hold a normal conversation and answer questions directly and concisely.
+
+If the user asks you to browse, click, open pages, or otherwise act on the web, explain that chat-only models can't drive the browser and that they'd need to select a tool-capable model to run the agent.`;

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -477,6 +477,18 @@ export type MessageType =
       userMessage: string;
     }
   | { type: "DOWNLOAD_MODEL"; modelId: string }
+  | {
+      type: "LOCAL_MODEL_LOAD_PROGRESS";
+      modelId: string;
+      progress: number;
+      text: string;
+    }
+  | {
+      type: "LOCAL_MODEL_OUTPUT_GARBLED";
+      modelId: string;
+      /** Human-readable signals that tripped the coherence check. */
+      reasons: string[];
+    }
   | { type: "DOWNLOAD_BROWSER_AI" }
   | { type: "CHECK_MODEL_CACHE"; modelIds: string[] }
   | { type: "DELETE_MODEL"; modelId: string }

--- a/apps/extension/src/registry/__tests__/agent-capability.test.ts
+++ b/apps/extension/src/registry/__tests__/agent-capability.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentModelGate,
+  composerModelGate,
+  isAgentCapableModel,
+  isChatOnlyModel,
+} from "../agent-capability";
+
+describe("agentModelGate", () => {
+  it("accepts a tool-capable model with a large context window", () => {
+    const r = agentModelGate({
+      capabilities: ["chat", "tools"],
+      contextWindow: 131_072,
+      maxOutputTokens: 4_096,
+    });
+    expect(r.ok).toBe(true);
+    expect(
+      isAgentCapableModel({
+        capabilities: ["chat", "tools"],
+        contextWindow: 131_072,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a chat-only model as 'Chat only'", () => {
+    const r = agentModelGate({
+      capabilities: ["chat"],
+      contextWindow: 131_072,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Chat only");
+  });
+
+  it("rejects Gemini Nano (chat-only, tiny window)", () => {
+    const r = agentModelGate({
+      capabilities: ["chat"],
+      contextWindow: 4_096,
+      maxOutputTokens: 2_048,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Chat only");
+  });
+
+  it("rejects a tool-capable model whose context window is too small", () => {
+    // usable = 8192 - 4096 - 20000 < 0
+    const r = agentModelGate({
+      capabilities: ["tools"],
+      contextWindow: 8_192,
+      maxOutputTokens: 4_096,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Context too small");
+  });
+
+  it("gives an unknown context window the benefit of the doubt", () => {
+    const r = agentModelGate({ capabilities: ["tools"] });
+    expect(r.ok).toBe(true);
+  });
+
+  it("treats missing capabilities as chat-only", () => {
+    const r = agentModelGate({});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Chat only");
+  });
+});
+
+describe("composerModelGate", () => {
+  it("lets a chat-only model be selected (advisory badge, not disabled)", () => {
+    const r = composerModelGate({
+      capabilities: ["chat"],
+      contextWindow: 131_072,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Chat only");
+    expect(r.allowSelect).toBe(true);
+  });
+
+  it("treats missing capabilities as selectable chat-only", () => {
+    const r = composerModelGate({});
+    expect(r.ok).toBe(false);
+    expect(r.allowSelect).toBe(true);
+  });
+
+  it("passes an agent-capable model through unchanged", () => {
+    const r = composerModelGate({
+      capabilities: ["chat", "tools"],
+      contextWindow: 131_072,
+      maxOutputTokens: 4_096,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.allowSelect).toBeUndefined();
+  });
+
+  it("keeps a too-small tool-capable model hard-disabled (not selectable)", () => {
+    const r = composerModelGate({
+      capabilities: ["tools"],
+      contextWindow: 8_192,
+      maxOutputTokens: 4_096,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("Context too small");
+    expect(r.allowSelect).toBeUndefined();
+  });
+});
+
+describe("isChatOnlyModel", () => {
+  it("is true for a model without tool calling", () => {
+    expect(isChatOnlyModel({ capabilities: ["chat"] })).toBe(true);
+    expect(isChatOnlyModel({ capabilities: ["chat", "thinking"] })).toBe(true);
+  });
+
+  it("is false for a tool-capable model", () => {
+    expect(isChatOnlyModel({ capabilities: ["chat", "tools"] })).toBe(false);
+  });
+
+  it("is independent of the context window", () => {
+    // A tool-capable model with a tiny window is NOT chat-only — it is simply
+    // gated out of the agent by `agentModelGate`. The two concepts are distinct.
+    expect(
+      isChatOnlyModel({ capabilities: ["tools"], contextWindow: 4_096 }),
+    ).toBe(false);
+  });
+
+  it("treats an empty capability list as chat-only", () => {
+    expect(isChatOnlyModel({ capabilities: [] })).toBe(true);
+    expect(isChatOnlyModel({})).toBe(true);
+  });
+
+  it("must only be applied to a resolved model, never a missing one", () => {
+    // Regression guard: the transport previously wrote
+    //   !(modelDef?.capabilities ?? []).includes("tools")
+    // which is `true` when `modelDef` is undefined, so an unresolved model
+    // (e.g. a gateway/dynamic model absent from a provider's static list) was
+    // silently routed to the chat-only path and lost every tool. Callers must
+    // check `modelDef != null` first; this documents why.
+    const unresolved: { capabilities?: string[] } | undefined = undefined;
+    expect(isChatOnlyModel(unresolved ?? {})).toBe(true);
+    expect(unresolved != null && isChatOnlyModel(unresolved)).toBe(false);
+  });
+});

--- a/apps/extension/src/registry/agent-capability.ts
+++ b/apps/extension/src/registry/agent-capability.ts
@@ -1,0 +1,103 @@
+import { getUsableTokens } from "@/lib/agent/compaction";
+
+/**
+ * Can a model serve as the **main browser-use agent**?
+ *
+ * The agent loop is driven entirely by tool calls and carries a large,
+ * non-compactable per-turn floor (system prompt + every tool's JSON schema +
+ * the current page's accessibility snapshot). Two hard requirements follow:
+ *
+ *  1. **Tool calling.** Without it there is nothing for the loop to drive.
+ *  2. **A viable context window.** When `getUsableTokens` (context − max
+ *     output − compaction buffer) is non-positive, a single turn cannot fit
+ *     and the compaction math degenerates into always-compact thrash. That
+ *     is the principled line below which a model is not agent-usable.
+ *
+ * This gate is intentionally scoped to the *primary agent* selection (chat
+ * composer, scheduled-task runner). Utility roles — tab tidy, chat-title and
+ * group-label generation, compaction summaries, completion evaluation — do
+ * NOT use it, because chat-only models are perfectly fine there.
+ */
+
+export interface AgentModelGateResult {
+  ok: boolean;
+  /** Short badge text shown on a gated-out picker row (e.g. "Chat only"). */
+  reason?: string;
+  /** Longer explanation for tooltips / error surfaces. */
+  detail?: string;
+  /**
+   * When `ok` is false, whether the picker should still allow selecting the
+   * model (rendering `reason` as an advisory badge rather than disabling the
+   * row). Used by the composer, where a chat-only model is a legitimate
+   * choice that runs the lightweight chat-only path instead of the agent.
+   */
+  allowSelect?: boolean;
+}
+
+/** The subset of model metadata the gate reads. */
+export interface AgentGateModel {
+  capabilities?: string[];
+  contextWindow?: number;
+  maxOutputTokens?: number;
+}
+
+export function agentModelGate(model: AgentGateModel): AgentModelGateResult {
+  const capabilities = model.capabilities ?? [];
+
+  if (!capabilities.includes("tools")) {
+    return {
+      ok: false,
+      reason: "Chat only",
+      detail:
+        "This model can't call tools, so it can't drive the browser agent. It's still available for chat-only features like tab tidy and title generation.",
+    };
+  }
+
+  // Only gate on context when the window is known. An unknown window falls
+  // back to the compaction default (large), so we give it the benefit of the
+  // doubt rather than hiding a legitimate model with missing metadata.
+  if (model.contextWindow != null && getUsableTokens(model) <= 0) {
+    return {
+      ok: false,
+      reason: "Context too small",
+      detail:
+        "This model's context window is too small to run the browser agent — the system prompt, tool definitions, and page state don't fit in a single turn.",
+    };
+  }
+
+  return { ok: true };
+}
+
+/** Convenience boolean form of {@link agentModelGate}. */
+export function isAgentCapableModel(model: AgentGateModel): boolean {
+  return agentModelGate(model).ok;
+}
+
+/**
+ * Does this model lack tool calling, and therefore run the lightweight
+ * chat-only path instead of the browser agent? (See `createChatOnlyTransport`.)
+ *
+ * Callers must only apply this to a model they actually resolved. A missing
+ * `ModelDefinition` means "unknown", NOT "chat-only" — routing an unresolved
+ * model here would silently strip every tool from a perfectly tool-capable
+ * model (e.g. a gateway/dynamic model absent from a provider's static list).
+ */
+export function isChatOnlyModel(model: AgentGateModel): boolean {
+  return !(model.capabilities ?? []).includes("tools");
+}
+
+/**
+ * Gate for the **chat composer** model picker. Identical to {@link agentModelGate}
+ * except a chat-only model (lacks `tools`) is marked `allowSelect: true`: it
+ * can't drive the browser agent, but the composer still lets the user pick it
+ * to hold a plain conversation via the chat-only transport. The "Context too
+ * small" case stays hard-disabled — that only applies to tool-capable models
+ * whose window can't fit the agent prompt, which chat-only mode never builds.
+ */
+export function composerModelGate(model: AgentGateModel): AgentModelGateResult {
+  const result = agentModelGate(model);
+  if (!result.ok && !(model.capabilities ?? []).includes("tools")) {
+    return { ...result, allowSelect: true };
+  }
+  return result;
+}

--- a/apps/extension/src/registry/models-dev/__tests__/from-models-dev.test.ts
+++ b/apps/extension/src/registry/models-dev/__tests__/from-models-dev.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { fromModelsDevProvider } from "../from-models-dev";
 import { QUIRKS } from "../quirks";
+import type { ModelsDevProvider } from "../types";
 import {
   ANTHROPIC_FIXTURE,
+  MULTIPLEX_FIXTURE,
   OPENAI_COMPATIBLE_FIXTURE,
   UNSUPPORTED_FIXTURE,
-  MULTIPLEX_FIXTURE,
 } from "./fixtures";
 
 describe("fromModelsDevProvider", () => {
@@ -55,7 +56,9 @@ describe("fromModelsDevProvider", () => {
     const result = fromModelsDevProvider(ANTHROPIC_FIXTURE, QUIRKS.anthropic);
     const ids = result.models.map((m) => m.id);
     expect(ids).toContain("claude-experimental-alpha");
-    const alpha = result.models.find((m) => m.id === "claude-experimental-alpha");
+    const alpha = result.models.find(
+      (m) => m.id === "claude-experimental-alpha",
+    );
     expect(alpha!.status).toBe("alpha");
   });
 
@@ -68,6 +71,51 @@ describe("fromModelsDevProvider", () => {
     const result = fromModelsDevProvider(OPENAI_COMPATIBLE_FIXTURE, undefined);
     const llama = result.models.find((m) => m.id === "llama-3.3-70b-versatile");
     expect(llama!.capabilities.sort()).toEqual(["chat", "tools"].sort());
+  });
+
+  it("excludes non-text-output models (image/video generators)", () => {
+    const provider = {
+      id: "gateway",
+      name: "AI Gateway",
+      models: {
+        "text-llm": {
+          id: "text-llm",
+          name: "A Real LLM",
+          modalities: { input: ["text"], output: ["text"] },
+          limit: { context: 128000, output: 8192 },
+        },
+        "seedance-video": {
+          id: "seedance-video",
+          name: "Seedance v1.0 Pro",
+          modalities: { input: ["text", "image"], output: ["video"] },
+          limit: { context: 0, output: 0 },
+        },
+      },
+    } as unknown as ModelsDevProvider;
+    const ids = fromModelsDevProvider(provider, undefined).models.map(
+      (m) => m.id,
+    );
+    expect(ids).toContain("text-llm");
+    expect(ids).not.toContain("seedance-video");
+  });
+
+  it("keeps models with no declared output modality", () => {
+    const provider = {
+      id: "gateway",
+      name: "AI Gateway",
+      models: {
+        "unknown-modality": {
+          id: "unknown-modality",
+          name: "Mystery Model",
+          modalities: { input: ["text"] },
+          limit: { context: 32000, output: 4096 },
+        },
+      },
+    } as unknown as ModelsDevProvider;
+    const ids = fromModelsDevProvider(provider, undefined).models.map(
+      (m) => m.id,
+    );
+    expect(ids).toContain("unknown-modality");
   });
 
   it("uses fallback description and undefined icon for unknown providers", () => {
@@ -90,7 +138,12 @@ describe("fromModelsDevProvider", () => {
 
     it("resolves default provider npm and substituted baseUrl for default model", async () => {
       const result = fromModelsDevProvider(MULTIPLEX_FIXTURE, quirks);
-      const model = await Promise.resolve(result.createLanguageModel({ resourceName: "test-res", apiKey: "x" }, "gpt-default"));
+      const model = await Promise.resolve(
+        result.createLanguageModel(
+          { resourceName: "test-res", apiKey: "x" },
+          "gpt-default",
+        ),
+      );
       expect(model).toBeDefined();
       expect((model as any).provider).toContain("azure"); // Verify we got an Azure model
     });
@@ -99,16 +152,24 @@ describe("fromModelsDevProvider", () => {
       const result = fromModelsDevProvider(MULTIPLEX_FIXTURE, quirks);
       // Wait, @ai-sdk/anthropic IS bundled! So it will try to import it and call it.
       // We don't want to make an actual API call, but `createLanguageModel` just returns the model instance, it doesn't make a fetch yet.
-      const model = await Promise.resolve(result.createLanguageModel({ resourceName: "test-res", apiKey: "x" }, "claude-override"));
-      // The model is a LanguageModel object. 
+      const model = await Promise.resolve(
+        result.createLanguageModel(
+          { resourceName: "test-res", apiKey: "x" },
+          "claude-override",
+        ),
+      );
+      // The model is a LanguageModel object.
       expect(model).toBeDefined();
       expect((model as any).provider).toContain("anthropic"); // Just to check it created an Anthropic model.
     });
 
     it("throws if required config value for substitution is missing", async () => {
       const result = fromModelsDevProvider(MULTIPLEX_FIXTURE, quirks);
-      expect(() => result.createLanguageModel({ apiKey: "x" }, "gpt-default"))
-        .toThrow(/Missing required configuration: resourceName \(for AZURE_RESOURCE_NAME\)/);
+      expect(() =>
+        result.createLanguageModel({ apiKey: "x" }, "gpt-default"),
+      ).toThrow(
+        /Missing required configuration: resourceName \(for AZURE_RESOURCE_NAME\)/,
+      );
     });
   });
 });

--- a/apps/extension/src/registry/models-dev/from-models-dev.ts
+++ b/apps/extension/src/registry/models-dev/from-models-dev.ts
@@ -6,17 +6,14 @@
  * (`../providers/index.ts`) consume this.
  */
 
-import {
-  createLanguageModelFor,
-  isSupportedNpm,
-} from "./bundled-sdks";
-import type { ProviderQuirks } from "./quirks";
-import type { ModelsDevModel, ModelsDevProvider } from "./types";
 import type {
   ConfigField,
   ModelDefinition,
   ProviderDefinition,
 } from "@/registry/providers/types";
+import { createLanguageModelFor, isSupportedNpm } from "./bundled-sdks";
+import type { ProviderQuirks } from "./quirks";
+import type { ModelsDevModel, ModelsDevProvider } from "./types";
 
 const DEFAULT_API_KEY_PLACEHOLDER = "sk-...";
 
@@ -63,7 +60,9 @@ function defaultConfigSchema(placeholder: string): ConfigField[] {
  * - `vision` from input modalities (image / pdf)
  * - `thinking` from `reasoning`
  */
-function capabilitiesOf(model: ModelsDevModel): ModelDefinition["capabilities"] {
+function capabilitiesOf(
+  model: ModelsDevModel,
+): ModelDefinition["capabilities"] {
   const caps: ModelDefinition["capabilities"] = ["chat"];
   if (model.tool_call) caps.push("tools");
   const inputs = new Set(model.modalities?.input ?? []);
@@ -89,7 +88,11 @@ function mapModel(
   if (typeof model.limit?.output === "number") {
     def.maxOutputTokens = model.limit.output;
   }
-  if (model.cost && typeof model.cost.input === "number" && typeof model.cost.output === "number") {
+  if (
+    model.cost &&
+    typeof model.cost.input === "number" &&
+    typeof model.cost.output === "number"
+  ) {
     def.pricing = {
       inputPer1M: model.cost.input,
       outputPer1M: model.cost.output,
@@ -101,11 +104,21 @@ function mapModel(
 }
 
 /**
- * Filters: deprecated models are always hidden. Alpha/beta surface;
- * the UI can choose to badge them but doesn't gate them.
+ * Filters:
+ * - Deprecated models are always hidden.
+ * - Non-language models are hidden: anything whose declared output modality
+ *   isn't text (image/video/audio generators, embeddings) has no place in a
+ *   chat/agent model picker. This is what keeps ByteDance Seedance (video)
+ *   and Seedream (image), surfaced via aggregators like Vercel AI Gateway,
+ *   out of the list. Models with no declared output modality are kept —
+ *   incomplete catalog metadata shouldn't hide a real LLM.
+ * - Alpha/beta surface; the UI can badge them but doesn't gate them.
  */
 function shouldIncludeModel(model: ModelsDevModel): boolean {
-  return model.status !== "deprecated";
+  if (model.status === "deprecated") return false;
+  const output = model.modalities?.output;
+  if (output && output.length > 0 && !output.includes("text")) return false;
+  return true;
 }
 
 function configSchemaFor(
@@ -135,7 +148,9 @@ function substituteUrlVars(
     const configKey = envVarMap?.[varName] ?? varName;
     const value = config[configKey];
     if (value === undefined || value === "") {
-      throw new Error(`Missing required configuration: ${configKey} (for ${varName})`);
+      throw new Error(
+        `Missing required configuration: ${configKey} (for ${varName})`,
+      );
     }
     return value;
   });

--- a/apps/extension/src/registry/providers/__bridge__/__tests__/local-model-sw-adapter.test.ts
+++ b/apps/extension/src/registry/providers/__bridge__/__tests__/local-model-sw-adapter.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LocalModelCallOptions } from "../local-model-messages";
+import { createLocalModelSwAdapter } from "../local-model-sw-adapter";
+
+/**
+ * The SW-side adapter is a `LanguageModelV3` proxy over a `chrome.runtime`
+ * Port. These tests drive it against a fake Port (no browser) and assert:
+ *
+ *  - `doStream` opens a port, sends a serializable `LM_START` (no
+ *    `abortSignal`), and surfaces `LM_CHUNK`/`LM_DONE`/`LM_ERROR`.
+ *  - Aborting the call posts `LM_CANCEL` and errors the stream.
+ *  - `doGenerate` resolves on `LM_GENERATE_RESULT` and rejects on `LM_ERROR`.
+ *  - A port disconnect before completion errors the consumer.
+ */
+
+interface FakePort {
+  port: chrome.runtime.Port;
+  posted: unknown[];
+  emit: (msg: unknown) => void;
+  emitDisconnect: () => void;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeFakePort(): FakePort {
+  const messageListeners: ((m: unknown) => void)[] = [];
+  const disconnectListeners: (() => void)[] = [];
+  const posted: unknown[] = [];
+  const disconnect = vi.fn();
+
+  const port = {
+    name: "",
+    postMessage: (m: unknown) => posted.push(m),
+    disconnect,
+    onMessage: {
+      addListener: (fn: (m: unknown) => void) => messageListeners.push(fn),
+      removeListener: (fn: (m: unknown) => void) => {
+        const i = messageListeners.indexOf(fn);
+        if (i >= 0) messageListeners.splice(i, 1);
+      },
+    },
+    onDisconnect: {
+      addListener: (fn: () => void) => disconnectListeners.push(fn),
+      removeListener: (fn: () => void) => {
+        const i = disconnectListeners.indexOf(fn);
+        if (i >= 0) disconnectListeners.splice(i, 1);
+      },
+    },
+  } as unknown as chrome.runtime.Port;
+
+  return {
+    port,
+    posted,
+    emit: (msg) => messageListeners.slice().forEach((fn) => fn(msg)),
+    emitDisconnect: () => disconnectListeners.slice().forEach((fn) => fn()),
+    disconnect,
+  };
+}
+
+function makeOptions(
+  extra: Partial<LocalModelCallOptions> = {},
+): LocalModelCallOptions {
+  return { prompt: [], ...extra } as unknown as LocalModelCallOptions;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeAdapter(
+  fake: FakePort,
+  connectInfoSink?: (i: { name: string }) => void,
+) {
+  return createLocalModelSwAdapter(
+    "web-llm",
+    { some: "config" },
+    "Llama-3.2-3B-Instruct-q4f16_1-MLC",
+    {
+      connect: (info) => {
+        connectInfoSink?.(info);
+        return fake.port;
+      },
+      ensureOffscreen: async () => {},
+      randomId: () => "test-uuid",
+    },
+  );
+}
+
+describe("createLocalModelSwAdapter", () => {
+  it("exposes a v3 model with provider/model identity and no supported URLs", () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    expect(model.specificationVersion).toBe("v3");
+    expect(model.provider).toBe("web-llm");
+    expect(model.modelId).toBe("Llama-3.2-3B-Instruct-q4f16_1-MLC");
+    expect(model.supportedUrls).toEqual({});
+  });
+
+  it("doStream sends a serializable LM_START and streams chunks then closes", async () => {
+    const fake = makeFakePort();
+    let connectedName = "";
+    const model = makeAdapter(fake, (i) => {
+      connectedName = i.name;
+    });
+
+    const abortSignal = new AbortController().signal;
+    const { stream } = await model.doStream(makeOptions({ abortSignal }));
+
+    expect(connectedName).toBe("offscreen-lm:test-uuid");
+    // First (and only) outbound message is LM_START without abortSignal.
+    expect(fake.posted).toHaveLength(1);
+    const start = fake.posted[0] as Record<string, unknown>;
+    expect(start.type).toBe("LM_START");
+    expect(start.mode).toBe("stream");
+    expect(start.providerId).toBe("web-llm");
+    expect(start.modelId).toBe("Llama-3.2-3B-Instruct-q4f16_1-MLC");
+    expect(
+      (start.options as Record<string, unknown>).abortSignal,
+    ).toBeUndefined();
+    expect((start.options as Record<string, unknown>).prompt).toEqual([]);
+
+    const reader = stream.getReader();
+
+    fake.emit({
+      type: "LM_CHUNK",
+      part: { type: "text-delta", id: "1", delta: "he" },
+    });
+    const r1 = await reader.read();
+    expect(r1.done).toBe(false);
+    expect(r1.value).toEqual({ type: "text-delta", id: "1", delta: "he" });
+
+    fake.emit({ type: "LM_DONE" });
+    const r2 = await reader.read();
+    expect(r2.done).toBe(true);
+    expect(fake.disconnect).toHaveBeenCalled();
+  });
+
+  it("doStream revives a response-metadata timestamp string into a Date", async () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    const { stream } = await model.doStream(makeOptions());
+    const reader = stream.getReader();
+
+    const iso = "2026-06-25T00:00:00.000Z";
+    fake.emit({
+      type: "LM_CHUNK",
+      part: { type: "response-metadata", timestamp: iso },
+    });
+    const r = await reader.read();
+    const part = r.value as { type: string; timestamp: unknown };
+    expect(part.timestamp).toBeInstanceOf(Date);
+    expect((part.timestamp as Date).toISOString()).toBe(iso);
+  });
+
+  it("doStream surfaces LM_ERROR as a stream error", async () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    const { stream } = await model.doStream(makeOptions());
+    const reader = stream.getReader();
+
+    fake.emit({ type: "LM_ERROR", message: "WebGPU unavailable" });
+    await expect(reader.read()).rejects.toThrow("WebGPU unavailable");
+  });
+
+  it("doStream errors when the port disconnects before completion", async () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    const { stream } = await model.doStream(makeOptions());
+    const reader = stream.getReader();
+
+    fake.emitDisconnect();
+    await expect(reader.read()).rejects.toThrow(/disconnected/);
+  });
+
+  it("aborting the signal posts LM_CANCEL and errors the stream", async () => {
+    const fake = makeFakePort();
+    const controller = new AbortController();
+    const model = makeAdapter(fake);
+    const { stream } = await model.doStream(
+      makeOptions({ abortSignal: controller.signal }),
+    );
+    const reader = stream.getReader();
+
+    controller.abort();
+
+    const cancel = fake.posted.find(
+      (m) => (m as Record<string, unknown>).type === "LM_CANCEL",
+    );
+    expect(cancel).toBeDefined();
+    await expect(reader.read()).rejects.toThrow();
+  });
+
+  it("stream.cancel() posts LM_CANCEL and disconnects", async () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    const { stream } = await model.doStream(makeOptions());
+    await stream.cancel();
+    const cancel = fake.posted.find(
+      (m) => (m as Record<string, unknown>).type === "LM_CANCEL",
+    );
+    expect(cancel).toBeDefined();
+    expect(fake.disconnect).toHaveBeenCalled();
+  });
+
+  it("doGenerate resolves on LM_GENERATE_RESULT", async () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    const promise = model.doGenerate(makeOptions());
+    // `doGenerate` awaits `ensureOffscreen` (a microtask) before posting.
+    await flush();
+
+    const start = fake.posted[0] as Record<string, unknown>;
+    expect(start.type).toBe("LM_START");
+    expect(start.mode).toBe("generate");
+
+    const result = {
+      content: [{ type: "text", text: "hi" }],
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    };
+    fake.emit({ type: "LM_GENERATE_RESULT", result });
+    await expect(promise).resolves.toMatchObject({ finishReason: "stop" });
+    expect(fake.disconnect).toHaveBeenCalled();
+  });
+
+  it("doGenerate rejects on LM_ERROR", async () => {
+    const fake = makeFakePort();
+    const model = makeAdapter(fake);
+    const promise = model.doGenerate(makeOptions());
+    await flush();
+    fake.emit({ type: "LM_ERROR", message: "boom" });
+    await expect(promise).rejects.toThrow("boom");
+  });
+});

--- a/apps/extension/src/registry/providers/__bridge__/local-model-messages.ts
+++ b/apps/extension/src/registry/providers/__bridge__/local-model-messages.ts
@@ -1,0 +1,113 @@
+/**
+ * Wire protocol for the local-model bridge (`web-llm` / `browser-ai`).
+ *
+ * The agent loop is hosted in the service worker, which has neither WebGPU
+ * (WebLLM) nor `chrome.ai` (Gemini Nano). Both live only in the offscreen
+ * document. This module defines the messages exchanged over a long-lived
+ * `chrome.runtime` Port so the SW-side `LanguageModelV3` adapter can drive a
+ * real model that physically runs in offscreen:
+ *
+ *   SW adapter  ──LM_START──▶  offscreen `lm-stream` handler
+ *               ◀─LM_CHUNK──   (streaming tokens / tool-call deltas)
+ *               ◀─LM_DONE───   (stream finished)
+ *               ◀─LM_GENERATE_RESULT (non-streaming doGenerate)
+ *               ◀─LM_ERROR──   (build or inference failure)
+ *   SW adapter  ──LM_CANCEL─▶  (abort in-flight generation)
+ *
+ * The types the AI SDK uses for `doStream`/`doGenerate` (`LanguageModelV3*`)
+ * are not part of `ai`'s public export surface and `@ai-sdk/provider` is not
+ * a direct dependency, so we derive exactly the shapes we need structurally
+ * from the public `LanguageModel` union. This keeps the bridge correct across
+ * AI SDK minor bumps without importing internal type names.
+ */
+
+import type { LanguageModel } from "ai";
+
+/** Providers whose inference must run in the offscreen document. */
+export type LocalModelProviderId = "web-llm" | "browser-ai";
+
+/** Port-name prefix; the suffix is a per-request UUID. */
+export const LOCAL_MODEL_PORT_PREFIX = "offscreen-lm:";
+
+/**
+ * The concrete `LanguageModelV3` object from the public `LanguageModel`
+ * union (which is `string | LanguageModelV3 | LanguageModelV2`). Selecting on
+ * the spec-version discriminant yields the v3 model shape without importing
+ * the non-exported `LanguageModelV3` name.
+ */
+export type LocalModelV3 = Extract<
+  LanguageModel,
+  { specificationVersion: "v3" }
+>;
+
+/** Full call options accepted by `doStream`/`doGenerate`. */
+export type LocalModelCallOptions = Parameters<LocalModelV3["doStream"]>[0];
+
+/**
+ * Call options minus the parts that cannot cross a `chrome.runtime` Port.
+ * `abortSignal` is a live object handled out-of-band via `LM_CANCEL`.
+ */
+export type SerializableCallOptions = Omit<
+  LocalModelCallOptions,
+  "abortSignal"
+>;
+
+type StreamResult = Awaited<ReturnType<LocalModelV3["doStream"]>>;
+
+/** A single streamed part (`text-delta`, `tool-call`, `finish`, ...). */
+export type LocalModelStreamPart =
+  StreamResult["stream"] extends ReadableStream<infer P> ? P : never;
+
+/** The result of a non-streaming `doGenerate` call. */
+export type LocalModelGenerateResult = Awaited<
+  ReturnType<LocalModelV3["doGenerate"]>
+>;
+
+// ── SW → offscreen ──────────────────────────────────────────────────────
+
+export interface LmStartMessage {
+  type: "LM_START";
+  /** `"stream"` drives `doStream`; `"generate"` drives `doGenerate`. */
+  mode: "stream" | "generate";
+  providerId: LocalModelProviderId;
+  config: Record<string, string>;
+  modelId: string;
+  options: SerializableCallOptions;
+}
+
+export interface LmCancelMessage {
+  type: "LM_CANCEL";
+}
+
+export type LocalModelRequest = LmStartMessage | LmCancelMessage;
+
+// ── offscreen → SW ──────────────────────────────────────────────────────
+
+export interface LmChunkMessage {
+  type: "LM_CHUNK";
+  part: LocalModelStreamPart;
+}
+
+export interface LmDoneMessage {
+  type: "LM_DONE";
+}
+
+export interface LmGenerateResultMessage {
+  type: "LM_GENERATE_RESULT";
+  result: LocalModelGenerateResult;
+}
+
+export interface LmErrorMessage {
+  type: "LM_ERROR";
+  message: string;
+}
+
+export type LocalModelResponse =
+  | LmChunkMessage
+  | LmDoneMessage
+  | LmGenerateResultMessage
+  | LmErrorMessage;
+
+export function isLocalModelPortName(name: string): boolean {
+  return name.startsWith(LOCAL_MODEL_PORT_PREFIX);
+}

--- a/apps/extension/src/registry/providers/__bridge__/local-model-sw-adapter.ts
+++ b/apps/extension/src/registry/providers/__bridge__/local-model-sw-adapter.ts
@@ -1,0 +1,293 @@
+/**
+ * Service-worker-side `LanguageModelV3` adapter for local providers.
+ *
+ * The SW hosts the agent loop but cannot run WebLLM (WebGPU) or Gemini Nano
+ * (`chrome.ai`) — those live only in the offscreen document. This adapter is
+ * a thin `LanguageModelV3` proxy: `doStream`/`doGenerate` open a long-lived
+ * `offscreen-lm:<uuid>` Port, forward the (serializable) call options to the
+ * offscreen `lm-stream` handler, and surface the streamed parts / generate
+ * result back to the AI SDK as if the model ran locally.
+ *
+ * `abortSignal` cannot cross the Port, so it is bridged via an out-of-band
+ * `LM_CANCEL` message; the offscreen side aborts the real generation.
+ *
+ * Dependencies (`connect`, `ensureOffscreen`, `randomId`) are injectable so
+ * the adapter can be unit-tested against a fake Port without a browser.
+ */
+
+import { ensureOffscreenDocument } from "@/entrypoints/background/messages";
+import {
+  LOCAL_MODEL_PORT_PREFIX,
+  type LocalModelCallOptions,
+  type LocalModelGenerateResult,
+  type LocalModelProviderId,
+  type LocalModelResponse,
+  type LocalModelStreamPart,
+  type LocalModelV3,
+  type SerializableCallOptions,
+} from "./local-model-messages";
+
+export interface SwAdapterDeps {
+  /** Open a Port. Defaults to `chrome.runtime.connect`. */
+  connect?: (connectInfo: { name: string }) => chrome.runtime.Port;
+  /** Ensure the offscreen document exists before connecting. */
+  ensureOffscreen?: () => Promise<void>;
+  /** Per-request id generator. Defaults to `crypto.randomUUID`. */
+  randomId?: () => string;
+}
+
+/** Strip the non-serializable `abortSignal` before sending over the Port. */
+function toSerializable(
+  options: LocalModelCallOptions,
+): SerializableCallOptions {
+  const { abortSignal: _abortSignal, ...rest } = options;
+  return rest;
+}
+
+/**
+ * `chrome.runtime` Port serialization does not always preserve `Date`
+ * instances (JSON turns them into strings). Revive the `response-metadata`
+ * timestamp the AI SDK expects to be a real `Date`.
+ */
+function revivePart(part: LocalModelStreamPart): LocalModelStreamPart {
+  const p = part as { type?: string; timestamp?: unknown };
+  if (p.type === "response-metadata" && typeof p.timestamp === "string") {
+    return {
+      ...(part as object),
+      timestamp: new Date(p.timestamp),
+    } as LocalModelStreamPart;
+  }
+  return part;
+}
+
+function reviveGenerate(
+  result: LocalModelGenerateResult,
+): LocalModelGenerateResult {
+  const ts = result.response?.timestamp as unknown;
+  if (typeof ts === "string") {
+    return {
+      ...result,
+      response: { ...result.response, timestamp: new Date(ts) },
+    } as LocalModelGenerateResult;
+  }
+  return result;
+}
+
+function abortError(signal: AbortSignal): unknown {
+  return (
+    signal.reason ??
+    new DOMException("The operation was aborted.", "AbortError")
+  );
+}
+
+export function createLocalModelSwAdapter(
+  providerId: LocalModelProviderId,
+  config: Record<string, string>,
+  modelId: string,
+  deps: SwAdapterDeps = {},
+): LocalModelV3 {
+  const connect = deps.connect ?? ((info) => chrome.runtime.connect(info));
+  const ensureOffscreen = deps.ensureOffscreen ?? ensureOffscreenDocument;
+  const randomId = deps.randomId ?? (() => crypto.randomUUID());
+
+  const openPort = async (): Promise<chrome.runtime.Port> => {
+    await ensureOffscreen();
+    return connect({ name: `${LOCAL_MODEL_PORT_PREFIX}${randomId()}` });
+  };
+
+  const model: LocalModelV3 = {
+    specificationVersion: "v3",
+    provider: providerId,
+    modelId,
+    // Local models never fetch remote URLs; nothing is natively supported.
+    supportedUrls: {},
+
+    async doStream(options: LocalModelCallOptions) {
+      const port = await openPort();
+      const abortSignal = options.abortSignal;
+
+      const stream = new ReadableStream<LocalModelStreamPart>({
+        start(controller) {
+          let closed = false;
+
+          const cleanup = () => {
+            try {
+              port.onMessage.removeListener(onMessage);
+            } catch {
+              /* noop */
+            }
+            try {
+              port.onDisconnect.removeListener(onDisconnect);
+            } catch {
+              /* noop */
+            }
+            try {
+              port.disconnect();
+            } catch {
+              /* noop */
+            }
+          };
+
+          const onMessage = (msg: LocalModelResponse) => {
+            if (closed) return;
+            if (msg.type === "LM_CHUNK") {
+              controller.enqueue(revivePart(msg.part));
+            } else if (msg.type === "LM_DONE") {
+              closed = true;
+              controller.close();
+              cleanup();
+            } else if (msg.type === "LM_ERROR") {
+              closed = true;
+              controller.error(new Error(msg.message));
+              cleanup();
+            }
+          };
+
+          const onDisconnect = () => {
+            if (closed) return;
+            closed = true;
+            try {
+              controller.error(
+                new Error("Offscreen local-model port disconnected"),
+              );
+            } catch {
+              /* already errored */
+            }
+          };
+
+          port.onMessage.addListener(onMessage);
+          port.onDisconnect.addListener(onDisconnect);
+
+          const onAbort = () => {
+            try {
+              port.postMessage({ type: "LM_CANCEL" });
+            } catch {
+              /* port already gone */
+            }
+            if (!closed) {
+              closed = true;
+              try {
+                controller.error(abortError(abortSignal!));
+              } catch {
+                /* already errored */
+              }
+            }
+            cleanup();
+          };
+
+          if (abortSignal) {
+            if (abortSignal.aborted) {
+              onAbort();
+              return;
+            }
+            abortSignal.addEventListener("abort", onAbort, { once: true });
+          }
+
+          port.postMessage({
+            type: "LM_START",
+            mode: "stream",
+            providerId,
+            config,
+            modelId,
+            options: toSerializable(options),
+          });
+        },
+        cancel() {
+          try {
+            port.postMessage({ type: "LM_CANCEL" });
+          } catch {
+            /* noop */
+          }
+          try {
+            port.disconnect();
+          } catch {
+            /* noop */
+          }
+        },
+      });
+
+      return { stream };
+    },
+
+    async doGenerate(options: LocalModelCallOptions) {
+      const port = await openPort();
+      const abortSignal = options.abortSignal;
+
+      return await new Promise<LocalModelGenerateResult>((resolve, reject) => {
+        let settled = false;
+
+        const cleanup = () => {
+          try {
+            port.onMessage.removeListener(onMessage);
+          } catch {
+            /* noop */
+          }
+          try {
+            port.onDisconnect.removeListener(onDisconnect);
+          } catch {
+            /* noop */
+          }
+          try {
+            port.disconnect();
+          } catch {
+            /* noop */
+          }
+        };
+
+        const onMessage = (msg: LocalModelResponse) => {
+          if (settled) return;
+          if (msg.type === "LM_GENERATE_RESULT") {
+            settled = true;
+            resolve(reviveGenerate(msg.result));
+            cleanup();
+          } else if (msg.type === "LM_ERROR") {
+            settled = true;
+            reject(new Error(msg.message));
+            cleanup();
+          }
+        };
+
+        const onDisconnect = () => {
+          if (settled) return;
+          settled = true;
+          reject(new Error("Offscreen local-model port disconnected"));
+        };
+
+        port.onMessage.addListener(onMessage);
+        port.onDisconnect.addListener(onDisconnect);
+
+        const onAbort = () => {
+          try {
+            port.postMessage({ type: "LM_CANCEL" });
+          } catch {
+            /* noop */
+          }
+          if (!settled) {
+            settled = true;
+            reject(abortError(abortSignal!));
+          }
+          cleanup();
+        };
+
+        if (abortSignal) {
+          if (abortSignal.aborted) {
+            onAbort();
+            return;
+          }
+          abortSignal.addEventListener("abort", onAbort, { once: true });
+        }
+
+        port.postMessage({
+          type: "LM_START",
+          mode: "generate",
+          providerId,
+          config,
+          modelId,
+          options: toSerializable(options),
+        });
+      });
+    },
+  };
+
+  return model;
+}

--- a/apps/extension/src/registry/providers/browser-ai.ts
+++ b/apps/extension/src/registry/providers/browser-ai.ts
@@ -1,19 +1,45 @@
+import {
+  isOffscreenContext,
+  isServiceWorkerContext,
+} from "@/lib/runtime/context";
 import type { ProviderDefinition } from "./types";
 
 export const definition: ProviderDefinition = {
   id: "browser-ai",
   name: "Built-in AI",
   icon: { light: "browser-ai.svg" },
-  description: "Chrome's built-in Gemini Nano — runs locally, no API key needed",
+  description:
+    "Chrome's built-in Gemini Nano — runs locally, no API key needed",
   setup: "browser-ai",
   models: [
-    { id: "gemini-nano", name: "Gemini Nano", capabilities: ["chat"], contextWindow: 4_096, maxOutputTokens: 2_048 },
+    {
+      id: "gemini-nano",
+      name: "Gemini Nano",
+      capabilities: ["chat"],
+      contextWindow: 4_096,
+      maxOutputTokens: 2_048,
+    },
   ],
-  createLanguageModel(_config, _modelId) {
-    // Same situation as web-llm: Chrome's built-in AI runs in the
-    // offscreen document; non-agent consumers message offscreen directly,
-    // and the agent loop has never supported local models (no offscreen→
-    // host streaming bridge exists yet). See web-llm.ts for context.
-    throw new Error("Browser AI models are created via chrome.ai API in offscreen document");
+  async createLanguageModel(config, modelId) {
+    // Same realm split as web-llm: Chrome's built-in AI (`chrome.ai`) runs
+    // only in the offscreen document. In the service worker (agent-run host)
+    // we return the bridge adapter that streams from offscreen; in offscreen
+    // we build the real model directly; in a renderer there is no local path.
+    // See `web-llm.ts` and `registry/providers/__bridge__` for details.
+    if (isServiceWorkerContext()) {
+      const { createLocalModelSwAdapter } = await import(
+        "./__bridge__/local-model-sw-adapter"
+      );
+      return createLocalModelSwAdapter("browser-ai", config, modelId);
+    }
+    if (isOffscreenContext()) {
+      const { getModelFromRegistry } = await import(
+        "@/entrypoints/offscreen/ai"
+      );
+      return await getModelFromRegistry("browser-ai", config, modelId);
+    }
+    throw new Error(
+      "Browser AI (Gemini Nano) runs in the offscreen document; the renderer does not host local-model inference. Reach it via the service-worker agent host.",
+    );
   },
 };

--- a/apps/extension/src/registry/providers/web-llm-model-context.ts
+++ b/apps/extension/src/registry/providers/web-llm-model-context.ts
@@ -1,0 +1,178 @@
+// AUTO-DERIVED — do not hand-edit the numeric values.
+//
+// Each model's real context window is read from its own
+// `mlc-chat-config.json` (`context_window_size`, or `sliding_window_size`
+// for sliding-window models), fetched from the model's Hugging Face repo.
+// This is the source of truth that overrides mlc's conservative prebuilt
+// `overrides.context_window_size: 4096` default.
+//
+// The prebuilt WASM libs are NOT context-capped: `@mlc-ai/web-llm` reads
+// only `prefill_chunk_size` from the compiled lib; `context_window_size` is
+// a runtime KV-cache ceiling (paged cache grows on demand, no load-time
+// cost), overridable via
+// `engineConfig.appConfig.model_list[].overrides.context_window_size`
+// (verified empirically at 131072 on Apple metal-3).
+//
+// Regenerate: for each id in `prebuiltAppConfig.model_list`, fetch
+// `<model>/resolve/main/mlc-chat-config.json` and read the window fields.
+
+export interface WebLLMModelContext {
+  /** Effective usable context window (sourced from the model config). */
+  contextWindow: number;
+  /**
+   * Value to write into `overrides.context_window_size` when loading. When
+   * omitted, the model uses a native sliding window and must not be
+   * overridden.
+   */
+  overrideContextWindowSize?: number;
+  /** `prefill_chunk_size` from the compiled lib / model config. */
+  prefillChunkSize?: number;
+  /** True when the model relies on a native sliding window. */
+  slidingWindow: boolean;
+  /** Approximate VRAM needed for weights (from the prebuilt entry). */
+  vramRequiredMB?: number;
+  /** True when the prebuilt entry flags it as low-resource. */
+  lowResource: boolean;
+}
+
+export const WEB_LLM_MODEL_CONTEXT: Record<string, WebLLMModelContext> = {
+  "DeepSeek-R1-Distill-Llama-8B-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5001.0, lowResource: false },
+  "DeepSeek-R1-Distill-Llama-8B-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 6101.01, lowResource: false },
+  "DeepSeek-R1-Distill-Qwen-7B-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5106.67, lowResource: false },
+  "DeepSeek-R1-Distill-Qwen-7B-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5900.09, lowResource: false },
+  "Hermes-2-Pro-Llama-3-8B-q4f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 4976.13, lowResource: false },
+  "Hermes-2-Pro-Llama-3-8B-q4f32_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 6051.27, lowResource: false },
+  "Hermes-2-Pro-Mistral-7B-q4f16_1-MLC": { contextWindow: 4096, prefillChunkSize: 2048, slidingWindow: true, vramRequiredMB: 4033.28, lowResource: false },
+  "Hermes-2-Theta-Llama-3-8B-q4f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 4976.13, lowResource: false },
+  "Hermes-2-Theta-Llama-3-8B-q4f32_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 6051.27, lowResource: false },
+  "Hermes-3-Llama-3.1-8B-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 4876.13, lowResource: false },
+  "Hermes-3-Llama-3.1-8B-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5779.27, lowResource: false },
+  "Hermes-3-Llama-3.2-3B-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2263.69, lowResource: true },
+  "Hermes-3-Llama-3.2-3B-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2951.51, lowResource: true },
+  "Llama-2-13b-chat-hf-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 11814.09, lowResource: false },
+  "Llama-2-7b-chat-hf-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 6749.02, lowResource: false },
+  "Llama-2-7b-chat-hf-q4f16_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 4618.52, lowResource: false },
+  "Llama-2-7b-chat-hf-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 9109.03, lowResource: false },
+  "Llama-2-7b-chat-hf-q4f32_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 5284.01, lowResource: false },
+  "Llama-3-70B-Instruct-q3f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 1024, slidingWindow: false, vramRequiredMB: 31153.13, lowResource: false },
+  "Llama-3-8B-Instruct-q4f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5001.0, lowResource: false },
+  "Llama-3-8B-Instruct-q4f16_1-MLC-1k": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 4598.34, lowResource: true },
+  "Llama-3-8B-Instruct-q4f32_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 6101.01, lowResource: false },
+  "Llama-3-8B-Instruct-q4f32_1-MLC-1k": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5295.7, lowResource: true },
+  "Llama-3.1-70B-Instruct-q3f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 31153.13, lowResource: false },
+  "Llama-3.1-8B-Instruct-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5001.0, lowResource: false },
+  "Llama-3.1-8B-Instruct-q4f16_1-MLC-1k": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 4598.34, lowResource: true },
+  "Llama-3.1-8B-Instruct-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 6101.01, lowResource: false },
+  "Llama-3.1-8B-Instruct-q4f32_1-MLC-1k": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5295.7, lowResource: true },
+  "Llama-3.2-1B-Instruct-q0f16-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2573.13, lowResource: true },
+  "Llama-3.2-1B-Instruct-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 879.04, lowResource: true },
+  "Llama-3.2-1B-Instruct-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 1128.82, lowResource: true },
+  "Llama-3.2-3B-Instruct-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2263.69, lowResource: true },
+  "Llama-3.2-3B-Instruct-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2951.51, lowResource: true },
+  "Ministral-3-3B-Base-2512-q4f16_1-MLC": { contextWindow: 262144, overrideContextWindowSize: 262144, prefillChunkSize: 1024, slidingWindow: false, lowResource: false },
+  "Ministral-3-3B-Instruct-2512-BF16-q4f16_1-MLC": { contextWindow: 262144, overrideContextWindowSize: 262144, prefillChunkSize: 1024, slidingWindow: false, lowResource: false },
+  "Ministral-3-3B-Reasoning-2512-q4f16_1-MLC": { contextWindow: 262144, overrideContextWindowSize: 262144, prefillChunkSize: 1024, slidingWindow: false, lowResource: false },
+  "Mistral-7B-Instruct-v0.2-q4f16_1-MLC": { contextWindow: 4096, prefillChunkSize: 4096, slidingWindow: true, vramRequiredMB: 4573.39, lowResource: false },
+  "Mistral-7B-Instruct-v0.3-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 4573.39, lowResource: false },
+  "Mistral-7B-Instruct-v0.3-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5619.27, lowResource: false },
+  "NeuralHermes-2.5-Mistral-7B-q4f16_1-MLC": { contextWindow: 4096, prefillChunkSize: 4096, slidingWindow: true, vramRequiredMB: 4573.39, lowResource: false },
+  "OpenHermes-2.5-Mistral-7B-q4f16_1-MLC": { contextWindow: 4096, prefillChunkSize: 4096, slidingWindow: true, vramRequiredMB: 4573.39, lowResource: false },
+  "Phi-3-mini-4k-instruct-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3672.07, lowResource: false },
+  "Phi-3-mini-4k-instruct-q4f16_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2520.07, lowResource: true },
+  "Phi-3-mini-4k-instruct-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5483.12, lowResource: false },
+  "Phi-3-mini-4k-instruct-q4f32_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3179.12, lowResource: true },
+  "Phi-3.5-mini-instruct-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3672.07, lowResource: false },
+  "Phi-3.5-mini-instruct-q4f16_1-MLC-1k": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2520.07, lowResource: true },
+  "Phi-3.5-mini-instruct-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5483.12, lowResource: false },
+  "Phi-3.5-mini-instruct-q4f32_1-MLC-1k": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3179.12, lowResource: true },
+  "Phi-3.5-vision-instruct-q4f16_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 3952.18, lowResource: true },
+  "Phi-3.5-vision-instruct-q4f32_1-MLC": { contextWindow: 131072, overrideContextWindowSize: 131072, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 5879.84, lowResource: true },
+  "Qwen2-0.5B-Instruct-q0f16-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1624.12, lowResource: true },
+  "Qwen2-0.5B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 944.62, lowResource: true },
+  "Qwen2-1.5B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1629.75, lowResource: true },
+  "Qwen2-1.5B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1888.97, lowResource: true },
+  "Qwen2-7B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5106.67, lowResource: false },
+  "Qwen2-7B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5900.09, lowResource: false },
+  "Qwen2-Math-1.5B-Instruct-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1629.75, lowResource: true },
+  "Qwen2-Math-1.5B-Instruct-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1888.97, lowResource: true },
+  "Qwen2-Math-7B-Instruct-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5106.67, lowResource: false },
+  "Qwen2-Math-7B-Instruct-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5900.09, lowResource: false },
+  "Qwen2.5-0.5B-Instruct-q0f16-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1624.12, lowResource: true },
+  "Qwen2.5-0.5B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 944.62, lowResource: true },
+  "Qwen2.5-0.5B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1060.2, lowResource: true },
+  "Qwen2.5-1.5B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1629.75, lowResource: true },
+  "Qwen2.5-1.5B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1888.97, lowResource: true },
+  "Qwen2.5-3B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2504.76, lowResource: true },
+  "Qwen2.5-3B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2893.64, lowResource: true },
+  "Qwen2.5-7B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5106.67, lowResource: false },
+  "Qwen2.5-7B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5900.09, lowResource: false },
+  "Qwen2.5-Coder-0.5B-Instruct-q0f16-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 1624.12, lowResource: true },
+  "Qwen2.5-Coder-0.5B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 944.62, lowResource: true },
+  "Qwen2.5-Coder-0.5B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 1060.2, lowResource: true },
+  "Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1629.75, lowResource: false },
+  "Qwen2.5-Coder-1.5B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1888.97, lowResource: false },
+  "Qwen2.5-Coder-3B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2504.76, lowResource: true },
+  "Qwen2.5-Coder-3B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2893.64, lowResource: true },
+  "Qwen2.5-Coder-7B-Instruct-q4f16_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5106.67, lowResource: false },
+  "Qwen2.5-Coder-7B-Instruct-q4f32_1-MLC": { contextWindow: 32768, overrideContextWindowSize: 32768, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5900.09, lowResource: false },
+  "Qwen2.5-Math-1.5B-Instruct-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 1629.75, lowResource: true },
+  "Qwen2.5-Math-1.5B-Instruct-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 1888.97, lowResource: true },
+  "Qwen3-0.6B-q0f16-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2220.38, lowResource: true },
+  "Qwen3-0.6B-q4f16_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1403.34, lowResource: true },
+  "Qwen3-0.6B-q4f32_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1924.98, lowResource: true },
+  "Qwen3-1.7B-q4f16_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2036.66, lowResource: true },
+  "Qwen3-1.7B-q4f32_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2635.44, lowResource: true },
+  "Qwen3-4B-q4f16_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3431.59, lowResource: true },
+  "Qwen3-4B-q4f32_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 4327.71, lowResource: true },
+  "Qwen3-8B-q4f16_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 5695.78, lowResource: false },
+  "Qwen3-8B-q4f32_1-MLC": { contextWindow: 40960, overrideContextWindowSize: 40960, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 6852.55, lowResource: false },
+  "RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2972.09, lowResource: false },
+  "RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2041.09, lowResource: true },
+  "RedPajama-INCITE-Chat-3B-v1-q4f32_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3928.09, lowResource: false },
+  "RedPajama-INCITE-Chat-3B-v1-q4f32_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2558.09, lowResource: true },
+  "SmolLM2-1.7B-Instruct-q4f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 1774.19, lowResource: true },
+  "SmolLM2-1.7B-Instruct-q4f32_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 2692.38, lowResource: true },
+  "SmolLM2-135M-Instruct-q0f16-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 359.69, lowResource: true },
+  "SmolLM2-135M-Instruct-q0f32-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 719.38, lowResource: true },
+  "SmolLM2-360M-Instruct-q0f16-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 871.99, lowResource: true },
+  "SmolLM2-360M-Instruct-q0f32-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 1743.99, lowResource: true },
+  "SmolLM2-360M-Instruct-q4f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 376.06, lowResource: true },
+  "SmolLM2-360M-Instruct-q4f32_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 8192, slidingWindow: false, vramRequiredMB: 579.61, lowResource: true },
+  "TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 697.24, lowResource: true },
+  "TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 675.24, lowResource: true },
+  "TinyLlama-1.1B-Chat-v0.4-q4f32_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 839.98, lowResource: true },
+  "TinyLlama-1.1B-Chat-v0.4-q4f32_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 795.98, lowResource: true },
+  "TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 697.24, lowResource: true },
+  "TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 675.24, lowResource: true },
+  "TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 839.98, lowResource: true },
+  "TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 795.98, lowResource: true },
+  "WizardMath-7B-V1.1-q4f16_1-MLC": { contextWindow: 4096, prefillChunkSize: 4096, slidingWindow: true, vramRequiredMB: 4573.39, lowResource: false },
+  "gemma-2-2b-it-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1895.3, lowResource: false },
+  "gemma-2-2b-it-q4f16_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1583.3, lowResource: true },
+  "gemma-2-2b-it-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2508.75, lowResource: false },
+  "gemma-2-2b-it-q4f32_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1884.75, lowResource: true },
+  "gemma-2-2b-jpn-it-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 1895.3, lowResource: true },
+  "gemma-2-2b-jpn-it-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 4096, slidingWindow: false, vramRequiredMB: 2508.75, lowResource: true },
+  "gemma-2-9b-it-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 6422.01, lowResource: false },
+  "gemma-2-9b-it-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 8383.33, lowResource: false },
+  "gemma-2b-it-q4f16_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 1024, slidingWindow: false, vramRequiredMB: 1476.52, lowResource: false },
+  "gemma-2b-it-q4f16_1-MLC-1k": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 1024, slidingWindow: false, vramRequiredMB: 1476.52, lowResource: true },
+  "gemma-2b-it-q4f32_1-MLC": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 1024, slidingWindow: false, vramRequiredMB: 1750.66, lowResource: false },
+  "gemma-2b-it-q4f32_1-MLC-1k": { contextWindow: 8192, overrideContextWindowSize: 8192, prefillChunkSize: 1024, slidingWindow: false, vramRequiredMB: 1750.66, lowResource: true },
+  "phi-1_5-q4f16_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1210.09, lowResource: true },
+  "phi-1_5-q4f16_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1210.09, lowResource: true },
+  "phi-1_5-q4f32_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1682.09, lowResource: true },
+  "phi-1_5-q4f32_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1682.09, lowResource: true },
+  "phi-2-q4f16_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 3053.97, lowResource: false },
+  "phi-2-q4f16_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2131.97, lowResource: true },
+  "phi-2-q4f32_1-MLC": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 4032.48, lowResource: false },
+  "phi-2-q4f32_1-MLC-1k": { contextWindow: 2048, overrideContextWindowSize: 2048, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2740.48, lowResource: true },
+  "snowflake-arctic-embed-m-q0f32-MLC-b32": { contextWindow: 512, overrideContextWindowSize: 512, prefillChunkSize: 512, slidingWindow: false, vramRequiredMB: 1407.51, lowResource: false },
+  "snowflake-arctic-embed-m-q0f32-MLC-b4": { contextWindow: 512, overrideContextWindowSize: 512, prefillChunkSize: 512, slidingWindow: false, vramRequiredMB: 539.4, lowResource: false },
+  "snowflake-arctic-embed-s-q0f32-MLC-b32": { contextWindow: 512, overrideContextWindowSize: 512, prefillChunkSize: 512, slidingWindow: false, vramRequiredMB: 1022.82, lowResource: false },
+  "snowflake-arctic-embed-s-q0f32-MLC-b4": { contextWindow: 512, overrideContextWindowSize: 512, prefillChunkSize: 512, slidingWindow: false, vramRequiredMB: 238.71, lowResource: false },
+  "stablelm-2-zephyr-1_6b-q4f16_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2087.66, lowResource: false },
+  "stablelm-2-zephyr-1_6b-q4f16_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1511.66, lowResource: true },
+  "stablelm-2-zephyr-1_6b-q4f32_1-MLC": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 2999.33, lowResource: false },
+  "stablelm-2-zephyr-1_6b-q4f32_1-MLC-1k": { contextWindow: 4096, overrideContextWindowSize: 4096, prefillChunkSize: 2048, slidingWindow: false, vramRequiredMB: 1847.33, lowResource: true },
+};

--- a/apps/extension/src/registry/providers/web-llm.ts
+++ b/apps/extension/src/registry/providers/web-llm.ts
@@ -1,4 +1,89 @@
-import type { ProviderDefinition } from "./types";
+import {
+  isOffscreenContext,
+  isServiceWorkerContext,
+} from "@/lib/runtime/context";
+import type { ModelDefinition, ProviderDefinition } from "./types";
+import { WEB_LLM_MODEL_CONTEXT } from "./web-llm-model-context";
+
+/**
+ * Models mlc compiles with native function-calling support — the source of
+ * truth for the `tools` capability (`functionCallingModelIds` in
+ * `@mlc-ai/web-llm`). We deliberately do NOT guess tool support for other
+ * models: `@browser-ai/web-llm` can prompt any model to emit JSON tool calls,
+ * but reliability is unverified, so only these carry `tools` (and thus qualify
+ * as the browser agent — see `agentModelGate`) until an empirical per-model
+ * tool probe says otherwise.
+ */
+const TOOLS_MODEL_IDS = new Set<string>([
+  "Hermes-2-Pro-Llama-3-8B-q4f16_1-MLC",
+  "Hermes-2-Pro-Llama-3-8B-q4f32_1-MLC",
+  "Hermes-2-Pro-Mistral-7B-q4f16_1-MLC",
+  "Hermes-3-Llama-3.1-8B-q4f32_1-MLC",
+  "Hermes-3-Llama-3.1-8B-q4f16_1-MLC",
+]);
+
+/**
+ * Human-readable name from an mlc model id, surfacing the quant variant so the
+ * (many) same-model quantizations remain distinguishable in the picker.
+ * "Llama-3.2-3B-Instruct-q4f16_1-MLC" -> "Llama 3.2 3B Instruct · q4f16".
+ */
+function deriveModelName(id: string): string {
+  let base = id.replace(/-MLC$/, "");
+  let quant = "";
+  const m = base.match(/-(q\d+f\d+(?:_\d+)?|q0f\d+)$/i);
+  if (m && m.index !== undefined) {
+    quant = m[1].toLowerCase().replace(/_\d+$/, "");
+    base = base.slice(0, m.index);
+  }
+  const label = base.replace(/-/g, " ").replace(/\s+/g, " ").trim();
+  return quant ? `${label} · ${quant}` : label;
+}
+
+function deriveCapabilities(id: string): ModelDefinition["capabilities"] {
+  const caps: ModelDefinition["capabilities"] = ["chat"];
+  if (TOOLS_MODEL_IDS.has(id)) caps.push("tools");
+  if (/vision/i.test(id)) caps.push("vision");
+  if (/deepseek-r1/i.test(id) || /qwq/i.test(id)) caps.push("thinking");
+  return caps;
+}
+
+/**
+ * Output-token budget. mlc's configs don't publish a generation cap, so this is
+ * derived rather than guessed per model: never more than a quarter of the
+ * context window (so a small-window model can't reserve its whole budget for
+ * output), capped at 4096 — enough for a full chat answer without starving the
+ * agent's usable context. Verified to leave every model's `agentModelGate`
+ * verdict unchanged versus the previous flat 1024.
+ */
+function deriveMaxOutputTokens(contextWindow: number): number {
+  return Math.min(4_096, Math.floor(contextWindow / 4));
+}
+
+/** Approximate download size from the model's VRAM requirement (weights). */
+function deriveDownloadSize(vramMB?: number): string | undefined {
+  if (!vramMB) return undefined;
+  return `${(vramMB / 1024).toFixed(1)} GB`;
+}
+
+/**
+ * Every prebuilt WebLLM model, generated from the source-derived context table
+ * (`web-llm-model-context.ts`) — the single source of truth for each model's
+ * real context window (no duplication with hand-maintained values). Ordered by
+ * display name.
+ */
+const models: ModelDefinition[] = Object.entries(WEB_LLM_MODEL_CONTEXT)
+  .map(([id, ctx]): ModelDefinition => {
+    const size = deriveDownloadSize(ctx.vramRequiredMB);
+    return {
+      id,
+      name: deriveModelName(id),
+      capabilities: deriveCapabilities(id),
+      contextWindow: ctx.contextWindow,
+      maxOutputTokens: deriveMaxOutputTokens(ctx.contextWindow),
+      ...(size ? { downloadSize: size } : {}),
+    };
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
 
 export const definition: ProviderDefinition = {
   id: "web-llm",
@@ -6,27 +91,34 @@ export const definition: ProviderDefinition = {
   icon: { light: "web-llm.svg" },
   description: "Run open-source models locally in your browser via WebGPU",
   setup: "web-llm",
-  models: [
-    { id: "Llama-3.2-3B-Instruct-q4f16_1-MLC", name: "Llama 3.2 3B", capabilities: ["chat"], contextWindow: 131_072, maxOutputTokens: 4_096, downloadSize: "2.0 GB" },
-    { id: "Llama-3.1-8B-Instruct-q4f16_1-MLC", name: "Llama 3.1 8B", capabilities: ["chat"], contextWindow: 131_072, maxOutputTokens: 4_096, downloadSize: "4.3 GB" },
-    { id: "gemma-2-9b-it-q4f16_1-MLC", name: "Gemma 2 9B", capabilities: ["chat"], contextWindow: 8_192, maxOutputTokens: 4_096, downloadSize: "5.5 GB" },
-    { id: "Hermes-3-Llama-3.1-8B-q4f16_1-MLC", name: "Hermes 3 8B", capabilities: ["chat", "tools"], contextWindow: 131_072, maxOutputTokens: 4_096, downloadSize: "4.3 GB" },
-    { id: "DeepSeek-R1-Distill-Llama-8B-q4f16_1-MLC", name: "DeepSeek R1 8B", capabilities: ["chat", "thinking"], contextWindow: 131_072, maxOutputTokens: 4_096, downloadSize: "4.3 GB" },
-    { id: "Phi-3.5-mini-instruct-q4f16_1-MLC", name: "Phi 3.5 Mini", capabilities: ["chat"], contextWindow: 131_072, maxOutputTokens: 4_096, downloadSize: "2.2 GB" },
-    { id: "Qwen2.5-7B-Instruct-q4f16_1-MLC", name: "Qwen 2.5 7B", capabilities: ["chat", "tools"], contextWindow: 131_072, maxOutputTokens: 4_096, downloadSize: "4.5 GB" },
-    { id: "SmolLM2-1.7B-Instruct-q4f16_1-MLC", name: "SmolLM2 1.7B", capabilities: ["chat"], contextWindow: 8_192, maxOutputTokens: 2_048, downloadSize: "1.0 GB" },
-  ],
-  createLanguageModel(_config, _modelId) {
-    // WebLLM inference runs in the offscreen document (`@browser-ai/web-llm`
-    // is loaded there by `entrypoints/offscreen/ai.ts`). Non-agent
-    // consumers (tab tidy, chat-title generation) route directly to
-    // offscreen via the existing `ai.ts` handlers and never call
-    // `createLanguageModel`. The agent loop — whether renderer-hosted
-    // (legacy) or SW-hosted (post-SW-host migration) — does not currently
-    // support local models because there is no offscreen→host streaming
-    // bridge yet; adding one is a future expansion, not a regression
-    // (this throw has always been the behaviour). See
-    // `.superpowers/plans/2026-06-25-sw-host-agent-runs.md` Task 5.
-    throw new Error("WebLLM models are created via web-llm runtime in offscreen document");
+  models,
+  async createLanguageModel(config, modelId) {
+    // WebLLM inference physically runs in the offscreen document
+    // (`@browser-ai/web-llm` against WebGPU). Where `createLanguageModel`
+    // resolves depends on which realm the caller lives in:
+    //
+    //   - Service worker (the agent-run host): return the bridge adapter,
+    //     which opens an `offscreen-lm:*` Port and streams tokens back from
+    //     offscreen. This is what makes local models work in the agent loop.
+    //   - Offscreen: build the real model directly (shared engine cache in
+    //     `ai.ts::getModelFromRegistry`). This is the path the bridge's
+    //     offscreen handler ultimately hits.
+    //   - Renderer: the agent loop is not hosted here, so there is no local
+    //     path to construct; callers must go through the SW.
+    if (isServiceWorkerContext()) {
+      const { createLocalModelSwAdapter } = await import(
+        "./__bridge__/local-model-sw-adapter"
+      );
+      return createLocalModelSwAdapter("web-llm", config, modelId);
+    }
+    if (isOffscreenContext()) {
+      const { getModelFromRegistry } = await import(
+        "@/entrypoints/offscreen/ai"
+      );
+      return await getModelFromRegistry("web-llm", config, modelId);
+    }
+    throw new Error(
+      "WebLLM inference runs in the offscreen document; the renderer does not host local-model inference. Reach it via the service-worker agent host.",
+    );
   },
 };


### PR DESCRIPTION
### Summary

Local WebLLM models can now drive the browser agent — previously impossible, since the agent loop runs in the service worker while WebGPU only exists in the offscreen document. Models without tool calling are also usable as plain chat models instead of being downloadable but unselectable.

### Changes

- **Bridge (SW ↔ offscreen).** Port protocol letting the service worker drive a `LanguageModelV3` that physically lives in the offscreen document. `createLanguageModel` dispatches on runtime context.
- **Source-derived catalog.** All 139 models generated from a snapshot of each model's `mlc-chat-config.json` (real context window, VRAM, prefill chunk size) instead of hand-maintained values. Each model's KV-cache ceiling is raised to its real window via `engineConfig.appConfig.model_list[].overrides`; the 5 sliding-window models are excluded. `maxOutputTokens` is derived rather than a flat 1024. Catalog UI is grouped by family with quant variants collapsed.
- **Agent gate + chat-only path.** `agentModelGate` requires tool calling plus a window that fits one turn, and is wired into the agent-only pickers. `composerModelGate` lets the composer select a chat-only model, which runs a lean transport: no tools, no page snapshot, no completion check, short system prompt.
- **Corrupted-output notice (WebLLM only).** Some builds load fine but emit token salad on specific GPUs/drivers — a known quantization + WebGPU issue. A pure detector scores replies the model *already* produced (no probing, no extra loads) and the composer shows a dismissible notice naming the cause and fix.
- **Fixes.** FIFO engine lock (fixes the UI freeze from double-loading weights on send); load-progress indicator for cold loads; serialized/de-duplicated downloads; non-text-output models excluded from the models.dev import; chat-title generation now resolves compound `provider:model` ids (it silently skipped before).

Full detail in `.changeset/feat-webllm-local-models.md`.

### Testing

- **+71 tests** covering the bridge adapter and offscreen handler (incl. mid-stream abort), the engine lock (FIFO order, rejection propagation, no wedge after failure), the gates, catalog helpers, and the coherence detector — scored against real captured q4f16 garbage plus healthy English/Japanese/Russian/Hindi, code, and URL/hash-heavy replies to pin down false positives.
- `pnpm compile` clean · **2686 tests pass** · `wxt build` OK.
- Manually exercised on an Apple Metal GPU during development: model selection, chat-only turns, download flow, and the garbled-output case. Worth one more `pnpm dev` pass on the rebased state.

### Screenshots / recordings

UI surfaces touched: settings model catalog, chat-only composer, corrupted-output notice. Not attached — worth adding before merge.

### Checklist

- [ ] Tested locally with `pnpm dev` <!-- exercised during development; not re-run on the rebased state -->
- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Ran `pnpm changeset` if this PR changes user-facing behavior
- [x] No unrelated changes
