### PR TITLE
fix(extension): give batched tool calls their own row labels

### DIFF
--- a/.changeset/fix-batch-child-tool-labels.md
+++ b/.changeset/fix-batch-child-tool-labels.md
@@ -1,0 +1,14 @@
+---
+"openbrowse": patch
+---
+
+**Batched tool calls now read like direct ones.** Expanding a `batch` row showed each invocation as its raw tool name plus a generic `key: value` argument dump — `webSearch  query: Kindle API read book content third party app…` — while the same call made on its own read `Searched “Kindle API read book content…” — 8 results`. Four batched searches gave no indication of whether any of them returned anything.
+
+The cause was that label resolution wasn't reusable: it lived as an inline ternary chain inside the `ToolCallBlock` component body, so `tool-results/batch.tsx` had no way to ask what a tool's row would say and fell back to summarizing arguments. It's now an exported `resolveToolLabels(toolName, args, result)`, injected into `BatchResult` the same way `renderChild` already is — the label table lives in `ToolCallBlock`, and importing it from `tool-results/batch` would form a cycle.
+
+- Child rows use the tool's own label, so a batched `webSearch` carries its query **and result count**, a batched `Grep` reads "Searched" rather than `Grep`, and a failed search reads "Search failed: …" instead of looking indistinguishable from a successful one.
+- Rows for a batch whose input is still streaming use the same labels in their `pending` form.
+- Tools with no specific label keep the existing argument summary rather than degrading to the bare tool name: `resolveToolLabels` returns `undefined` in that case and each caller picks its own fallback.
+- No behaviour change for top-level rows. The denied paths still read `deniedReplace`/`denied` from the tool's static entry, which the per-tool helpers don't customize.
+
++9 tests on the extracted resolver, covering the reported `webSearch` case, static-only tools, result-derived labels, the `undefined` signal, and malformed arguments.

--- a/apps/extension/src/components/chat/ToolCallBlock.tsx
+++ b/apps/extension/src/components/chat/ToolCallBlock.tsx
@@ -79,6 +79,9 @@ const BUILTIN_RESULT_RENDERERS: Record<string, ResultRenderer> = {
           state: "result",
         })
       }
+      // Reuse each child tool's own row label too, so an invocation reads
+      // the same as the call would on its own.
+      childLabel={resolveToolLabels}
     />
   ),
   snapshot: ({ result }) => <SnapshotResult result={result} />,
@@ -167,7 +170,7 @@ interface ToolCallBlockProps {
   errorKind?: "failed" | "interrupted";
 }
 
-type ToolLabels = {
+export type ToolLabels = {
   pending: string;
   done: string;
   /**
@@ -705,6 +708,61 @@ export function batchLabels(
   };
 }
 
+/**
+ * The label a tool's collapsed row shows: the tool's static entry (or its
+ * MCP connector's) refined by any tool-specific dynamic label function.
+ *
+ * Returns `undefined` when nothing tool-specific applies, so each caller
+ * chooses its own fallback — `ToolCallBlock` shows a generic
+ * "Running <name>...", while a batch child row keeps its argument summary
+ * instead of degrading to the bare tool name. Every tool with a dynamic
+ * label function also has a `TOOL_LABELS` entry, so a missing entry is a
+ * sufficient signal that there is nothing specific to say.
+ *
+ * Exported, and injected into `BatchResult`, so an invocation inside a
+ * `batch` reads the same as the same call made directly — `Searched “bio
+ * AI startups” — 8 results` rather than `webSearch  query: bio AI
+ * startups`. Injected rather than imported for the same reason as
+ * `renderChild`: importing this module from `tool-results/batch` would
+ * form a cycle.
+ */
+export function resolveToolLabels(
+  toolName: string,
+  args: Record<string, unknown>,
+  result: unknown,
+): ToolLabels | undefined {
+  const { mcpInfo } = resolveMcpToolDisplay(toolName);
+  const base =
+    TOOL_LABELS[toolName] ??
+    mcpInfo?.connector.formatLabel?.(mcpInfo.toolName, result) ??
+    null;
+  if (!base) return undefined;
+
+  return toolName === "batch"
+    ? batchLabels(args, result, base)
+    : toolName === "webSearch"
+      ? webSearchLabels(args, result, base)
+      : toolName === "webFetch"
+        ? webFetchLabels(args, base)
+        : toolName === "computer"
+          ? computerLabels(args, base)
+          : toolName === "closeTabs"
+            ? closeTabsLabels(args, base)
+            : toolName === "create_scheduled_task" ||
+                toolName === "update_scheduled_task"
+              ? scheduledTaskLabels(toolName, args, base)
+              : toolName === "Delete"
+                ? deleteLabels(args, base)
+                : toolName === "executeOnPage"
+                  ? executeOnPageLabels(args, base)
+                  : toolName === "patch_site_skill" ||
+                      toolName === "delete_site_skill"
+                    ? siteSkillLabels(args, base)
+                    : toolName === "read_artifact_diagnostics"
+                      ? artifactDiagnosticsLabels(result, base)
+                      : base;
+}
+
 export function ToolCallBlock({
   toolName,
   toolCallId,
@@ -721,42 +779,21 @@ export function ToolCallBlock({
   const resolvedResult = result ?? toolResultStore.get(toolCallId);
   const { mcpInfo, readableName, readableNameSentence } =
     resolveMcpToolDisplay(toolName);
-  const connectorLabels =
-    mcpInfo?.connector.formatLabel?.(mcpInfo.toolName, resolvedResult) ?? null;
+  // The tool's static entry. Kept separate from `dynamicLabels` because
+  // the denied paths below read `deniedReplace`/`denied` off it — the
+  // per-tool helpers only re-shape pending/done.
   const labels: ToolLabels =
     TOOL_LABELS[toolName] ??
-    connectorLabels ?? {
+    mcpInfo?.connector.formatLabel?.(mcpInfo.toolName, resolvedResult) ?? {
       pending: readableName ? `Running ${readableName}...` : `${toolName}...`,
       done: readableNameSentence ? readableNameSentence : toolName,
     };
-
-  // For webFetch, splice in the requested URL's host so the collapsed
-  // row shows the user something concrete (e.g. "Fetching openbrowse.ai...")
-  // rather than a generic "Fetching URL...".
+  // Tool-specific text where we have it — e.g. webFetch splices in the
+  // requested URL's host so the row reads "Fetching openbrowse.ai..."
+  // rather than a generic "Fetching URL...". Falls back to the static
+  // entry, which is what `resolveToolLabels` returning `undefined` means.
   const dynamicLabels: ToolLabels =
-    toolName === "batch"
-      ? batchLabels(args, resolvedResult, labels)
-      : toolName === "webSearch"
-        ? webSearchLabels(args, resolvedResult, labels)
-        : toolName === "webFetch"
-          ? webFetchLabels(args, labels)
-          : toolName === "computer"
-            ? computerLabels(args, labels)
-            : toolName === "closeTabs"
-              ? closeTabsLabels(args, labels)
-              : toolName === "create_scheduled_task" ||
-                  toolName === "update_scheduled_task"
-                ? scheduledTaskLabels(toolName, args, labels)
-                : toolName === "Delete"
-                  ? deleteLabels(args, labels)
-                  : toolName === "executeOnPage"
-                    ? executeOnPageLabels(args, labels)
-                    : toolName === "patch_site_skill" ||
-                        toolName === "delete_site_skill"
-                      ? siteSkillLabels(args, labels)
-                      : toolName === "read_artifact_diagnostics"
-                        ? artifactDiagnosticsLabels(resolvedResult, labels)
-                        : labels;
+    resolveToolLabels(toolName, args, resolvedResult) ?? labels;
 
   const showTabBadge = TAB_TOOLS.has(toolName);
 

--- a/apps/extension/src/components/chat/__tests__/resolve-tool-labels.test.ts
+++ b/apps/extension/src/components/chat/__tests__/resolve-tool-labels.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { resolveToolLabels } from "../ToolCallBlock";
+
+/**
+ * `resolveToolLabels` is the seam that lets a batched invocation reuse the
+ * label its tool would show on its own row. Before it existed, batch child
+ * rows fell back to a generic `key: value` argument dump, so a batched
+ * `webSearch` read `webSearch  query: bio AI startups` while the same call
+ * on its own read `Searched “bio AI startups” — 8 results`.
+ */
+describe("resolveToolLabels", () => {
+  it("gives a batched webSearch the same label as a direct call", () => {
+    const labels = resolveToolLabels(
+      "webSearch",
+      { query: "bio AI startups" },
+      { results: [{}, {}, {}] },
+    );
+
+    expect(labels?.done).toBe("Searched “bio AI startups” — 3 results");
+    expect(labels?.pending).toBe("Searching “bio AI startups”...");
+  });
+
+  it("surfaces a failed search rather than reporting it as done", () => {
+    const labels = resolveToolLabels(
+      "webSearch",
+      { query: "bio AI startups" },
+      { results: [], error: "upstream refused" },
+    );
+
+    expect(labels?.done).toBe("Search failed: “bio AI startups”");
+  });
+
+  it("reports the result count in the singular", () => {
+    const labels = resolveToolLabels("webSearch", { query: "q" }, { results: [{}] });
+    expect(labels?.done).toBe("Searched “q” — 1 result");
+  });
+
+  it("falls back to the static entry for a tool with no dynamic label", () => {
+    // A batched Grep should read "Searched", not the bare tool name.
+    expect(resolveToolLabels("Grep", { pattern: "x" }, undefined)).toEqual({
+      pending: "Searching...",
+      done: "Searched",
+    });
+  });
+
+  it("splices the host into a webFetch label", () => {
+    const labels = resolveToolLabels(
+      "webFetch",
+      { url: "https://openbrowse.ai/docs/tools" },
+      undefined,
+    );
+
+    expect(labels?.done).toContain("openbrowse.ai");
+  });
+
+  it("reads read_artifact_diagnostics from the result, not the arguments", () => {
+    const clean = resolveToolLabels(
+      "read_artifact_diagnostics",
+      {},
+      { rendered: true, errors: [] },
+    );
+    expect(clean?.done).toBeTruthy();
+    expect(clean?.done).not.toBe("read_artifact_diagnostics");
+  });
+
+  it("returns undefined for a tool with nothing specific to say", () => {
+    // The signal a batch row uses to keep its argument summary instead of
+    // degrading to the bare tool name.
+    expect(resolveToolLabels("someUnknownTool", { a: 1 }, undefined)).toBeUndefined();
+  });
+
+  it("still resolves the batch tool itself, for a nested render", () => {
+    const labels = resolveToolLabels(
+      "batch",
+      { description: "Comparing pricing pages", invocations: [{}, {}] },
+      undefined,
+    );
+
+    expect(labels?.done).toBe("Comparing pricing pages");
+  });
+
+  it("does not throw on malformed arguments", () => {
+    // Rows must render even when an invocation failed to parse its input.
+    expect(() => resolveToolLabels("webSearch", {}, undefined)).not.toThrow();
+    expect(() => resolveToolLabels("closeTabs", {}, undefined)).not.toThrow();
+    expect(() => resolveToolLabels("computer", {}, undefined)).not.toThrow();
+  });
+});

--- a/apps/extension/src/components/chat/tool-results/batch.tsx
+++ b/apps/extension/src/components/chat/tool-results/batch.tsx
@@ -27,6 +27,21 @@ interface Props {
     childArgs: Record<string, unknown>,
     childResult: unknown,
   ) => ReactNode | undefined;
+  /**
+   * The label the child tool's own collapsed row would show, so a batched
+   * `webSearch` reads `Searched “…” — 8 results` rather than the raw tool
+   * name plus a `key: value` argument dump.
+   *
+   * Injected for the same reason as `renderChild`: the label table lives
+   * in `ToolCallBlock` and importing it would form a cycle. Returns
+   * `undefined` for a tool with no specific label, in which case the row
+   * keeps its argument summary.
+   */
+  childLabel: (
+    name: string,
+    childArgs: Record<string, unknown>,
+    childResult: unknown,
+  ) => { pending: string; done: string } | undefined;
 }
 
 /**
@@ -92,14 +107,19 @@ function InvocationRow({
   invocationResult,
   childArgs,
   renderChild,
+  childLabel,
 }: {
   invocationResult: BatchInvocationResult;
   childArgs: Record<string, unknown>;
   renderChild: Props["renderChild"];
+  childLabel: Props["childLabel"];
 }) {
   const [open, setOpen] = useState(false);
   const { name, ok, output, error } = invocationResult;
-  const summary = summarizeArgs(childArgs);
+  // Prefer the label the tool would show on its own row; fall back to an
+  // argument summary for tools that have no specific label.
+  const summary =
+    childLabel(name, childArgs, output)?.done ?? summarizeArgs(childArgs);
   // A failed invocation may still carry output — tools that report
   // failure in-band (`{ results: [], error }`) hand back a payload their
   // own renderer already presents well. Prefer that over our error text.
@@ -168,7 +188,12 @@ function InvocationRow({
  * is still streaming there is no result yet, so the requested invocations
  * render as inert rows.
  */
-export function BatchResult({ args, result, renderChild }: Props) {
+export function BatchResult({
+  args,
+  result,
+  renderChild,
+  childLabel,
+}: Props) {
   const invocations = readBatchInvocations(args);
   const results = readBatchResults(result);
 
@@ -191,20 +216,24 @@ export function BatchResult({ args, result, renderChild }: Props) {
     if (invocations.length === 0) return null;
     return (
       <div className="ml-3 mt-1 flex flex-col border-l border-muted pb-1 pl-3 text-xs">
-        {invocations.map((invocation, index) => (
-          <div
-            key={`${invocation.name}-${index}`}
-            className="flex items-center gap-1.5 py-1"
-          >
-            <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-            <span className="shrink-0 font-mono text-foreground/70">
-              {invocation.name}
-            </span>
-            <span className="truncate text-muted-foreground/70">
-              {summarizeArgs(argsOf(invocation.arguments))}
-            </span>
-          </div>
-        ))}
+        {invocations.map((invocation, index) => {
+          const childArgs = argsOf(invocation.arguments);
+          return (
+            <div
+              key={`${invocation.name}-${index}`}
+              className="flex items-center gap-1.5 py-1"
+            >
+              <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+              <span className="shrink-0 font-mono text-foreground/70">
+                {invocation.name}
+              </span>
+              <span className="truncate text-muted-foreground/70">
+                {childLabel(invocation.name, childArgs, undefined)?.pending ??
+                  summarizeArgs(childArgs)}
+              </span>
+            </div>
+          );
+        })}
       </div>
     );
   }
@@ -217,6 +246,7 @@ export function BatchResult({ args, result, renderChild }: Props) {
           invocationResult={invocationResult}
           childArgs={argsOf(invocations[index]?.arguments)}
           renderChild={renderChild}
+          childLabel={childLabel}
         />
       ))}
     </div>


### PR DESCRIPTION
### Summary

Invocations inside a `batch` rendered as the raw tool name plus a generic `key: value` argument dump, instead of the label the same call shows on its own row. A fan-out of four `webSearch` calls gave no indication of whether any of them returned anything.

### Linked issue

Closes #

### Changes

Before / after for a batched `webSearch`:

```
✓ webSearch   query: Kindle API read book content third party app…   (before)
✓ webSearch   Searched “Kindle API read book content…” — 8 results   (after)
```

- **Extracted `resolveToolLabels(toolName, args, result)`** from the inline ternary chain in the `ToolCallBlock` component body. That chain was the reason for the bug: `tool-results/batch.tsx` had no function to call, so it summarized arguments instead.
- **Injected into `BatchResult`**, matching how `renderChild` is already passed — the label table lives in `ToolCallBlock` and importing it from `tool-results/batch` would form a cycle (documented on the existing `renderChild` prop).
- Child rows now carry the query **and result count**; a batched `Grep` reads "Searched" rather than `Grep`; a failed search reads "Search failed: …" instead of being indistinguishable from a successful one.
- Rows for a batch whose input is still streaming use the same labels in their `pending` form.
- **Tools with no specific label keep the argument summary.** `resolveToolLabels` returns `undefined` when neither a static entry nor a connector label applies, so each caller picks its own fallback rather than the row degrading to a bare tool name.
- **No behaviour change for top-level rows.** The denied paths still read `deniedReplace`/`denied` from the tool's static entry, which the per-tool helpers don't customize — kept as a separate `labels` binding for exactly that reason.

### Testing

- **+9 tests** on the extracted resolver: the reported `webSearch` case, singular/plural result counts, failed searches, static-only tools, host-splicing for `webFetch`, result-derived labels (`read_artifact_diagnostics`), the `undefined` signal that preserves the argument-summary fallback, and malformed arguments not throwing.
- `pnpm test` — 2,853 extension tests pass (2,844 before, +9), plus mcp-server 125.
- `pnpm compile` — clean across all workspaces.
- `wxt build` — succeeds.
- The six existing label suites (`batch-labels`, `computer-labels`, `close-tabs-labels`, `artifact-diagnostics-labels`, `scheduled-task-labels`, `site-script-labels`) still import the per-tool helpers from `ToolCallBlock` unchanged, so they act as regression cover for the extraction.

**Not verified in the browser** — the rendering change is one line per row site and the label functions are unit-tested, but I haven't confirmed the rows visually in `pnpm dev`.

### Screenshots / recordings

<!-- TODO: before/after of an expanded batch row -->

### Checklist

- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Ran `pnpm changeset` if this PR changes user-facing behavior
- [x] No unrelated changes
- [ ] Tested locally with `pnpm dev` — not yet; see **Testing**
