### PR TITLE
fix(agent): stop subagent transcripts leaking into the parent's context

### DIFF
--- a/.changeset/subagent-transcript-context-leak.md
+++ b/.changeset/subagent-transcript-context-leak.md
@@ -1,0 +1,11 @@
+---
+"openbrowse": patch
+---
+
+Stop a subagent's transcript from leaking into the parent agent's context, and fix subagent token/cost accounting.
+
+`delegate` returned the subagent's full `transcript` — every assistant message with the complete input and output of every tool it called (DOM snapshots, page text, base64 screenshots) — as part of its tool output. The AI SDK puts a tool's return value straight into the model's prompt unless the tool declares a `toModelOutput`, and only `screenshot` had one, so a single `explore`/`general` delegation (up to 100 steps) could push hundreds of thousands of tokens into the parent's context and keep re-sending them for the rest of the turn. No compaction pass could recover it: pruning runs once per turn at send time, never inside the SDK's tool loop, and the screenshot pruners key on the top-level `part.toolName`, so images nested in another tool's output are invisible to them — the same hazard that keeps `screenshot` out of the batchable registry. `toSDKTool` now projects UI-only fields out of the model-facing view; the persisted part keeps the full output, so the inline trace renders unchanged.
+
+Subagent tokens were also recorded nowhere — both the standard and CUA loops only counted steps — so a delegation's spend landed in no conversation's `costUsd` and child Context cards stayed empty. Both loops now attribute usage to the child conversation (CUA against the model that actually ran, which is often not the parent's), and a conversation's cost is its own row plus its children, summed at read time so repeated heal-path finalizes can't double-count.
+
+Finally, the context indicator showed `inputTokens + outputTokens` against an input-only ceiling — the reason it had to clamp at 100%. Display now uses input tokens ("Context Used"), and the compaction trigger keeps the input+output projection under an explicit name, since that's the right number for deciding whether the *next* request fits.

--- a/apps/extension/src/components/chat/ContextUsage.tsx
+++ b/apps/extension/src/components/chat/ContextUsage.tsx
@@ -8,6 +8,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  occupiedTokens,
+  sumSubagentCostUsd,
+} from "@/lib/agent/usage-aggregate";
 import { chatDb } from "@/lib/chat-db";
 import type { ConversationUsage } from "@/lib/types";
 import { getProvider } from "@/registry/providers";
@@ -33,23 +37,30 @@ export function formatCount(count: number): string {
   return tokenFmt.format(count);
 }
 
-/** Whole-number percent of context window used, clamped to 0–100; 0 when window is unknown. */
+/**
+ * Whole-number percent of context window used, clamped to 0–100; 0 when the
+ * window is unknown.
+ *
+ * `occupiedTokens` must be the latest request's INPUT tokens, not
+ * `usage.totalTokens` — see `ConversationUsage` in lib/types.ts for why the
+ * two differ. The clamp is now purely defensive (input tokens can't exceed
+ * the window the provider accepted them into); it stays because the value
+ * drives an SVG arc that would render wrong above 100.
+ */
 export function usagePercentValue(
-  totalTokens: number,
+  occupiedTokens: number,
   contextWindow: number,
 ): number {
   if (!contextWindow || contextWindow <= 0) return 0;
-  // totalTokens (input+output of the latest step) can exceed the input-only
-  // contextWindow when output is large; clamp the ceiling at 100.
-  return Math.min(100, Math.round((totalTokens / contextWindow) * 100));
+  return Math.min(100, Math.round((occupiedTokens / contextWindow) * 100));
 }
 
 /** Whole-number percent of context window used (clamped to 100); 0% when window is unknown. */
 export function formatUsagePercent(
-  totalTokens: number,
+  occupiedTokens: number,
   contextWindow: number,
 ): string {
-  return `${usagePercentValue(totalTokens, contextWindow)}%`;
+  return `${usagePercentValue(occupiedTokens, contextWindow)}%`;
 }
 
 /**
@@ -181,6 +192,12 @@ interface ConvSnapshot {
   createdAt: number;
   updatedAt: number;
   messageCount: number;
+  /**
+   * Cumulative spend across this conversation's subagent children. Kept
+   * separate from `usage.costUsd` (which is this row only) so the popover can
+   * show the split as well as the true total.
+   */
+  subagentCostUsd: number;
 }
 
 /**
@@ -205,9 +222,10 @@ export function ContextUsage({
     let mounted = true;
     async function refresh() {
       try {
-        const [conv, messageCount] = await Promise.all([
+        const [conv, messageCount, subagentCostUsd] = await Promise.all([
           chatDb.getConversation(conversationId),
           chatDb.getMessageCount(conversationId),
+          sumSubagentCostUsd(conversationId),
         ]);
         if (!mounted) return;
         if (!conv?.usage) {
@@ -220,6 +238,7 @@ export function ContextUsage({
           createdAt: conv.createdAt,
           updatedAt: conv.updatedAt,
           messageCount,
+          subagentCostUsd,
         });
       } catch (err) {
         // Transient DB error: keep the last-good snapshot rather than
@@ -238,8 +257,16 @@ export function ContextUsage({
 
   if (!snapshot) return null;
 
-  const { usage, title, createdAt, updatedAt, messageCount } = snapshot;
-  const showCost = usage.costUsd > 0;
+  const { usage, title, createdAt, updatedAt, messageCount, subagentCostUsd } =
+    snapshot;
+  // Context-window occupancy is the latest request's INPUT tokens. Using
+  // `totalTokens` here would charge the response against an input-only
+  // ceiling. See ConversationUsage in lib/types.ts.
+  const occupied = occupiedTokens(usage);
+  // A subagent's spend lands on its own child row, so the conversation's true
+  // cost is this row plus its children.
+  const totalCostUsd = usage.costUsd + subagentCostUsd;
+  const showCost = totalCostUsd > 0;
   const { providerLabel, modelLabel } = resolveModelsLabel(
     usage.modelIds,
     usage.modelId,
@@ -256,7 +283,7 @@ export function ContextUsage({
               aria-label="Context usage"
             >
               <ContextRing
-                percent={usagePercentValue(usage.totalTokens, usage.contextWindow)}
+                percent={usagePercentValue(occupied, usage.contextWindow)}
                 className={compact ? "size-3.5" : "size-4"}
               />
             </button>
@@ -265,21 +292,19 @@ export function ContextUsage({
         <TooltipContent align="end">
           <dl className="space-y-1">
             <div className="flex items-center justify-between gap-4">
-              <dd className="order-1 font-medium">
-                {formatTokens(usage.totalTokens)}
-              </dd>
-              <dt className="order-2 opacity-70">Tokens</dt>
+              <dd className="order-1 font-medium">{formatTokens(occupied)}</dd>
+              <dt className="order-2 opacity-70">Context</dt>
             </div>
             <div className="flex items-center justify-between gap-4">
               <dd className="order-1 font-medium">
-                {formatUsagePercent(usage.totalTokens, usage.contextWindow)}
+                {formatUsagePercent(occupied, usage.contextWindow)}
               </dd>
               <dt className="order-2 opacity-70">Usage</dt>
             </div>
             {showCost && (
               <div className="flex items-center justify-between gap-4">
                 <dd className="order-1 font-medium">
-                  {formatCost(usage.costUsd)}
+                  {formatCost(totalCostUsd)}
                 </dd>
                 <dt className="order-2 opacity-70">Cost</dt>
               </div>
@@ -297,13 +322,10 @@ export function ContextUsage({
             label="Context Limit"
             value={formatTokens(usage.contextWindow)}
           />
-          <DetailCell
-            label="Total Tokens"
-            value={formatTokens(usage.totalTokens)}
-          />
+          <DetailCell label="Context Used" value={formatTokens(occupied)} />
           <DetailCell
             label="Usage"
-            value={formatUsagePercent(usage.totalTokens, usage.contextWindow)}
+            value={formatUsagePercent(occupied, usage.contextWindow)}
           />
           <DetailCell
             label="Input Tokens"
@@ -313,7 +335,13 @@ export function ContextUsage({
             label="Output Tokens"
             value={formatTokens(usage.outputTokens)}
           />
-          <DetailCell label="Total Cost" value={formatCost(usage.costUsd)} />
+          <DetailCell label="Total Cost" value={formatCost(totalCostUsd)} />
+          {subagentCostUsd > 0 && (
+            <DetailCell
+              label="Subagent Cost"
+              value={formatCost(subagentCostUsd)}
+            />
+          )}
           <DetailCell label="Session Created" value={formatDateTime(createdAt)} />
           <DetailCell label="Last Activity" value={formatDateTime(updatedAt)} />
         </div>

--- a/apps/extension/src/components/chat/__tests__/context-usage.test.ts
+++ b/apps/extension/src/components/chat/__tests__/context-usage.test.ts
@@ -32,7 +32,9 @@ describe("ContextUsage formatters", () => {
     expect(formatUsagePercent(1_000, 0)).toBe("0%");
     // rounds to nearest integer
     expect(formatUsagePercent(7_500, 200_000)).toBe("4%");
-    // clamps the display ceiling at 100% when total exceeds the window
+    // Defensive clamp. Callers now pass INPUT tokens, which can't exceed the
+    // window the provider accepted them into, so this should be unreachable
+    // in practice — but the value drives an SVG arc, so it must stay bounded.
     expect(formatUsagePercent(250_000, 200_000)).toBe("100%");
   });
 
@@ -42,7 +44,7 @@ describe("ContextUsage formatters", () => {
     expect(usagePercentValue(1_000, 0)).toBe(0);
     // rounds to nearest integer
     expect(usagePercentValue(7_500, 200_000)).toBe(4);
-    // clamps the ceiling at 100
+    // defensive clamp — see above
     expect(usagePercentValue(250_000, 200_000)).toBe(100);
   });
 

--- a/apps/extension/src/hooks/useAgentChat.ts
+++ b/apps/extension/src/hooks/useAgentChat.ts
@@ -13,6 +13,7 @@ import { setTargetTabId } from "@/lib/agent/active-tab";
 import { healPendingTools } from "@/lib/agent/heal-pending-tools";
 import { bindSharedTab } from "@/lib/agent/bind-shared-tab";
 import { normalizeToolInputForPersistence } from "@/lib/agent/tool-input-normalize";
+import { projectedNextPromptTokens } from "@/lib/agent/usage-aggregate";
 import { setAgentActive, setAgentInactive } from "@/lib/active-agents";
 import {
   abortAgentRun,
@@ -1429,9 +1430,9 @@ export function useAgentChat({
       // Under SW-host the agent loop runs in a different realm than this
       // hook, so the legacy `needsCompaction()` (which read a
       // module-scope `lastTotalTokens` mutated by the loop) always
-      // returned false here. We instead read the authoritative
-      // `conv.usage.totalTokens` that the SW persists to chat-db on
-      // every step, and feed it directly to `shouldCompact`.
+      // returned false here. We instead read the authoritative usage
+      // snapshot the SW persists to chat-db on every step —
+      // provider-reported counts, so it reflects what was actually sent.
       if (
         wasInitiator &&
         conversationId &&
@@ -1455,7 +1456,14 @@ export function useAgentChat({
             maxOutputTokens:
               conv.usage.maxOutputTokens ?? getCurrentModelDef()?.maxOutputTokens,
           };
-          if (shouldCompact(conv.usage.totalTokens, modelLimits)) {
+          // Deliberately the NEXT prompt's projected size, not current
+          // occupancy: this turn's output becomes part of the next request,
+          // and the threshold (`contextWindow - maxOutput - buffer`) is the
+          // room that request has to fit in. `occupiedTokens` is the number
+          // to show a user; this is the number to decide on.
+          if (
+            shouldCompact(projectedNextPromptTokens(conv.usage), modelLimits)
+          ) {
             runCompaction(cid, localMessages, { auto: true });
           }
         });

--- a/apps/extension/src/lib/agent/__tests__/delegate-model-output.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/delegate-model-output.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Guard tests for the model-facing output projection in `toSDKTool`.
+ *
+ * The AI SDK sends a tool's `execute` return value to the model verbatim
+ * unless the tool declares a `toModelOutput`. `delegate` returns a
+ * `SubagentRunResult` whose `transcript` field carries EVERY assistant
+ * message of the subagent run — each with the full input and output of every
+ * tool it called (DOM snapshots, page text, base64 screenshots). Shipping
+ * that to the parent's model defeats the entire point of delegating
+ * (summary-only, fresh context) and is unrecoverable afterwards: every
+ * compaction pruner keys on the top-level `part.toolName`, so payload nested
+ * inside another tool's output is structurally invisible to them.
+ *
+ * These tests lock in that the projection exists, drops exactly the UI-only
+ * field, and leaves every other tool's model output alone.
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { toSDKTool } from "../agent-transport";
+import type { SubagentRunResult } from "../subagents/types";
+import type { BrowserTool } from "../types";
+
+type ModelOutputFn = (arg: { output: unknown }) => unknown;
+
+/** Read the SDK-facing `toModelOutput` off a wrapped tool, if it has one. */
+function modelOutputOf(tool: unknown): ModelOutputFn | undefined {
+  return (tool as { toModelOutput?: ModelOutputFn }).toModelOutput;
+}
+
+/** Minimal BrowserTool stub; only the wrapper's name-keyed behavior matters. */
+function stubTool(name: string): BrowserTool<Record<string, never>, unknown> {
+  return {
+    name,
+    description: `stub ${name}`,
+    parameters: z.object({}),
+    execute: async () => ({}),
+  };
+}
+
+describe("toSDKTool — delegate output projection", () => {
+  it("strips `transcript` from what the model sees", () => {
+    const wrapped = toSDKTool(stubTool("delegate"), "delegate");
+    const toModelOutput = modelOutputOf(wrapped);
+    expect(toModelOutput).toBeTypeOf("function");
+
+    // A realistic result: the transcript is the bulk of the payload.
+    const output: SubagentRunResult = {
+      finalText: "Found 3 pricing tiers: Free, Pro, Enterprise.",
+      childConversationId: "subagent-abc-123",
+      status: "completed",
+      transcript: [
+        {
+          id: "m1",
+          parts: [
+            {
+              type: "dynamic-tool",
+              toolName: "screenshot",
+              toolCallId: "c1",
+              state: "output-available",
+              input: {},
+              output: {
+                imageDataUrl: `data:image/png;base64,${"A".repeat(50_000)}`,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const projected = toModelOutput!({ output }) as {
+      type: string;
+      value: Record<string, unknown>;
+    };
+
+    expect(projected.type).toBe("json");
+    expect(projected.value).not.toHaveProperty("transcript");
+    // Everything the parent's loop actually needs survives.
+    expect(projected.value).toEqual({
+      finalText: "Found 3 pricing tiers: Free, Pro, Enterprise.",
+      childConversationId: "subagent-abc-123",
+      status: "completed",
+    });
+    // And the projection is genuinely small — the whole point.
+    expect(JSON.stringify(projected.value).length).toBeLessThan(200);
+  });
+
+  it("does not mutate the original output (the UI still renders the trace)", () => {
+    const wrapped = toSDKTool(stubTool("delegate"), "delegate");
+    const output: SubagentRunResult = {
+      finalText: "done",
+      childConversationId: "c1",
+      status: "completed",
+      transcript: [{ id: "m1", parts: [{ type: "text", text: "hello" }] }],
+    };
+
+    modelOutputOf(wrapped)!({ output });
+
+    expect(output.transcript).toHaveLength(1);
+  });
+
+  it("passes through an output that has no transcript", () => {
+    const wrapped = toSDKTool(stubTool("delegate"), "delegate");
+    const output: SubagentRunResult = {
+      finalText: "Subagent 'explore' could not run: unknown agent",
+      childConversationId: null,
+      status: "failed",
+      errorMessage: "unknown agent",
+    };
+
+    const projected = modelOutputOf(wrapped)!({ output }) as {
+      value: unknown;
+    };
+    // Same object identity — the no-op path must not allocate.
+    expect(projected.value).toBe(output);
+  });
+
+  it("tolerates a non-object output", () => {
+    const wrapped = toSDKTool(stubTool("delegate"), "delegate");
+    const fn = modelOutputOf(wrapped)!;
+    expect((fn({ output: "plain string" }) as { value: unknown }).value).toBe(
+      "plain string",
+    );
+    expect((fn({ output: null }) as { value: unknown }).value).toBe(null);
+    expect((fn({ output: [1, 2] }) as { value: unknown }).value).toEqual([
+      1, 2,
+    ]);
+  });
+});
+
+describe("toSDKTool — projection scope", () => {
+  it("leaves ordinary tools without a toModelOutput", () => {
+    for (const name of [
+      "snapshot",
+      "readPage",
+      "navigate",
+      "batch",
+      "extract",
+    ]) {
+      expect(modelOutputOf(toSDKTool(stubTool(name), name))).toBeUndefined();
+    }
+  });
+
+  it("still gives `screenshot` the image-content adapter", () => {
+    // Regression guard: the delegate branch must not shadow the image branch.
+    const wrapped = toSDKTool(stubTool("screenshot"), "screenshot");
+    const projected = modelOutputOf(wrapped)!({
+      output: { imageDataUrl: "data:image/png;base64,QUJD" },
+    });
+    expect(projected).toEqual({
+      type: "content",
+      value: [{ type: "image-data", data: "QUJD", mediaType: "image/png" }],
+    });
+  });
+
+  it("does not resolve a projection from Object.prototype", () => {
+    // The registry is a Map precisely so a tool named `constructor` /
+    // `toString` can't inherit one.
+    for (const name of ["constructor", "toString", "hasOwnProperty"]) {
+      expect(modelOutputOf(toSDKTool(stubTool(name), name))).toBeUndefined();
+    }
+  });
+});

--- a/apps/extension/src/lib/agent/__tests__/usage-aggregate.test.ts
+++ b/apps/extension/src/lib/agent/__tests__/usage-aggregate.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for read-time usage aggregation.
+ *
+ * A subagent's tokens and cost accumulate on its OWN child conversation row,
+ * so a parent's `usage.costUsd` alone under-reports a delegation-heavy
+ * session by most of its actual spend. `sumSubagentCostUsd` closes that gap at
+ * READ time rather than by rolling into the parent's row at write time —
+ * which matters because the heal paths (`finalizeOrphanedChildrenForHeals`,
+ * `finalizeAllRunningChildrenAtStartup`) can finalize the same child more
+ * than once, and a write-time roll-up would double-count.
+ */
+
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chatDb } from "../../chat-db";
+import type { ConversationUsage } from "../../types";
+import {
+  occupiedTokens,
+  projectedNextPromptTokens,
+  sumSubagentCostUsd,
+} from "../usage-aggregate";
+
+function usage(partial: Partial<ConversationUsage>): ConversationUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+    contextWindow: 200_000,
+    modelId: "anthropic:claude-x",
+    updatedAt: 1,
+    ...partial,
+  };
+}
+
+describe("sumSubagentCostUsd", () => {
+  beforeEach(async () => {
+    indexedDB = new IDBFactory();
+    chatDb._resetForTests();
+    await chatDb.createConversation({
+      id: "parent-1",
+      title: "Parent",
+      spaceId: "space-A",
+      createdAt: 100,
+      updatedAt: 100,
+      usage: usage({ costUsd: 0.5 }),
+    });
+  });
+
+  afterEach(() => {
+    chatDb._resetForTests();
+  });
+
+  async function addChild(id: string, costUsd: number | undefined) {
+    await chatDb.createConversation({
+      id,
+      title: id,
+      spaceId: "space-A",
+      createdAt: 200,
+      updatedAt: 200,
+      parentConversationId: "parent-1",
+      subagentSlug: "explore",
+      subagentStatus: "completed",
+      ...(costUsd !== undefined && { usage: usage({ costUsd }) }),
+    });
+  }
+
+  it("returns 0 for a conversation with no children", async () => {
+    expect(await sumSubagentCostUsd("parent-1")).toBe(0);
+  });
+
+  it("sums cost across every child", async () => {
+    await addChild("subagent-1", 1.25);
+    await addChild("subagent-2", 0.75);
+    expect(await sumSubagentCostUsd("parent-1")).toBeCloseTo(2, 6);
+  });
+
+  it("treats a child with no usage row yet as 0 rather than NaN", async () => {
+    await addChild("subagent-1", 1.5);
+    await addChild("subagent-running", undefined);
+    expect(await sumSubagentCostUsd("parent-1")).toBeCloseTo(1.5, 6);
+  });
+
+  it("counts a still-running child's spend immediately", async () => {
+    await chatDb.createConversation({
+      id: "subagent-live",
+      title: "live",
+      spaceId: "space-A",
+      createdAt: 200,
+      updatedAt: 200,
+      parentConversationId: "parent-1",
+      subagentSlug: "general",
+      subagentStatus: "running",
+      usage: usage({ costUsd: 0.4 }),
+    });
+    expect(await sumSubagentCostUsd("parent-1")).toBeCloseTo(0.4, 6);
+  });
+
+  it("is stable across repeated reads (no write-side accumulation)", async () => {
+    await addChild("subagent-1", 1.25);
+    const first = await sumSubagentCostUsd("parent-1");
+    const second = await sumSubagentCostUsd("parent-1");
+    const third = await sumSubagentCostUsd("parent-1");
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it("does not attribute another parent's children", async () => {
+    await chatDb.createConversation({
+      id: "parent-2",
+      title: "Other",
+      spaceId: "space-A",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+    await chatDb.createConversation({
+      id: "subagent-other",
+      title: "other child",
+      spaceId: "space-A",
+      createdAt: 200,
+      updatedAt: 200,
+      parentConversationId: "parent-2",
+      subagentSlug: "explore",
+      subagentStatus: "completed",
+      usage: usage({ costUsd: 99 }),
+    });
+    expect(await sumSubagentCostUsd("parent-1")).toBe(0);
+  });
+
+  it("returns 0 instead of throwing when the lookup fails", async () => {
+    chatDb._resetForTests();
+    const real = indexedDB;
+    try {
+      // @ts-expect-error — force the underlying DB away to simulate failure.
+      indexedDB = undefined;
+      expect(await sumSubagentCostUsd("parent-1")).toBe(0);
+    } finally {
+      // Restore so this test can't strand a later DB-backed test in the file.
+      indexedDB = real;
+    }
+  });
+});
+
+describe("token accessors name which quantity they mean", () => {
+  it("occupiedTokens is the latest request's input only", () => {
+    expect(
+      occupiedTokens(
+        usage({
+          inputTokens: 120_000,
+          outputTokens: 8_000,
+          totalTokens: 128_000,
+        }),
+      ),
+    ).toBe(120_000);
+  });
+
+  it("projectedNextPromptTokens includes the output that becomes next input", () => {
+    expect(
+      projectedNextPromptTokens(
+        usage({
+          inputTokens: 120_000,
+          outputTokens: 8_000,
+          totalTokens: 128_000,
+        }),
+      ),
+    ).toBe(128_000);
+  });
+
+  it("the two differ exactly by the latest output, which is why display and compaction disagree", () => {
+    const u = usage({
+      inputTokens: 190_000,
+      outputTokens: 20_000,
+      totalTokens: 210_000,
+      contextWindow: 200_000,
+    });
+    // Occupancy fits the window; the projection does not. Showing the
+    // projection is what used to force a 100% clamp in the UI.
+    expect(occupiedTokens(u)).toBeLessThan(u.contextWindow);
+    expect(projectedNextPromptTokens(u)).toBeGreaterThan(u.contextWindow);
+    expect(projectedNextPromptTokens(u) - occupiedTokens(u)).toBe(20_000);
+  });
+});

--- a/apps/extension/src/lib/agent/agent-transport.ts
+++ b/apps/extension/src/lib/agent/agent-transport.ts
@@ -687,6 +687,53 @@ export function getAgentContext(): {
 
 const IMAGE_TOOLS = new Set(["screenshot"]);
 
+/**
+ * Fields on a tool's output that exist ONLY to drive the UI and must never
+ * enter the model's context.
+ *
+ * The AI SDK sends a tool's `execute` return value to the model verbatim
+ * (`createToolModelOutput` JSON-serializes it) unless the tool declares a
+ * `toModelOutput`. That makes any UI-only payload on an output a silent
+ * context leak — and one that no compaction pass can recover, because every
+ * pruner keys on the TOP-LEVEL `part.toolName` (`stripScreenshotsFromParts`,
+ * `keepOnlyLatestScreenshot`), so payload nested inside another tool's output
+ * is structurally invisible to them. This is the same hazard that keeps
+ * `screenshot` out of the batchable registry.
+ *
+ * `delegate` is the motivating case: `SubagentRunResult.transcript` carries
+ * every assistant message of the subagent run — each with the full `input`
+ * and `output` of every tool it called (DOM snapshots, page text, base64
+ * screenshots). `explore`/`general` run up to 100 steps, so a single
+ * delegation could push several hundred thousand tokens into the parent's
+ * prompt and keep re-sending them for the rest of the turn. The subagent
+ * contract is summary-only (`SubagentRunResult.finalText` is documented as
+ * "what the parent's LLM sees; the rest is metadata"), and the UI reads the
+ * trace from the child conversation via chat-db rather than from this field,
+ * so omitting it costs the renderer nothing.
+ *
+ * A Map (not an object literal) so a tool named e.g. `constructor` can't
+ * resolve a prototype property.
+ */
+const UI_ONLY_OUTPUT_FIELDS = new Map<string, readonly string[]>([
+  ["delegate", ["transcript"]],
+]);
+
+/**
+ * Shallow-copy `output` without `fields`. Returns the input unchanged when
+ * it isn't a plain object or carries none of the fields, so the common case
+ * allocates nothing.
+ */
+function omitUiOnlyFields(output: unknown, fields: readonly string[]): unknown {
+  if (output === null || typeof output !== "object" || Array.isArray(output)) {
+    return output;
+  }
+  const record = output as Record<string, unknown>;
+  if (!fields.some((f) => f in record)) return output;
+  const rest = { ...record };
+  for (const f of fields) delete rest[f];
+  return rest;
+}
+
 export const toolResultStore = new Map<string, unknown>();
 
 // Stores the tab ID captured at tool-call time for approval-required tools,
@@ -1109,6 +1156,7 @@ export function toSDKTool<TInput, TOutput>(
 ): ToolSet[string] {
   const isTabTool = TAB_INTERACTING_TOOLS.has(toolKey);
   const isImageTool = IMAGE_TOOLS.has(toolKey);
+  const uiOnlyOutputFields = UI_ONLY_OUTPUT_FIELDS.get(toolKey);
 
   const approvalRequired = t.approval?.required ?? false;
 
@@ -1803,7 +1851,15 @@ export function toSDKTool<TInput, TOutput>(
           ],
         };
       }
-    : undefined;
+    : uiOnlyOutputFields
+      ? // Project away UI-only payload before the model sees the result. The
+        // tool part persisted for the renderer keeps the full output —
+        // `toModelOutput` only rewrites the model-facing view.
+        ({ output }: { output: TOutput }) => ({
+          type: "json" as const,
+          value: omitUiOnlyFields(output, uiOnlyOutputFields) as JSONValue,
+        })
+      : undefined;
 
   // ToolSet[string] is Tool<any, any> — the SDK's Tool type uses conditional
   // types that can't be satisfied with generic type parameters.
@@ -2794,6 +2850,16 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
         }
       }
 
+      // Resolve the CUA model's definition (pricing + context window) and
+      // its qualified key so the run's tokens and cost are attributed to
+      // the model that ACTUALLY executed. CUA commonly runs on a different
+      // model than the parent (an explicit `cuaModel` setting), so reusing
+      // the parent's `modelDef` here would misprice the run.
+      const cuaModelDef = cuaRegistryProvider.models.find(
+        (m) => m.id === cuaActualModelId,
+      );
+      const cuaQualifiedModelId = `${cuaRegistryProvider.id}:${cuaActualModelId}`;
+
       const result = await cuaProvider.runLoop({
         model: cuaModel,
         driver: extensionDriver,
@@ -2810,6 +2876,14 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
         conversationId: cfg.childConversationId,
         spaceColor: childSpaceColor,
         ...(cfg.abortSignal && { abortSignal: cfg.abortSignal }),
+        onStepUsage: (usage) => {
+          void recordUsageForStep(
+            cfg.childConversationId,
+            usage,
+            cuaModelDef,
+            cuaQualifiedModelId,
+          );
+        },
         onUiMessage: (m) => {
           if (!cuaPersister) return;
           persistChain = persistChain
@@ -2883,8 +2957,31 @@ To minimize wasted rejection rounds: before producing a final response, re-read 
       instructions: cfg.systemPrompt,
       ...(providerOptions && { providerOptions }),
       experimental_context: cfg.toolContext,
-      onStepFinish: () => {
+      onStepFinish: (stepResult) => {
         stepCount += 1;
+        // Attribute the subagent's tokens to its OWN conversation row.
+        // Without this the run is invisible to accounting: the child's
+        // Context card stays empty, `useChildModel` can never resolve the
+        // model that actually executed, and — most importantly — the spend
+        // lands in no conversation's `costUsd`, so a delegation-heavy
+        // session under-reports cost by most of its actual total. The
+        // parent aggregates child cost at read time (see
+        // `sumSubagentCostUsd`), which keeps the roll-up idempotent even
+        // though the heal paths can finalize a child more than once.
+        //
+        // The subagent runs on the PARENT's resolved model (it's
+        // constructed with the same `model` above), so the parent's
+        // `modelDef` / `qualifiedModelId` are the correct attribution.
+        const usage = stepResult.usage;
+        void recordUsageForStep(
+          cfg.childConversationId,
+          {
+            inputTokens: usage.inputTokens,
+            outputTokens: usage.outputTokens,
+          },
+          modelDef,
+          qualifiedModelId,
+        );
       },
       stopWhen: stepCountIs(maxSteps),
     });

--- a/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
+++ b/apps/extension/src/lib/agent/cua/__tests__/cua-loop.test.ts
@@ -18,6 +18,12 @@ let capturedRunAction:
   | null = null;
 let mockBetweenSteps: ((stepIndex: number) => void | Promise<void>) | null =
   null;
+// Per-step provider usage the fake reports through `onStepFinish`. `null`
+// simulates a provider that reports no usage at all.
+let mockStepUsage: { inputTokens?: number; outputTokens?: number } | null = {
+  inputTokens: 100,
+  outputTokens: 20,
+};
 
 // Mock the `ai` module so we can drive `onStepFinish` and the streamed
 // UIMessages without a live model. `runCuaToolLoop` constructs
@@ -25,8 +31,8 @@ let mockBetweenSteps: ((stepIndex: number) => void | Promise<void>) | null =
 // truncation → budget-exceeded mapping.
 vi.mock("ai", () => {
   class FakeToolLoopAgent {
-    private onStepFinish?: () => void;
-    constructor(config: { onStepFinish?: () => void }) {
+    private onStepFinish?: (stepResult: unknown) => void;
+    constructor(config: { onStepFinish?: (stepResult: unknown) => void }) {
       this.onStepFinish = config.onStepFinish;
     }
     async stream() {
@@ -44,7 +50,11 @@ vi.mock("ai", () => {
         if (mockBetweenSteps) {
           await mockBetweenSteps(i);
         }
-        this.onStepFinish?.();
+        // Mirror the real SDK: `onStepFinish` receives the step result,
+        // whose `usage` carries the provider-reported token counts.
+        this.onStepFinish?.(
+          mockStepUsage === null ? {} : { usage: mockStepUsage },
+        );
       }
       return {
         toUIMessageStream: () => ({}) as never,
@@ -116,6 +126,7 @@ beforeEach(() => {
   mockFinalText = "";
   capturedRunAction = null;
   mockBetweenSteps = null;
+  mockStepUsage = { inputTokens: 100, outputTokens: 20 };
 });
 
 describe("executeAndShoot", () => {
@@ -267,6 +278,60 @@ describe("runCuaToolLoop — status mapping", () => {
   it("returns completed when under the step cap", async () => {
     mockSteps = 1;
     mockFinalText = "";
+    const result = await runCuaToolLoop(fakeRunConfig(5), fakeBuild());
+    expect(result.status).toBe("completed");
+  });
+});
+
+/**
+ * A CUA run's tokens used to be recorded nowhere: `onStepFinish` only
+ * incremented the step counter, so the run's spend landed in no
+ * conversation's `costUsd` and the child conversation's Context card stayed
+ * empty. `onStepUsage` is the hook the caller uses to attribute it. The
+ * callback stays here (rather than a chat-db write inside this module) so the
+ * loop keeps no persistence dependency — same rationale as `onUiMessage`.
+ */
+describe("runCuaToolLoop — usage reporting", () => {
+  it("reports each step's provider usage to onStepUsage", async () => {
+    mockSteps = 3;
+    mockFinalText = "done";
+    mockStepUsage = { inputTokens: 1_000, outputTokens: 250 };
+
+    const seen: Array<{ inputTokens?: number; outputTokens?: number }> = [];
+    await runCuaToolLoop(
+      { ...fakeRunConfig(5), onStepUsage: (u) => seen.push(u) },
+      fakeBuild(),
+    );
+
+    expect(seen).toEqual([
+      { inputTokens: 1_000, outputTokens: 250 },
+      { inputTokens: 1_000, outputTokens: 250 },
+      { inputTokens: 1_000, outputTokens: 250 },
+    ]);
+  });
+
+  it("skips the callback when the provider reports no usage", async () => {
+    mockSteps = 2;
+    mockFinalText = "done";
+    mockStepUsage = null;
+
+    const onStepUsage = vi.fn();
+    await runCuaToolLoop({ ...fakeRunConfig(5), onStepUsage }, fakeBuild());
+
+    expect(onStepUsage).not.toHaveBeenCalled();
+  });
+
+  it("still counts steps for the budget-exceeded mapping when usage is absent", async () => {
+    mockSteps = 3;
+    mockFinalText = "";
+    mockStepUsage = null;
+    const result = await runCuaToolLoop(fakeRunConfig(3), fakeBuild());
+    expect(result.status).toBe("budget-exceeded");
+  });
+
+  it("runs fine with no onStepUsage wired (optional hook)", async () => {
+    mockSteps = 1;
+    mockFinalText = "ok";
     const result = await runCuaToolLoop(fakeRunConfig(5), fakeBuild());
     expect(result.status).toBe("completed");
   });

--- a/apps/extension/src/lib/agent/cua/cua-loop.ts
+++ b/apps/extension/src/lib/agent/cua/cua-loop.ts
@@ -350,8 +350,11 @@ export async function runCuaToolLoop(
     tools: tools as never,
     instructions: cfg.systemPrompt,
     ...(providerOptions && { providerOptions: providerOptions as never }),
-    onStepFinish: (() => {
+    onStepFinish: ((stepResult: {
+      usage?: { inputTokens?: number; outputTokens?: number };
+    }) => {
       stepCount += 1;
+      if (stepResult?.usage) cfg.onStepUsage?.(stepResult.usage);
     }) as never,
     stopWhen: stepCountIs(cfg.maxSteps) as never,
   });

--- a/apps/extension/src/lib/agent/cua/provider.ts
+++ b/apps/extension/src/lib/agent/cua/provider.ts
@@ -38,6 +38,18 @@ export interface CuaRunConfig {
   abortSignal?: AbortSignal;
   /** Called with each assistant UIMessage so the runner can persist the trace. */
   onUiMessage?: (message: unknown) => void;
+  /**
+   * Called after each step with that step's provider-reported token usage,
+   * so the caller can attribute the run's tokens and cost to a conversation
+   * row. Kept as a callback rather than writing to chat-db here so this
+   * module stays free of persistence concerns (same rationale as
+   * `onUiMessage`). Fields may be undefined for providers that don't report
+   * usage.
+   */
+  onStepUsage?: (usage: {
+    inputTokens?: number;
+    outputTokens?: number;
+  }) => void;
 }
 
 export interface CuaRunResult {

--- a/apps/extension/src/lib/agent/usage-aggregate.ts
+++ b/apps/extension/src/lib/agent/usage-aggregate.ts
@@ -1,0 +1,77 @@
+/**
+ * Read-time aggregation of conversation usage.
+ *
+ * ## The two token numbers, and why they differ
+ *
+ * `ConversationUsage` carries two easily-conflated quantities, and they answer
+ * different questions:
+ *
+ *  - **`inputTokens`** — how much of the context window the latest request
+ *    actually occupied. This is the honest "how full is the context" number,
+ *    and the one the UI should display.
+ *
+ *  - **`totalTokens`** (`inputTokens + outputTokens`) — a projection of the
+ *    NEXT request's prompt, because this step's output becomes part of it.
+ *    That makes it the right input to the compaction trigger, which compares
+ *    against `contextWindow - maxOutput - buffer` (see `shouldCompact`).
+ *
+ * Using `totalTokens` for display is what forced `usagePercentValue` to clamp
+ * at 100% — output tokens are counted against an input-only ceiling, so the
+ * ratio could legitimately exceed 1. Displaying `inputTokens` removes the
+ * cause rather than the symptom.
+ *
+ * ## Why cost is summed at read time
+ *
+ * Subagent runs accumulate `costUsd` on their OWN child conversation rows
+ * (see `recordUsageForStep` wiring in `agent-transport.ts`). Summing children
+ * here, at read time, keeps the roll-up idempotent: the heal paths
+ * (`finalizeOrphanedChildrenForHeals`, `finalizeAllRunningChildrenAtStartup`)
+ * can finalize the same child more than once, which a write-time roll-up into
+ * the parent's `costUsd` could not survive without an extra "already counted"
+ * marker on the row. It also means a still-running subagent's spend is
+ * visible immediately instead of only at finalize.
+ *
+ * One level of children is exhaustive: `delegate` enforces depth = 1, so a
+ * subagent cannot spawn subagents of its own.
+ */
+
+import { chatDb } from "../chat-db";
+import type { ConversationUsage } from "../types";
+
+/**
+ * Sum of `costUsd` across every subagent child of `parentConversationId`.
+ * Returns 0 when the conversation has no children or the lookup fails —
+ * cost display must never break the header indicator.
+ */
+export async function sumSubagentCostUsd(
+  parentConversationId: string,
+): Promise<number> {
+  try {
+    const children = await chatDb.listChildren(parentConversationId);
+    return children.reduce((sum, c) => sum + (c.usage?.costUsd ?? 0), 0);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Context-window occupancy of the latest request, in tokens.
+ *
+ * Prefer this over `usage.totalTokens` for anything user-facing: it's what
+ * the model actually received, so it's directly comparable to
+ * `usage.contextWindow`.
+ */
+export function occupiedTokens(usage: ConversationUsage): number {
+  return usage.inputTokens;
+}
+
+/**
+ * Projected size of the NEXT request's prompt, in tokens — the quantity the
+ * compaction trigger reasons about. Exported for symmetry with
+ * {@link occupiedTokens} so callers name which of the two they mean instead
+ * of reaching for `totalTokens` and inheriting whichever meaning the reader
+ * assumes.
+ */
+export function projectedNextPromptTokens(usage: ConversationUsage): number {
+  return usage.totalTokens;
+}

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -385,13 +385,35 @@ export interface Conversation {
  * The two intentionally differ in scope.
  */
 export interface ConversationUsage {
-  /** Latest step's input tokens (current context input). */
+  /**
+   * Latest step's input tokens — i.e. how much of the context window the
+   * most recent request actually occupied, as reported by the provider.
+   *
+   * This is the honest "how full is the context" number and the one
+   * user-facing surfaces should show (see `occupiedTokens` in
+   * `lib/agent/usage-aggregate.ts`).
+   */
   inputTokens: number;
   /** Latest step's output tokens. */
   outputTokens: number;
-  /** inputTokens + outputTokens — the current context size. */
+  /**
+   * `inputTokens + outputTokens` for the latest step.
+   *
+   * NOT current occupancy — it's a projection of the NEXT request's prompt,
+   * since this step's output becomes part of it. That's what makes it the
+   * right input to the compaction trigger (`shouldCompact` compares it
+   * against `contextWindow - maxOutput - buffer`) and the WRONG input to a
+   * "percent of context window used" display, where it can exceed the
+   * input-only ceiling. Use `inputTokens` for display.
+   */
   totalTokens: number;
-  /** Cumulative USD spent across all steps in this conversation. */
+  /**
+   * Cumulative USD spent across all steps in this conversation.
+   *
+   * Scoped to THIS row only. A subagent's spend accumulates on its own child
+   * conversation row; callers that want a conversation's true total must add
+   * `sumSubagentCostUsd` (see `lib/agent/usage-aggregate.ts`).
+   */
   costUsd: number;
   /** Snapshot of the model's context window at write time. */
   contextWindow: number;


### PR DESCRIPTION
### Summary

`delegate` was returning the subagent's full `transcript` as part of its tool output, so the entire subagent run landed in the parent agent's context — the opposite of what delegating is for. Also fixes two token/cost accounting defects the leak exposed.

### Linked issue

Closes #

### Changes

**The leak** — `agent-transport.ts`

The AI SDK serializes a tool's return value into the model's prompt verbatim unless the tool declares a `toModelOutput`, and only `screenshot` had one. So every assistant message of the subagent run — each with the complete input *and* output of every tool it called (DOM snapshots, page text, base64 screenshots) — went into the parent's prompt and was re-sent for every remaining step of the turn. `explore`/`general` run up to 100 steps.

Nothing downstream could recover it:
- `rewriteForLLM`/`prunePartsAtSendTime` run once per turn in `sendMessages`, never inside the SDK's own tool loop, so the payload is never seen mid-turn.
- The screenshot pruners (`stripScreenshotsFromParts`, `keepOnlyLatestScreenshot`) key on the **top-level** `part.toolName`, so images nested inside another tool's output are structurally invisible to them. This is the same hazard that keeps `screenshot` out of the batchable registry — `delegate` had it too.

`toSDKTool` now projects UI-only fields out of the model-facing view via a name-keyed registry. The persisted tool part keeps the full output, so `DelegateResult` renders identically — it already reads the trace from the child conversation via chat-db.

**Subagent accounting** — `agent-transport.ts`, `cua/{provider,cua-loop}.ts`, `usage-aggregate.ts` (new)

Subagent tokens were recorded nowhere: both the standard subagent loop and the CUA loop only incremented a step counter. A 100-step delegation's spend landed in no conversation's `costUsd`, child Context cards stayed empty, and `useChildModel`'s documented first choice (the model that actually executed, reflecting a `cuaModel` override) was unreachable because nothing ever wrote the child's `usage`.

- Both loops now call `recordUsageForStep` against the child conversation. CUA attributes to the model that *actually* ran, which is often not the parent's — reusing the parent's `modelDef` would misprice it.
- CUA gets an `onStepUsage` callback rather than a chat-db write inside `cua-loop.ts`, keeping that module free of persistence deps (same rationale as `onUiMessage`).
- A conversation's true cost is its own row plus its children, summed at **read** time (`sumSubagentCostUsd`). Deliberate: the heal paths can finalize the same child more than once, which a write-time roll-up couldn't survive without an extra marker field. It also surfaces a still-running subagent's spend immediately.

**`totalTokens` meant two things** — `ContextUsage.tsx`, `useAgentChat.ts`, `types.ts`

The indicator divided `inputTokens + outputTokens` by an input-only `contextWindow`, which is why `usagePercentValue` had to clamp at 100% — the clamp was treating the symptom.

- Display now uses `inputTokens` (`occupiedTokens`); popover cell renamed "Total Tokens" → "Context Used", plus a "Subagent Cost" cell when non-zero.
- The compaction trigger keeps the input+output projection but names it (`projectedNextPromptTokens`) — that *is* the right number for deciding whether the next request fits, since this turn's output becomes part of it. The arithmetic is unchanged.
- `ConversationUsage` doc comments now state which field means what, and that `costUsd` is this-row-only.

Worth noting: the context number itself was never wrong — it's the provider's own count from `onStepFinish`. The 800K-token compactions were real, and fixing the leak fixes the number. No estimator was introduced.

### Testing

- `pnpm compile` clean across the workspace.
- `pnpm test`: **2,865 pass** / 299 files (2,844 baseline + 21 new).
  - `delegate-model-output.test.ts` (7): projection strips `transcript`, no-op path keeps object identity, non-object outputs, original not mutated, `screenshot`'s image adapter not shadowed, no prototype-property resolution.
  - `usage-aggregate.test.ts` (10): child cost summing, missing/running child rows, parent isolation, read-repeatability, occupancy vs. projection.
  - `cua-loop.test.ts` (+4): per-step usage reporting, absent-usage path, step counting still drives `budget-exceeded`.

Not covered by a unit test: the standard subagent's `onStepFinish` closure lives inside `createAgentTransport`, which needs full provider/settings wiring. It mirrors the parent's already-tested call and is covered by typecheck.

### Screenshots / recordings

n/a — the only UI delta is the Context popover labels ("Context Used", "Subagent Cost").

### Checklist

- [x] `pnpm compile` passes
- [x] `pnpm test` passes
- [x] Ran `pnpm changeset` if this PR changes user-facing behavior
- [x] No unrelated changes
- [ ] Tested locally with `pnpm dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subagent transcript isolation so model responses exclude UI-only transcript details while the full trace remains available in the interface.
  * Corrected token and cost tracking across delegated conversations, including accurate model attribution and prevention of duplicate costs.
  * Improved context usage reporting by basing it on input tokens and displaying combined subagent costs.
  * Compaction checks now account for projected tokens in the next prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->