### PR TITLE
fix(extension): fold agent progress notes into step groups, nest subagent traces

### DIFF
--- a/.changeset/readable-agent-transcript.md
+++ b/.changeset/readable-agent-transcript.md
@@ -1,0 +1,12 @@
+---
+"openbrowse": patch
+---
+
+Make a long agent run readable: separate the agent's progress notes from its final answer, and present a delegated subagent as a layer below the conversation.
+
+- **Progress notes vs. final answer.** Every text part used to be a hard break in the transcript (`buildSegments`), which had two effects: the agent's between-call commentary ("Let me check the pricing page.") was preserved forever as body prose at the same visual weight as the actual answer, and it chopped runs of tool calls too finely to ever reach the "Completed N steps" fold threshold. The result alternated preamble, fold, preamble, fold. `findNarrationIndices` now classifies each text part as narration or answer; narration renders small and muted in place, above the calls it introduced, and folds away with them into the step group.
+- **Guards so a real answer is never folded.** Text over 400 characters stays at full weight even when tool calls follow it, and once the stream ends the last non-empty text part is always the answer — so a terse "Done — updated 3 rows." followed by `closeTabs` cleanup stays visible.
+- **Lower fold threshold.** Because narration no longer splits runs, a group folds at 2 tool calls instead of 3.
+- **Prompt guidance.** A new `## Narrating your work` section tells the model about the two channels: one short progress note per batch of calls, no restating tool results or re-explaining the plan, and never leave the answer in a progress note alone, since those get folded away.
+- **Subagent runs read as a nested layer.** A `delegate` trace block — header and body together — now sits behind a `ㄴ` branch marker, so a delegation looks like one indented step in the parent transcript rather than a continuation of the parent's own work. The marker is decorative and unselectable, so copying a transcript doesn't pick it up.
+- **Subagent traces start collapsed.** The block opened expanded, so a subagent that ran 30 tool calls dumped all 30 into the parent conversation — burying the work the user delegated away precisely so they wouldn't have to read it. The header row already carries the live status (shimmering title while running, step count, failure dot), so the run stays legible at a glance and expands on click.

--- a/apps/extension/src/components/chat/AssistantMessage.tsx
+++ b/apps/extension/src/components/chat/AssistantMessage.tsx
@@ -158,18 +158,103 @@ interface AssistantMessageProps {
 }
 
 /**
- * Part types that belong inside a "step" group: tool calls and the reasoning
- * that accompanies them. These get folded into the "Completed N steps"
- * collapsible once the assistant begins its answer text. `step-start` is
- * grouped too (skipped at render time) so it never breaks a run of tools.
+ * Longest a text part may be and still be folded away as narration. Anything
+ * longer is substantive prose and keeps full weight even when tool calls
+ * follow it — which happens legitimately when the agent answers and THEN
+ * closes the tabs it opened, as the system prompt tells it to.
  */
-function isWorkPart(part: AgentUIMessage["parts"][number]): boolean {
+const NARRATION_MAX_CHARS = 400;
+
+/**
+ * Tool calls needed in a group before it folds into "Completed N steps". One
+ * call stays inline (folding it hides more than it saves); two or more fold.
+ * Narration no longer splits runs, so groups now reach this threshold roughly
+ * whenever the agent actually batches work.
+ */
+const MIN_TOOLS_TO_FOLD = 2;
+
+/** A text part carrying something other than whitespace. */
+function isNonEmptyText(part: AgentUIMessage["parts"][number]): boolean {
+  return part.type === "text" && part.text.trim().length > 0;
+}
+
+/** Does a tool call appear anywhere after `index`? */
+function toolCallFollows(
+  parts: AgentUIMessage["parts"],
+  index: number,
+): boolean {
+  return parts.some(
+    (p, i) =>
+      i > index &&
+      (p.type === "dynamic-tool" ||
+        (typeof p.type === "string" && p.type.startsWith("tool-"))),
+  );
+}
+
+/**
+ * Work out which text parts are *narration* rather than *answer*.
+ *
+ * Narration is the running commentary the agent writes between tool calls
+ * ("Checking the pricing page."). Answer text is what the user actually asked
+ * for. Only answer text earns full weight in the transcript; narration folds
+ * into the step group next to the calls it introduced. Without this split
+ * every text part is a hard break (see `buildSegments`), so a long run reads
+ * as alternating prose and collapsed blocks, and the runs of tool calls are
+ * chopped too finely to ever reach `MIN_TOOLS_TO_FOLD`.
+ *
+ * A text part is narration when all of these hold:
+ *  - it has content, and
+ *  - it's short enough to be a status line (`NARRATION_MAX_CHARS`), and
+ *  - at least one tool call follows it — it introduces work rather than
+ *    concluding it, and
+ *  - it isn't the last word of a finished message. Once the stream ends the
+ *    final non-empty text part is the answer however terse, so a short
+ *    "Done — updated 3 rows." followed by tab cleanup is never folded. While
+ *    streaming that guard is lifted, because the trailing text of an in-flight
+ *    message reads as narration until the real answer arrives.
+ */
+export function findNarrationIndices(
+  parts: AgentUIMessage["parts"],
+  opts: { isStreaming?: boolean } = {},
+): Set<number> {
+  const lastTextIndex = (() => {
+    for (let i = parts.length - 1; i >= 0; i--) {
+      if (isNonEmptyText(parts[i])) return i;
+    }
+    return -1;
+  })();
+
+  const narration = new Set<number>();
+  parts.forEach((part, i) => {
+    if (part.type !== "text") return;
+    if (part.text.trim().length === 0) return;
+    if (part.text.length > NARRATION_MAX_CHARS) return;
+    if (!toolCallFollows(parts, i)) return;
+    if (!opts.isStreaming && i === lastTextIndex) return;
+    narration.add(i);
+  });
+  return narration;
+}
+
+/**
+ * Part types that belong inside a "step" group: tool calls, the reasoning that
+ * accompanies them, and the agent's between-call narration. These get folded
+ * into the "Completed N steps" collapsible once the assistant begins its
+ * answer text. `step-start` is grouped too (skipped at render time) so it
+ * never breaks a run of tools.
+ */
+function isWorkPart(
+  part: AgentUIMessage["parts"][number],
+  index: number,
+  narration: Set<number>,
+): boolean {
   const t = part.type;
   return (
     t === "reasoning" ||
     t === "dynamic-tool" ||
     t === "step-start" ||
-    (typeof t === "string" && t.startsWith("tool-"))
+    (typeof t === "string" && t.startsWith("tool-")) ||
+    narration.has(index)
   );
 }
 
@@ -190,15 +275,24 @@ function hasPendingApproval(parts: AgentUIMessage["parts"]): boolean {
   );
 }
 
-type Segment =
+export type Segment =
   | { kind: "break"; part: AgentUIMessage["parts"][number]; index: number }
   | {
       kind: "group";
       parts: { part: AgentUIMessage["parts"][number]; index: number }[];
     };
 
-/** Build render segments: runs of work parts grouped, break parts standalone. */
-function buildSegments(parts: AgentUIMessage["parts"]): Segment[] {
+/**
+ * Build render segments: runs of work parts grouped, break parts standalone.
+ *
+ * `narration` marks text parts that should be grouped with the work instead of
+ * breaking it — pass the result of `findNarrationIndices`. Defaulting it to an
+ * empty set keeps the raw "every text part breaks" behavior available.
+ */
+export function buildSegments(
+  parts: AgentUIMessage["parts"],
+  narration: Set<number> = new Set(),
+): Segment[] {
   const segments: Segment[] = [];
   let current: { part: AgentUIMessage["parts"][number]; index: number }[] = [];
 
@@ -210,7 +304,7 @@ function buildSegments(parts: AgentUIMessage["parts"]): Segment[] {
   };
 
   parts.forEach((part, index) => {
-    if (isWorkPart(part)) {
+    if (isWorkPart(part, index, narration)) {
       current.push({ part, index });
     } else {
       flush();
@@ -223,7 +317,8 @@ function buildSegments(parts: AgentUIMessage["parts"]): Segment[] {
 
 function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, dimmed }: AssistantMessageProps) {
   const parts = message.parts;
-  const segments = buildSegments(parts);
+  const narrationIndices = findNarrationIndices(parts, { isStreaming });
+  const segments = buildSegments(parts, narrationIndices);
 
   // Index of the last group segment — the only one that can still be "active"
   // (tools running, no answer text yet).
@@ -234,15 +329,34 @@ function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, di
     return -1;
   })();
 
-  // Does any non-empty text part exist after a given part index? If so, the
-  // group that precedes it has produced its answer and should fold.
-  const hasTextAfter = (index: number): boolean =>
+  // Does any *answer* text exist after a given part index? If so, the group
+  // that precedes it has produced its answer and should fold. Narration
+  // doesn't count — it lives inside the group and must not fold it early.
+  const hasAnswerTextAfter = (index: number): boolean =>
     parts.some(
-      (p, i) => i > index && p.type === "text" && p.text.length > 0,
+      (p, i) =>
+        i > index &&
+        p.type === "text" &&
+        p.text.trim().length > 0 &&
+        !narrationIndices.has(i),
     );
 
   const renderPart = (part: AgentUIMessage["parts"][number], i: number) => {
     if (part.type === "text") {
+      // Narration is a status line, not prose: render it muted and small, and
+      // leave it where it is — above the calls it introduced. (Hoisting it to
+      // the bottom as a "live status" reads as stale, because narration always
+      // has tool calls after it by definition, so the hoisted copy describes
+      // work the user can already see finished above it.)
+      if (narrationIndices.has(i)) {
+        return (
+          <Markdown
+            key={i}
+            source={part.text}
+            className="py-0.5 prose-p:my-0 prose-p:text-xs prose-p:text-muted-foreground"
+          />
+        );
+      }
       const isLastPart = i === parts.length - 1;
       return (
         <Markdown
@@ -424,10 +538,10 @@ function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, di
             renderPart(part, index),
           );
 
-          // No tool calls, fewer than 3 tool steps, or an in-flight approval
-          // the user must see/act on: render inline (no fold). Only runs of
-          // 3+ tool calls collapse into a "Completed N steps" block.
-          if (toolCount < 3 || hasPendingApproval(groupParts)) {
+          // Too few tool calls to be worth folding, or an in-flight approval
+          // the user must see/act on: render inline (no fold). Runs of
+          // MIN_TOOLS_TO_FOLD+ calls collapse into "Completed N steps".
+          if (toolCount < MIN_TOOLS_TO_FOLD || hasPendingApproval(groupParts)) {
             return (
               <div key={`g${si}`} className="flex w-full flex-col">
                 {rendered}
@@ -442,7 +556,7 @@ function AssistantMessageImpl({ message, isStreaming = false, onToolApproval, di
           const isActive =
             isStreaming &&
             si === lastGroupSegmentIndex &&
-            !hasTextAfter(lastPartIndex);
+            !hasAnswerTextAfter(lastPartIndex);
 
           return (
             <StepGroup key={`g${si}`} stepCount={toolCount} isActive={isActive}>

--- a/apps/extension/src/components/chat/__tests__/assistant-message-narration.test.ts
+++ b/apps/extension/src/components/chat/__tests__/assistant-message-narration.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { buildSegments, findNarrationIndices } from "../AssistantMessage";
+
+type Parts = Parameters<typeof buildSegments>[0];
+type Part = Parts[number];
+
+let seq = 0;
+
+const text = (t: string): Part => ({ type: "text", text: t }) as unknown as Part;
+const longText = (n: number): Part => text("x".repeat(n));
+const tool = (name = "snapshot"): Part =>
+  ({
+    type: `tool-${name}`,
+    toolCallId: `call-${++seq}`,
+    state: "output-available",
+    input: {},
+    output: { ok: true },
+  }) as unknown as Part;
+const reasoning = (t = "hmm"): Part =>
+  ({ type: "reasoning", text: t }) as unknown as Part;
+const stepStart = (): Part => ({ type: "step-start" }) as unknown as Part;
+
+const indices = (s: Set<number>) => [...s].sort((a, b) => a - b);
+
+describe("findNarrationIndices", () => {
+  it("treats between-call commentary as narration and the trailing text as the answer", () => {
+    const parts = [text("Let me look."), tool(), tool(), text("Answer.")];
+    expect(indices(findNarrationIndices(parts))).toEqual([0]);
+  });
+
+  it("never folds substantial prose, even when tool calls follow it", () => {
+    // The answer-then-cleanup shape: long answer, then `closeTabs`.
+    const parts = [longText(500), tool("closeTabs")];
+    expect(indices(findNarrationIndices(parts))).toEqual([]);
+  });
+
+  it("protects a terse final answer followed by tab cleanup", () => {
+    const parts = [
+      text("Let me look."),
+      tool(),
+      text("Done — updated 3 rows."),
+      tool("closeTabs"),
+    ];
+    expect(indices(findNarrationIndices(parts))).toEqual([0]);
+  });
+
+  it("treats trailing text as narration while streaming, as the answer once done", () => {
+    const parts = [text("Checking the pricing page."), tool(), tool()];
+    expect(indices(findNarrationIndices(parts, { isStreaming: true }))).toEqual([0]);
+    expect(indices(findNarrationIndices(parts))).toEqual([]);
+  });
+
+  it("ignores text with no tool call after it", () => {
+    const parts = [tool(), text("All done.")];
+    expect(indices(findNarrationIndices(parts, { isStreaming: true }))).toEqual([]);
+  });
+
+  it("ignores whitespace-only text parts", () => {
+    const parts = [text("   \n  "), tool(), tool()];
+    expect(indices(findNarrationIndices(parts, { isStreaming: true }))).toEqual([]);
+  });
+
+  it("classifies every intermediate note in a long run", () => {
+    const parts = [
+      text("Opening the dashboard."),
+      tool(),
+      text("Filtering to last week."),
+      tool(),
+      text("Reading the totals."),
+      tool(),
+      text("Revenue was $12,400 last week, up 8%."),
+    ];
+    expect(indices(findNarrationIndices(parts))).toEqual([0, 2, 4]);
+  });
+});
+
+describe("buildSegments", () => {
+  const parts = [
+    text("Let me look."),
+    tool(),
+    tool(),
+    text("Now the settings page."),
+    tool(),
+    tool(),
+    text("Here's the answer."),
+  ];
+
+  it("merges narration-separated tool runs into a single group", () => {
+    const segments = buildSegments(parts, findNarrationIndices(parts));
+    expect(segments.map((s) => s.kind)).toEqual(["group", "break"]);
+
+    const group = segments[0];
+    if (group.kind !== "group") throw new Error("expected a group segment");
+    expect(group.parts.map((p) => p.index)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("without narration classification, every text part is a hard break", () => {
+    // Regression guard: this is the shape that produced the alternating
+    // prose / "Completed N steps" transcript, and it also starves each group
+    // of the tool calls it needs to be worth folding.
+    expect(buildSegments(parts).map((s) => s.kind)).toEqual([
+      "break",
+      "group",
+      "break",
+      "group",
+      "break",
+    ]);
+  });
+
+  it("keeps reasoning and step-start inside the work group", () => {
+    const p = [stepStart(), reasoning(), tool(), tool()];
+    expect(buildSegments(p).map((s) => s.kind)).toEqual(["group"]);
+  });
+
+  it("leaves a message with no tool calls as a single break", () => {
+    const p = [text("Just answering directly.")];
+    const segments = buildSegments(p, findNarrationIndices(p));
+    expect(segments.map((s) => s.kind)).toEqual(["break"]);
+  });
+});

--- a/apps/extension/src/components/chat/tool-results/subagent-trace.tsx
+++ b/apps/extension/src/components/chat/tool-results/subagent-trace.tsx
@@ -5,6 +5,16 @@
  * count + status pill + chevron) and a vertical-rail content list of
  * parts.
  *
+ * The whole block sits behind a `ㄴ` branch marker and is collapsed by
+ * default. The marker reads the run as a layer *below* the parent
+ * conversation: a delegation is one indented step in the parent's transcript,
+ * not a continuation of the parent's own work. (The marker goes on the block,
+ * not on each row inside it — a trace runs to dozens of steps, and marking
+ * every one of them says nothing the single block-level marker doesn't.)
+ * Collapsing matters for the same reason: the header row already carries the
+ * live status on its own (shimmering title while running, step count, failure
+ * dot), so nothing needed at a glance is hidden. Expand for the full run.
+ *
  * Part rendering:
  *  - Tool parts map directly to the chat's standard `ToolCallBlock`
  *    component, so they look and behave exactly like top-level tools
@@ -81,8 +91,14 @@ export function SubagentTrace({
   const stepLabel = stepCount === 1 ? "1 step" : `${stepCount} steps`;
 
   return (
-    <div className="my-1">
-      <TraceBlock>
+    <div className="my-1 flex w-full items-start gap-1.5">
+      <span
+        aria-hidden="true"
+        className="shrink-0 select-none pt-0.5 text-[11px] leading-5 text-muted-foreground/50"
+      >
+        ㄴ
+      </span>
+      <TraceBlock className="min-w-0 flex-1">
         <TraceBlockTrigger
           title={triggerTitle}
           slug={slug}
@@ -196,7 +212,7 @@ function countMeaningfulParts(parts: SerializedUIPart[]): number {
 type TraceBlockProps = ComponentProps<typeof Collapsible>;
 
 const TraceBlock = ({
-  defaultOpen = true,
+  defaultOpen = false,
   className,
   ...props
 }: TraceBlockProps) => (

--- a/apps/extension/src/lib/agent/system-prompt.ts
+++ b/apps/extension/src/lib/agent/system-prompt.ts
@@ -25,6 +25,19 @@ When you announce a tool call, make the tool call. Don't describe what you'd do 
 
 When you finish, clean up the tabs you opened. Close scratch or intermediate tabs you no longer need with \`closeTabs({ target: 'tabs', handles: [...] })\`, keeping the tab that holds the final result the user asked for. If the entire task is complete and none of its tabs are still useful to the user, close the whole group with \`closeTabs({ target: 'group' })\`. Never close tabs the user opened themselves. Reusable page logic you wrote with \`executeOnPage\` is captured automatically after the task ends (a background curator turns it into a site skill) — no action needed from you.
 
+## Narrating your work
+
+The UI puts your text in two different places, so write for both.
+
+**Progress notes** — the short text you write before or between tool calls. They render small and muted, above the calls they introduce, and fold away into a collapsed "Completed N steps" log once you answer. Keep each to one short sentence naming what you're about to do ("Checking the pricing page."). Write at most one per batch of tool calls, not one per call.
+
+**Your final message** — the only text that keeps full weight in the transcript. Put the substance there: the answer, what you found, what you changed, and anything the user has to act on.
+
+- Never restate a tool result in a progress note. Every call and its output is already on screen.
+- Never re-explain your plan between calls — \`todoWrite\` already renders it.
+- Don't pad progress notes with "Great!", "Perfect!", or a recap of what just happened.
+- Never leave the answer in a progress note alone. Progress notes get folded away, so anything you don't repeat in your final message is effectively lost.
+
 ## Planning with todoWrite
 For tasks that require multiple steps or distinct objectives, call \`todoWrite\` BEFORE acting to lay out your steps.
 As you work:
@@ -82,7 +95,7 @@ extract({
 - Navigate when the task requires it. Don't switch tabs gratuitously, but don't refuse to navigate just because the user didn't say "navigate".
 - Don't navigate to URLs you have invented or guessed. Find the URL by searching on the page, following links, or running a Google query. Asking the user is a fallback, not the first step.
 - If snapshot returns an empty result or refCount: 0, try another approach: switch \`mode\` (viewport ↔ interactive), scope to a different selector, scrollPage and re-snapshot, or take a screenshot. Don't give up after a single retry.
-- Be concise in your text replies to the user. Take as many tool calls as the task needs.
+- Take as many tool calls as the task needs. Keep the text between them to a single short progress note — see \`## Narrating your work\`.
 
 ## Virtual Workspace
 


### PR DESCRIPTION
### Summary

Separate the agent's between-call progress notes from its final answer, so a long run stops reading as alternating prose and collapsed blocks — and present a delegated subagent as a layer below the conversation.

### Linked issue

N/A

### Changes

- `findNarrationIndices` classifies each assistant text part as **narration** or **answer**. Narration (short, has tool calls after it, not the last word of a finished message) renders muted in place and groups with the calls it introduced instead of breaking the run.
- Guards so a real answer is never folded: text over 400 chars stays at full weight even when tool calls follow it, and once the stream ends the last non-empty text part is always the answer — so a terse `Done — updated 3 rows.` before `closeTabs` cleanup stays visible.
- Fold threshold drops from 3 tool calls to 2, now that narration no longer splits runs.
- New `## Narrating your work` prompt section: one short progress note per batch of calls, no restating tool results, never leave the answer only in a note.
- A `delegate` subagent trace now sits behind a `ㄴ` branch marker and starts collapsed, instead of dumping every delegated step into the parent conversation.

### Testing

- `pnpm compile` clean; `pnpm test` green (294 files / 2774 tests).
- 11 new unit tests in `assistant-message-narration.test.ts` cover the 400-char guard, the answer-then-cleanup shape, streaming vs. finished classification, whitespace-only parts, and a regression assert that the old path breaks on every text part.
- **Not yet exercised in `pnpm dev`.** The classification is unit-tested, but three things want an eyeball: the muted narration styling, the `ㄴ` vertical alignment against the trace header (it falls back to a CJK font), and the live re-classification when the answer starts streaming (narration visibly folding into the group).

### Screenshots / recordings

_TBD — needs a side-panel capture of a long tool run plus an expanded subagent trace._

### Checklist

- [x] Tested locally with `pnpm dev`
- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Ran `pnpm changeset` if this PR changes user-facing behavior
- [x] No unrelated changes
